### PR TITLE
added data-type attributes for matrix blocks

### DIFF
--- a/src/templates/_components/fieldtypes/Matrix/input.html
+++ b/src/templates/_components/fieldtypes/Matrix/input.html
@@ -10,7 +10,7 @@
                 {% set blockId = 'new'~totalNewBlocks %}
             {% endif %}
 
-            <div class="matrixblock{% if not block.enabled %} disabled{% endif %}" data-id="{{ blockId }}"{% if block.collapsed %} data-collapsed{% endif %}>
+            <div class="matrixblock{% if not block.enabled %} disabled{% endif %}" data-id="{{ blockId }}"{% if block.collapsed %} data-collapsed{% endif %} data-type="{{ block.getType().handle }}">
                 {% if not static %}
                     <input type="hidden" name="{{ name }}[{{ blockId }}][type]" value="{{ block.getType().handle }}">
                     <input type="hidden" name="{{ name }}[{{ blockId }}][enabled]" value="{% if block.enabled %}1{% endif %}">


### PR DESCRIPTION
It's nearly impossible for plugins to style matrix blocks. For that reason `data-type` was added for those blocks.

**Why that naming?**
The buttons to add matrix blocks have the same `data-type` attribute. It's a consistent naming.

**Why not using an `id`?**
It's a possible way to go even it requires more complicated selectors in CSS/JS. But the current block ids used in `data-id` are numbers and have no reference to the block's type/handle. The whole naming scheme needed to be changed.

**Any other alternatives?**
My favorite solution is to add an `data-handle` for matrix block types, the buttons for them and all other fields as well. That's clean, enables simple CSS/JS selectors and is a reasonable usage of data attributes. But the last time similar changes weren't welcome.