### PR TITLE
Fix crash when URL rules are added by Yii modules.

### DIFF
--- a/src/web/UrlManager.php
+++ b/src/web/UrlManager.php
@@ -348,7 +348,7 @@ class UrlManager extends \yii\web\UrlManager
             }
 
             if ($route !== false) {
-                if ($rule->params) {
+                if ($rule instanceof \craft\web\UrlRule && $rule->params) {
                     $this->setRouteParams($rule->params);
                 }
 


### PR DESCRIPTION
Most UrlRules will be an instance of \craft\web\UrlRules, but if rules are inserted via a plugin (module), they might be a \yii\web\UrlRule, which doesn't have the params property, causing a crash.