### PR TITLE
allowing more granular configurations for 'appType'

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -209,7 +209,8 @@ $config = ArrayHelper::merge(
     ],
     require "{$srcPath}/config/app/main.php",
     require "{$srcPath}/config/app/{$appType}.php",
-    $configService->getConfigFromFile('app')
+    $configService->getConfigFromFile('app'),
+    $configService->getConfigFromFile(empty($appConfig) ? $appType : $appConfig)
 );
 
 if (defined('CRAFT_SITE') || defined('CRAFT_LOCALE')) {


### PR DESCRIPTION
For example, this would allow a console app to specify it's own configuration independently of web app or rest app (ahem).