### PR TITLE
Allow plugins to implement custom eager loading

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1382,6 +1382,9 @@ class Elements extends Component
                     /** @var Element $sourceElementType */
                     $sourceElementType = $elementTypesByPath[$sourcePath];
                     $map = $sourceElementType::eagerLoadingMap($elementsByPath[$sourcePath], $segment);
+                    if (is_null($map)) {
+                        break;
+                    }
 
                     if ($map && !empty($map['map'])) {
                         // Remember the element type in case there are more segments after this


### PR DESCRIPTION
Eager loading is a great feature of Craft, basically the user marks relations / fields he is going to access on queries and the CMS can preload those fields in oder to speed up things. However, the current implementation is very strict on how this works, basically a field can only eager load one element type, the field will be completely replaced by the eager loaded elements and the field must supply the element ids in a certain fashion; all this magic happens in one [big method](https://github.com/craftcms/cms/blob/develop/src/services/Elements.php#L1330).

**Suggestion**
I guess it would be quite difficult to extend the current technique so it fits multiple purposes, so I would like to suggest to _open up a way for fields to take care of eager loading stuff on their behalf_ and bypass the default behavior.

**Simple approach**
Currently fields can implement the interface `EagerLoadingFieldInterface` whose method `getEagerLoadingMap` can either return an array if elements should be eager loaded or `false` if for some reason the field is sure all values will be empty. No matter what it returns, the core will set the eager loaded property [here](https://github.com/craftcms/cms/blob/develop/src/services/Elements.php#L1435) on all elements and we have no way to prevent this. As a simple solution, allow `getEagerLoadingMap` to return something (like `null` or `true`) to signal that it will take care of eager loading by itself.

**Usage example**
I'm the author a a link field plugin and I've noticed the field can produce an immense amount of additional database hits if a lot of element links must be fetched (e.g. when building a navigation that contains redirect pages). Unfortunately I cannot use the default eager loading path as a) the field can contain different element links (e.g. links to assets and elements) and b) would replace the link model with the eager loaded elements. I've highjacked the `with` property (by looking for my fields handle in `Field::modifyElementsQuery` and [filtering it out](https://github.com/sebastian-lenz/craft-linkfield/blob/v2.0/src/fields/LinkFieldLoader.php#L235)) and was able to greatly improve the performance, but the current implementation feels more than wacky.
