### PR TITLE
Use setError for unsuccessful password update

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -428,7 +428,7 @@ class UsersController extends Controller
             return $this->redirect($url);
         }
 
-        Craft::$app->getSession()->setNotice(Craft::t('app',
+        Craft::$app->getSession()->setError(Craft::t('app',
             'Couldn’t update password.'));
 
         $errors = $userToProcess->getErrors('newPassword');

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -428,8 +428,7 @@ class UsersController extends Controller
             return $this->redirect($url);
         }
 
-        Craft::$app->getSession()->setError(Craft::t('app',
-            'Couldn’t update password.'));
+        Craft::$app->getSession()->setError(Craft::t('app', 'Couldn’t update password.'));
 
         $errors = $userToProcess->getErrors('newPassword');
 


### PR DESCRIPTION
If a password was unable to be updated, a session error should be sent instead of a notice