### PR TITLE
Add htmlTagAttributes filter to Twig

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -16,6 +16,7 @@ use craft\helpers\ArrayHelper;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\FileHelper;
+use craft\helpers\Html;
 use craft\helpers\Json;
 use craft\helpers\Sequence;
 use craft\helpers\StringHelper;
@@ -214,6 +215,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('filterByValue', [ArrayHelper::class, 'filterByValue']),
             new TwigFilter('group', [$this, 'groupFilter']),
             new TwigFilter('hash', [$security, 'hashData']),
+            new TwigFilter('htmlTagAttributes', [$this, 'htmlTagAttributesFilter']),
             new TwigFilter('id', [$this->view, 'formatInputId']),
             new TwigFilter('index', [ArrayHelper::class, 'index']),
             new TwigFilter('indexOf', [$this, 'indexOfFilter']),
@@ -705,6 +707,17 @@ class Extension extends AbstractExtension implements GlobalsInterface
         $array = array_merge($array);
         ArrayHelper::multisort($array, $key, $direction, $sortFlag);
         return $array;
+    }
+
+    /**
+     * Renders HTML tag attributes with [[\craft\helpers\Html::renderTagAttributes()]]
+     *
+     * @param array $attributes
+     * @return Markup
+     */
+    public function htmlTagAttributesFilter(array $attributes): Markup
+    {
+        return TemplateHelper::raw(Html::renderTagAttributes($attributes));
     }
 
     /**

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -215,7 +215,6 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('filterByValue', [ArrayHelper::class, 'filterByValue']),
             new TwigFilter('group', [$this, 'groupFilter']),
             new TwigFilter('hash', [$security, 'hashData']),
-            new TwigFilter('htmlTagAttributes', [$this, 'htmlTagAttributesFilter']),
             new TwigFilter('id', [$this->view, 'formatInputId']),
             new TwigFilter('index', [ArrayHelper::class, 'index']),
             new TwigFilter('indexOf', [$this, 'indexOfFilter']),
@@ -710,17 +709,6 @@ class Extension extends AbstractExtension implements GlobalsInterface
     }
 
     /**
-     * Renders HTML tag attributes with [[\craft\helpers\Html::renderTagAttributes()]]
-     *
-     * @param array $attributes
-     * @return Markup
-     */
-    public function htmlTagAttributesFilter(array $attributes): Markup
-    {
-        return TemplateHelper::raw(Html::renderTagAttributes($attributes));
-    }
-
-    /**
      * @inheritdoc
      */
     public function getFunctions(): array
@@ -729,6 +717,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFunction('alias', [Craft::class, 'getAlias']),
             new TwigFunction('actionInput', [$this, 'actionInputFunction']),
             new TwigFunction('actionUrl', [UrlHelper::class, 'actionUrl']),
+            new TwigFunction('attr', [$this, 'attrFunction']),
             new TwigFunction('cpUrl', [UrlHelper::class, 'cpUrl']),
             new TwigFunction('ceil', 'ceil'),
             new TwigFunction('className', 'get_class'),
@@ -757,6 +746,17 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFunction('getHeadHtml', [$this, 'getHeadHtml']),
             new TwigFunction('getFootHtml', [$this, 'getFootHtml']),
         ];
+    }
+
+    /**
+     * Renders HTML tag attributes with [[\craft\helpers\Html::renderTagAttributes()]]
+     *
+     * @param array $attributes
+     * @return Markup
+     */
+    public function attrFunction(array $config): Markup
+    {
+        return TemplateHelper::raw(Html::renderTagAttributes($config));
     }
 
     /**


### PR DESCRIPTION
…because `yii\helpers\BaseHtml::renderTagAttributes` is awesome!

Back in the day I wrote a Craft 2 plugin for this: https://github.com/timkelty/htmlattributes-craft

Now that it can be added to Craft with a couple lines of code, seems like a big win.

Example usage:

```twig
{% set attributes = {
      class: ['one', 'two'],
      disabled: true,
      readonly: false,
      data: {
        baz: 'Escape this "',
        qux: {
          some: ['data', '"quoted"']
        }
      },
      style: {
        'background-color': 'red',
        'font-size': '20px'
      },
} %}

<div {{ attributes|htmlTagAttributes }}></div>
```