### PR TITLE
Update app.php with missing entry 'and'

### DIFF
--- a/src/translations/de/app.php
+++ b/src/translations/de/app.php
@@ -59,6 +59,7 @@ return [
     'Admin' => 'Admin',
     'Administrate users' => 'Benutzer verwalten',
     'Admins' => 'Administratoren',
+    'and' => 'und',
     'Advanced' => 'Erweitert',
     'All' => 'Alle',
     'All Fields' => 'Alle Felder',


### PR DESCRIPTION
Added the entry 'and' with the correct German translation. This fixes an issue with the |duration twig filter where the conjugation 'and' is not properly translated.

Should probably added to '3.1' too.