### PR TITLE
add additional documentation for status

### DIFF
--- a/docs/extend/element-types.md
+++ b/docs/extend/element-types.md
@@ -394,6 +394,68 @@ public static function statuses(): array
 }
 ```
 
+This updates the dropdown on the `elementsindex` template, showing the custom statuses (`Foo` and `Bar`) you added.
+However, these don't do anything out of the box; you'll have to specify when a status applies to a particular instance of your element with the `getStatus` method.
+
+```php
+public function getStatus()
+{
+    if ($this->fooIsTrue) // some boolean condition on your element
+    {
+        return 'foo';
+    }
+    return 'bar';
+}
+```
+
+This method should return a string that matches one of the keys specified in your static `statuses` method.
+These statuses will be applied as a class on the HTML element, indicating the current state of an element.
+You can specify the color you want to for a particular status, making it easier for users to visually see the state of their elements.
+
+```css
+.status.foo {
+      background-color: #27AE60; /* green -- same as enabled */
+  }
+  .status.bar {
+      background-color: #F2842D; /* orange */
+  }
+```
+
+Now the indicator at the beginning of each row will change color based on the status of that particular element.
+
+Visually, the elements look correct, however selecting `Foo` or `Bar` from the dropdown will not filter the list.
+To do this, we need to update the `statusCondition` method on the `ElementQuery` class, otherwise our plugin won't know how to properly filter this list when a status is selected.
+
+```php
+protected function statusCondition(string $status)
+{
+    switch ($status) {
+      case 'foo':
+          return [
+              '<', 'product_table.age', 18
+          ];
+        case 'bar':
+            return [
+                'and',
+                [
+                    '>=', 'product_table.age', 18
+                ],
+                [
+                    'product_table.approved' => true
+                ]
+            ];
+        default:
+            return parent::statusCondition($status); // call the base method for `enabled` or `disabled`
+    }
+}
+```
+
+Here, we are querying our `product_table`, where our data for these elements live.
+We indicate that an element has a status of `foo` if the age specified is under 18.
+For the status of `bar`, we have two conditions -- the element must have an age over 18 specified and it must be marked as `approved`.
+
+Now, making a selection from the dropdown will properly filter our list, which is also color coded based based on status.
+
 ## Sources
 
 Your element type can define “sources”, which are groups of elements defined by criteria parameters.


### PR DESCRIPTION
## What's in this PR?

I have been working on a plugin at work and recently worked on adding status to our custom elements.  I found the documentation didn't cover the whole picture (at least not the section I read) and all though I could add status to the dropdown, they didn't do anything without some additional work.

This PR adds a couple more snippets to get a fully working example of statuses on elements, including how to filter them and color-code them.