### PR TITLE
#2453 Update dependency to Yii 2.0.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "pixelandtonic/imagine": "~0.7.1.2",
     "seld/cli-prompt": "~1.0.3",
     "twig/twig": "~2.4.4",
-    "yiisoft/yii2": "~2.0.13.0",
+    "yiisoft/yii2": "~2.0.14.0",
     "yiisoft/yii2-debug": "~2.0.10",
     "yiisoft/yii2-swiftmailer": "~2.1.0",
     "yiisoft/yii2-queue": "~2.0.1",


### PR DESCRIPTION
Fixes two CVE's in the Yii framework.
See http://www.yiiframework.com/news/165/yii-2-0-14-is-released/