### PR TITLE
Fixes typo

### DIFF
--- a/src/Craft.php
+++ b/src/Craft.php
@@ -66,7 +66,7 @@ class Craft extends Yii
      * ---
      *
      * ```php
-     * $value1 = Craft::parseEnv('$SMPT_PASSWORD');
+     * $value1 = Craft::parseEnv('$SMTP_PASSWORD');
      * $value2 = Craft::parseEnv('@webroot');
      * ```
      *


### PR DESCRIPTION
Unless `SMPT_PASSWORD` is commonly valid.