### PR TITLE
Add badge option to element sources

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Craft now sends system messages authored for the same root language as the requested language, if an exact language match can’t be found. ([#3888](https://github.com/craftcms/cms/issues/3888))
+- Element source definitions can now include a `badgeCount` key.
 
 ### Fixed
 - Fixed a bug where the System Messages utility wouldn’t update message previews after editing a message for the primary site’s language, if the user had a different preferred language selected.

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -214,6 +214,7 @@ interface ElementInterface extends ComponentInterface
      * - **`key`** – The source’s key. This is the string that will be passed into the $source argument of [[actions()]],
      *   [[indexHtml()]], and [[defaultTableAttributes()]].
      * - **`label`** – The human-facing label of the source.
+     * - **`badgeCount`** – The badge count that should be displayed alongside the label. (Optional)
      * - **`sites`** – An array of site IDs that the source should be shown for, on multi-site element indexes. (Optional;
      *   by default the source will be shown for all sites.)
      * - **`criteria`** – An array of element criteria parameters that the source should use when the source is selected.

--- a/src/templates/_elements/sources.html
+++ b/src/templates/_elements/sources.html
@@ -27,8 +27,8 @@
                             </span>
                         {% endif %}
                         <span class="label">{{ source.label }}</span>
-                        {% if source.badge is defined %}
-                            <span class="badge">{{ source.badge }}</span>
+                        {% if source.badgeCount is defined %}
+                            <span class="badge">{{ source.badgeCount }}</span>
                         {% endif %}
                 </a>
                 {% if source.nested is defined and source.nested is not empty %}

--- a/src/templates/_elements/sources.html
+++ b/src/templates/_elements/sources.html
@@ -27,6 +27,9 @@
                             </span>
                         {% endif %}
                         <span class="label">{{ source.label }}</span>
+                        {% if source.badge is defined %}
+                            <span class="badge">{{ source.badge }}</span>
+                        {% endif %}
                 </a>
                 {% if source.nested is defined and source.nested is not empty %}
                     <div class="toggle"></div>


### PR DESCRIPTION
Allows an optional badge to be added to the element index source:

![image](https://user-images.githubusercontent.com/133571/53333687-8475bc80-3931-11e9-97ce-bf85a6f6af2d.png)

