### PR TITLE
Allow widget icon to be an SVG string (not just a path)

### DIFF
--- a/src/controllers/DashboardController.php
+++ b/src/controllers/DashboardController.php
@@ -557,6 +557,9 @@ class DashboardController extends Controller
         if ($iconPath === null) {
             return $this->_getDefaultWidgetIconSvg($widget);
         }
+        
+        if (strpos($iconPath, '<svg') === 0)
+        	return $iconPath;
 
         if (!is_file($iconPath)) {
             Craft::warning("Widget icon file doesn't exist: {$iconPath}", __METHOD__);


### PR DESCRIPTION
Just so I can have a _dynamic_ icon for one of my widgets. Very important. Totally not staggeringly unnecessary.