### PR TITLE
Move the opcache invalidation to the File Helper

### DIFF
--- a/src/Craft.php
+++ b/src/Craft.php
@@ -301,11 +301,6 @@ EOD;
         $fileContents = str_replace($search, $replace, $fileContents);
         FileHelper::writeToFile($destinationPath, $fileContents);
 
-        // Invalidate opcache
-        if (function_exists('opcache_invalidate')) {
-            @opcache_invalidate($destinationPath, true);
-        }
-
         include $destinationPath;
     }
 }

--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -370,6 +370,11 @@ class FileHelper extends \yii\helpers\FileHelper
             throw new ErrorException("Unable to write new contents to \"{$file}\".");
         }
 
+        // Invalidate opcache
+        if (function_exists('opcache_invalidate')) {
+            @opcache_invalidate($file, true);
+        }
+
         if ($lock) {
             $mutex->release($lockName);
         }


### PR DESCRIPTION
This way, all users of the method will benefit from the invalidation.

E.g. https://github.com/enupal/translate/blob/6e706885e61ba9460b18ef565ed88a05781e6f2a/src/services/Translate.php#L125