### PR TITLE
propagateEntries deprecation fix.

### DIFF
--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -598,7 +598,7 @@ class Sections extends Component
             $sectionRecord->handle = $data['handle'];
             $sectionRecord->type = $data['type'];
             $sectionRecord->enableVersioning = (bool)$data['enableVersioning'];
-            $sectionRecord->propagateEntries = (bool)$data['propagateEntries'];
+            $sectionRecord->propagationMethod = (bool)$data['propagationMethod'];
 
             $isNewSection = $sectionRecord->getIsNewRecord();
 


### PR DESCRIPTION
Replaced the deprecated `craft\models\Section::$propagateEntries` with `$propagationMethod` #3554 