### PR TITLE
Check if the parentId from the POST request is an array

### DIFF
--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -163,6 +163,11 @@ class EntriesController extends BaseEntriesController
             // Get the initially selected parent
             $parentId = Craft::$app->getRequest()->getParam('parentId');
 
+            // Get first element if query contained an array and not a single id
+            if ($parentId && is_array($parentId)) {
+                $parentId = $parentId[0];
+            }
+
             if ($parentId === null && $entry->id !== null) {
                 // Is it already set on the model (e.g. if we're loading a draft)?
                 if ($entry->newParentId !== null) {


### PR DESCRIPTION
Checks if the `parentId` request param value is an array and uses the first value if it is. Seems like it always is an array of one element anyway.