### PR TITLE
Use a better referrer strategy

### DIFF
--- a/src/templates/_layouts/base.html
+++ b/src/templates/_layouts/base.html
@@ -13,7 +13,7 @@
 	<title>{{ docTitle ~ (docTitle and siteName ? ' - ') ~ siteName }}</title>
 	{{ getHeadHtml() }}
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<meta name="referrer" content="no-referrer">
+	<meta name="referrer" content="origin-when-cross-origin">
 
 	<link rel="apple-touch-icon" sizes="76x76" href="{{ resourceUrl("images/touch-icons/ipad_1x.png") }}">
 	<link rel="apple-touch-icon" sizes="120x120" href="{{ resourceUrl("images/touch-icons/iphone_2x.png") }}">


### PR DESCRIPTION
Use the `origin-when-cross-origin` referrer strategy

This keeps referrers working internally (for redirecting back for example), but only sends the main domain to external sites.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy