### PR TITLE
Add `tablePrefix` to `SetupController.php`, allowing it to be used as a command-line parameter

### DIFF
--- a/src/console/controllers/SetupController.php
+++ b/src/console/controllers/SetupController.php
@@ -83,6 +83,7 @@ class SetupController extends Controller
             $options[] = 'password';
             $options[] = 'database';
             $options[] = 'schema';
+            $options[] = 'tablePrefix';
         }
 
         return $options;


### PR DESCRIPTION
We're doing the following in our own command-line scaffolding, and it works great! However, it seems like `tablePrefix` is the only option not able to be set via the command line. For instance, we're doing:

```
$dbOptions = [
    'driver' => 'mysql',
    'user' => 'root',
    'server' => 'localhost',
    'port' => '3306',
    'password' => 'somepassword',
    'database' => 'craft_database',
    'tablePrefix' => 'craft_',
];

Craft::$app->runAction('setup/db-creds', $dbOptions);
```

Which throws an error `Error: Unknown option: --tablePrefix`. Adding this fixes the issue.