### PR TITLE
ArrayValidator clean up

### DIFF
--- a/src/validators/ArrayValidator.php
+++ b/src/validators/ArrayValidator.php
@@ -102,36 +102,12 @@ class ArrayValidator extends Validator
     /**
      * @inheritdoc
      */
-    public function validateAttribute($model, $attribute)
+    protected function validateValue($value)
     {
-        $value = $model->$attribute;
-
         if (!$value instanceof \Countable && !is_array($value)) {
             $this->addError($model, $attribute, $this->message);
 
             return;
-        }
-
-        $count = count($value);
-
-        if ($this->min !== null && $count < $this->min) {
-            $this->addError($model, $attribute, $this->tooFew, ['min' => $this->min]);
-        }
-        if ($this->max !== null && $count > $this->max) {
-            $this->addError($model, $attribute, $this->tooMany, ['max' => $this->max]);
-        }
-        if ($this->count !== null && $count !== $this->count) {
-            $this->addError($model, $attribute, $this->notEqual, ['count' => $this->count]);
-        }
-    }
-
-    /**
-     * @inheritdoc
-     */
-    protected function validateValue($value)
-    {
-        if (!is_string($value)) {
-            return [$this->message, []];
         }
 
         $count = count((array)$value);

--- a/src/validators/ArrayValidator.php
+++ b/src/validators/ArrayValidator.php
@@ -105,12 +105,10 @@ class ArrayValidator extends Validator
     protected function validateValue($value)
     {
         if (!$value instanceof \Countable && !is_array($value)) {
-            $this->addError($model, $attribute, $this->message);
-
-            return;
+            return [$this->message, []];
         }
 
-        $count = count((array)$value);
+        $count = count($value);
 
         if ($this->min !== null && $count < $this->min) {
             return [$this->tooFew, ['min' => $this->min]];


### PR DESCRIPTION
I was extending ArrayValidator and this threw me for a loop…I certainly could be missing something, but I couldn't figure out why it was written this way.

- The validation logic was duplicated in both validateAttribute and validateValue
- validateValue was actually never called, as it is `protected` and not called from `validateAttribute` (unless something else extended ArrayValidator)
- the `!is_string($value)` check in `validateAttribute` seemed backward