### PR TITLE
Fix drag'n'drop asset when using elementSelect

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -20,6 +20,7 @@
 - Fixed a bug where global set, Matrix block, tag, and user queries weren’t respecting `fixedOrder` params.
 - Fixed a bug where `craft\helpers\MigrationHelper::renameColumn()` was only restoring the last foreign key for each table that had multiple foreign keys referencing the table with the renamed column.
 - Fixed a few RTL language styling issues.
+- Fixed a bug where drap-and-drop uploading would not work for asset fields.
 
 ## 3.0.36 - 2018-12-18
 

--- a/src/templates/_includes/forms/elementSelect.html
+++ b/src/templates/_includes/forms/elementSelect.html
@@ -10,6 +10,7 @@
 {% set storageKey = (storageKey is defined and storageKey ? storageKey : null) -%}
 {% set viewMode = (viewMode is defined ? viewMode : 'list') %}
 {% set sortable = (sortable is defined ? sortable : true) %}
+{% set fieldId = (fieldId is defined ? fieldId : null) %}
 
 <div id="{{ id }}" class="elementselect"
         {%- if block('attr') is defined %} {{ block('attr') }}{% endif %}>
@@ -36,6 +37,7 @@
     limit: limit ?? null,
     showSiteMenu: showSiteMenu ?? false,
     modalStorageKey: storageKey,
+    fieldId: fieldId,
     sortable: sortable
 } %}
 


### PR DESCRIPTION
This allows passing the asset field id to the elementSelect form component, which is needed to determine where to store assets uploaded via drag'n'drop.

Without this fix, dropping an image on an elementSelect component defined like this would result in an error:

```twig
{{ forms.elementSelect({
    name: 'desktopImage',
    elements: value.desktopImage.all(),
    sources: asset.sources,
    criteria: { kind: asset.allowedKinds },
    jsClass: 'Craft.AssetSelectInput',
    elementType: 'craft\\elements\\Asset',
}) }}
```

**Error:** 
> The field provided is not an Assets field