### PR TITLE
Fixed users save button on every tab (related to #892)

### DIFF
--- a/src/templates/users/_edit.html
+++ b/src/templates/users/_edit.html
@@ -156,8 +156,6 @@
 							value: account.weekStartDay
 						}) }}
 					{% endif %}
-
-					{{ saveUserButtons }}
 				</div>
 
 				{% if CraftEdition == CraftPro %}
@@ -232,10 +230,11 @@
 							</div>
 						{% endif %}
 
-						{{ saveUserButtons }}
-
 					</div>
 				{% endif %}
+
+				{{ saveUserButtons }}
+
 			</form>
 		</div><!--/item-->
 


### PR DESCRIPTION
Discovered that the save button is not appearing on the custom user field tabs. Changed the button location from inside a tab-content-div to below those divs and before the closing form tag.