### PR TITLE
Avoid null as return for getMimeType() -> TypeError

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -717,7 +717,8 @@ class Asset extends Element
     {
         // todo: maybe we should be passing this off to volume types
         // so Local volumes can call FileHelper::getMimeType() (uses magic file instead of ext)
-        return FileHelper::getMimeTypeByExtension($this->filename);
+        $mimeType = FileHelper::getMimeTypeByExtension($this->filename);
+        return ($mimeType) ? $mimeType: "application/octet-stream";
     }
 
     /**

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -718,7 +718,7 @@ class Asset extends Element
         // todo: maybe we should be passing this off to volume types
         // so Local volumes can call FileHelper::getMimeType() (uses magic file instead of ext)
         $mimeType = FileHelper::getMimeTypeByExtension($this->filename);
-        return ($mimeType) ? $mimeType: "application/octet-stream";
+        return ($mimeType) ? $mimeType : "application/octet-stream";
     }
 
     /**


### PR DESCRIPTION
Make sure getMimeType does not return null for some filetypes, because this throws an TypeError.
For example "img" extension returns null.

> Return value of craft\elements\Asset::getMimeType() must be of the type string, null returned