### PR TITLE
data-type attributes for matrix blocks and fields

### DIFF
--- a/src/templates/_components/fieldtypes/Matrix/input.html
+++ b/src/templates/_components/fieldtypes/Matrix/input.html
@@ -10,7 +10,7 @@
                 {% set blockId = 'new'~totalNewBlocks %}
             {% endif %}
 
-            <div class="matrixblock{% if not block.enabled %} disabled{% endif %}" data-id="{{ blockId }}"{% if block.collapsed %} data-collapsed{% endif %}>
+            <div class="matrixblock{% if not block.enabled %} disabled{% endif %}" data-id="{{ blockId }}"{% if block.collapsed %} data-collapsed{% endif %} data-type="{{ block.getType().handle }}">
                 {% if not static %}
                     <input type="hidden" name="{{ name }}[{{ blockId }}][type]" value="{{ block.getType().handle }}">
                     <input type="hidden" name="{{ name }}[{{ blockId }}][enabled]" value="{% if block.enabled %}1{% endif %}">

--- a/src/templates/_includes/field.html
+++ b/src/templates/_includes/field.html
@@ -22,6 +22,7 @@
         instructions: instructions|e,
         id: field.handle,
         errors: errors,
-        input: input
+        input: input,
+        handle: field.handle
     } only %}
 {% endif %}

--- a/src/templates/_includes/field.html
+++ b/src/templates/_includes/field.html
@@ -22,7 +22,6 @@
         instructions: instructions|e,
         id: field.handle,
         errors: errors,
-        input: input,
-        handle: field.handle
+        input: input
     } only %}
 {% endif %}

--- a/src/templates/_includes/forms/field.html
+++ b/src/templates/_includes/forms/field.html
@@ -15,7 +15,7 @@
     (fieldClass is defined and fieldClass ? fieldClass : null)
 ]|filter|join(' ') -%}
 
-<div class="{{ fieldClass }}"{% if fieldId %} id="{{ fieldId }}"{% endif %}>
+<div class="{{ fieldClass }}"{% if fieldId %} id="{{ fieldId }}"{% endif %}{% if handle is defined %} data-type="{{ handle }}"{% endif %}>
     {% if label or instructions %}
         <div class="heading">
             {% if label %}

--- a/src/templates/_includes/forms/field.html
+++ b/src/templates/_includes/forms/field.html
@@ -15,7 +15,7 @@
     (fieldClass is defined and fieldClass ? fieldClass : null)
 ]|filter|join(' ') -%}
 
-<div class="{{ fieldClass }}"{% if fieldId %} id="{{ fieldId }}"{% endif %}{% if handle is defined %} data-type="{{ handle }}"{% endif %}>
+<div class="{{ fieldClass }}"{% if fieldId %} id="{{ fieldId }}"{% endif %}{% if id is defined %} data-type="{{ id }}"{% endif %}>
     {% if label or instructions %}
         <div class="heading">
             {% if label %}


### PR DESCRIPTION
It's nearly impossible for plugins to style matrix blocks and fields. For that reason `data-type` was added to the those blocks and all fields. (The matrix buttons already have a `data-type` attribute but the added blocks have no reference to that type/handle)

For example the change enables stylings like:
```
.matrixblock[data-type="quote"] .field[data-type="position"] {
	background: lightgreen;
	padding: 10px;
}
```