### PR TITLE
Optimise Job Progress

### DIFF
--- a/src/queue/BaseJob.php
+++ b/src/queue/BaseJob.php
@@ -73,8 +73,14 @@ abstract class BaseJob extends BaseObject implements JobInterface
      */
     protected function setProgress($queue, float $progress)
     {
-        if ($progress !== $this->_progress && $queue instanceof QueueInterface) {
-            $queue->setProgress(round(100 * $progress));
+        $progress = round(100 * $progress);
+
+        if ($progress !== $this->_progress) {
+            $this->_progress = $progress;
+
+            if ($queue instanceof QueueInterface) {
+                $queue->setProgress($progress);
+            }
         }
     }
 }


### PR DESCRIPTION
The current progress is never updated, resulting in the database being updated regardless of whether the value of `$this->_progress` has changed or not.

Additionally, `$this->_progress` should be stored as a rounded integer to avoid updating the database more times than necessary. For example, if there are 1,000 steps then the database will be update 1,000 times instead of the expected 100.