### PR TITLE
Return the errors in the warning message

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -396,7 +396,7 @@ class Elements extends Component
 
         // Validate
         if ($runValidation && !$element->validate()) {
-            Craft::info('Element not saved due to validation error.', __METHOD__);
+            Craft::info('Element not saved due to validation error: ' . print_r($element->errors, true), __METHOD__);
 
             return false;
         }


### PR DESCRIPTION
Rather than just logging that the validation failed, show the validation errors, to help with debugging.