### PR TITLE
Fix broken Code of Conduct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ That comes with some limitations on what you can do with the code:
 
 ### Code of Conduct
 
-Please take a couple minutes to read through Craft’s [code of conduct](https://github.com/craftcms/docs/blob/v3/en/coc.md). By participating here, you are expected to uphold this code. Please report unacceptable behavior to [support@craftcms.com][support].
+Please take a couple minutes to read through Craft’s [code of conduct](https://github.com/craftcms/docs/blob/v3/docs/coc.md). By participating here, you are expected to uphold this code. Please report unacceptable behavior to [support@craftcms.com][support].
 
 ## Security Disclosures
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ That comes with some limitations on what you can do with the code:
 
 ### Code of Conduct
 
-Please take a couple minutes to read through Craft’s [code of conduct](https://github.com/craftcms/docs/blob/v3/docs/coc.md). By participating here, you are expected to uphold this code. Please report unacceptable behavior to [support@craftcms.com][support].
+Please take a couple minutes to read through Craft’s [code of conduct](https://docs.craftcms.com/v3/coc.html). By participating here, you are expected to uphold this code. Please report unacceptable behavior to [support@craftcms.com][support].
 
 ## Security Disclosures
 


### PR DESCRIPTION
After commit [5c08c60](https://github.com/craftcms/docs/commit/5c08c60ef59396cdb159d341d21c7c6c1e254380) in craftcms/docs the code of conduct link in CONTRIBUTING.md needs to be updated to reflect the change.