### PR TITLE
Updates Schema.php to support pdo_mysql.default_socket

### DIFF
--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -323,9 +323,12 @@ SQL;
             'host=' . $dbConfig->server . PHP_EOL .
             'port=' . $dbConfig->port;
 
+        $unixSocketDefaultPath = ini_get('pdo_mysql.default_socket');
         if ($dbConfig->unixSocket) {
             $contents .= PHP_EOL . 'socket=' . $dbConfig->unixSocket;
-        }
+        } else if ($unixSocketDefaultPath) {
+            $contents .= PHP_EOL . 'socket=' . $unixSocketDefaultPath;
+	    }
 
         FileHelper::writeToFile($filePath, $contents);
 


### PR DESCRIPTION
Updates Schema.php to support pdo_mysql.default_socket for Unix socket usage when using mysqldump. The current code does not look for the default PDO socket path, which results in mysqldump failing to connect to the socket if mysqldump itself is not explicitly told (via MySQL configuration or similar) where the socket exists. For server installations that use the standard pdo_mysql.default_socket INI setting, this is unnecessary since that default socket location can be looked up and attempted. That's what this code change does.

Code style may need a bit of adjustment. GitHub interface is showing me different things from page to page.