### PR TITLE
Added `json_decode` Twig filter

### DIFF
--- a/docs/dev/filters.md
+++ b/docs/dev/filters.md
@@ -243,6 +243,10 @@ Returns an array containing only the values that are also in a passed-in array.
 %}
 ```
 
+## `json_decode`
+
+Runs PHP's [json_decode()](http://php.net/manual/en/function.json-decode.php) function, but with `assoc` set to true by default.
+
 ## `json_encode`
 
 Like Twig’s core [json_encode](https://twig.symfony.com/doc/2.x/filters/json_encode.html) filter, but if the `options` argument isn’t set, it will default to `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT` if the response content type is either `text/html` or `application/xhtml+xml`.  

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -211,6 +211,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
             new \Twig_SimpleFilter('index', [ArrayHelper::class, 'index']),
             new \Twig_SimpleFilter('indexOf', [$this, 'indexOfFilter']),
             new \Twig_SimpleFilter('intersect', 'array_intersect'),
+            new \Twig_SimpleFilter('json_decode', [$this, 'jsonDecodeFilter']),
             new \Twig_SimpleFilter('json_encode', [$this, 'jsonEncodeFilter']),
             new \Twig_SimpleFilter('kebab', [$this, 'kebabFilter']),
             new \Twig_SimpleFilter('lcfirst', [$this, 'lcfirstFilter']),
@@ -360,6 +361,21 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
         return StringHelper::toSnakeCase((string)$string);
     }
 
+    /**
+     * JSON decodes a variable.
+     *
+     * @param string $value The value to JSON decode.
+     * @param bool|null $assoc Whether to convert into associative array. We're overriding the default to true, because
+     * that is far more useful in Twig.
+     * @param int $depth The maximum depth
+     * @param int|null $options Either null or a bitmask consisting of JSON_BIGINT_AS_STRING, JSON_OBJECT_AS_ARRAY,
+     * JSON_THROW_ON_ERROR
+     * @return mixed The JSON decoded value.
+     */
+    public function jsonDecodeFilter(string $value, bool $assoc = true, int $depth = 512, int $options = null)
+    {
+        return json_decode($value, $assoc, $depth, $options);
+    }
 
     /**
      * This method will JSON encode a variable. We're overriding Twig's default implementation to set some stricter


### PR DESCRIPTION
Bringing a little balance to the force. Adds a `json_decode` filter to counter the native `json_encode` filter.

No idea why it's not part of Twig's core, but now it doesn't matter! ¯\\\_(ツ)_/¯