### PR TITLE
Renamed the urlModel to UrlModel

### DIFF
--- a/src/models/UrlModel.php
+++ b/src/models/UrlModel.php
@@ -11,7 +11,7 @@ namespace Craft;
  * @package   craft.app.models
  * @since     1.3
  */
-class urlModel extends BaseModel
+class UrlModel extends BaseModel
 {
 	// Properties
 	// =========================================================================


### PR DESCRIPTION
Caused a Class 'Craft\UrlModel' not found (FeedsService.php:108)