### PR TITLE
The docsurl property is removed

### DIFF
--- a/src/controllers/FieldsController.php
+++ b/src/controllers/FieldsController.php
@@ -242,7 +242,6 @@ class FieldsController extends Controller
             'groupOptions' => $groupOptions,
             'crumbs' => $crumbs,
             'title' => $title,
-            'docsUrl' => 'http://craftcms.com/docs/fields#field-layouts',
         ]);
     }
 


### PR DESCRIPTION
This property is removed from the src/templates/_layouts/cp.html template and useless now.