### PR TITLE
Throw error if calling migrate with type='plugin' but not plugin handle

### DIFF
--- a/src/console/controllers/MigrateController.php
+++ b/src/console/controllers/MigrateController.php
@@ -131,6 +131,8 @@ class MigrateController extends BaseMigrateController
                     throw new Exception('Invalid plugin handle: '.$this->plugin);
                 }
                 $this->plugin = $plugin;
+            } else {
+                throw new Exception('You must pass --plugin when --type="plugin"');
             }
         }
 


### PR DESCRIPTION
It's not inherintly clear from the docs or errors provided that you need to specify a plugin handle when calling "craft migrate --type=plugin".  This exception clarifies that (as I would think it would iterate all plugins if --plugin is blank).