### PR TITLE
Fixed bug where getFieldParamNamespace returns wrong namespace

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -867,7 +867,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface
             $fieldNamespace = $element->getFieldParamNamespace();
 
             if ($fieldNamespace !== null) {
-                $blockFieldNamespace = ($fieldNamespace ? $fieldNamespace.'.' : '').'.'.$this->handle.'.'.$blockId.'.fields';
+                $blockFieldNamespace = ($fieldNamespace ? $fieldNamespace.'.' : '').$this->handle.'.'.$blockId.'.fields';
                 $block->setFieldParamNamespace($blockFieldNamespace);
             }
 


### PR DESCRIPTION
@brandonkelly I found a bug when  `getFieldParamNamespace()` is called from a custom field and the field is inside a Matrix field. Returns  an extra dot inside the namespace 
``` php
public function normalizeValue($value, ElementInterface $element = null)
    {
        $namespace = $element->getFieldParamNamespace();
        ...
        ...
```
Best