### PR TITLE
make the html lang attribute dynamic in CP

### DIFF
--- a/src/templates/_layouts/base.html
+++ b/src/templates/_layouts/base.html
@@ -8,7 +8,7 @@
 {% hook "cp.layouts.base" -%}
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="{{ craft.app.language }}">
 <head>
     {% block head %}
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
While my client using a browser plugin to translate the page, the content automatically translated in entry edit pages.
I found out the html lang attribute has been fixed to "en-US" and it cause the problem.
```
lang="{{ craft.app.language }}"
```
that follows the locale admin user set in their preferences page.