### PR TITLE
Added an event when saving in an ElementEditor

### DIFF
--- a/src/resources/js/craft.js
+++ b/src/resources/js/craft.js
@@ -10361,6 +10361,9 @@ Craft.ElementEditor = Garnish.Base.extend(
 					{
 						Craft.livePreview.updateIframe(true);
 					}
+					
+					// Trigger an event so that other js can react to this action
+					Garnish.$win.trigger('elementEditor.saveElement');
 
 					this.closeHud();
 					this.onSaveElement(response);


### PR DESCRIPTION
This allows any other cp JavaScript to listen to this event and therefore react when an element is saved from an ElementEditor.

I have made this change against Craft 2, but it should work on both.