### PR TITLE
Allow conditionally empty uri patterns

### DIFF
--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -54,9 +54,11 @@ class ElementHelper
     {
         /** @var Element $element */
         $uriFormat = $element->getUriFormat();
+        $testUri = self::_renderUriFormat($uriFormat, $element);
 
         // No URL format, no URI.
-        if ($uriFormat === null) {
+        // If no URI after rendering, this element has been conditionally excluded.
+        if ($uriFormat === null || !$testUri) {
             $element->uri = null;
 
             return;
@@ -64,7 +66,6 @@ class ElementHelper
 
         // Does the URL format even have a {slug} tag?
         if (!static::doesUriFormatHaveSlugTag($uriFormat)) {
-            $testUri = self::_renderUriFormat($uriFormat, $element);
 
             // Make sure it's unique
             if (!self::_isUniqueUri($testUri, $element)) {


### PR DESCRIPTION
Fixes #4254

This allows the URI format to render to empty, so that entries in the same section may optionally omit URLs.

![Screen Shot 2019-05-13 at 10 40 00 AM](https://user-images.githubusercontent.com/18329/57630374-7ff19500-756b-11e9-9b19-0db530e9235e.png)

<img width="308" alt="Screen Shot 2019-05-13 at 10 38 34 AM" src="https://user-images.githubusercontent.com/18329/57630261-4587f800-756b-11e9-8aad-b06fb6902254.png">
