### PR TITLE
Add doesTableExist MigrationHelper function

### DIFF
--- a/src/helpers/MigrationHelper.php
+++ b/src/helpers/MigrationHelper.php
@@ -59,6 +59,24 @@ class MigrationHelper
     }
 
     /**
+     * Returns whether a table exists.
+     *
+     * @param string $tableName
+     * @return bool
+     */
+    public static function doesTableExist(string $tableName, Migration $migration = null)
+    {
+        $db = $migration ? $migration->db : Craft::$app->getDb();
+        $schema = $db->getSchema();
+        $schema->refresh();
+
+        $rawTableName = $schema->getRawTableName($tableName);
+        $table = $schema->getTableSchema($rawTableName);
+
+        return $table !== null;
+    }
+
+    /**
      * Returns whether a foreign key exists.
      *
      * @param string $tableName


### PR DESCRIPTION
When uninstalling a plugin, sometimes we might try dropping foreign keys on a
table that doesn't exist yet. This function lets us check whether or not
that table exists yet before dropping foreign keys.

For example, in `Install::safeDown()` we could have this which would throw if the table hadn't been created yet:

```php
MigrationHelper::dropAllForeignKeysToTable('{{%table_does_not_exist}}', $this);
$this->dropTableIfExists('{{%table_does_not_exist}}');
```

With this, we can check if the table exists first:

```php
if (MigrationHelper::doesTableExist('{{%table_does_not_exist}}', $this) {
    MigrationHelper::dropAllForeignKeysToTable('{{%table_does_not_exist}}', $this);
    $this->dropTable('{{%table_does_not_exist}}');
}
```