### PR TITLE
Enforce requirement of authenticated Craft session

### DIFF
--- a/src/controllers/ExportController.php
+++ b/src/controllers/ExportController.php
@@ -37,11 +37,6 @@ class ExportController extends Controller
      */
     public $defaultAction = 'export';
 
-    /**
-     * @inheritdoc
-     */
-    protected $allowAnonymous = true;
-
     // Public Methods
     // =========================================================================
 


### PR DESCRIPTION
This pull request enforces the requirement of an authenticated Craft session by removing anonymous access to the controller actions, as specified in the comment on line 25. If this was intentional then the change should be reverted and line 25 should be updated accordingly.

> Note that all actions in the controller require an authenticated Craft session via [[allowAnonymous]].