### PR TITLE
Include showSiteMenu option in elementSelect field

### DIFF
--- a/src/templates/_includes/forms/elementSelect.html
+++ b/src/templates/_includes/forms/elementSelect.html
@@ -33,6 +33,7 @@
     sourceElementId: sourceElementId,
     viewMode: viewMode,
     limit: limit ?? null,
+    showSiteMenu: showSiteMenu ?? false,
     modalStorageKey: storageKey
 } %}
 


### PR DESCRIPTION
I'm not sure if there's a reason why this isn't included, but it would be nice if showing the `showSiteMenu` could be configured in cases where the `Craft.BaseElementSelectInput` is being included in for example a custom field type.