### PR TITLE
Fix deprecation error

### DIFF
--- a/src/helpers/Template.php
+++ b/src/helpers/Template.php
@@ -260,7 +260,12 @@ class Template
             }
         }
 
-        $key = "DateTime::{$item}()";
+        if ($item === 'uiTimestamp') {
+            $key = timestamp('short');
+        } else {
+            $key = "DateTime::{$item}()";
+        }
+        
         /** @noinspection PhpUndefinedVariableInspection */
         $message = "DateTime::{$item}".($type === \Twig_Template::METHOD_CALL ? '()' : '')." is deprecated. Use the |{$filter} filter instead.";
 


### PR DESCRIPTION
In my install of `3.0.0-beta.19` I get the following deprecation warning:

```DateTime::uiTimestamp() is deprecated. Use the |timestamp('short') filter instead.	/home/vagrant/Code/pod-point/intranet/vendor/craftcms/cms/src/helpers/Template.php (267)```

So this should fix.