### PR TITLE
Fixed ElementQuery count() method always returns an integer.

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1153,7 +1153,7 @@ class ElementQuery extends Query implements ElementQueryInterface
             return count($cachedResult);
         }
 
-        return parent::count($q, $db) ?: 0;
+        return (int)parent::count($q, $db) ?: 0;
     }
 
     /**


### PR DESCRIPTION
Now there are two situations, when calling the parent, it returns a string instead of an integer.