### PR TITLE
Added PGPASSWORD environment variable to Postgres restore command.

### DIFF
--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -160,7 +160,14 @@ class Schema extends \yii\db\pgsql\Schema
      */
     public function getDefaultRestoreCommand(): string
     {
-        return 'psql'.
+        if (Platform::isWindows()) {
+            $envCommand = 'set PGPASSWORD="{password}" && ';
+        } else {
+            $envCommand = 'PGPASSWORD="{password}" ';
+        }
+
+        return $envCommand.
+            'psql'.
             ' --dbname={database}'.
             ' --host={server}'.
             ' --port={port}'.


### PR DESCRIPTION
Using the Postgres driver, attempt to restore using `Craft::$app->getDb()->restore($backupPath)` fails with the following error. This pull request adds the password to the environment using the same method as the `getDefaultBackupCommand` method.

```
craft\errors\ShellCommandException: The shell command "psql --dbname=craft --host=postgres --port=5432 --username=craft_user --no-password < "storage/backups/backup.sql"" failed with exit code 2: psql: fe_sendauth: no password supplied in /usr/share/nginx/craft/vendor/craftcms/cms/src/errors/ShellCommandException.php:47
Stack trace:
#0 /usr/share/nginx/craft/vendor/craftcms/cms/src/db/Connection.php(561): craft\errors\ShellCommandException::createFromCommand(Object(mikehaertl\shellcommand\Command))
#1 /usr/share/nginx/craft/vendor/craftcms/cms/src/db/Connection.php(308): craft\db\Connection->_executeDatabaseShellCommand(Object(mikehaertl\shellcommand\Command)
...
```