### PR TITLE
Handle disabled element index ids as string (as well as array)

### DIFF
--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -385,14 +385,13 @@ class ElementIndexesController extends BaseElementsController
             $responseData['actionsFootHtml'] = $view->getBodyHtml();
         }
 
-        $disabledElementIds = Craft::$app->getRequest()->getParam('disabledElementIds', []);
         $showCheckboxes = !empty($this->actions);
         /** @var string|ElementInterface $elementType */
         $elementType = $this->elementType;
 
         $responseData['html'] = $elementType::indexHtml(
             $this->elementQuery,
-            $disabledElementIds,
+            $this->disabledElementIds(),
             $this->viewState,
             $this->sourceKey,
             $this->context,
@@ -404,6 +403,19 @@ class ElementIndexesController extends BaseElementsController
         $responseData['footHtml'] = $view->getBodyHtml();
 
         return $responseData;
+    }
+
+    /**
+     * @return array|null
+     */
+    protected function disabledElementIds()
+    {
+        $disabledElementIds = Craft::$app->getRequest()->getParam('disabledElementIds', []);
+        if (is_string($disabledElementIds)) {
+            $disabledElementIds = explode(",", $disabledElementIds);
+        }
+
+        return $disabledElementIds;
     }
 
     /**


### PR DESCRIPTION
When sending a lot (thousands) of disabled element Ids via array, it's possible to exceed the `max_input_vars` limits.  Sending as comma delimited string alleviates this.