### PR TITLE
fix small typo on plugin-editions.md

### DIFF
--- a/docs/extend/plugin-editions.md
+++ b/docs/extend/plugin-editions.md
@@ -2,7 +2,7 @@
 
 The Plugin Store will soon add **limited** support for multi-edition plugins, which will work similarly to Craft’s two editions (Solo and Pro).
 
-- Plugins that support mulitple editions are still comprised of a single Composer package.
+- Plugins that support multiple editions are still comprised of a single Composer package.
 - Plugins’ active edition is recorded in the [project config](../project-config.md).
 - Plugins can implement feature toggles by checking their active edition.
 
@@ -81,4 +81,4 @@ You can toggle the active edition by changing the `plugins.<plugin-handle>.editi
 If you don’t have a `config/project.yaml` file, you need to enable the <config:useProjectConfigFile> config setting.
 :::
 
-After changing the value to a valid edition handle (one returned by your plugin’s `editions()` method), Craft will prompt you to sync your `project.yaml` changes into the loaded project config. Once that’s done, your plugin’s active edition will be set to the new edition, and feature toggles should start behaving accordingly. 
+After changing the value to a valid edition handle (one returned by your plugin’s `editions()` method), Craft will prompt you to sync your `project.yaml` changes into the loaded project config. Once that’s done, your plugin’s active edition will be set to the new edition, and feature toggles should start behaving accordingly.


### PR DESCRIPTION
## What's in this PR?

Fix small typo on `plugin-editions.md`