### PR TITLE
Update Paginator.php

### DIFF
--- a/src/db/Paginator.php
+++ b/src/db/Paginator.php
@@ -10,7 +10,7 @@ namespace craft\db;
 use craft\helpers\ArrayHelper;
 use yii\base\BaseObject;
 use yii\db\Connection as YiiConnection;
-use yii\db\Query;
+// use yii\db\Query;
 use yii\db\QueryInterface;
 use yii\di\Instance;
 


### PR DESCRIPTION
This Query class doesn't seem to be used in this file, and is causing this weird intermittent error: "PHP Compile Error – yii\base\ErrorException, Cannot use yii\db\Query as Query because the name is already in use." Error happens when using {% paginate %} in Twig template.

Since this class is not really in use in this file, can you consider removing it?