### PR TITLE
Fix charts not recognising en-AU as a locale

### DIFF
--- a/lib/d3-format/en-AU.json
+++ b/lib/d3-format/en-AU.json
@@ -1,0 +1,1 @@
+{"decimal":".","thousands":",","grouping":[3],"currency":["$",""]}


### PR DESCRIPTION
Just uncovered an interesting issue, when our site's locale is set to `en-AU` (as it most often is for us), the Commerce charts seem to render `₹` instead of a dollar sign. 

![screen shot 2018-11-23 at 12 12 37 pm](https://user-images.githubusercontent.com/1221575/48925600-8e92b400-ef19-11e8-9f19-47ed71cd079b.png)

Diving into the code it relies on:

https://github.com/craftcms/cms/blob/develop/src/web/assets/d3/D3Asset.php#L57-L75

It'll try and locate a `lib/d3-format/en-AU.json` file, but since that doesn't exist, it'll find the first `en-*.json` file, which happens to be `en-IN.json`. I can see there's the default for `en-US`, but it never reaches that if there's at least one other english-variant file.

Adding this file (duplicating en-US) works as expected.