### PR TITLE
Fixed and cleaned up maxLevel check

### DIFF
--- a/src/controllers/CategoriesController.php
+++ b/src/controllers/CategoriesController.php
@@ -270,7 +270,7 @@ class CategoriesController extends Controller
         // Parent Category selector variables
         // ---------------------------------------------------------------------
 
-        if ($variables['group']->maxLevels != 1) {
+        if ((int)$variables['group']->maxLevels !== 1) {
             $variables['elementType'] = Category::class;
 
             // Define the parent options criteria

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -129,7 +129,7 @@ class EntriesController extends BaseEntriesController
 
         if (
             $section->type === Section::TYPE_STRUCTURE &&
-            $section->maxLevels !== 1
+            (int)$section->maxLevels !== 1
         ) {
             $variables['elementType'] = Entry::class;
 

--- a/src/services/Categories.php
+++ b/src/services/Categories.php
@@ -314,7 +314,7 @@ class Categories extends Component
         }
 
         // If they've set maxLevels to 0 (don't ask why), then pretend like there are none.
-        if ($group->maxLevels === 0) {
+        if ((int)$group->maxLevels === 0) {
             $group->maxLevels = null;
         }
 

--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -410,7 +410,7 @@ class Sections extends Component
                 }
 
                 // If they've set maxLevels to 0 (don't ask why), then pretend like there are none.
-                if ($section->maxLevels === 0 || $section->maxLevels === '0') {
+                if ((int)$section->maxLevels === 0) {
                     $section->maxLevels = null;
                 }
 


### PR DESCRIPTION
E.g. the following was `true` for all structures even if `maxLevels` is set to `1` because the value is a `string`.
```
if (
    $section->type === Section::TYPE_STRUCTURE &&
    $section->maxLevels !== 1
)
```
The problem of wrong types seems not to be new because in other cases the string values were handled before - see changes.

Maybe the better solution is a cast inside the models, but all other numeric model values like `id`s are strings as well. Maybe a Yii/PDO problem, but the database table columns have the right type (`int`, `smallint`) (MySQL)