### PR TITLE
Added 'email.onBeforeSendMailer' event just before the email is actually being send

### DIFF
--- a/src/services/EmailService.php
+++ b/src/services/EmailService.php
@@ -220,6 +220,16 @@ class EmailService extends BaseApplicationComponent
 	}
 
 	/**
+	 * Fires an 'onBeforeSendMailer' event.
+	 *
+	 * @param Event $event
+	 */
+	public function onBeforeSendMailer(Event $event)
+	{
+		$this->raiseEvent('onBeforeSendMailer', $event);
+	}
+
+	/**
 	 * Fires an 'onSendEmail' event.
 	 *
 	 * @param Event $event
@@ -456,9 +466,20 @@ class EmailService extends BaseApplicationComponent
 				// Explicitly hide the XMailer header.
 				$email->XMailer = ' ';
 
-				if (!$email->Send())
+				// Fire an 'onBeforeSendMailer' event
+				$this->onBeforeSendMailer(new Event($this, array(
+					'user' => $user,
+					'emailModel' => $emailModel,
+					'variables' => $variables,
+					'mailer' => $email,
+				)));
+
+				if ($event->performAction)
 				{
-					$errorMessage = $email->ErrorInfo;
+					if (!$email->Send())
+					{
+						$errorMessage = $email->ErrorInfo;
+					}
 				}
 			}
 			catch(\Exception $e)


### PR DESCRIPTION
Brandon,

Since Yii (or Craft) doesn't support priorities for events, hooking in on the email system to send emails via another provider is not that easy in Craft 2.
For multiple customer projects I had to make something to work with Mandrill API. I have managed this, but with a downside of the 'email.onBeforeSendEmail' event being fired twice (to catch all plugins their possible additions).
More details on the projects README;
https://bitbucket.org/bertoost/craft-cms-mandrill-service#take-over-control-of-all-outgoing-emails

That's why I added this event, just before the `$email->Send()` is being called. This way the email service could collect all additional data on the previous event, and another plugin can hook-in just before sending the actual email.

A little extra addition to make this happen.