### PR TITLE
Typo in example

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -170,7 +170,7 @@ abstract class Element extends Component implements ElementInterface
      *     if ($entry->uri === 'pricing') {
      *         $e->route = 'module/pricing/index';
      *     }
-     * }
+     * });
      * ```
      */
     const EVENT_SET_ROUTE = 'setRoute';


### PR DESCRIPTION
The example was missing the closing parenthesis and semicolon.