### PR TITLE
ElementsService optimization - switch to where-in statement when querying for elements with array of IDs

### DIFF
--- a/src/services/ElementsService.php
+++ b/src/services/ElementsService.php
@@ -704,7 +704,14 @@ class ElementsService extends BaseApplicationComponent
 
 		if ($criteria->id)
 		{
-			$query->andWhere(DbHelper::parseParam('elements.id', $criteria->id, $query->params));
+			if (is_array($criteria->id))
+			{
+				$query->andWhere(array('in', 'elements.id', $criteria->id));
+			}
+			else
+			{
+				$query->andWhere(DbHelper::parseParam('elements.id', $criteria->id, $query->params));
+			}
 		}
 
 		if ($criteria->archived)


### PR DESCRIPTION
Hi,

I found a performance bottleneck in a project that includes quite a complicated document search page...

When querying for entries by using a _large_ set of IDs, ~4000 or so,  (eg. `$criteria->id = [large array]`) the default behaviour creates a group of "OR" statements i.e.
```
... (elements.id='26819') OR (elements.id='27612') OR (elements.id='27968') ...
```
This query was taking in the area of 2500ms to return a result.

When I experimented and switched this to a IN statement i.e.
```
`elements`.`id` IN ('27612', '26819', '27613' ...)
```
... then the query time is dramatically improved to around 370ms. The total load is taken down from 10s to 2.5s.

For me this is a *must keep* update in the project I'm working on and I'd be interested to see if it could be included in the main project.