### PR TITLE
Allow Entry authorId being set from the query url parameters

### DIFF
--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -812,9 +812,11 @@ class EntriesController extends BaseEntriesController
                     throw new NotFoundHttpException('Entry not found');
                 }
             } else {
+                $authorId = Craft::$app->getRequest()->getQueryParam('authorId', Craft::$app->getUser()->getIdentity()->id);
+
                 $variables['entry'] = new Entry();
                 $variables['entry']->sectionId = $variables['section']->id;
-                $variables['entry']->authorId = Craft::$app->getUser()->getIdentity()->id;
+                $variables['entry']->authorId = $authorId;
                 $variables['entry']->enabled = true;
                 $variables['entry']->siteId = $site->id;
 


### PR DESCRIPTION
When a plugin (or something else) using Entries as data storage it could be useful being able to pre-set the ID of the author of the Entry. Currently this is hard coded to the current user's ID.
With this little update it's possible to pass a query parameter to overwrite it.

### Example

Let's say you have a plugin, based on your users. You want a button to create a resource (which is an Entry) and your logic is configured to have the author of an Entry is the user where the resource belongs too. Now you can create that link with the ID of the user to set a different author than the default current user.