### PR TITLE
Update README.md

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -74,8 +74,8 @@ You can define additional custom aliases using the <config:aliases> config setti
 
 ```php
 'aliases' => [
-    '@assetBaseUrl' => 'http://my-project.com/assets',
-    '@assetBasePath' => '/path/to/web/assets',
+    'assetBaseUrl' => 'http://my-project.com/assets',
+    'assetBasePath' => '/path/to/web/assets',
 ],
 ```
 


### PR DESCRIPTION
The @ sign in front of the assetBaseUrl and assetBasePath prevents the alias from working correctly.  In my config when I removed the @ sign I was then able to properly utilize the aliases @assetBaseUrl and @assetBasePath