### PR TITLE
Commerce Issue 814

### DIFF
--- a/src/web/assets/cp/dist/css/_main.scss
+++ b/src/web/assets/cp/dist/css/_main.scss
@@ -628,7 +628,30 @@ td.right {
 }
 
 .info-hud {
-  max-width: 250px;
+
+  table {
+    max-width: 280px;
+    table-layout: auto;
+  }
+
+  td {
+    word-wrap: break-word;
+    width: 100%;
+  }
+
+}
+
+@media (max-width: 450px) {
+
+  .info-hud {
+
+    table {
+      table-layout: fixed;
+      width: 100%;
+    }
+
+  }
+
 }
 
 /* ----------------------------------------


### PR DESCRIPTION
Partial fix for [Commerce Issue 814](https://github.com/craftcms/commerce/issues/814).

Modify the info-hud popup for:

  - Expanded max width
  - Fixed table size on smaller viewpoints
  - Word wrapping for the long string.

See attached screenshot for before behavior and expected post styling 

![info-hud-modal-before](https://user-images.githubusercontent.com/856595/55689088-942fea00-594e-11e9-99de-4c81fedb7177.png)
![info-hud-without-max-sizing](https://user-images.githubusercontent.com/856595/55689089-942fea00-594e-11e9-8d0f-2b4650078bc3.png)
![info-hud-without-max-sizing-mobile](https://user-images.githubusercontent.com/856595/55689090-942fea00-594e-11e9-8192-2a76d83316e4.png)
