### PR TITLE
Add `id="photo-field"` to container div

### DIFF
--- a/src/templates/users/_edit.html
+++ b/src/templates/users/_edit.html
@@ -58,7 +58,8 @@
 
             {% if not isNewUser %}
                 {{ forms.field({
-                    label: "Photo"|t('app')
+                    label: "Photo"|t('app'),
+                    id: 'photo'
                 }, include('users/_photo', {user: user}, with_context = false)) }}
             {% endif %}
 


### PR DESCRIPTION
This would make it much easier for custom CSS (or JS) to target the photo div.

    <div class="field" id="photo-field">

Useful in scenarios where the developer may want to hide the photo field.