### PR TITLE
Update UsersController.php

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -498,12 +498,11 @@ class UsersController extends BaseController
 	 *
 	 * @param array       $variables
 	 * @param string|null $account
-	 * @param array       $variables
 	 *
 	 * @throws HttpException
 	 * @return null
 	 */
-	public function actionEditUser(array $variables = array(), $account = null, array $variables = array())
+	public function actionEditUser(array $variables = array(), $account = null)
 	{
 		if (!empty($variables['errors']))
 		{


### PR DESCRIPTION
The CP login page shows me this error

```
Fatal error: Redefinition of parameter $variables in /var/www/html/craft/app/controllers/UsersController.php on line 506
```

Removing the double definition is removing the error and make the login work as expected again