### PR TITLE
CRAFT_STORAGE_PATH target needs to exist

### DIFF
--- a/docs/config/php-constants.md
+++ b/docs/config/php-constants.md
@@ -66,7 +66,9 @@ define('CRAFT_SITE', 'de');
 
 The path to the [storage/](../directory-structure.md#storage) folder. (It is assumed to live within the base directory by default.)
 
-When changing the storage path, Craft checks to see if the target directory exists. If it does not, CRAFT_STORAGE_PATH will be ignored.
+::: tip
+Make sure you set this to a valid folder path, otherwise it will be ignored.
+:::
 
 ### `CRAFT_TEMPLATES_PATH`
 

--- a/docs/config/php-constants.md
+++ b/docs/config/php-constants.md
@@ -66,6 +66,8 @@ define('CRAFT_SITE', 'de');
 
 The path to the [storage/](../directory-structure.md#storage) folder. (It is assumed to live within the base directory by default.)
 
+When changing the storage path, Craft checks to see if the target directory exists. If it does not, CRAFT_STORAGE_PATH will be ignored.
+
 ### `CRAFT_TEMPLATES_PATH`
 
 The path to the [templates/](../directory-structure.md#templates) folder. (It is assumed to live within the base directory by default.)


### PR DESCRIPTION
Make it clearer that Craft performs a realpath() check on CRAFT_STORAGE_PATH and returns false if the directory does not exist. 

Currently, if the target of CRAFT_STORAGE_PATH doesn't exist, Craft just looks like it is ignoring CRAFT_STORAGE_PATH.