### PR TITLE
Add file_exists check in front of filesize lookup in Asset validation

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -250,7 +250,7 @@ class Assets extends BaseRelationField
                     $filenames[] = $file['filename'];
                 }
             } else {
-                if (filesize($file['location']) > $maxSize) {
+                if (file_exists($file['location']) && (filesize($file['location']) > $maxSize)) {
                     $filenames[] = $file['filename'];
                 }
             }


### PR DESCRIPTION
Fixes the issue discussed with @lukeholder over at https://github.com/craftcms/commerce/issues/355.