### PR TITLE
Don't allow testToEmailAddress to be false

### DIFF
--- a/src/mail/Mailer.php
+++ b/src/mail/Mailer.php
@@ -150,10 +150,10 @@ class Mailer extends \yii\swiftmailer\Mailer
         }
 
         // Apply the testToEmailAddress config setting
-        $testToEmailAddress = (array)Craft::$app->getConfig()->getGeneral()->testToEmailAddress;
+        $testToEmailAddress = Craft::$app->getConfig()->getGeneral()->testToEmailAddress;
         if (!empty($testToEmailAddress)) {
             $to = [];
-            foreach ($testToEmailAddress as $emailAddress => $name) {
+            foreach ((array)$testToEmailAddress as $emailAddress => $name) {
                 if (is_numeric($emailAddress)) {
                     $to[$name] = Craft::t('app', 'Test Recipient');
                 } else {


### PR DESCRIPTION
This caused some confusion, as I had a line like this in my config:

```
'testToEmailAddress' => getenv('TEST_TO_EMAIL_ADDRESS'),
```

Since `getenv` returns `false` if not found, this results in:

```php
$to = [0 => 'Test Recipient']
``` 