### PR TITLE
BUGFIX: Template cache memory exhausted. #2903

### DIFF
--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -230,13 +230,17 @@ class TemplateCaches extends Component
             $elementQuery->customFields = $customFields;
             $hash = md5($serialized);
 
+            gc_disable();
             foreach ($this->_cachedQueries as &$queries) {
                 $queries[$hash] = [
                     $elementQuery->elementType,
                     $serialized
                 ];
+                gc_collect_cycles();
             }
+            $queries = null;
             unset($queries);
+            gc_enable();
         }
     }
 


### PR DESCRIPTION
### Issue:
https://github.com/craftcms/cms/issues/2903

### Detail:
-. We disable the automatic garbage collector in order to do it manually.
-. We add `NULL` assignation to free the memory before break the binding between variable name and variable content with the `unset`.