### PR TITLE
Fixed problem with path not being preserved

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -395,6 +395,10 @@ class GeneralConfig extends BaseObject
      */
     public $omitScriptNameInUrls = false;
     /**
+     * @var bool Whether Craft should keep the path as is.
+     */
+    public $alwaysPreserveURI = false;
+    /**
      * @var bool Whether Craft should optimize images for reduced file sizes without noticeably reducing image quality.
      * (Only supported when ImageMagick is used.)
      * @see imageDriver

--- a/src/helpers/UrlHelper.php
+++ b/src/helpers/UrlHelper.php
@@ -427,10 +427,14 @@ class UrlHelper
 
         $host = $url;
 
-        // Trim off the URI
-        $uriPos = strpos($host, '/', $slashes + 2);
-        if ($uriPos !== false) {
-            $host = substr($host, 0, $uriPos);
+        // Trim off the URI if not specified otherwise in config
+        if(Craft::$app->getConfig()->getGeneral()->alwaysPreserveURI){
+            $host = rtrim($host, '/');
+        }else{
+            $uriPos = strpos($host, '/', $slashes + 2);
+            if ($uriPos !== false) {
+                $host = substr($host, 0, $uriPos);
+            }
         }
 
         return $host;

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -179,8 +179,12 @@ class Elements extends Component
      * Defaults to the current site.
      * @return ElementInterface|null The matching element, or `null`.
      */
-    public function getElementById(int $elementId, string $elementType = null, int $siteId = null)
+    public function getElementById($elementId, string $elementType = null, int $siteId = null)
     {
+        if(!is_int($elementId)) {
+            $elementId = intval($elementId);
+        }
+        
         if (!$elementId) {
             return null;
         }

--- a/src/web/assets/cp/CpAsset.php
+++ b/src/web/assets/cp/CpAsset.php
@@ -248,6 +248,7 @@ JS;
             'limitAutoSlugsToAscii' => (bool)$generalConfig->limitAutoSlugsToAscii,
             'maxUploadSize' => Assets::getMaxUploadSize(),
             'omitScriptNameInUrls' => (bool)$generalConfig->omitScriptNameInUrls,
+            'alwaysPreserveURI' => (bool)$generalConfig->alwaysPreserveURI,
             'orientation' => $orientation,
             'path' => $request->getPathInfo(),
             'primarySiteId' => $primarySite ? (int)$primarySite->id : null,


### PR DESCRIPTION
Had some trouble getting Craft to work with a forwarded request, so I added an option to preserve URI.

Due to a host to host forward, the access url for craft had to be on a specific path. This seems to fix the issue.