### PR TITLE
Fix setPasswordSuccessPath config name in docs

### DIFF
--- a/docs/templating/set-password-form.md
+++ b/docs/templating/set-password-form.md
@@ -27,4 +27,4 @@ Within that template, place the following code:
 </form>
 ```
 
-The <config:setPasswordSuccess> config setting designates where the user should be redirected to after they finish resetting their password (and get automatically logged-in).
+The <config:setPasswordSuccessPath> config setting designates where the user should be redirected to after they finish resetting their password (and get automatically logged-in).


### PR DESCRIPTION
Set password form docs: <https://docs.craftcms.com/v2/templating/set-password-form.html>
Config docs: <https://docs.craftcms.com/v2/config-settings.html#setpasswordsuccesspath>