### PR TITLE
Fix `json_decode` Twig filter

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -214,7 +214,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
             new \Twig_SimpleFilter('indexOf', [$this, 'indexOfFilter']),
             new \Twig_SimpleFilter('intersect', 'array_intersect'),
             new \Twig_SimpleFilter('json_encode', [$this, 'jsonEncodeFilter']),
-            new \Twig_SimpleFilter('json_decode', [Json::class, 'json_decode']),
+            new \Twig_SimpleFilter('json_decode', [Json::class, 'decode']),
             new \Twig_SimpleFilter('kebab', [$this, 'kebabFilter']),
             new \Twig_SimpleFilter('lcfirst', [$this, 'lcfirstFilter']),
             new \Twig_SimpleFilter('literal', [$this, 'literalFilter']),


### PR DESCRIPTION
Looks like the docs for this were correct (that it called `Json::decode(...)`), but the actual method name was still just the raw PHP function name.

See the original PR: #3678