### PR TITLE
Schema.php chmod the DumpConfigFile to 0644

### DIFF
--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -323,7 +323,10 @@ SQL;
         }
 
         FileHelper::writeToFile($filePath, $contents);
-
+        // Chmod the file. On some distribution, the php user write files too 'open', which generate a :
+        // [Warning] World-writable config file 'my.cnf' is ignored
+        // Therefore preventing the dump as it uses incorrect settings
+        chmod($filePath, 0644); 
         return $filePath;
     }
 }


### PR DESCRIPTION
Chmod the file. On some distribution, the php user write files too 'open', which generate a :
`[Warning] World-writable config file 'my.cnf' is ignored`
Therefore preventing the dump as it uses incorrect settings