### PR TITLE
data-type attributes for fields

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -139,6 +139,8 @@ abstract class Field extends SavableComponent implements FieldInterface
         if ($this->translationMethod !== self::TRANSLATION_METHOD_CUSTOM) {
             $this->translationKeyFormat = null;
         }
+
+        $this->type = get_class($this);
     }
 
     /**

--- a/src/base/FieldTrait.php
+++ b/src/base/FieldTrait.php
@@ -54,6 +54,11 @@ trait FieldTrait
     public $translationKeyFormat;
 
     /**
+     * @var string|null The field’s type
+     */
+    public $type;
+
+    /**
      * @var string|null The field’s previous handle
      */
     public $oldHandle;

--- a/src/templates/_includes/field.html
+++ b/src/templates/_includes/field.html
@@ -21,6 +21,7 @@
         required: (not static ? required : false),
         instructions: instructions|e,
         id: field.handle,
+        type: field.type,
         errors: errors,
         input: input
     } only %}

--- a/src/templates/_includes/forms/field.html
+++ b/src/templates/_includes/forms/field.html
@@ -15,7 +15,7 @@
     (fieldClass is defined and fieldClass ? fieldClass : null)
 ]|filter|join(' ') -%}
 
-<div class="{{ fieldClass }}"{% if fieldId %} id="{{ fieldId }}"{% endif %}>
+<div class="{{ fieldClass }}"{% if fieldId %} id="{{ fieldId }}"{% endif %}{% if type is defined %} data-type="{{ type }}"{% endif %}>
     {% if label or instructions %}
         <div class="heading">
             {% if label %}


### PR DESCRIPTION
Because there is no way to style field inputs by `type` at all, a `data-type` attribute was added for those.  With this addition it's possible to have selectors like `.field[data-type$="RadioButtons"]`

Any improvement suggestions?