### PR TITLE
Allow Titles to be published from draft

### DIFF
--- a/src/services/EntryRevisions.php
+++ b/src/services/EntryRevisions.php
@@ -247,7 +247,7 @@ class EntryRevisions extends Component
     public function publishDraft(EntryDraft $draft, bool $runValidation = true): bool
     {
         // If this is a single, we'll have to set the title manually
-        if ($draft->getSection()->type == Section::TYPE_SINGLE) {
+        if ($draft->getSection()->type == Section::TYPE_SINGLE && empty($draft->title)) {
             $draft->title = $draft->getSection()->name;
         }
 


### PR DESCRIPTION
**Currently**
If you set a `$draft->title` on when it is published it gets replaced with the `getSection()->name` on a `Section::TYPE_SINGLE` entry. 

**Changes**
Checks for a `$draft->title` on `Section::TYPE_SINGLE` and only replaces it wit the `getSection()->name` if there isn't a title provided.