### PR TITLE
Use entry model to get ID rather than variable

### DIFF
--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -770,7 +770,7 @@ class EntriesController extends BaseEntriesController
         }
 
         if ($variables['entry']->id) {
-            $versions = Craft::$app->getEntryRevisions()->getVersionsByEntryId($variables['entryId'], $site->id, 1, true);
+            $versions = Craft::$app->getEntryRevisions()->getVersionsByEntryId($variables['entry']->id, $site->id, 1, true);
             /** @var EntryVersion $currentVersion */
             $currentVersion = reset($versions);
 


### PR DESCRIPTION
This fixes an issue where changing the entryType of an existing entry triggers a 500 error.

Found in 3.0.0-beta.19 - 2017-05-31

```
PHP Notice 'yii\base\ErrorException' with message 'Undefined index: entryId' 

in /Volumes/Sites/Personal/craft3/vendor/craftcms/cms/src/controllers/EntriesController.php:773

Stack trace:
#0 … vendor/yiisoft/yii2/base/InlineAction.php(57): craft\controllers\EntriesController->actionSwitchEntryType()
#1 … vendor/yiisoft/yii2/base/InlineAction.php(57): ::call_user_func_array:{/Volumes/Sites/Personal/craft3/vendor/yiisoft/yii2/base/InlineAction.php:57}('???', '???')
#2 … vendor/yiisoft/yii2/base/Controller.php(156): yii\base\InlineAction->runWithParams('???')
#3 … vendor/yiisoft/yii2/base/Module.php(523): yii\base\Controller->runAction('???', '???')
#4 … vendor/craftcms/cms/src/web/Application.php(246): yii\base\Module->runAction('???', '???')
#5 … vendor/craftcms/cms/src/web/Application.php(385): craft\web\Application->runAction('???', '???')
#6 … vendor/craftcms/cms/src/web/Application.php(206): craft\web\Application->_processActionRequest('???')
#7 … vendor/yiisoft/yii2/base/Application.php(380): craft\web\Application->handleRequest('???')
#8 … web/index.php(33): yii\base\Application->run()
#9 {main}
```

![screen shot 2017-06-01 at 20 31 25](https://cloud.githubusercontent.com/assets/25124/26675988/55083fde-4709-11e7-9bfd-7283fb1b5cb3.png)
