### PR TITLE
When checking mime type of SVG files, be forgiving if they lack an XML declaration

### DIFF
--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -259,7 +259,7 @@ class FileHelper extends \yii\helpers\FileHelper
         $mimeType = parent::getMimeType($file, $magicFile, $checkExtension);
 
         // Be forgiving of SVG files, etc., that don't have an XML declaration
-        if ($checkExtension && in_array($mimeType, ['text/plain', 'text/html'])) {
+        if ($checkExtension && in_array($mimeType, ['text/plain', 'text/html', 'image/svg'])) {
             return static::getMimeTypeByExtension($file, $magicFile) ?? $mimeType;
         }
 


### PR DESCRIPTION
When trying to read SVG files to pass through the svg() TWIG function, if they lack a XML declaration, they are not read as `FileHelper::isSvg` returns false.

Given the comment in `FileHelper::getMimeType`, this seemed like the appropriate place to make the change.  Otherwise, you could allow 'image/svg' in the FileHelper::isSvg.

Either way, this allows you to reference local SVG files that lack an XML declaration.

To reproduce:

1. Create a local asset volume.
2. Create an Asset field linking to it.
3. Upload this SVG into the folder and pick it in the asset picker:  [alarm-clock.svg.txt](https://github.com/craftcms/cms/files/1968530/alarm-clock.svg.txt) (Rename it to alarm-clock.svg, renamed due to Github not allowing SVG uploads).
4. In your template, add the following twig code:
`{{ svg(icon.folder.volume.path ~ "/" ~ icon.filename) }}`
5. Notice the function returns an empty string rather than the content of the file.

Note: this is an icon from Font-Awesome Pro, so adding XML declarations to all of the 800+ files is not practical.  Given the comment in FileHelper::getMimeType, it seems that was supposed to cover SVG files anyway.

