### PR TITLE
Pass relation field sortable to js settings

### DIFF
--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -694,6 +694,7 @@ JS;
             'limit' => $this->allowLimit ? $this->limit : null,
             'viewMode' => $this->viewMode(),
             'selectionLabel' => $this->selectionLabel ? Craft::t('site', $this->selectionLabel) : static::defaultSelectionLabel(),
+            'sortable' => $this->sortable,
         ];
     }
 

--- a/src/templates/_includes/forms/elementSelect.html
+++ b/src/templates/_includes/forms/elementSelect.html
@@ -9,6 +9,7 @@
 {% set sourceElementId = (sourceElementId is defined and sourceElementId ? sourceElementId : null) -%}
 {% set storageKey = (storageKey is defined and storageKey ? storageKey : null) -%}
 {% set viewMode = (viewMode is defined ? viewMode : 'list') %}
+{% set sortable = (sortable is defined ? sortable : true) %}
 
 <div id="{{ id }}" class="elementselect"
         {%- if block('attr') is defined %} {{ block('attr') }}{% endif %}>

--- a/src/templates/_includes/forms/elementSelect.html
+++ b/src/templates/_includes/forms/elementSelect.html
@@ -34,7 +34,8 @@
     viewMode: viewMode,
     limit: limit ?? null,
     showSiteMenu: showSiteMenu ?? false,
-    modalStorageKey: storageKey
+    modalStorageKey: storageKey,
+    sortable: sortable
 } %}
 
 {% js %}


### PR DESCRIPTION
This passes the `$sortable` attribute to the elementSelect js settings. This improves extensibility.

For example, it makes this plugin _really_ non-sortable (whereas `$sortable = false` didn't do anything in the front-end before): https://github.com/robuust/craft-reverserelations/blob/master/src/fields/ReverseEntries.php#L45