### PR TITLE
reused GetAssetUrlEvent for thumbs - resolves #2073

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -13,6 +13,7 @@ Craft CMS 3.0 Working Changelog
 - The installer now creates a “Common” field group.
 - It's now possible to specify subpath for uploaded user photos. ([#1575](https://github.com/craftcms/cms/issues/1575))
 - Added the `preserveExifData` config setting, `false` by default and requries Imagick. ([#2034](https://github.com/craftcms/cms/issues/2034))
+- Added `craft\events\GetAssetThumbUrlEvent` which plugins can use to modify the URL of an Asset thumbnail being fetched.
 
 ### Changed
 - Explicitly added `craft\base\PluginInterface::getVersion()`. ([#2012](https://github.com/craftcms/cms/issues/2012))

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -13,7 +13,6 @@ Craft CMS 3.0 Working Changelog
 - The installer now creates a “Common” field group.
 - It's now possible to specify subpath for uploaded user photos. ([#1575](https://github.com/craftcms/cms/issues/1575))
 - Added the `preserveExifData` config setting, `false` by default and requries Imagick. ([#2034](https://github.com/craftcms/cms/issues/2034))
-- Added `craft\events\GetAssetThumbUrlEvent` which plugins can use to modify the URL of an Asset thumbnail being fetched.
 
 ### Changed
 - Explicitly added `craft\base\PluginInterface::getVersion()`. ([#2012](https://github.com/craftcms/cms/issues/2012))

--- a/src/events/GetAssetThumbUrlEvent.php
+++ b/src/events/GetAssetThumbUrlEvent.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @link      https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license   https://craftcms.com/license
+ */
+
+namespace craft\events;
+
+use craft\elements\Asset;
+use yii\base\Event;
+
+/**
+ * Get Asset thumb url event class
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since  3.0
+ */
+class GetAssetThumbUrlEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var Asset The Asset which the thumbnail should be for.
+     */
+    public $asset;
+
+    /**
+     * @var int Requested thumbnail size (width and height)
+     */
+    public $size;
+
+    /**
+     * @var bool Whether the thumbnail should be generated if it doesn't exist yet.
+     */
+    public $generate;
+
+    /**
+     * @var string|null Url to requested Asset that should be used instead.
+     */
+    public $url;
+}

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -603,6 +603,22 @@ class Assets extends Component
      */
     public function getThumbUrl(Asset $asset, int $size, bool $generate = false): string
     {
+        // Maybe a plugin wants to do something here
+        $event = new GetAssetUrlEvent([
+            'transform' => new AssetTransform([
+                'width' => $size,
+                'height' => $size,
+                'mode' => 'fit',
+            ]),
+            'asset' => $asset,
+        ]);
+        $this->trigger(self::EVENT_GET_ASSET_URL, $event);
+
+        // If a plugin set the url, we'll just use that.
+        if ($event->url !== null) {
+            return $event->url;
+        }
+
         $ext = $asset->getExtension();
 
         // If it's not an image, return a generic file extension icon

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -9,20 +9,19 @@ namespace craft\services;
 
 use Craft;
 use craft\base\Volume;
-use craft\base\VolumeInterface;
 use craft\db\Query;
 use craft\elements\Asset;
 use craft\elements\db\AssetQuery;
 use craft\elements\User;
 use craft\errors\ActionCancelledException;
 use craft\errors\AssetConflictException;
-use craft\errors\AssetException;
 use craft\errors\AssetLogicException;
 use craft\errors\FileException;
 use craft\errors\ImageException;
 use craft\errors\VolumeException;
 use craft\errors\VolumeObjectExistsException;
 use craft\errors\VolumeObjectNotFoundException;
+use craft\events\GetAssetThumbUrlEvent;
 use craft\events\GetAssetUrlEvent;
 use craft\events\ReplaceAssetEvent;
 use craft\helpers\Assets as AssetsHelper;
@@ -66,9 +65,14 @@ class Assets extends Component
     const EVENT_AFTER_REPLACE_ASSET = 'afterReplaceFile';
 
     /**
-     * @event AssetGenerateTransformEvent The event that is triggered when a transform is being generated for an Asset.
+     * @event GetAssetUrlEvent The event that is triggered when a transform is being generated for an Asset.
      */
     const EVENT_GET_ASSET_URL = 'getAssetUrl';
+
+    /**
+     * @event GetAssetThumbUrlEvent The event that is triggered when a thumbnail is being generated for an Asset.
+     */
+    const EVENT_GET_ASSET_THUMB_URL = 'getAssetThumbUrl';
 
     // Properties
     // =========================================================================
@@ -604,15 +608,12 @@ class Assets extends Component
     public function getThumbUrl(Asset $asset, int $size, bool $generate = false): string
     {
         // Maybe a plugin wants to do something here
-        $event = new GetAssetUrlEvent([
-            'transform' => new AssetTransform([
-                'width' => $size,
-                'height' => $size,
-                'mode' => 'fit',
-            ]),
+        $event = new GetAssetThumbUrlEvent([
             'asset' => $asset,
+            'size' => $size,
+            'generate' => $generate,
         ]);
-        $this->trigger(self::EVENT_GET_ASSET_URL, $event);
+        $this->trigger(self::EVENT_GET_ASSET_THUMB_URL, $event);
 
         // If a plugin set the url, we'll just use that.
         if ($event->url !== null) {


### PR DESCRIPTION
Reused the `GetAssetUrlEvent` for thumbs, which adds the possibility to overwrite the thumb urls as well. See #2073 