### PR TITLE
added “body can not contain emoji error message”

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -1080,6 +1080,7 @@ abstract class Element extends Component implements ElementInterface
                 // Don't count multibyte characters as a single char
                 'encoding' => '8bit',
                 'max' => Db::getTextualColumnStorageCapacity($columnType) ?: null,
+                'disallowMb4' => true,
             ]);
         }
 


### PR DESCRIPTION
added the `'dissallowMb4'` rule to the string validator for custom fields. 
issue: https://github.com/craftcms/cms/issues/2725