### PR TITLE
Add new() Twig function to create PHP objects

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -721,6 +721,7 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
             new \Twig_SimpleFunction('expression', [$this, 'expressionFunction']),
             new \Twig_SimpleFunction('floor', 'floor'),
             new \Twig_SimpleFunction('getenv', 'getenv'),
+            new \Twig_SimpleFunction('new', [$this, 'newFunction']),
             new \Twig_SimpleFunction('parseEnv', [Craft::class, 'parseEnv']),
             new \Twig_SimpleFunction('plugin', [$this, 'pluginFunction']),
             new \Twig_SimpleFunction('redirectInput', [$this, 'redirectInputFunction']),
@@ -778,6 +779,19 @@ class Extension extends \Twig_Extension implements \Twig_Extension_GlobalsInterf
     public function expressionFunction($expression, $params = [], $config = []): Expression
     {
         return new Expression($expression, $params, $config);
+    }
+
+    /**
+     * Returns a new object of the given $class, configured with $config.
+     *
+     * @param mixed $class
+     * @param array $config
+     *
+     * @return mixed
+     */
+    public function newFunction($class, $config = [])
+    {
+        return new $class($config);
     }
 
     /**


### PR DESCRIPTION
Craft has already added the `clone()` function, and exposed all of `craft.app` in Twig templates. One missing piece of the puzzle is the ability to create new PHP objects via Twig.

Many plugins exist just to expose this functionality, and this would eliminate the need. For example, a recent discussion came up as whether to use my [Cookies](https://github.com/nystudio107/craft-cookies) plugin or use functionality already exposed by Craft.

From the Yii2 docs:

> Yii represents each cookie as an object of yii\web\Cookie. Both yii\web\Request and yii\web\Response maintain a collection of cookies via the property named cookies. The cookie collection in the former represents the cookies submitted in a request, while the cookie collection in the latter represents the cookies that are to be sent to the user.

We can get most of the way there via:

```twig
{%  set requestCookies = craft.app.request.cookies %}
{%  set responseCookies = craft.app.response.cookies %}
```

...which will give us a [CookieCollection](https://www.yiiframework.com/doc/api/2.0/yii-web-cookiecollection) that we can use to access or remove cookies... but we can't add new cookies, because `::add()` needs a `yii\web\Cookie` object passed to it.

This is just one example where a plugin could be eliminated, and the core functionality of Craft used to accomplish some common things.