### PR TITLE
Prevent Flash JS when deleting a Matrix block on the frontend

### DIFF
--- a/src/elements/MatrixBlock.php
+++ b/src/elements/MatrixBlock.php
@@ -400,7 +400,7 @@ class MatrixBlock extends Element
      */
     public function afterDelete()
     {
-        if (!Craft::$app->getRequest()->getIsConsoleRequest()) {
+        if (!Craft::$app->getRequest()->getIsConsoleRequest() and !Craft::$app->getRequest()->getIsSiteRequest()) {
             // Tell the browser to forget about this block
             $session = Craft::$app->getSession();
             $session->addAssetBundleFlash(MatrixAsset::class);


### PR DESCRIPTION
When deleting matrix blocks from the front end of the site a number of cpresources are injected into the page at reload adding additional styling and a number of errors in the console.

<img width="946" alt="screen shot 2018-04-24 at 13 35 16" src="https://user-images.githubusercontent.com/1016558/39187216-9a4ecc7c-47c4-11e8-88fd-473b3b4f352f.png">

The afterDelete method in src/elements/MatrixBlock.php is injecting the cpresources to clean up the browser's Local Storage of collapsed matrix blocks. As we're deleting them from the frontend, we don't need this functionality so I've updated the if statement to check if the request is a site request as well as a console request, and if so, skip including the cpresources.

This issue has also come up on the Craft CMS StackExchange:
https://craftcms.stackexchange.com/questions/25637/craft-3-resaving-matrix-from-frontend-causing-issues-craft-is-not-defined