### PR TITLE
Sort plugins by name

### DIFF
--- a/src/services/Plugins.php
+++ b/src/services/Plugins.php
@@ -211,6 +211,10 @@ class Plugins extends Component
             }
         }
         unset($row);
+        
+        // Sort plugins by their names
+        $names = array_column($this->_plugins, 'name');
+        array_multisort($names, SORT_NATURAL | SORT_FLAG_CASE, $this->_plugins);
 
         $this->_loadingPlugins = false;
         $this->_pluginsLoaded = true;


### PR DESCRIPTION
They are currently sorted by ID in the sidebar and settings page.