### PR TITLE
Blank column type for Craft.EditableTable

### DIFF
--- a/src/templates/_includes/forms/editableTable.html
+++ b/src/templates/_includes/forms/editableTable.html
@@ -31,7 +31,7 @@
                     {% set value = cell.value is defined ? cell.value : cell %}
                     {% if col.type == 'heading' %}
                         <th scope="row" class="{{ cell.class ?? col.class ?? '' }}">{{ value|raw }}</th>
-                    {% elseif col.type == 'blank' %}
+                    {% elseif col.type == 'html' %}
                         <td class="{{ cell.class ?? col.class ?? '' }}">{{ value|raw }}</td>
                     {% else %}
                         {% set hasErrors = cell.hasErrors ?? false %}

--- a/src/templates/_includes/forms/editableTable.html
+++ b/src/templates/_includes/forms/editableTable.html
@@ -31,6 +31,8 @@
                     {% set value = cell.value is defined ? cell.value : cell %}
                     {% if col.type == 'heading' %}
                         <th scope="row" class="{{ cell.class ?? col.class ?? '' }}">{{ value|raw }}</th>
+                    {% elseif col.type == 'blank' %}
+                        <td class="{{ cell.class ?? col.class ?? '' }}">{{ value|raw }}</td>
                     {% else %}
                         {% set hasErrors = cell.hasErrors ?? false %}
                         {% set cellName = name~'['~rowId~']['~colId~']' %}


### PR DESCRIPTION
This allows to insert custom HTML into columns, similar to the `headline` column type but without the `th`-semantics and styling.