### PR TITLE
Stub getIsLivePreview for console requests

### DIFF
--- a/src/console/Request.php
+++ b/src/console/Request.php
@@ -54,4 +54,14 @@ class Request extends \yii\console\Request
     {
         return false;
     }
+	
+    /**
+     * Returns whether this is a Live Preview request. (Narrator: It isn't.)
+     *
+     * @return bool Whether this is a Live Preview request.
+     */
+    public function getIsLivePreview(): bool
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
I'm importing data into a Craft 3 site via a console command. I'm populating matrix fields, and they check getIsLivePreview(), but that method isn't available on the Console Request. This stub method helps.

`yii\base\UnknownMethodException: Calling unknown method: craft\console\Request::getIsLivePreview() yii\base\Component->__call()  (../vendor/yiisoft/yii2/base/Component.php line 290).`