### PR TITLE
Fix _normalizeEmails($emails)

### DIFF
--- a/src/mail/Message.php
+++ b/src/mail/Message.php
@@ -126,7 +126,14 @@ class Message extends \yii\swiftmailer\Message
         if (is_array($emails)) {
             foreach ($emails as $key => $email) {
                 if (is_numeric($key)) {
-                    $emails[$key] = $this->_normalizeEmail($email);
+                    if (is_array($normalizedEmail = $this->_normalizeEmail($email))) {
+                        foreach ($normalizedEmail as $emailAddress => $emailName) {
+                            unset($emails[$key]);
+                            $emails[$emailAddress] = $emailName;
+                        }
+                    } else {
+                        $emails[$key] = $normalizedEmail;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Fix an issue preventing passing User[] as $emails. This is related to issue #4048

Because _$normalizeEmail() can return both array or string, therefore the logic in _normalizedEmails() should cater for that.