### PR TITLE
Updated empty array check in saveRelations.

### DIFF
--- a/src/services/RelationsService.php
+++ b/src/services/RelationsService.php
@@ -52,7 +52,7 @@ class RelationsService extends BaseApplicationComponent
 			craft()->db->createCommand()->delete('relations', $oldRelationConditions, $oldRelationParams);
 
 			// Add the new ones
-			if ($targetIds)
+			if (array_filter($targetIds))
 			{
 				$values = array();
 


### PR DESCRIPTION
 I ran into a funky if statement in saveRelations(), services/RelationsService.php:55, triggered by a Sprout Forms submit. The $targetIds array is passed with one empty string element, [0 => ''], so ($targetIds) evaluates to true, but that borks the insert because it wants something that evaluates to an integer.

Array_filter checks the truthiness of the values and returns the true ones. This might be more appropriately fixed further upstream, but this works for me.