### PR TITLE
Adjust documentation to match token routing implementation

### DIFF
--- a/src/services/Tokens.php
+++ b/src/services/Tokens.php
@@ -41,9 +41,10 @@ class Tokens extends Component
     /**
      * Creates a new token and returns it.
      *
-     * @param mixed $route Where matching requests should be routed to. If you
-     * want them to be routed to a controller action, pass:
-     * `['action' => "controller/action", 'params' => ['foo' => 'bar']]`.
+     * @param mixed $route The controller and action a matching request should
+     * be routed to. Pass the controller path as the first element in an array,
+     * and any action param names and values as the second element:
+     * `['controller/action', ['fooParam' => 'barValue']]`.
      * @param int|null $usageLimit The maximum number of times this token can be
      * used. Defaults to no limit.
      * @param DateTime|null $expiryDate The date that the token expires.


### PR DESCRIPTION
Opening to address the discrepancy noted in #3967!

I wasn't sure what language should be used to describe the "matching request…" 🤔 