### PR TITLE
Migration Installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "league/flysystem": "~1.0.35",
     "mikehaertl/php-shellcommand": "~1.2.5",
     "pixelandtonic/imagine": "0.7.1.1",
+    "seld/cli-prompt": "^1.0",
     "twig/twig": "~2.3.0",
     "yiisoft/yii2": "~2.0.12.0",
     "yiisoft/yii2-debug": "2.0.8",

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -261,7 +261,7 @@ trait ApplicationTrait
             return false;
         }
 
-        return $this->_isInstalled = (bool)($this->getRequest()->getIsConsoleRequest() || $this->getDb()->tableExists('{{%info}}', false));
+        return $this->_isInstalled = (bool)($this->getDb()->tableExists('{{%info}}', false));
     }
 
     /**

--- a/src/console/controllers/MigrateController.php
+++ b/src/console/controllers/MigrateController.php
@@ -11,6 +11,8 @@ use Craft;
 use craft\base\Plugin;
 use craft\db\MigrationManager;
 use craft\helpers\FileHelper;
+use craft\migrations\Install;
+use craft\models\Site;
 use yii\console\controllers\BaseMigrateController;
 use yii\console\Exception;
 use yii\helpers\Console;

--- a/src/console/controllers/MigrateController.php
+++ b/src/console/controllers/MigrateController.php
@@ -59,6 +59,36 @@ class MigrateController extends BaseMigrateController
     public $plugin;
 
     /**
+     * @var string|null The default email address for the first user to create during install
+     */
+    public $email;
+
+    /**
+     * @var string|null The default username for the first user to create during install
+     */
+    public $username;
+
+    /**
+     * @var string|null The default password for the first user to create during install
+     */
+    public $password;
+
+    /**
+     * @var string|null The default site name for the first site to create during install
+     */
+    public $siteName;
+
+    /**
+     * @var string|null The default site url for the first site to create during install
+     */
+    public $siteUrl;
+
+    /**
+     * @var string|null The default langcode for the first site to create during install
+     */
+    public $siteLangcode;
+
+    /**
      * @var MigrationManager|null The migration manager that will be used in this request
      */
     private $_migrator;
@@ -86,6 +116,15 @@ class MigrateController extends BaseMigrateController
         // Global options
         $options[] = 'type';
         $options[] = 'plugin';
+
+        if ($actionID == 'install') {
+            $options[] = 'email';
+            $options[] = 'username';
+            $options[] = 'password';
+            $options[] = 'siteName';
+            $options[] = 'siteUrl';
+            $options[] = 'siteLangcode';
+        }
 
         return $options;
     }
@@ -174,6 +213,53 @@ class MigrateController extends BaseMigrateController
 
             FileHelper::writeToFile($file, $content);
             $this->stdout("New migration created successfully.\n", Console::FG_GREEN);
+        }
+    }
+
+    public function actionInstall()
+    {
+        // Run the install migration
+        $migrator = Craft::$app->getMigrator();
+
+        $email = $this->email ?: $this->prompt('Email', ['required' => true]);
+        $username = $this->username ?: $this->prompt('Username', ['required' => true]);
+        
+        if ($this->password) {
+            $password = $this->password;
+        }
+        else {
+            echo 'Password ';
+            $password = \Seld\CliPrompt\CliPrompt::hiddenPrompt();
+        }
+        
+        $siteName = $this->siteName ?: $this->prompt('Site Name', ['required' => true]);
+        $siteUrl = $this->siteUrl ?: $this->prompt('Site Url', ['required' => true]);
+        $siteLangcode = $this->siteLangcode ?: $this->prompt('Site Langcode', ['required' => true]);
+
+        $site = new Site([
+            'name' => $siteName,
+            'handle' => 'default',
+            'hasUrls' => true,
+            'baseUrl' => $siteUrl,
+            'language' => $siteLangcode,
+        ]);
+
+        $migration = new Install([
+            'username' => $username,
+            'password' => $password,
+            'email' => $email,
+            'site' => $site,
+        ]);
+
+        if ($migrator->migrateUp($migration) !== false) {
+            $this->stdout("{$siteName} was successfully installed.\n", Console::FG_GREEN);
+
+            // Mark all existing migrations as applied
+            foreach ($migrator->getNewMigrations() as $name) {
+                $migrator->addMigrationHistory($name);
+            }
+        } else {
+            $this->stderr("There was a problem installing {$siteName}.\n", Console::FG_GREEN);
         }
     }
 

--- a/src/db/MigrationManager.php
+++ b/src/db/MigrationManager.php
@@ -336,6 +336,10 @@ class MigrationManager extends Component
      */
     public function getMigrationHistory(int $limit = 0): array
     {
+        if (Craft::$app->getIsInstalled() == false) {
+            return [];
+        }
+
         $query = $this->_createMigrationQuery();
         if ($limit !== 0) {
             $query->limit($limit);


### PR DESCRIPTION
This takes the (currently) web-only install controller and copies it over into a console controller. With this you can install Craft with a simple `./craft migrate/install`. For CI testing I'd love to not have to bundle a SQL dump with my repo just to get a fresh instance spun up.

```bash
$ ./craft migrate/install --email=foo@example.com --username=admin --siteName="Test Site" --siteUrl="http://localhost" --siteLangcode=en --password=foobar
Yii Migration Tool (based on Yii v2.0.12)

    > create table {{%assetindexdata}} ... done (time: 0.022s)
    > create table {{%assets}} ... done (time: 0.013s)
    > create table {{%assettransformindex}} ... done (time: 0.016s)
    > ...
    > create index assetindexdata_sessionId_volumeId_idx on {{%assetindexdata}} (sessionId,volumeId) ... done (time: 0.016s)
    > create index assetindexdata_volumeId_idx on {{%assetindexdata}} (volumeId) ... done (time: 0.014s)
    > create unique index assets_filename_folderId_unq_idx on {{%assets}} (filename,folderId) ... done (time: 0.010s)
    > ...
    > add primary key searchindex_elementId_attribute_fieldId_siteId_unq_idx on {{%searchindex}} (elementId,attribute,fieldId,siteId) ... done (time: 0.015s)
    > add foreign key assetindexdata_volumeId_fk: {{%assetindexdata}} (volumeId) references {{%volumes}} (id) ... done (time: 0.022s)
    > add foreign key assets_folderId_fk: {{%assets}} (folderId) references {{%volumefolders}} (id) ... done (time: 0.020s)
    > ...
    > populate the info table ... done
    > save the first user ... done
    > save the email settings ... done
Test CraftQL was successfully installed.
```