### PR TITLE
Added sent parameter to 'email.onBeforeSendEmail' event (Craft 2)

### DIFF
--- a/src/services/EmailService.php
+++ b/src/services/EmailService.php
@@ -267,10 +267,12 @@ class EmailService extends BaseApplicationComponent
 		$event = new Event($this, array(
 			'user' => $user,
 			'emailModel' => $emailModel,
-			'variables'	 => $variables
+			'variables'	 => $variables,
+			'success'    => false,
 		));
 
 		$this->onBeforeSendEmail($event);
+		$beforeEventSuccess = $event->params['success'];
 
 		// Is the event giving us the go-ahead?
 		if ($event->performAction)
@@ -499,7 +501,7 @@ class EmailService extends BaseApplicationComponent
 			return true;
 		}
 
-		return false;
+		return $beforeEventSuccess;
 	}
 
 	/**

--- a/src/services/EmailService.php
+++ b/src/services/EmailService.php
@@ -272,10 +272,10 @@ class EmailService extends BaseApplicationComponent
 		));
 
 		$this->onBeforeSendEmail($event);
-		$beforeEventSent = $event->params['sent'];
+		$sent = $event->params['sent'];
 
 		// Is the event giving us the go-ahead?
-		if ($event->performAction)
+		if (!$sent && $event->performAction)
 		{
 			try
 			{
@@ -501,7 +501,7 @@ class EmailService extends BaseApplicationComponent
 			return true;
 		}
 
-		return $beforeEventSent;
+		return $sent;
 	}
 
 	/**

--- a/src/services/EmailService.php
+++ b/src/services/EmailService.php
@@ -268,11 +268,11 @@ class EmailService extends BaseApplicationComponent
 			'user' => $user,
 			'emailModel' => $emailModel,
 			'variables'	 => $variables,
-			'success'    => false,
+			'sent'       => false,
 		));
 
 		$this->onBeforeSendEmail($event);
-		$beforeEventSuccess = $event->params['success'];
+		$beforeEventSent = $event->params['sent'];
 
 		// Is the event giving us the go-ahead?
 		if ($event->performAction)
@@ -501,7 +501,7 @@ class EmailService extends BaseApplicationComponent
 			return true;
 		}
 
-		return $beforeEventSuccess;
+		return $beforeEventSent;
 	}
 
 	/**


### PR DESCRIPTION
To give listeners the ability to report a success state when they take over control of sending the email (performAction: false).

## The problem

When you have a listener (a plugin, or whatever), which is taking over control of sending emails, it will set `$event->performAction = false;` to stop Craft from sending the email.
When that one is set to false, it will always return boolean false to wherever the call is coming from.

For example; when you run "Test email" from the CP in the Email settings, it will always show you a failure message since the return value was false.

## The solution

The solution is simple, give the plugins the ability to determine and set the success state from the `email.onBeforeSendEmail` event and use that when the performAction is set to false by the listener.

With this fix, it is possible!