### PR TITLE
Showing no results message if no plugins found.

### DIFF
--- a/src/web/assets/pluginstore/src/js/pages/search.vue
+++ b/src/web/assets/pluginstore/src/js/pages/search.vue
@@ -9,7 +9,12 @@
             <div class="spinner"></div>
         </template>
         <template v-else>
-            <plugin-grid :plugins="pluginsToRender"></plugin-grid>
+            <template v-if="pluginsToRender.length">
+                <plugin-grid :plugins="pluginsToRender"></plugin-grid>
+            </template>
+            <template v-else>
+              <p>No plugins found.</p>
+            </template>
         </template>
     </div>
 </template>


### PR DESCRIPTION
I have added another if statement to show a 'no results found' message if there are no search results.

I have been unable to test it locally (not sure how to get my local Craft project to fetch the updated vendor .vue files! A pointer on how to learn this would be good 👍🏼).

Cheers