### PR TITLE
Make local volumes respect defaultFileMode and defaultDirMode

### DIFF
--- a/src/volumes/Local.php
+++ b/src/volumes/Local.php
@@ -119,6 +119,15 @@ class Local extends FlysystemVolume implements LocalVolumeInterface
      */
     protected function createAdapter(): LocalAdapter
     {
-        return new LocalAdapter($this->getRootPath());
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+
+        return new LocalAdapter($this->getRootPath(), LOCK_EX, LocalAdapter::DISALLOW_LINKS, [
+            'file' => [
+                'public' => $generalConfig->defaultFileMode ?: 0644
+            ],
+            'dir' => [
+                'public' => $generalConfig->defaultDirMode ?: 0755
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
This patch makes Local volumes respect the `defaultFileMode` and `defaultDirMode` config settings by passing them into the Flysystem adapter. The documentation reads as if this was the intended behavior.

When a mode isn't set, it defaults back to what Flysystem uses internally: 0755 and 0644.

I couldn't find any existing reports regarding this issue.

Thanks!