### PR TITLE
Add method for element tabs to use on elementsindex template

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2357,6 +2357,37 @@ abstract class Element extends Component implements ElementInterface
         }
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function getElementEditTabs(): array
+    {
+        $tabs = $this->getFieldLayout()->getTabs();
+
+        return array_map(function($tab) {
+            $hasErrors = $this->hasErrors() ? $this->doesTabHaveErrors($tab) : false;
+            return [
+                'label' => Craft::t('site', $tab->name),
+                'url' => '#' . $tab->getHtmlId(),
+                'class' => $hasErrors ? 'error' : null
+            ];
+        }, $tabs);
+    }
+
+    protected function doesTabHaveErrors($tab)
+    {
+        $errors = array_filter($tab->getFields(), function ($field) {
+            return $this->doesHandleHaveError($field->handle);
+        });
+
+        return sizeof($errors) > 0;
+    }
+
+    protected function doesHandleHaveErrors(string $handle)
+    {
+        return $this->hasErrors($handle . '.*');
+    }
+
     // Protected Methods
     // =========================================================================
 

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -1003,4 +1003,11 @@ interface ElementInterface extends ComponentInterface
      * @param int $structureId The structure ID
      */
     public function afterMoveInStructure(int $structureId);
+
+    /**
+     * Returns the tab labels for a given element.
+     *
+     * @return array
+     */
+    public function getElementEditTabs();
 }

--- a/src/controllers/CategoriesController.php
+++ b/src/controllers/CategoriesController.php
@@ -722,27 +722,7 @@ class CategoriesController extends Controller
         // Define the content tabs
         // ---------------------------------------------------------------------
 
-        $variables['tabs'] = [];
-
-        foreach ($variables['group']->getFieldLayout()->getTabs() as $index => $tab) {
-            // Do any of the fields on this tab have errors?
-            $hasErrors = false;
-
-            if ($variables['category']->hasErrors()) {
-                foreach ($tab->getFields() as $field) {
-                    /** @var Field $field */
-                    if ($hasErrors = $variables['category']->hasErrors($field->handle . '.*')) {
-                        break;
-                    }
-                }
-            }
-
-            $variables['tabs'][] = [
-                'label' => Craft::t('site', $tab->name),
-                'url' => '#' . $tab->getHtmlId(),
-                'class' => $hasErrors ? 'error' : null
-            ];
-        }
+        $variables['tabs'] = $variables['category']->getElementEditTabs();
     }
 
     /**

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -624,28 +624,7 @@ class EntriesController extends BaseEntriesController
         // Define the content tabs
         // ---------------------------------------------------------------------
 
-        $variables['tabs'] = [];
-
-        foreach ($variables['entryType']->getFieldLayout()->getTabs() as $index => $tab) {
-            // Do any of the fields on this tab have errors?
-            $hasErrors = false;
-
-            if ($variables['entry']->hasErrors()) {
-                foreach ($tab->getFields() as $field) {
-                    /** @var Field $field */
-                    if ($hasErrors = $variables['entry']->hasErrors($field->handle . '.*')) {
-                        break;
-                    }
-                }
-            }
-
-            $variables['tabs'][] = [
-                'label' => Craft::t('site', $tab->name),
-                'url' => '#' . $tab->getHtmlId(),
-                'class' => $hasErrors ? 'error' : null
-            ];
-        }
-
+        $variables['tabs'] = $variables['entry']->getElementEditTabs();
         return null;
     }
 


### PR DESCRIPTION
## What's in this PR?

This PR adds a method for `getElementEditTabs` to elements, allowing plugin developers to easily show responsive tabs for their custom elements.  Previously, if I had a custom element with multiple fields/tabs, I would have to manually write something to return those tabs when rendering my edit template and ensure they had a `label`, `url` and `class`.

I had the assumption that I could just use `$element->getTabs()` but that has to be cleaned before the template will properly render it.

With this, you can easily do this for an edit template
```
return $this->renderTemplate(
    'plugin-name/element/_edit',
    [
        'element' => $element,
        'id' => $id,
        'tabs' => $element->getElementEditTabs(), // get the tabs pre-formatted
        'title'              => 'Edit Element',
        'continueEditingUrl' => 'plugin-name/element/{handle}'
    ]
);
```

This also reduces some duplicated logic on the Entries and Categories controllers, which do this manual tab creation.