### PR TITLE
Added extra Twig template file extension (html.twig)

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -203,7 +203,7 @@ class GeneralConfig extends BaseObject
     /**
      * @var string[] The template file extensions Craft will look for when matching a template path to a file on the front end.
      */
-    public $defaultTemplateExtensions = ['html', 'twig'];
+    public $defaultTemplateExtensions = ['html', 'twig', 'html.twig'];
     /**
      * @var mixed The default amount of time tokens can be used before expiring.
      *

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -1023,7 +1023,7 @@ JS;
         // Update everything
         if ($templateMode == self::TEMPLATE_MODE_CP) {
             $this->setTemplatesPath(Craft::$app->getPath()->getCpTemplatesPath());
-            $this->_defaultTemplateExtensions = ['html', 'twig'];
+            $this->_defaultTemplateExtensions = ['html', 'twig', 'html.twig'];
             $this->_indexTemplateFilenames = ['index'];
         } else {
             $this->setTemplatesPath(Craft::$app->getPath()->getSiteTemplatesPath());


### PR DESCRIPTION
To be compatible with IDE's and other frameworks etc.

When you also use other systems like Symfony, you'd probably used to create templates like `template.html.twig` and probably you've configured your IDE to recognize `.html.twig` as Twig templates (in terms of syntax highlighting).

I always set these in the general config. But I think this should be default. So, here's my PR :-)