### PR TITLE
added a possibility to define the HTML input type of plain texts

### DIFF
--- a/src/fields/PlainText.php
+++ b/src/fields/PlainText.php
@@ -57,6 +57,11 @@ class PlainText extends Field implements PreviewableFieldInterface
     public $charLimit;
 
     /**
+     * @var string The HTML5 input type (text, email, tel, url)
+     */
+    public $inputType;
+
+    /**
      * @var string The type of database column the field should have in the content table
      */
     public $columnType = Schema::TYPE_TEXT;
@@ -72,6 +77,7 @@ class PlainText extends Field implements PreviewableFieldInterface
         $rules = parent::rules();
         $rules[] = [['initialRows', 'charLimit'], 'integer', 'min' => 1];
         $rules[] = [['charLimit'], 'validateCharLimit'];
+        $rules[] = [['inputType'], 'string', 'max' => 50];
 
         return $rules;
     }

--- a/src/fields/PlainText.php
+++ b/src/fields/PlainText.php
@@ -57,7 +57,7 @@ class PlainText extends Field implements PreviewableFieldInterface
     public $charLimit;
 
     /**
-     * @var string The HTML5 input type (text, email, tel, url)
+     * @var string|null The HTML5 input type (text, email, tel, url)
      */
     public $inputType;
 
@@ -77,7 +77,6 @@ class PlainText extends Field implements PreviewableFieldInterface
         $rules = parent::rules();
         $rules[] = [['initialRows', 'charLimit'], 'integer', 'min' => 1];
         $rules[] = [['charLimit'], 'validateCharLimit'];
-        $rules[] = [['inputType'], 'string', 'max' => 50];
 
         return $rules;
     }

--- a/src/templates/_components/fieldtypes/PlainText/input.html
+++ b/src/templates/_components/fieldtypes/PlainText/input.html
@@ -8,7 +8,8 @@
     maxlength: field.charLimit,
     showCharsLeft: true,
     placeholder: field.placeholder|t('site'),
-    rows: field.initialRows
+    rows: field.initialRows,
+    type: field.inputType
 } %}
 
 {% if field.multiline %}

--- a/src/templates/_components/fieldtypes/PlainText/settings.html
+++ b/src/templates/_components/fieldtypes/PlainText/settings.html
@@ -40,10 +40,24 @@
     }) }}
 </div>
 
-{% if craft.app.db.isMysql %}
-    <hr>
-    <a class="fieldtoggle" data-target="advanced">{{ "Advanced"|t('app') }}</a>
-    <div id="advanced" class="hidden">
+<hr>
+<a class="fieldtoggle" data-target="advanced">{{ "Advanced"|t('app') }}</a>
+<div id="advanced" class="hidden">
+    {{ forms.selectField({
+        label: "HTML5 Input Type"|t('app'),
+        instructions: "Which HTML5 type of plain text is this?"|t('app'),
+        id: 'inputType',
+        name: 'inputType',
+        options: {
+            'text': 'text',
+            'email': 'email',
+            'tel': 'tel',
+            'url': 'url'
+        },
+        value: field.inputType
+    }) }}
+
+    {% if craft.app.db.isMysql %}
         {{ forms.selectField({
             label: "Column Type"|t('app'),
             id: 'column-type',
@@ -57,5 +71,5 @@
             value: field.columnType,
             warning: (field.id ? "Changing this may result in data loss."|t('app')),
         }) }}
-    </div>
-{% endif %}
+    {% endif %}
+</div>


### PR DESCRIPTION
Added a possibility to define the HTML input type of plain texts because of:
- Support of browser validation for the entered values
- Improved keyboard layouts based on input type on touch devices

## Settings screenshot:
![bildschirmfoto 2017-09-11 um 19 46 17](https://user-images.githubusercontent.com/568574/30288710-046b3042-972a-11e7-8cbe-1d9b3833fe40.png)

## Settings screenshot with opened dropdown:
![bildschirmfoto 2017-09-11 um 19 46 21](https://user-images.githubusercontent.com/568574/30288711-046c38e8-972a-11e7-814a-bdd87be8d1f6.png)

## Additional information:
The other HTML5 input types (like date, time or color) are missing because they have their own Craft field types.