### PR TITLE
Add `url` option to DB config

### DIFF
--- a/src/config/defaults/db.php
+++ b/src/config/defaults/db.php
@@ -41,6 +41,11 @@ return [
      */
     'schema' => 'public',
     /**
+     * The database credentials in a string format following the standard uri syntax.
+     * Format: <driver>://<user>:<password>@<server>:<port>/<database>
+     */
+    'url' => null,
+    /**
      * If you're sharing Craft installs in a single database (MySQL) or a single
      * database and using a shared schema (PostgreSQL), then you can set a table
      * prefix here to avoid table naming conflicts per install. This can be no more than 5

--- a/src/services/Config.php
+++ b/src/services/Config.php
@@ -915,6 +915,34 @@ class Config extends Component
             }
         }
 
+        if ($category === self::CATEGORY_DB && $configSettings['url']) {
+            $url = parse_url($configSettings['url']);
+
+            if (isset($url['scheme'])) {
+                $configSettings['driver'] = $url['scheme'];
+            }
+
+            if (isset($url['user'])) {
+                $configSettings['user'] = $url['user'];
+            }
+
+            if (isset($url['password'])) {
+                $configSettings['database'] = $url['pass'];
+            }
+
+            if (isset($url['host'])) {
+                $configSettings['server'] = $url['host'];
+            }
+
+            if (isset($url['port'])) {
+                $configSettings['port'] = $url['port'];
+            }
+
+            if (isset($url['path'])) {
+                $configSettings['database'] = trim($url['path'], '/');
+            }
+        }
+
         $this->_configSettings[$category] = $configSettings;
     }
 


### PR DESCRIPTION
PaaS solutions (Heroku, Dokku, CloudFoundry, etc) often provide database credentials in the form of a single string via an environment variable. This string contains the driver, username, password, server, port and database name.

This patch defines the `url` option in the config, parses the `url` option parts if defined, and then assigns the parts to existing DB config options when the DB config is loaded, having no impact on existing calls to the DB config.