### PR TITLE
Abstract logging logic to trait for non-FileTarget logging

### DIFF
--- a/src/base/LogTrait.php
+++ b/src/base/LogTrait.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\base;
+
+use Craft;
+use craft\helpers\ArrayHelper;
+use yii\helpers\VarDumper;
+use yii\web\Request;
+
+/**
+ * LogTrait implements the common methods and properties for log target classes.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.2
+ */
+trait LogTrait
+{
+    /**
+     * @var bool Whether the user IP should be included in the default log prefix.
+     * @since 3.0.25
+     * @see prefix
+     */
+    public $includeUserIp = false;
+
+
+    public function init()
+    {
+        parent::init();
+
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+        $this->includeUserIp = $generalConfig->storeUserIps;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMessagePrefix($message)
+    {
+        if ($this->prefix !== null) {
+            return call_user_func($this->prefix, $message);
+        }
+
+        if (Craft::$app === null) {
+            return '';
+        }
+
+        if ($this->includeUserIp) {
+            $request = Craft::$app->getRequest();
+            $ip = $request instanceof Request ? $request->getUserIP() : '-';
+        } else {
+            $ip = '-';
+        }
+
+        /* @var $user \yii\web\User */
+        $user = Craft::$app->has('user', true) ? Craft::$app->get('user') : null;
+        if ($user && ($identity = $user->getIdentity(false))) {
+            $userID = $identity->getId();
+        } else {
+            $userID = '-';
+        }
+
+        /* @var $session \yii\web\Session */
+        $session = Craft::$app->has('session', true) ? Craft::$app->get('session') : null;
+        $sessionID = $session && $session->getIsActive() ? $session->getId() : '-';
+
+        return "[$ip][$userID][$sessionID]";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getContextMessage()
+    {
+        $context = ArrayHelper::filter($GLOBALS, $this->logVars);
+        $result = [];
+        $security = Craft::$app->getSecurity();
+
+        foreach ($context as $key => $value) {
+            $value = $security->redactIfSensitive($key, $value);
+            $result[] = "\${$key} = " . VarDumper::dumpAsString($value);
+        }
+
+        return implode("\n\n", $result);
+    }
+}

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -489,24 +489,13 @@ class App
             return null;
         }
 
-        $generalConfig = Craft::$app->getConfig()->getGeneral();
-
         $target = [
             'class' => FileTarget::class,
-            'fileMode' => $generalConfig->defaultFileMode,
-            'dirMode' => $generalConfig->defaultDirMode,
-            'includeUserIp' => $generalConfig->storeUserIps,
         ];
 
-        if ($isConsoleRequest) {
-            $target['logFile'] = '@storage/logs/console.log';
-        } else {
-            $target['logFile'] = '@storage/logs/web.log';
-
-            // Only log errors and warnings, unless Craft is running in Dev Mode or it's being installed/updated
-            if (!YII_DEBUG && Craft::$app->getIsInstalled() && !Craft::$app->getUpdates()->getIsCraftDbMigrationNeeded()) {
-                $target['levels'] = Logger::LEVEL_ERROR | Logger::LEVEL_WARNING;
-            }
+        // Only log errors and warnings, unless Craft is running in Dev Mode or it's being installed/updated
+        if (!$isConsoleRequest && !YII_DEBUG && Craft::$app->getIsInstalled() && !Craft::$app->getUpdates()->getIsCraftDbMigrationNeeded()) {
+            $target['levels'] = Logger::LEVEL_ERROR | Logger::LEVEL_WARNING;
         }
 
         return [

--- a/src/log/FileTarget.php
+++ b/src/log/FileTarget.php
@@ -8,9 +8,7 @@
 namespace craft\log;
 
 use Craft;
-use craft\helpers\ArrayHelper;
-use yii\helpers\VarDumper;
-use yii\web\Request;
+use craft\base\LogTrait;
 
 /**
  * Class FileTarget
@@ -20,62 +18,24 @@ use yii\web\Request;
  */
 class FileTarget extends \yii\log\FileTarget
 {
-    /**
-     * @var bool Whether the user IP should be included in the default log prefix.
-     * @since 3.0.25
-     * @see prefix
-     */
-    public $includeUserIp = false;
+    use LogTrait;
 
     /**
      * @inheritdoc
      */
-    public function getMessagePrefix($message)
+    public function init()
     {
-        if ($this->prefix !== null) {
-            return call_user_func($this->prefix, $message);
-        }
+        parent::init();
 
-        if (Craft::$app === null) {
-            return '';
-        }
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+        $isConsoleRequest = Craft::$app->getRequest()->getIsConsoleRequest();
+        $this->fileMode = $generalConfig->defaultFileMode;
+        $this->dirMode = $generalConfig->defaultDirMode;
 
-        if ($this->includeUserIp) {
-            $request = Craft::$app->getRequest();
-            $ip = $request instanceof Request ? $request->getUserIP() : '-';
+        if ($isConsoleRequest) {
+            $this->logFile = '@storage/logs/console.log';
         } else {
-            $ip = '-';
+            $this->logFile = '@storage/logs/web.log';
         }
-
-        /* @var $user \yii\web\User */
-        $user = Craft::$app->has('user', true) ? Craft::$app->get('user') : null;
-        if ($user && ($identity = $user->getIdentity(false))) {
-            $userID = $identity->getId();
-        } else {
-            $userID = '-';
-        }
-
-        /* @var $session \yii\web\Session */
-        $session = Craft::$app->has('session', true) ? Craft::$app->get('session') : null;
-        $sessionID = $session && $session->getIsActive() ? $session->getId() : '-';
-
-        return "[$ip][$userID][$sessionID]";
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function getContextMessage()
-    {
-        $context = ArrayHelper::filter($GLOBALS, $this->logVars);
-        $result = [];
-        $security = Craft::$app->getSecurity();
-
-        foreach ($context as $key => $value) {
-            $value = $security->redactIfSensitive($key, $value);
-            $result[] = "\${$key} = " . VarDumper::dumpAsString($value);
-        }
-
-        return implode("\n\n", $result);
     }
 }


### PR DESCRIPTION
This abstracts the non-FileTarget specific logic to a trait, and uses the init methods of `FileTarget` and `LogTrait` to set things dynamically (e.g. from Craft config).

This lets someone make a new logger with all the Craft-added stuff (message formatting, ip logging, etc) as simple as:

```
class MyTarget extends \yii\log\SyslogTarget
{
    use \craft\base\LogTrait;
}
```