### PR TITLE
Correct 'Singles' Dutch translation

### DIFF
--- a/src/translations/nl/app.php
+++ b/src/translations/nl/app.php
@@ -893,7 +893,7 @@ return [
     'Similar issues on GitHub' => 'Vergelijkbare issues op GitHub',
     'Similar questions on Stack Exchange' => 'Vergelijkbare vragen op Stack Exchange',
     'Single-line text' => 'Enkele-lijn tekst',
-    'Singles' => 'Eenmalig',
+    'Singles' => 'Singles',
     'Site' => 'Website',
     'Site Icon' => 'Site icoon',
     'Site Settings' => 'Website-instellingen',


### PR DESCRIPTION
After discussing this change in the official Dutch Craft Slack channel, we decided 'Eenmalig' doesn't fit the context and can be found confusing.