### PR TITLE
Remove .all()

### DIFF
--- a/docs/table-fields.md
+++ b/docs/table-fields.md
@@ -31,7 +31,7 @@ Calling a Table field in your templates will return an array of the rows. Each r
     <h3>Whiskeys</h3>
 
     <ul>
-        {% for row in entry.whiskeyTableHandle.all() %}
+        {% for row in entry.whiskeyTableHandle %}
             <li>{{ row.whiskey }} - {{ row.description }} - {{ row.proof }}</li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
Believe .all() is wrong here.

I had to remove .all(). With the .all() I get `Impossible to invoke a method ("all") on an array.`

According to this then the docs might be wrong: https://craftcms.stackexchange.com/questions/20193/limit-rows-using-table