### PR TITLE
 Add template hooks to global set editor pages

### DIFF
--- a/src/templates/globals/_edit.html
+++ b/src/templates/globals/_edit.html
@@ -2,6 +2,7 @@
 {% set title = globalSet.name|t('site') %}
 {% set fullPageForm = true %}
 
+{% hook "cp.globals.edit" %}
 
 {% block contextMenu %}
     {% if craft.app.getIsMultiSite() %}
@@ -44,4 +45,7 @@
     {% else %}
         {{ "This global set doesn’t have any fields assigned to it in its field layout."|t('app') }}
     {% endif %}
+
+    {# Give plugins a chance to add other things here #}
+    {% hook "cp.globals.edit.content" %}
 {% endblock %}


### PR DESCRIPTION
This mimics the hooks found in the entry edit page templates.