### PR TITLE
Suppress exceptions on Twig getEnvSuggestions

### DIFF
--- a/src/web/twig/variables/Cp.php
+++ b/src/web/twig/variables/Cp.php
@@ -333,7 +333,7 @@ class Cp extends Component
         foreach (array_keys($_ENV) as $var) {
             $envSuggestions[] = [
                 'name' => '$' . $var,
-                'hint' => $security->redactIfSensitive($var, Craft::getAlias(getenv($var)))
+                'hint' => $security->redactIfSensitive($var, Craft::getAlias(getenv($var), false))
             ];
         }
         ArrayHelper::multisort($envSuggestions, 'name');


### PR DESCRIPTION
Suppresses exceptions thrown by Twig's autosuggest field when an alias's value starts with "@"

Fixes #3769 