### PR TITLE
CP: Disable (gif) animation *before* resizing

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fixed an error that occurred when installing a missing plugin from the Settings → Plugins page.
 - Fixed PHP type errors that could occur when calling some deprecated `craft.request` methods in templates. ([#4124](https://github.com/craftcms/cms/issues/4124))
+- Fixed an error where uploading gifs to control panel could cause performance issues.
 
 ## 3.1.22 - 2019-04-10
 

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -717,13 +717,14 @@ class Assets extends Component
 
             // hail Mary
             try {
-                $image = Craft::$app->getImages()->loadImage($imageSource, false, $svgSize)
-                    ->scaleToFit($width, $height);
+                $image = Craft::$app->getImages()->loadImage($imageSource, false, $svgSize);
 
+                // Prevent resize of all layers
                 if ($image instanceof Raster) {
                     $image->disableAnimation();
                 }
 
+                $image->scaleToFit($width, $height);
                 $image->saveAs($path);
             } catch (ImageException $exception) {
                 Craft::warning($exception->getMessage());


### PR DESCRIPTION
Hey P&T,

Correct me if I'm wrong; I assume it's your intention to  prevent resizing all layers of an animated gif for CP thumbnails. Unfortunatly animations are disabled after the actual resize happens.


