### PR TITLE
Sort fields secondarily by handle to fix order flakiness

### DIFF
--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -1394,7 +1394,7 @@ class Fields extends Component
                 'fields.settings'
             ])
             ->from(['{{%fields}} fields'])
-            ->orderBy(['fields.name' => SORT_ASC]);
+            ->orderBy(['fields.name' => SORT_ASC, 'fields.handle' => SORT_ASC]);
     }
 
     /**


### PR DESCRIPTION
When two or more fields have the same name (but a different handle of course), their sort order becomes unreliable (at least with PostgreSQL). This PR fixes that by secondarily sorting by handle.