### PR TITLE
Divide By Zero Bug

### DIFF
--- a/src/helpers/Template.php
+++ b/src/helpers/Template.php
@@ -89,7 +89,7 @@ class Template
 
         // Get the total result count, without applying the limit
         $query->limit = null;
-        $total = $query->count();
+        $total = (int)$query->count();
         $query->limit = $limit;
         
         // Bail out early if there are no results. Also avoids a divide by zero bug in the calculation of $totalPages
@@ -129,7 +129,7 @@ class Template
 
         $paginateVariable->first = $offset + 1;
         $paginateVariable->last = $last;
-        $paginateVariable->total = (int)$total;
+        $paginateVariable->total = $total;
         $paginateVariable->currentPage = $currentPage;
         $paginateVariable->totalPages = $totalPages;
 

--- a/src/helpers/Template.php
+++ b/src/helpers/Template.php
@@ -91,6 +91,11 @@ class Template
         $query->limit = null;
         $total = $query->count();
         $query->limit = $limit;
+        
+        // Bail out early if there are no results. Also avoids a divide by zero bug in the calculation of $totalPages
+        if ($total === 0) {
+            return [new Paginate(), $query->all()];
+        }
 
         // If they specified limit as null or 0 (for whatever reason), just assume it's all going to be on one page.
         if (!$limit) {


### PR DESCRIPTION
I'm not sure if this is actually a bug but wanted to propose it. When I use the `{% paginate` tag or try to call `\craft\helpers\Template::paginateCriteria` manually with a query that returns 0 rows I get a "divide by zero" error. This seems to be because when the limit is not set it is assigned the total.

This all means if no limit is set, and the query returns zero results you'll end up with the following,

```php
$totalPages = (int)ceil(0 / 0);
```

This PR adds a check early on that avoids this and bails out with an empty pagination object if the total results are 0.