### PR TITLE
Add a hardDeprecationErrors setting (default false) that throws an exception if a deprecation error is logged

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -353,6 +353,10 @@ class GeneralConfig extends BaseObject
      */
     public $generateTransformsBeforePageLoad = false;
     /**
+     * @var bool Whether logged deprecation errors should throw an exception.
+     */
+    public $hardDeprecationErrors = false;
+    /**
      * @var mixed The image driver Craft should use to cleanse and transform images. By default Craft will auto-detect if ImageMagick is installed and fallback to GD if not. You can explicitly set
      * either `'imagick'` or `'gd'` here to override that behavior.
      */

--- a/src/errors/DeprecationException.php
+++ b/src/errors/DeprecationException.php
@@ -10,7 +10,7 @@ namespace craft\errors;
 use yii\base\UserException;
 
 /**
- * Class FileException
+ * Class DeprecationException
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0

--- a/src/errors/DeprecationException.php
+++ b/src/errors/DeprecationException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\errors;
+
+use yii\base\UserException;
+
+/**
+ * Class FileException
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.0
+ */
+class DeprecationException extends UserException
+{
+    /**
+     * @return string the user-friendly name of this exception
+     */
+    public function getName()
+    {
+        return 'Deprecation Error Exception';
+    }
+}

--- a/src/services/Deprecator.php
+++ b/src/services/Deprecator.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\db\Query;
 use craft\db\Table;
 use craft\elements\db\ElementQuery;
+use craft\errors\DeprecationException;
 use craft\helpers\Db;
 use craft\helpers\Json;
 use craft\helpers\StringHelper;
@@ -126,6 +127,10 @@ class Deprecator extends Component
             $log->id = $db->getLastInsertID();
         } catch (IntegrityException $e) {
             // todo: remove this try/catch after the next breakpoint
+        }
+        // Throw an exception if $hardDeprecationErrors is true
+        if (Craft::$app->getConfig()->getGeneral()->hardDeprecationErrors) {
+            throw new DeprecationException($message);
         }
     }
 


### PR DESCRIPTION
Puts Craft in "hard mode" where any deprecation error that gets logged will throw an exception if the general config setting `hardDeprecationErrors` is `true` (defaults to `false`).

It can be convenient to throw exceptions whenever a deprecation is encountered, so that you're forced to go in and fix them.