### PR TITLE
Add `rel="noopener"` for external links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://craftcms.com/" target="_blank"><img width="312" height="90" src="https://craftcms.com/craftcms.svg" alt="Craft CMS"></a></p>
+<p align="center"><a href="https://craftcms.com/" rel="noopener" target="_blank"><img width="312" height="90" src="https://craftcms.com/craftcms.svg" alt="Craft CMS"></a></p>
 
 ## About Craft CMS
 

--- a/bootstrap/web.php
+++ b/bootstrap/web.php
@@ -14,7 +14,7 @@ if (PHP_VERSION_ID < 70000) {
 
 // Check for this early because Craft uses it before the requirements checker gets a chance to run.
 if (!extension_loaded('mbstring') || (extension_loaded('mbstring') && ini_get('mbstring.func_overload') != 0)) {
-    exit('Craft requires the <a href="http://php.net/manual/en/book.mbstring.php" target="_blank">PHP multibyte string</a> extension in order to run. Please talk to your host/IT department about enabling it on your server.');
+    exit('Craft requires the <a href="http://php.net/manual/en/book.mbstring.php" rel="noopener" target="_blank">PHP multibyte string</a> extension in order to run. Please talk to your host/IT department about enabling it on your server.');
 }
 
 // PHP environment normalization

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2040,7 +2040,7 @@ abstract class Element extends Component implements ElementInterface
                 $url = $this->getUrl();
 
                 if ($url !== null) {
-                    return '<a href="' . $url . '" target="_blank" data-icon="world" title="' . Craft::t('app', 'Visit webpage') . '"></a>';
+                    return '<a href="' . $url . '" rel="noopener" target="_blank" data-icon="world" title="' . Craft::t('app', 'Visit webpage') . '"></a>';
                 }
 
                 return '';
@@ -2068,7 +2068,7 @@ abstract class Element extends Component implements ElementInterface
                         $value = str_replace($find, $replace, $value);
                     }
 
