### PR TITLE
Prevent exception in console request

### DIFF
--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -119,6 +119,11 @@ class TemplateCaches extends Component
             return null;
         }
 
+        // Don't return anything if it's not a global request and it is a console request.
+        if (!$global && Craft::$app->getRequest()->getIsConsoleRequest()) {
+            return null;
+        }
+
         // Don't return anything if it's not a global request and the path > 255 characters.
         if (!$global && strlen($this->_getPath()) > 255) {
             return null;
@@ -256,6 +261,11 @@ class TemplateCaches extends Component
     {
         // Make sure template caching is enabled
         if ($this->_isTemplateCachingEnabled() === false) {
+            return;
+        }
+
+        // Don't return anything if it's not a global request and it's a console request.
+        if (!$global && Craft::$app->getRequest()->getIsConsoleRequest()) {
             return;
         }
 


### PR DESCRIPTION
When attempting to render a template that contains `{% cache %}` tags in a console request, an exception is thrown because the `craft\console\Request::getPathInfo` method does not exists.

```
Exception 'Twig\Error\RuntimeError' with message 'An exception has been thrown during the rendering of a template ("Calling unknown method: craft\console\Request::getPathInfo()").'
```

This pull request prevents the `getPathInfo` method from being called (and therefore the exception being thrown) if `$global` is false and the request is a console request.