### PR TITLE
Make MoveElementEvent extend ElementEvent

### DIFF
--- a/src/events/MoveElementEvent.php
+++ b/src/events/MoveElementEvent.php
@@ -8,7 +8,6 @@
 namespace craft\events;
 
 use craft\base\ElementInterface;
-use yii\base\Event;
 
 /**
  * Move element event class.
@@ -16,7 +15,7 @@ use yii\base\Event;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0
  */
-class MoveElementEvent extends Event
+class MoveElementEvent extends ElementEvent
 {
     // Properties
     // =========================================================================
@@ -25,9 +24,4 @@ class MoveElementEvent extends Event
      * @var int|null The ID of the structure the element is being moved within.
      */
     public $structureId;
-
-    /**
-     * @var ElementInterface|null The element being moved.
-     */
-    public $element;
 }


### PR DESCRIPTION
This pull request makes _MoveElementEvent_ extend _ElementEvent_ just like _DeleteElementEvent_ does, thereby removing some code and making it easier to work with from other classes:
https://github.com/craftcms/cms/blob/3.2/src/events/DeleteElementEvent.php