### PR TITLE
Add a Twig function to create yii\db\Expression objects

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -713,7 +713,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
             new \Twig_SimpleFunction('className', 'get_class'),
             new \Twig_SimpleFunction('clone', [$this, 'cloneFunction']),
             new \Twig_SimpleFunction('csrfInput', [$this, 'csrfInputFunction']),
-            new \Twig_SimpleFunction('dbExpression', [$this, 'dbExpressionFunction']),
+            new \Twig_SimpleFunction('expression', [$this, 'expressionFunction']),
             new \Twig_SimpleFunction('floor', 'floor'),
             new \Twig_SimpleFunction('getenv', 'getenv'),
             new \Twig_SimpleFunction('redirectInput', [$this, 'redirectInputFunction']),
@@ -760,14 +760,14 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     {
         return clone $var;
     }
-    
+
     /**
      * @param mixed $expression
      * @param mixed $params
      * @param mixed $config
      * @return Expression
      */
-    public function dbExpressionFunction($expression, $params = [], $config = []): Expression
+    public function expressionFunction($expression, $params = [], $config = []): Expression
     {
         return new Expression($expression, $params, $config);
     }

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -45,6 +45,7 @@ use DateTimeZone;
 use enshrined\svgSanitize\Sanitizer;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
+use yii\db\Expression;
 use yii\helpers\Markdown;
 
 /**
@@ -712,6 +713,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
             new \Twig_SimpleFunction('className', 'get_class'),
             new \Twig_SimpleFunction('clone', [$this, 'cloneFunction']),
             new \Twig_SimpleFunction('csrfInput', [$this, 'csrfInputFunction']),
+            new \Twig_SimpleFunction('dbExpression', [$this, 'dbExpressionFunction']),
             new \Twig_SimpleFunction('floor', 'floor'),
             new \Twig_SimpleFunction('getenv', 'getenv'),
             new \Twig_SimpleFunction('redirectInput', [$this, 'redirectInputFunction']),
@@ -757,6 +759,17 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     public function cloneFunction($var)
     {
         return clone $var;
+    }
+    
+    /**
+     * @param mixed $expression
+     * @param mixed $params
+     * @param mixed $config
+     * @return Expression
+     */
+    public function dbExpressionFunction($expression, $params = [], $config = []): Expression
+    {
+        return new Expression($expression, $params, $config);
     }
 
     /**


### PR DESCRIPTION
Sometimes it’s not possible to pass a db expression as a string, becaus Yii escapes it and generates invalid SQL. https://github.com/yiisoft/yii2/issues/553

Example use of the function:

```twig
{% set ids = [1639, 2079] %}

{% set orderByParam = ids ?
    dbExpression('FIELD(elements.id, ' ~ ids|reverse|join(', ') ~ ') desc, title asc') :
    'title asc' %}

{% set query = craft.entries
    .limit(50)
    .orderBy(orderByParam) %}
```