### PR TITLE
Show JobInterface::getDescription() for queue/run -v

### DIFF
--- a/src/queue/Command.php
+++ b/src/queue/Command.php
@@ -32,6 +32,13 @@ class Command extends \yii\queue\cli\Command
      */
     public $defaultAction = 'info';
 
+    /**
+     * @inheritdoc
+     */
+    public $verboseConfig = [
+        'class' => VerboseBehavior::class,
+    ];
+
     // Protected Methods
     // =========================================================================
 

--- a/src/queue/VerboseBehavior.php
+++ b/src/queue/VerboseBehavior.php
@@ -18,7 +18,7 @@ use yii\queue\ExecEvent;
 class VerboseBehavior extends \yii\queue\cli\VerboseBehavior
 {
     /**
-     * @inheritdoc
+     *
      */
     protected function jobTitle(ExecEvent $event)
     {

--- a/src/queue/VerboseBehavior.php
+++ b/src/queue/VerboseBehavior.php
@@ -1,4 +1,11 @@
-<?php namespace craft\queue;
+<?php
+/**
+ * @link      https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license   https://craftcms.github.io/license/
+ */
+
+namespace craft\queue;
 
 use yii\queue\cli\VerboseBehavior as VerboseBehaviorBase;
 use yii\queue\ExecEvent;
@@ -21,10 +28,12 @@ class VerboseBehavior extends VerboseBehaviorBase
         }
 
         $description = $event->job->getDescription();
-        $extra = "attempt: $event->attempt";
+        $extra       = "attempt: $event->attempt";
+
         if ($pid = $event->sender->getWorkerPid()) {
             $extra .= ", pid: $pid";
         }
+
         return " [$event->id] $description ($extra)";
     }
 }

--- a/src/queue/VerboseBehavior.php
+++ b/src/queue/VerboseBehavior.php
@@ -7,19 +7,18 @@
 
 namespace craft\queue;
 
-use yii\queue\cli\VerboseBehavior as VerboseBehaviorBase;
 use yii\queue\ExecEvent;
-
 
 /**
  * Verbose Behavior
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since  3.0
  */
-class VerboseBehavior extends VerboseBehaviorBase
+class VerboseBehavior extends \yii\queue\cli\VerboseBehavior
 {
     /**
-     * @param \yii\queue\ExecEvent $event
-     *
-     * @return string
+     * @inheritdoc
      */
     protected function jobTitle(ExecEvent $event)
     {
@@ -28,12 +27,12 @@ class VerboseBehavior extends VerboseBehaviorBase
         }
 
         $description = $event->job->getDescription();
-        $extra       = "attempt: $event->attempt";
+        $extra = 'attempt: '.$event->attempt;
 
         if ($pid = $event->sender->getWorkerPid()) {
-            $extra .= ", pid: $pid";
+            $extra .= ', pid: '.$pid;
         }
 
-        return " [$event->id] $description ($extra)";
+        return " [{$event->id}] {$description} ({$extra})";
     }
 }

--- a/src/queue/VerboseBehavior.php
+++ b/src/queue/VerboseBehavior.php
@@ -1,0 +1,30 @@
+<?php namespace craft\queue;
+
+use yii\queue\cli\VerboseBehavior as VerboseBehaviorBase;
+use yii\queue\ExecEvent;
+
+
+/**
+ * Verbose Behavior
+ */
+class VerboseBehavior extends VerboseBehaviorBase
+{
+    /**
+     * @param \yii\queue\ExecEvent $event
+     *
+     * @return string
+     */
+    protected function jobTitle(ExecEvent $event)
+    {
+        if (!$event->job instanceof JobInterface) {
+            return parent::jobTitle($event);
+        }
+
+        $description = $event->job->getDescription();
+        $extra = "attempt: $event->attempt";
+        if ($pid = $event->sender->getWorkerPid()) {
+            $extra .= ", pid: $pid";
+        }
+        return " [$event->id] $description ($extra)";
+    }
+}


### PR DESCRIPTION
Similar to the output in the CP, the verbose output of the `./craft queue/run -v` command should include the job description. This can be more meaningful than the class name.

*before* 🤔


```
./craft queue/run -v
2018-01-25 23:14:41 [29] ostark\upper\jobs\PurgeCacheJob (attempt: 1) - Started
2018-01-25 23:14:41 [29] ostark\upper\jobs\PurgeCacheJob (attempt: 1) - Done (0.001 s)
2018-01-25 23:14:41 [30] craft\queue\jobs\DeleteStaleTemplateCaches (attempt: 1) - Started
2018-01-25 23:14:41 [30] craft\queue\jobs\DeleteStaleTemplateCaches (attempt: 1) - Done (0.002 
``` 
---

after 😎

```
 ./craft queue/run -v
2018-01-25 23:15:59 [31] Purge Tag: el74 (attempt: 1) - Started
2018-01-25 23:15:59 [31] Purge Tag: el74 (attempt: 1) - Done (0.002 s)
2018-01-25 23:15:59 [32] Deleting stale template caches (attempt: 1) - Started
2018-01-25 23:15:59 [32] Deleting stale template caches (attempt: 1) - Done (0.003 s)
```
