### PR TITLE
Fix bug in migration 3.2.0-alpha.5

### DIFF
--- a/src/migrations/m190417_085010_add_image_editor_permissions.php
+++ b/src/migrations/m190417_085010_add_image_editor_permissions.php
@@ -54,11 +54,15 @@ class m190417_085010_add_image_editor_permissions extends Migration
                 $newPermissions = [];
                 foreach ($groupUids as $groupUid) {
                     $permissions = $projectConfig->get('users.groups.' . $groupUid . '.permissions');
-                    foreach ($volumeUids as $volumeUid) {
-                        if (in_array('saveassetinvolume:' . $volumeUid, $permissions, true) &&
-                            in_array('deletefilesandfoldersinvolume:' . $volumeUid, $permissions, true)) {
-                            $permissionName = 'editimagesinvolume:' . $volumeUid;
-                            $newPermissions[$groupUid][] = $permissionName;
+                    
+                    // If user group permissions are defined
+                    if ($permissions !== null) {
+                        foreach ($volumeUids as $volumeUid) {
+                            if (in_array('saveassetinvolume:' . $volumeUid, $permissions, true) &&
+                                in_array('deletefilesandfoldersinvolume:' . $volumeUid, $permissions, true)) {
+                                $permissionName = 'editimagesinvolume:' . $volumeUid;
+                                $newPermissions[$groupUid][] = $permissionName;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This pull request fixes the following exception that is thrown if user groups exist in project config without any permissions set in 3.2.0-alpha.5.

```
yii\base\ErrorException: in_array() expects parameter 2 to be array, null given

Migration: craft\migrations\m190417_085010_add_image_editor_permissions

Output:

Exception: in_array() expects parameter 2 to be array, null given (/vendor/craftcms/cms/src/migrations/m190417_085010_add_image_editor_permissions.php:58)
#0 /vendor/craftcms/cms/src/migrations/m190417_085010_add_image_editor_permissions.php(58): ::in_array('???', '???', '???')
```