### PR TITLE
Fixed using CRAFT_FRAMEWORK_PATH for including framework files in console file

### DIFF
--- a/src/etc/console/yiic.php
+++ b/src/etc/console/yiic.php
@@ -59,7 +59,7 @@ ini_set('display_errors', 1);
 defined('YII_DEBUG') || define('YII_DEBUG', true);
 defined('YII_TRACE_LEVEL') || define('YII_TRACE_LEVEL', 3);
 
-require_once dirname(__FILE__).'/../../framework/yii.php';
+require_once CRAFT_FRAMEWORK_PATH.'yii.php';
 require_once CRAFT_APP_PATH.'Craft.php';
 require_once CRAFT_APP_PATH.'Info.php';
 
@@ -77,7 +77,7 @@ Yii::$enableIncludePath = false;
 require_once(dirname(__FILE__).'/ConsoleApp.php');
 
 // Because CHttpRequest is one of those stupid Yii files that has multiple classes defined in it.
-require_once(CRAFT_APP_PATH.'framework/web/CHttpRequest.php');
+require_once(CRAFT_FRAMEWORK_PATH.'web/CHttpRequest.php');
 
 Yii::setPathOfAlias('app', CRAFT_APP_PATH);
 Yii::setPathOfAlias('plugins', CRAFT_PLUGINS_PATH);


### PR DESCRIPTION
For dev installations with vendor files etc.

This way you can create a "console" PHP file in your dev installation root, the same way as for the web index.php file, setting some constants.

```php
#!/usr/bin/env php
<?php

define('CRAFT_BASE_PATH', __DIR__ . '/craft/');
define('CRAFT_VENDOR_PATH', dirname(__DIR__) . '/craft_git/vendor/');
define('CRAFT_FRAMEWORK_PATH', CRAFT_VENDOR_PATH . 'yiisoft/yii/framework/');

require CRAFT_BASE_PATH . 'app/etc/console/yiic.php';
```