### PR TITLE
Update broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Learn more about Craft at [craftcms.com](https://craftcms.com).
 
 ## How to Install Craft 3
 
-See the Craft 3 documentation for [installation](https://github.com/craftcms/docs/blob/master/en/installation.md) and [updating](https://github.com/craftcms/docs/blob/master/en/upgrade.md) instructions.
+See the Craft 3 documentation for [installation](https://github.com/craftcms/docs/blob/v3/en/installation.md) and [updating](https://github.com/craftcms/docs/blob/v3/en/upgrade.md) instructions.
 
 ## Resources
 


### PR DESCRIPTION
Firstly, thanks so much for Craft. It's such a good CMS 🙂

I imagine this will be a temporary change, but when I went to go through the upgrade docs, I hit a 404. I've just replaced the `master` segment with `v3` so the links work again. 