-                    return '<a href="' . $url . '" target="_blank" class="go" title="' . Craft::t('app', 'Visit webpage') . '"><span dir="ltr">' . $value . '</span></a>';
+                    return '<a href="' . $url . '" rel="noopener" target="_blank" class="go" title="' . Craft::t('app', 'Visit webpage') . '"><span dir="ltr">' . $value . '</span></a>';
                 }
 
                 return '';

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -81,7 +81,7 @@ class Cp
             // Domain mismatch?
             if ($licenseKeyStatus === LicenseKeyStatus::Mismatched) {
                 $licensedDomain = Craft::$app->getCache()->get('licensedDomain');
-                $domainLink = '<a href="http://' . $licensedDomain . '" target="_blank">' . $licensedDomain . '</a>';
+                $domainLink = '<a href="http://' . $licensedDomain . '" rel="noopener" target="_blank">' . $licensedDomain . '</a>';
 
                 if (defined('CRAFT_LICENSE_KEY')) {
                     $message = Craft::t('app', 'The license key in use belongs to {domain}', [

--- a/src/services/Plugins.php
+++ b/src/services/Plugins.php
@@ -858,7 +858,7 @@ class Plugins extends Component
             switch ($status) {
                 case LicenseKeyStatus::Mismatched:
                     $info['licenseStatusMessage'] = Craft::t('app', 'This license is tied to another Craft install. Visit {url} to resolve.', [
-                        'url' => '<a href="https://id.craftcms.com" target="_blank">id.craftcms.com</a>',
+                        'url' => '<a href="https://id.craftcms.com" rel="noopener" target="_blank">id.craftcms.com</a>',
                     ]);
                     break;
                 case LicenseKeyStatus::Astray:

--- a/src/templates/_layouts/cp.html
+++ b/src/templates/_layouts/cp.html
@@ -101,7 +101,7 @@
 
             <div class="menu" data-align="left">
                 <ul>
-                    <li><a href="{{ siteUrl }}" target="_blank">{{ 'View site'|t('app') }}</a></li>
+                    <li><a href="{{ siteUrl }}" rel="noopener" target="_blank">{{ 'View site'|t('app') }}</a></li>
                 </ul>
                 <hr>
                 <ul>

--- a/src/templates/categories/_edit.html
+++ b/src/templates/categories/_edit.html
@@ -18,7 +18,7 @@
             <div class="btn livepreviewbtn">{{ "Live Preview"|t('app') }}</div>
         {% endif %}
         {% if shareUrl is defined %}
-            <a href="{{ shareUrl }}" class="btn sharebtn" target="_blank">{{ 'Share'|t('app') }}</a>
+            <a href="{{ shareUrl }}" class="btn sharebtn" rel="noopener" target="_blank">{{ 'Share'|t('app') }}</a>
         {% endif %}
         <div class="flex-grow"></div>
     {% endif %}

--- a/src/templates/entries/_edit.html
+++ b/src/templates/entries/_edit.html
@@ -26,7 +26,7 @@
             <div class="btn livepreviewbtn">{{ "Live Preview"|t('app') }}</div>
         {% endif %}
         {% if shareUrl is defined %}
-            <a href="{{ shareUrl }}" class="btn sharebtn" target="_blank">{{ 'Share'|t('app') }}</a>
+            <a href="{{ shareUrl }}" class="btn sharebtn" rel="noopener" target="_blank">{{ 'Share'|t('app') }}</a>
         {% endif %}
         <div class="flex-grow"></div>
     {% endif %}

--- a/src/templates/plugin-store/_index.html
+++ b/src/templates/plugin-store/_index.html
@@ -89,7 +89,7 @@
 
 		<div class="menu">
 			<ul>
-				<li><a href="{{ craft.cp.craftIdAccountUrl() }}" target="_blank">{{ "Manage your Craft ID"|t('app') }}</a></li>
+				<li><a href="{{ craft.cp.craftIdAccountUrl() }}" rel="noopener" target="_blank">{{ "Manage your Craft ID"|t('app') }}</a></li>
 				<li>
 					<form method="post" id="disconnect">
 						{{ csrfInput() }}

--- a/src/templates/settings/general/_index.html
+++ b/src/templates/settings/general/_index.html
@@ -10,7 +10,7 @@
 
 {% macro configWarning(setting, file) -%}
     {{ "This is being overridden by the {setting} config setting."|t('app', {
-        setting: '<a href="https://docs.craftcms.com/api/v3/craft-config-generalconfig.html#property-'~setting|lower~'" target="_blank">'~setting~'</a>'
+        setting: '<a href="https://docs.craftcms.com/api/v3/craft-config-generalconfig.html#property-'~setting|lower~'" rel="noopener" target="_blank">'~setting~'</a>'
     })|raw }}
 {%- endmacro %}
 

--- a/src/templates/settings/plugins/index.html
+++ b/src/templates/settings/plugins/index.html
@@ -42,12 +42,12 @@
                                         <p class="links">
                                             {%- spaceless %}
                                             {#{% if config.developerUrl %}#}
-                                                {#<a href="{{ config.developerUrl }}" target="_blank">{{ config.developer ?: config.developerUrl }}</a>#}
+                                                {#<a href="{{ config.developerUrl }}" rel="noopener" target="_blank">{{ config.developer ?: config.developerUrl }}</a>#}
                                             {#{% elseif config.developer %}#}
                                                 {#{{ config.developer }}#}
                                             {#{% endif %}#}
                                             {% if config.documentationUrl %}
-                                                <a href="{{ config.documentationUrl }}" target="_blank">{{ "Documentation"|t('app') }}</a>
+                                                <a href="{{ config.documentationUrl }}" rel="noopener" target="_blank">{{ "Documentation"|t('app') }}</a>
                                             {% endif %}
                                             {% if config.hasCpSettings %}
                                                 <a href="{{ url('settings/plugins/'~config.moduleId) }}"><span data-icon="settings"></span>{{ "Settings"|t('app') }}</a>

--- a/src/web/assets/cp/src/js/CP.js
+++ b/src/web/assets/cp/src/js/CP.js
@@ -124,7 +124,7 @@ Craft.CP = Garnish.Base.extend(
             // hat tip: https://stackoverflow.com/a/2911045/1688568
             $('a').each(function() {
                 if (this.hostname.length && this.hostname !== location.hostname && typeof $(this).attr('target') === 'undefined') {
-                    $(this).attr('target', '_blank')
+                    $(this).attr('rel', 'noopener').attr('target', '_blank')
                 }
             });
         },

--- a/src/web/assets/pluginstore/src/js/components/modal/steps/PluginDetails.vue
+++ b/src/web/assets/pluginstore/src/js/components/modal/steps/PluginDetails.vue
@@ -101,8 +101,8 @@
                                 </ul>
 
                                 <ul v-if="(plugin.documentationUrl || plugin.changelogUrl)" class="plugin-meta-links">
-                                    <li v-if="plugin.documentationUrl"><a :href="plugin.documentationUrl" class="btn fullwidth" target="_blank">{{ "Documentation"|t('app') }}</a></li>
-                                    <li v-if="plugin.changelogUrl"><a :href="plugin.changelogUrl" class="btn fullwidth" target="_blank">{{ "Changelog"|t('app') }}</a></li>
+                                    <li v-if="plugin.documentationUrl"><a :href="plugin.documentationUrl" class="btn fullwidth" rel="noopener" target="_blank">{{ "Documentation"|t('app') }}</a></li>
+                                    <li v-if="plugin.changelogUrl"><a :href="plugin.changelogUrl" class="btn fullwidth" rel="noopener" target="_blank">{{ "Changelog"|t('app') }}</a></li>
                                 </ul>
                             </div>
                         </div>


### PR DESCRIPTION
Fixes #3201 

Some notes:

* **this is totally untested**
* not sure if I should change `getTableAttributeHtml()`
* these two are left but I guess they have their own repos so it should be changed there:
    * https://github.com/craftcms/cms/blob/develop/src/web/assets/craftsupport/dist/CraftSupportWidget.js#L315
    * https://github.com/craftcms/cms/blob/develop/src/web/assets/feed/dist/FeedWidget.js#L27