### PR TITLE
Better queue logs

### DIFF
--- a/src/controllers/QueueController.php
+++ b/src/controllers/QueueController.php
@@ -10,7 +10,6 @@ namespace craft\controllers;
 use Craft;
 use craft\queue\QueueInterface;
 use craft\web\Controller;
-use yii\log\FileTarget;
 use yii\web\BadRequestHttpException;
 use yii\web\Response;
 use yii\web\ServerErrorHttpException;

--- a/src/controllers/QueueController.php
+++ b/src/controllers/QueueController.php
@@ -51,14 +51,6 @@ class QueueController extends Controller
             throw new ServerErrorHttpException('The queue class '.get_class(Craft::$app->getQueue()).' doesn’t support web-based runners.');
         }
 
-        // Set the log target to queue.log
-        $logDispatcher = Craft::$app->getLog();
-        if (isset($logDispatcher->targets[0]) && $logDispatcher->targets[0] instanceof FileTarget) {
-            /** @var FileTarget $logTarget */
-            $logTarget = $logDispatcher->targets[0];
-            $logTarget->logFile = Craft::getAlias('@storage/logs/queue.log');
-        }
-
         return true;
     }
 

--- a/src/queue/Command.php
+++ b/src/queue/Command.php
@@ -62,14 +62,6 @@ class Command extends \yii\queue\cli\Command
             return false;
         }
 
-        // Set the log target to queue.log
-        $logDispatcher = Craft::$app->getLog();
-        if (isset($logDispatcher->targets[0]) && $logDispatcher->targets[0] instanceof FileTarget) {
-            /** @var FileTarget $logTarget */
-            $logTarget = $logDispatcher->targets[0];
-            $logTarget->logFile = Craft::getAlias('@storage/logs/queue.log');
-        }
-
         return true;
     }
 

--- a/src/queue/Queue.php
+++ b/src/queue/Queue.php
@@ -84,6 +84,8 @@ class Queue extends \yii\queue\cli\Queue implements QueueInterface
         $this->on(self::EVENT_AFTER_EXEC, function(ExecEvent $e) {
             $this->_executingJobId = null;
         });
+
+        $this->attachBehavior('queue_logger', QueueLogBehaviour::class);
     }
 
     /**

--- a/src/queue/Queue.php
+++ b/src/queue/Queue.php
@@ -86,6 +86,7 @@ class Queue extends \yii\queue\cli\Queue implements QueueInterface
         });
 
         $this->attachBehavior('queue_logger', QueueLogBehaviour::class);
+
     }
 
     /**

--- a/src/queue/QueueLogBehaviour.php
+++ b/src/queue/QueueLogBehaviour.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: os
+ * Date: 26.01.18
+ * Time: 12:33
+ */
+
+namespace craft\queue;
+
+use craft\log\FileTarget;
+use yii\queue\ErrorEvent;
+use yii\queue\ExecEvent;
+
+class QueueLogBehaviour extends VerboseBehavior
+{
+    /**
+     * @var float timestamp
+     */
+    private $jobStartedAt;
+
+    /**
+     * @inheritdoc
+     */
+    public function events()
+    {
+        return [
+            Queue::EVENT_BEFORE_EXEC => 'beforeExec',
+            Queue::EVENT_AFTER_EXEC  => 'afterExec',
+            Queue::EVENT_AFTER_ERROR => 'afterError',
+        ];
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+
+        // Set the log target to queue.log
+        $logDispatcher = \Craft::$app->getLog();
+        foreach ($logDispatcher->targets as $target) {
+            if ($target instanceof FileTarget) {
+                $target->logFile = \Craft::getAlias('@storage/logs/queue.log');
+                $target->logVars = [];
+            }
+        }
+
+        // Prevent verbose query logs
+        if (!\Craft::$app->getConfig()->getGeneral()->devMode) {
+            $DbConnection = \Craft::$app->getDb();
+            $DbConnection->enableLogging   = false;
+            $DbConnection->enableProfiling = false;
+        }
+    }
+
+
+    /**
+     * @param ExecEvent $event
+     */
+    public function beforeExec(ExecEvent $event)
+    {
+        $this->jobStartedAt = microtime(true);
+
+        \Craft::info(sprintf(
+            "%s - Started",
+            parent::jobTitle($event)
+        ));
+    }
+
+    /**
+     * @param ExecEvent $event
+     */
+    public function afterExec(ExecEvent $event)
+    {
+        $duration = $this->getDuration();
+
+        \Craft::info(sprintf(
+            "%s - Done (%s s)",
+            parent::jobTitle($event),
+            $duration
+        ));
+    }
+
+    /**
+     * @param ErrorEvent $event
+     */
+    public function afterError(ErrorEvent $event)
+    {
+        $duration = $this->getDuration();
+        $error    = $event->error->getMessage();
+
+        \Craft::error(sprintf(
+            "%s - Error (%s s): %s",
+            parent::jobTitle($event),
+            $duration,
+            $error
+        ));
+
+    }
+
+
+    /**
+     * @return string
+     */
+    protected function getDuration(): string
+    {
+        return number_format(round(microtime(true) - $this->jobStartedAt, 3), 3);
+    }
+
+
+}


### PR DESCRIPTION
Before only "GLOBALS" and sql queries got logged to `queue.log` - I guess that was not intended. 

Now we log something that is very similar to the `craft queue/run -v` output.
If `devMode` is enabled sql queries are logged as well, but "GLOBALS" are still suppressed.

