### PR TITLE
Fix status menu for All Users source

### DIFF
--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -164,7 +164,6 @@ class User extends Element implements IdentityInterface
             [
                 'key' => '*',
                 'label' => Craft::t('app', 'All users'),
-                'criteria' => ['status' => null],
                 'hasThumbs' => true
             ]
         ];


### PR DESCRIPTION
This pull request fixes an issue in which the status filter menu is not shown when _All Users_ is selected due to the changes introduced in https://github.com/craftcms/cms/commit/973cd7654bfa88d133041f741dde731b6d899dae.

<img width="468" alt="Screenshot 2019-05-23 at 23 49 35" src="https://user-images.githubusercontent.com/2318222/58289149-db1a5780-7db5-11e9-8678-d402c5874ed2.png">