### PR TITLE
Anonymise logs

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -73,6 +73,10 @@ class GeneralConfig extends BaseObject
      */
     public $allowUppercaseInSlug = false;
     /**
+     * @var bool Whether Craft logs should be anonymized.
+     */
+    public $anonymizeLogs = false;
+    /**
      * @var bool Whether users should automatically be logged in after activating their account.
      */
     public $autoLoginAfterAccountActivation = false;

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -381,6 +381,12 @@ class App
             'dirMode' => $generalConfig->defaultDirMode,
         ];
 
+        if ($generalConfig->anonymizeLogs) {
+            $target['prefix'] = function () {
+                return null;
+            };
+        }
+
         if ($isConsoleRequest) {
             $target['logFile'] = '@storage/logs/console.log';
         } else {


### PR DESCRIPTION
Due to GDPR it would be really handy if we were able to anonymise the log prefixes. 

This PR allows for log anonymisation to be enabled from the general config file.