### PR TITLE
Revert an erroneous German translation change

### DIFF
--- a/src/translations/de/app.php
+++ b/src/translations/de/app.php
@@ -340,7 +340,7 @@ return [
     'Delete {site}' => '{site} löschen',
     'Delete…' => 'Löschen',
     'Deleting stale template caches' => 'Cache abgelaufener Templates löschen',
-    'Deprecation Warnings' => 'Wertminderungswarnung',
+    'Deprecation Warnings' => 'Veralteter Code',
     'Descending' => 'Absteigend',
     'Description' => 'Beschreibung',
     'Deselect All' => 'Gesamte Auswahl aufheben',


### PR DESCRIPTION
Current translation added with 3.1 ('Deprecation Warnings' => 'Wertminderungswarnung') is translated as if in context of finance/tax deprecation. The previous translation was correct.