### PR TITLE
Really display up to ten search results

### DIFF
--- a/docs/.vuepress/config-en.js
+++ b/docs/.vuepress/config-en.js
@@ -7,7 +7,8 @@ module.exports = {
         apiKey: '1014b55e7f916b20c5d6834bf7666dc3',
         indexName: 'craftcms',
         algoliaOptions: {
-            facetFilters: ['version:v3', 'tags:doc', 'tags:en']
+            facetFilters: ['version:v3', 'tags:doc', 'tags:en'],
+            hitsPerPage: 10
         }
     },
     sidebar: {

--- a/docs/.vuepress/config-ja.js
+++ b/docs/.vuepress/config-ja.js
@@ -6,7 +6,8 @@ module.exports = {
         apiKey: '1014b55e7f916b20c5d6834bf7666dc3',
         indexName: 'craftcms',
         algoliaOptions: {
-            facetFilters: ['version:v3', 'tags:doc', 'tags:ja']
+            facetFilters: ['version:v3', 'tags:doc', 'tags:ja'],
+            hitsPerPage: 10
         }
     },
     sidebar: {


### PR DESCRIPTION
This is just like [my last PR](https://github.com/craftcms/cms/pull/3966), except that it'll work. Algolia results don't honor `searchMaxSuggestions` (previous PR), but that's safe to leave in place since it impacts the native VuePress search. 

I made sure this is legit before submitting. See the [Snipcart docs](https://snipcart.docs.workingconcept.com) for a demo of the exact behavior this would enable.