### PR TITLE
Monospace setting for plain text fields

### DIFF
--- a/src/fields/PlainText.php
+++ b/src/fields/PlainText.php
@@ -43,6 +43,11 @@ class PlainText extends Field implements PreviewableFieldInterface
     public $placeholder;
 
     /**
+     * @var bool Whether the input should use monospace font
+     */
+    public $code = false;
+
+    /**
      * @var bool Whether the input should allow line breaks
      */
     public $multiline = false;

--- a/src/templates/_components/fieldtypes/PlainText/input.html
+++ b/src/templates/_components/fieldtypes/PlainText/input.html
@@ -1,10 +1,15 @@
 {% import "_includes/forms" as forms %}
 
+{%- set class = [
+    'nicetext',
+    (field.code ? 'code' : null)
+]|filter|join(' ') %}
+
 {% set config = {
     id: name,
     name: name,
     value: value,
-    class: 'nicetext',
+    class: class,
     maxlength: field.charLimit,
     showCharsLeft: true,
     placeholder: field.placeholder|t('site'),

--- a/src/templates/_components/fieldtypes/PlainText/settings.html
+++ b/src/templates/_components/fieldtypes/PlainText/settings.html
@@ -22,6 +22,12 @@
 }) }}
 
 {{ forms.checkboxField({
+    label: "Use monospace font"|t('app'),
+    name: 'code',
+    checked: field.code,
+}) }}
+
+{{ forms.checkboxField({
     label: "Allow line breaks"|t('app'),
     name: 'multiline',
     checked: field.multiline,


### PR DESCRIPTION
Would be nice to have this as a setting, or merge the Simple Text plugin into core and use it in places where multiline code input is used, e.g. Email Messages.