### PR TITLE
Feature/field type refactoring

### DIFF
--- a/src/templates/_includes/field.html
+++ b/src/templates/_includes/field.html
@@ -14,14 +14,16 @@
 {% endif %}
 
 {% if instructions or input %}
-    {% include "_includes/forms/field" with {
-        label: field.name|t('site')|e,
-        translatable: translatable,
-        siteId: siteId,
-        required: (not static ? required : false),
-        instructions: instructions|e,
-        id: field.handle,
-        errors: errors,
-        input: '<div data-type="'~className(field)~'">'~input~'</div>'
-    } only %}
+    <div class="field-wrapper" data-type="{{ className(field) }}">
+        {% include "_includes/forms/field" with {
+            label: field.name|t('site')|e,
+            translatable: translatable,
+            siteId: siteId,
+            required: (not static ? required : false),
+            instructions: instructions|e,
+            id: field.handle,
+            errors: errors,
+            input: input
+        } only %}
+    </div>
 {% endif %}

--- a/src/templates/_includes/field.html
+++ b/src/templates/_includes/field.html
@@ -14,7 +14,7 @@
 {% endif %}
 
 {% if instructions or input %}
-    <div class="field-wrapper" data-type="{{ className(field) }}">
+    <div class="field-wrapper" id="{{ field.handle }}-field-wrapper" data-type="{{ className(field) }}">
         {% include "_includes/forms/field" with {
             label: field.name|t('site')|e,
             translatable: translatable,


### PR DESCRIPTION
Thanks again for your commit 2abba73, @brandonkelly!

Maybe even better is to wrap the whole field with the `data-type` attribute. This allows full control of the fields by `handle` and by `type`.

Useful for cases where you want to improve the styling for whole fields, e.g. highlight the headline of a certain field type or hide the headline because the field input has several ones.

Of course I don't want to make changes of Craft's core just for our use cases, but I have to because the fields miss important information and there is no other way to add them. But I think this is also useful for many other developers creating custom fields or heavily customizing the control panel interface.