### PR TITLE
Optimized saving of images where just the focal point was changed

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -664,6 +664,7 @@ class AssetsController extends Controller
             $imageCropped = ($cropData['width'] !== $imageDimensions['width'] || $cropData['height'] !== $imageDimensions['height']);
             $imageRotated = $viewportRotation !== 0 || $imageRotation !== 0.0;
             $imageFlipped = !empty($flipData['x']) || !empty($flipData['y']);
+            $imageChanged = $imageCropped || $imageRotated || $imageFlipped;
 
             $imageCopy = $asset->getCopyOfFile();
 
@@ -723,7 +724,7 @@ class AssetsController extends Controller
                 $image->crop($x, $x + $width, $y, $y + $height);
             }
 
-            if ($imageCropped || $imageRotated || $imageFlipped) {
+            if ($imageChanged) {
                 $image->saveAs($imageCopy);
             }
 
@@ -731,7 +732,7 @@ class AssetsController extends Controller
                 $asset->focalPoint = $focal;
 
                 // Only replace file if it changed, otherwise just save changed focal points
-                if ($imageCropped || $imageRotated || $imageFlipped) {
+                if ($imageChanged) {
                     $assets->replaceAssetFile($asset, $imageCopy, $asset->filename);
                 } else if($focal) {
                     Craft::$app->getElements()->saveElement($asset);

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -729,7 +729,13 @@ class AssetsController extends Controller
 
             if ($replace) {
                 $asset->focalPoint = $focal;
-                $assets->replaceAssetFile($asset, $imageCopy, $asset->filename);
+
+                // Only replace file if it changed, otherwise just save changed focal points
+                if ($imageCropped || $imageRotated || $imageFlipped) {
+                    $assets->replaceAssetFile($asset, $imageCopy, $asset->filename);
+                } else if($focal) {
+                    Craft::$app->getElements()->saveElement($asset);
+                }
             } else {
                 $newAsset = new Asset();
                 $newAsset->avoidFilenameConflicts = true;


### PR DESCRIPTION
If only the focal point did change, the file does not be to be replaced.
Fully solved #1588 

Future improvement requests:
- `actionSaveImage` should be fully refactored and `imageChanged` should be checked before `$imageCopy` is created and all possible changes are checked one by one
- The UI could offer a simple "Save" button as long the image itself wasn't changed. No reason to offer the buttons "Replace Asset" and "Save as New Asset"