### PR TITLE
Add NULL check for field settings during migration

### DIFF
--- a/src/migrations/m160807_144858_sites.php
+++ b/src/migrations/m160807_144858_sites.php
@@ -441,7 +441,13 @@ class m160807_144858_sites extends Migration
 
         foreach ($fields as $field) {
 
-            $settings = Json::decodeIfJson($field['settings']);
+            if ($field['settings'] === null) {
+                echo 'Field ' . $field['id'] . ' (' . $field['type'] . ') settings were null' . "\n";
+                $settings = [];
+            } else {
+                $settings = Json::decodeIfJson($field['settings']);
+            }
+
 
             if (!is_array($settings)) {
                 echo 'Field ' . $field['id'] . ' (' . $field['type'] . ') settings were invalid JSON: ' . $field['settings'] . "\n";

--- a/src/migrations/m160807_144858_sites.php
+++ b/src/migrations/m160807_144858_sites.php
@@ -446,12 +446,10 @@ class m160807_144858_sites extends Migration
                 $settings = [];
             } else {
                 $settings = Json::decodeIfJson($field['settings']);
-            }
-
-
-            if (!is_array($settings)) {
-                echo 'Field ' . $field['id'] . ' (' . $field['type'] . ') settings were invalid JSON: ' . $field['settings'] . "\n";
-                $settings = [];
+                if (!is_array($settings)) {
+                    echo 'Field ' . $field['id'] . ' (' . $field['type'] . ') settings were invalid JSON: ' . $field['settings'] . "\n";
+                    $settings = [];
+                }
             }
 
             $localized = ($field['translationMethod'] === 'site');


### PR DESCRIPTION
This would happen during Craft2 to Craft3 upgrade when a fields' setting is NULL.

Error/stack trace:

```
Exception: Argument 1 passed to craft\helpers\Json::decodeIfJson() must be of the type string, null given, called in /Users/erik/dev/craft3-upgrade-migrationfix/vendor/craftcms/cms/src/migrations/m160807_144858_sites.php on line 444 (/Users/erik/dev/craft3-upgrade-migrationfix/vendor/craftcms/cms/src/helpers/Json.php:30)
#0 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/craftcms/cms/src/migrations/m160807_144858_sites.php(444): craft\helpers\Json::decodeIfJson(NULL)
#1 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/craftcms/cms/src/db/Migration.php(56): craft\migrations\m160807_144858_sites->safeUp()
#2 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/craftcms/cms/src/db/MigrationManager.php(243): craft\db\Migration->up(true)
#3 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/craftcms/cms/src/db/MigrationManager.php(163): craft\db\MigrationManager->migrateUp(Object(craft\migrations\m160807_144858_sites))
#4 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/craftcms/cms/src/services/Updates.php(207): craft\db\MigrationManager->up()
#5 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/craftcms/cms/src/console/controllers/MigrateController.php(243): craft\services\Updates->runMigrations(Array)
#6 [internal function]: craft\console\controllers\MigrateController->actionAll()
#7 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)
#8 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/yiisoft/yii2/base/Controller.php(157): yii\base\InlineAction->runWithParams(Array)
#9 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/yiisoft/yii2/console/Controller.php(148): yii\base\Controller->runAction('all', Array)
#10 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/yiisoft/yii2/base/Module.php(528): yii\console\Controller->runAction('all', Array)
#11 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/yiisoft/yii2/console/Application.php(180): yii\base\Module->runAction('migrate/all', Array)
#12 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/yiisoft/yii2/console/Application.php(147): yii\console\Application->runAction('migrate/all', Array)
#13 /Users/erik/dev/craft3-upgrade-migrationfix/vendor/yiisoft/yii2/base/Application.php(386): yii\console\Application->handleRequest(Object(craft\console\Request))
#14 /Users/erik/dev/craft3-upgrade-migrationfix/craft(22): yii\base\Application->run()
#15 {main}
Exception 'craft\errors\MigrateException' with message 'An error occurred while migrating Craft CMS.'
``` 

In my case I had an 'Entries' field with null value:
```mysql> select * from craft_fields where id=77;
+----+---------+------------------+---------------------------+---------+--------------+--------------+---------+----------+---------------------+---------------------+--------------------------------------+
| id | groupId | name             | handle                    | context | instructions | translatable | type    | settings | dateCreated         | dateUpdated         | uid                                  |
+----+---------+------------------+---------------------------+---------+--------------+--------------+---------+----------+---------------------+---------------------+--------------------------------------+
| 77 |       1 | Page edit access | frontendeditor_pageaccess | global  | NULL         |            0 | Entries | NULL     | 2016-08-24 09:10:54 | 2016-08-24 09:10:54 | 6476201c-36ac-4c58-b1d3-3771f2083c3e |
+----+---------+------------------+---------------------------+---------+--------------+--------------+---------+----------+---------------------+---------------------+--------------------------------------+
1 row in set (0.00 sec)```

