### PR TITLE
Better handling of template UnknownMethodExceptions

### DIFF
--- a/src/helpers/Template.php
+++ b/src/helpers/Template.php
@@ -15,6 +15,7 @@ use craft\elements\db\ElementQueryInterface;
 use craft\i18n\Locale;
 use craft\web\twig\variables\Paginate;
 use yii\base\Object;
+use Twig_Error_Runtime;
 
 /**
  * Class Template
@@ -70,8 +71,12 @@ class Template
         if ($object instanceof \DateTime && ($value = self::_dateTimeAttribute($object, $item, $type)) !== false) {
             return $value;
         }
-
-        return \twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck);
+        
+        try {
+            return \twig_get_attribute($env, $source, $object, $item, $arguments, $type, $isDefinedTest, $ignoreStrictCheck);
+        } catch (\Exception $e) {
+            throw new Twig_Error_Runtime("$item is not a known method.", -1, $source);
+        }
     }
 
     /**


### PR DESCRIPTION
Right now if you encounter an UnknownMethodException in a template, you are only given the compiled template as the source of the error, and it is difficult to trace back to the source of the original issue.

This would throw a Twig_Error_Runtime instead (as it looks like it is supposed to?), which will give the developer better information of the source of the exception.

There may be a bette way to handle this, or issues I'm not foreseeing that this causes, but this has helped us on debugging template issues.