### PR TITLE
Fixed Dutch homepage translation

### DIFF
--- a/src/translations/nl/app.php
+++ b/src/translations/nl/app.php
@@ -947,7 +947,7 @@ return [
     'Single-line text' => 'Enkele-lijn tekst',
     'Singles' => 'Eenmalig',
     'Site' => 'Website',
-    'Site Homepage' => 'Homepae',
+    'Site Homepage' => 'Homepage',
     'Site Icon' => 'Site icoon',
     'Site Settings' => 'Website-instellingen',
     'Site saved.' => 'Website opgeslagen.',


### PR DESCRIPTION
Homepage is missing the g in Dutch translation