### PR TITLE
Add block.getType().handle to matrixblock class

### DIFF
--- a/src/templates/_components/fieldtypes/Matrix/input.html
+++ b/src/templates/_components/fieldtypes/Matrix/input.html
@@ -10,7 +10,7 @@
                 {% set blockId = 'new'~totalNewBlocks %}
             {% endif %}
 
-            <div class="matrixblock{% if not block.enabled %} disabled{% endif %}" data-id="{{ blockId }}"{% if block.collapsed %} data-collapsed{% endif %} data-type="{{ block.getType().handle }}">
+            <div class="matrixblock matrixblock-{{ block.getType().handle }}{% if not block.enabled %} disabled{% endif %}" data-id="{{ blockId }}"{% if block.collapsed %} data-collapsed{% endif %} data-type="{{ block.getType().handle }}">
                 {% if not static %}
                     <input type="hidden" name="{{ name }}[{{ blockId }}][type]" value="{{ block.getType().handle }}">
                     <input type="hidden" name="{{ name }}[{{ blockId }}][enabled]" value="{% if block.enabled %}1{% endif %}">


### PR DESCRIPTION
Adds a new class as a styling hook for third party addons.

It would be great if this was back ported to v2.