### PR TITLE
Upsert bugfix

### DIFF
--- a/src/db/Command.php
+++ b/src/db/Command.php
@@ -117,7 +117,9 @@ class Command extends \yii\db\Command
 
         // todo: hack for BC with our old upsert() method. Remove in Craft 4
         // Merge any updateColumn data into insertColumns
-        $insertColumns = array_merge($updateColumns, $insertColumns);
+        if (is_array($updateColumns)) {
+            $insertColumns = array_merge($updateColumns, $insertColumns);
+        }
 
         parent::upsert($table, $insertColumns, $updateColumns, $params);
         return $this;


### PR DESCRIPTION
If `$updateColumns` is passed in as a boolean then an exception is thrown:

```
array_merge(): Argument #1 is not an array
```

Adding a conditional to check that is an array solves this.