### PR TITLE
Add a new user permission, "customizeSources"

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added the “Customize element sources” user permission. ([#4282](https://github.com/craftcms/cms/pull/4282))
+
 ### Fixed
 - Fixed a bug where slugs could get double-hyphenated. ([#4266](https://github.com/craftcms/cms/issues/4266))
 - Fixed an error that would occur when installing Craft if the `allowAdminChanges` config setting was disabled. ([#4267](https://github.com/craftcms/cms/issues/4267))

--- a/src/controllers/ElementIndexSettingsController.php
+++ b/src/controllers/ElementIndexSettingsController.php
@@ -29,11 +29,7 @@ class ElementIndexSettingsController extends BaseElementsController
      */
     public function actionGetCustomizeSourcesModalData(): Response
     {
-        try {
-            $this->requireAdmin(false);
-        } catch (\yii\web\ForbiddenHttpException $e) {
-            $this->requirePermission('customizeSources');
-        }
+        $this->requirePermission('customizeSources');
 
         $elementType = $this->elementType();
 
@@ -81,11 +77,7 @@ class ElementIndexSettingsController extends BaseElementsController
      */
     public function actionSaveCustomizeSourcesModalSettings(): Response
     {
-        try {
-            $this->requireAdmin(false);
-        } catch (\yii\web\ForbiddenHttpException $e) {
-            $this->requirePermission('customizeSources');
-        }
+        $this->requirePermission('customizeSources');
 
         $elementType = $this->elementType();
 

--- a/src/controllers/ElementIndexSettingsController.php
+++ b/src/controllers/ElementIndexSettingsController.php
@@ -29,7 +29,11 @@ class ElementIndexSettingsController extends BaseElementsController
      */
     public function actionGetCustomizeSourcesModalData(): Response
     {
-        $this->requireAdmin(false);
+        try {
+            $this->requireAdmin(false);
+        } catch (\yii\web\ForbiddenHttpException $e) {
+            $this->requirePermission('customizeSources');
+        }
 
         $elementType = $this->elementType();
 
@@ -77,7 +81,11 @@ class ElementIndexSettingsController extends BaseElementsController
      */
     public function actionSaveCustomizeSourcesModalSettings(): Response
     {
-        $this->requireAdmin(false);
+        try {
+            $this->requireAdmin(false);
+        } catch (\yii\web\ForbiddenHttpException $e) {
+            $this->requirePermission('customizeSources');
+        }
 
         $elementType = $this->elementType();
 

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -86,6 +86,9 @@ class UserPermissions extends Component
                     ],
                 ]
             ],
+            'customizeSources' => [
+                'label' => Craft::t('app', 'Customize element sources'),
+            ],
         ];
 
         foreach (Craft::$app->getPlugins()->getAllPlugins() as $plugin) {

--- a/src/templates/_layouts/elementindex.html
+++ b/src/templates/_layouts/elementindex.html
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% set sources = craft.app.elementIndexes.getSources(elementType, 'index') %}
-{% set customizableSources = (sources is not empty and context == 'index' and (currentUser.admin or currentUser.can('customizeSources'))) %}
+{% set customizableSources = (sources is not empty and context == 'index' and currentUser.can('customizeSources')) %}
 
 {% set showSiteMenu = (craft.app.getIsMultiSite() ? (showSiteMenu ?? 'auto') : false) %}
 {% if showSiteMenu == 'auto' %}

--- a/src/templates/_layouts/elementindex.html
+++ b/src/templates/_layouts/elementindex.html
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% set sources = craft.app.elementIndexes.getSources(elementType, 'index') %}
-{% set customizableSources = (sources is not empty and context == 'index' and currentUser.admin) %}
+{% set customizableSources = (sources is not empty and context == 'index' and (currentUser.admin or currentUser.can('customizeSources'))) %}
 
 {% set showSiteMenu = (craft.app.getIsMultiSite() ? (showSiteMenu ?? 'auto') : false) %}
 {% if showSiteMenu == 'auto' %}


### PR DESCRIPTION
Non-admin clients would like the ability to show/hide certain table columns/sources. This patch allows non-admin users, with this new permission enabled, to see the cog wheel in an element index page and save their preferences.