### PR TITLE
Fixes: #3874 : Modify how padding is applied to #content element

### DIFF
--- a/src/web/assets/cp/dist/css/_cp.scss
+++ b/src/web/assets/cp/dist/css/_cp.scss
@@ -737,7 +737,7 @@ $sidebarLinkSecondaryColor: hsl($hue, 5%, 75%);
           @include border-right(1px solid $hairlineColorAlpha);
         }
 
-        & > * {
+        & > *:last-child {
           padding-bottom: 48px;
         }
       }

--- a/src/web/assets/cp/dist/css/_cp.scss
+++ b/src/web/assets/cp/dist/css/_cp.scss
@@ -732,9 +732,13 @@ $sidebarLinkSecondaryColor: hsl($hue, 5%, 75%);
           flex: 1;
           background: #fff;
           background-clip: padding-box;
-          padding: 24px 24px 48px;
+          padding: 24px 24px 0;
           word-wrap: break-word;
           @include border-right(1px solid $hairlineColorAlpha);
+        }
+
+        & > * {
+          padding-bottom: 48px;
         }
       }
 


### PR DESCRIPTION
Fixes issue with Firefox not supporting padding on element with parent of max-height 0 and flex.

The issue is caused by min-height: 0  on the #main-content element.  I am assuming that they design intention was to keep all of the columns (header, sidebar and content) equally aligned with an overflow scroll y being set.  

I did QA this solution on a local website on mine at height of 500px to reproduce the issue.  This solution did fix the problem on all pages. I didn’t see any negative effects on main nav pages (dashboard, entires, globals, etc) or plugins (SEOmatic, or my own).  I also tested in Chrome and Safari and didn’t see any issues with this fix.  

Note: I consider this a band-aid fix.  In my opinion, a long term solution would be a restructuring on the HTML to avoid nesting of multiple layers of flex box.  Another solution, would to be modify the CSS to use grid.  Both of those would take more time than it might currently be worth.  

In hindsight, I think the wildcard selector should be set with the last-child attribute.  I don't want to edit the PR to avoid confusion (and I haven't QA'ed it) but *:last-child could help to avoid any possibility of multiple child elements.  Applying the padding specifically to the last child element.  