### PR TITLE
Fix MigrationHelper::dropAllForeignKeysToTable

### DIFF
--- a/src/helpers/MigrationHelper.php
+++ b/src/helpers/MigrationHelper.php
@@ -545,21 +545,15 @@ class MigrationHelper
         $schema = $db->getSchema();
         $rawTableName = $schema->getRawTableName($tableName);
         $table = $db->getTableSchema($rawTableName);
-        $otherColumns = [];
 
         foreach ($table->getColumnNames() as $columnName) {
             $fks = static::findForeignKeysTo($rawTableName, $columnName);
 
             foreach ($fks as $otherTable => $row) {
-                foreach ($row as $columnInfo) {
-                    foreach ($columnInfo as $count => $value) {
-                        if ($count !== 0) {
-                            $otherColumns[] = $count;
-                        }
-                    }
+                foreach ($row as $fk) {
+                    $otherColumns = static::_getColumnsForFK($fk, true);
+                    static::dropForeignKeyIfExists($otherTable, $otherColumns, $migration);
                 }
-
-                static::dropForeignKeyIfExists($otherTable, $otherColumns, $migration);
             }
         }
     }


### PR DESCRIPTION
Seems like `dropAllForeignKeysToTable` was silently failing, which was causing some fails in `dropTable` due to FK constraints.

The extra `updateType` and `deleteType` columns weren't being excluded from the column list, and it seems like it was collecting _all_ the columns, across both FKs and tables, while trying to remove them.

Noticed there's already a helper to cull out the non-column data from a FK array, so I've just swapped that into place.