### PR TITLE
Fix casing in Dashboard.js asset

### DIFF
--- a/src/web/assets/dashboard/DashboardAsset.php
+++ b/src/web/assets/dashboard/DashboardAsset.php
@@ -31,7 +31,7 @@ class DashboardAsset extends AssetBundle
         ];
 
         $this->js = [
-            'dashboard'.$this->dotJs(),
+            'Dashboard'.$this->dotJs(),
         ];
 
         parent::init();


### PR DESCRIPTION
The asset failed to load on my Nginx server because of the casing.