### PR TITLE
Document session component config

### DIFF
--- a/docs/config/app.md
+++ b/docs/config/app.md
@@ -78,7 +78,7 @@ return [
 
 ## Session Component
 
-In a load-balanced environment, you may want to override the default session component to store them in a centralized store (e.g. Redis):
+In a load-balanced environment, you may want to override the default session component to store them in a centralized location (e.g. Redis):
 
 ```php
 <?php
@@ -99,6 +99,11 @@ return [
     ],
 ];
 ```
+
+::: tip
+`as session` is a [Yii configuration concept](https://www.yiiframework.com/doc/guide/2.0/en/concept-configurations#configuration-format) attaches a given behavior to an object.
+:::
+
 
 ## Mailer Component
 

--- a/docs/config/app.md
+++ b/docs/config/app.md
@@ -63,7 +63,7 @@ To use Redis cache storage, you will first need to install the [yii2-redis](http
 return [
     'components' => [
         'redis' => [
-            'class' => \yii\redis\Connection::class,
+            'class' => yii\redis\Connection::class,
             'hostname' => 'localhost',
             'port' => 6379,
             'password' => getenv('REDIS_PASSWORD'),
@@ -85,15 +85,15 @@ In a load-balanced environment, you may want to override the default session com
 return [
     'components' => [
         'redis' => [
-            'class' => \yii\redis\Connection::class,
+            'class' => yii\redis\Connection::class,
             'hostname' => 'localhost',
             'port' => 6379,
             'password' => getenv('REDIS_PASSWORD'),
         ],
         'session' => [
-            'class' => \yii\redis\Session::class,
+            'class' => yii\redis\Session::class,
             'as session' => [
-                'class' => \craft\behaviors\SessionBehavior::class,
+                'class' => craft\behaviors\SessionBehavior::class,
             ],
         ],
     ],

--- a/docs/config/app.md
+++ b/docs/config/app.md
@@ -78,7 +78,7 @@ return [
 
 ## Session Component
 
-In a load-balanced environment, you may want to override the default session component to store them in a centralized location (e.g. Redis):
+In a load-balanced environment, you may want to override the default `session` component to store PHP session data in a centralized location (e.g. Redis):
 
 ```php
 <?php
@@ -92,16 +92,14 @@ return [
         ],
         'session' => [
             'class' => yii\redis\Session::class,
-            'as session' => [
-                'class' => craft\behaviors\SessionBehavior::class,
-            ],
+            'as session' => craft\behaviors\SessionBehavior::class,
         ],
     ],
 ];
 ```
 
 ::: tip
-`as session` is a [Yii configuration concept](https://www.yiiframework.com/doc/guide/2.0/en/concept-configurations#configuration-format) attaches a given behavior to an object.
+The `session` component **must** be configured with the <api:craft\behaviors\SessionBehavior> behavior, which adds methods to the component that the system relies on.
 :::
 
 ## Mailer Component

--- a/docs/config/app.md
+++ b/docs/config/app.md
@@ -62,19 +62,43 @@ To use Redis cache storage, you will first need to install the [yii2-redis](http
 <?php
 return [
     'components' => [
+        'redis' => [
+            'class' => \yii\redis\Connection::class,
+            'hostname' => 'localhost',
+            'port' => 6379,
+            'password' => getenv('REDIS_PASSWORD'),
+        ],
         'cache' => [
             'class' => yii\redis\Cache::class,
             'defaultDuration' => 86400,
-            'redis' => [
-                'hostname' => 'localhost',
-                'port' => 6379,
-                'password' => getenv('REDIS_PASSWORD'),
-                'database' => 0,
-            ],
         ],
     ],
 ];
 ``` 
+
+## Session Component
+
+In a load-balanced environment, you may want to override the default session component to store them in a centralized store (e.g. Redis):
+
+```php
+<?php
+return [
+    'components' => [
+        'redis' => [
+            'class' => \yii\redis\Connection::class,
+            'hostname' => 'localhost',
+            'port' => 6379,
+            'password' => getenv('REDIS_PASSWORD'),
+        ],
+        'session' => [
+            'class' => \yii\redis\Session::class,
+            'as session' => [
+                'class' => \craft\behaviors\SessionBehavior::class,
+            ],
+        ],
+    ],
+];
+```
 
 ## Mailer Component
 

--- a/docs/config/app.md
+++ b/docs/config/app.md
@@ -104,7 +104,6 @@ return [
 `as session` is a [Yii configuration concept](https://www.yiiframework.com/doc/guide/2.0/en/concept-configurations#configuration-format) attaches a given behavior to an object.
 :::
 
-
 ## Mailer Component
 
 To override the `mailer` component config (which is responsible for sending emails), do this in `config/app.php`:


### PR DESCRIPTION
There seems to be a lot of confusion on how to do this, so I thought an example would help.
I also update the example to configure the redis component separately, which seemed better to me.

I also tried to track down the Yii docs for `as xxxxxx` behavior stuff, but can't seem to find anything.

Pretty sure @boboldehampsink found them before. I think we discussed [here](https://github.com/craftcms/cms/issues/3428), but the page seems dead now.

Any idea where this documentation is?