### PR TITLE
Should csrfInput() be in the searchform?

### DIFF
--- a/docs/dev/examples/search-form.md
+++ b/docs/dev/examples/search-form.md
@@ -4,7 +4,6 @@ To create a search form, first create a normal HTML form with a `search` input:
 
 ```twig
 <form action="{{ url('search/results') }}">
-    {{ csrfInput() }}
     <input type="search" name="q" placeholder="Search">
     <input type="submit" value="Go">
 </form>


### PR DESCRIPTION
When using csrfInput() in the search form my query string shows the entire csrf value

http://test.com/search/results?CRAFT_CSRF_TOKEN=cYQRha8ZP7UqU0h5erCZ6KAwCZrhCd6kGr78nrpEKoncI5OVd-8CuV-cz5fl5KkD8z3S_SWznZJ-a6sHvjAERIDQ_eAuSWIL4yT4L4RyKakUiwZUchiBqUEr_qqel8CPbR9-_qTBJt8aBg6GX2v2DRurLJ-IiaNOzkN1piWiloJj_g_ruEdHLjmQBIt4V-vvx3RQujO3Mq9HCE9aBM6DgeLFwwMMpSXu37Yr6UuRaBCDatCpmJ9gCTRNlio0DO0zFqUSxJdA3WH-JokUQ8zT6kDqf9TBcg7gWgYuEk3q0675Q3z8qEud71Xajc2OAU_PnnXR0Q-MeIgj-vyh0NeaMpcEt89B0KSrTl-YPopSPHOz4s6BH35bbdNGyxi9FhzILbo3Y0oruZ9yGp_I-q6jvFsoTpvG8UDpezdg6A4FnTxO23n54775BIgaBtND69TBKLFrmutzAkt_0lLJPC-IlfYIYcYXhUuLdjtrDmui0PSykoBTQuJkwabscZsIoysp5gWm883IV3xxYtl8fXuYUUTtap3iK-pWzGW4XXG5pq0%3D&q=test

This makes me believe the doc is wrong and csrfInput() should not be in the search form. Happylager theme does not use it either. Since search does not alter the DB I guess its safe to not use csrfInput()

Please let me know if this type of "perhaps wrong docs" should be email instead.