### PR TITLE
Update German translation for stack trace

### DIFF
--- a/src/translations/de/app.php
+++ b/src/translations/de/app.php
@@ -905,7 +905,7 @@ return [
     'Sources' => 'Quellen',
     'Square' => 'Quadrat',
     'Square SVG file recommended. The logo will be displayed at {size} by {size}.' => 'Quadratische SVG-Datei empfohlen Das Logo wird in der Größe {size} x {size} angezeigt.',
-    'Stack Trace' => 'Stapelspur',
+    'Stack Trace' => 'Stack Trace',
     'Staff Picks' => 'Auswahl unserer Mitarbeiter',
     'Status' => 'Status',
     'Status updated, with some failures due to validation errors.' => 'Status wurde – aufgrund von Validierungsfehlern nicht vollständig erfolgreich – aktualisiert.',


### PR DESCRIPTION
In German there is no translation for stack trace. People just use the English term. I'm a native German and software developer but never heard the term "Stapelspur". Searching in Google gives 492 results.