### PR TITLE
Add support for custom fields and matrix fields in in testing fixtures

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -10,6 +10,8 @@
 ### Changed
 - Craft now deletes expired template caches as part of its garbage collection routine.
 - `craft\test\console\ConsoleTest::consoleCommand()` now accepts a third argument to ignore `stdOut` calls. 
+- `craft\test\fixtures\elements\ElementFixture` now accepts a `fieldLayoutType` key value pair used for setting an Element's field layout.
+- `craft\test\fixtures\FieldLayoutFixture` now has support for adding Matrix fields. 
 
 ### Fixed
 - Fixed a SQL error that occurred when creating new entries on multi-site installs. ([#4363](https://github.com/craftcms/cms/issues/4363))

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -10,8 +10,8 @@
 ### Changed
 - Craft now deletes expired template caches as part of its garbage collection routine.
 - `craft\test\console\ConsoleTest::consoleCommand()` now accepts a third argument to ignore `stdOut` calls. 
-- `craft\test\fixtures\elements\ElementFixture` now accepts a `fieldLayoutType` key value pair used for setting an Element's field layout.
-- `craft\test\fixtures\FieldLayoutFixture` now has support for adding Matrix fields. 
+- `craft\test\fixtures\elements\ElementFixture` now supports a `fieldLayoutType` key in fixture data.
+- `craft\test\fixtures\FieldLayoutFixture` now supports Matrix fields. 
 
 ### Fixed
 - Fixed a SQL error that occurred when creating new entries on multi-site installs. ([#4363](https://github.com/craftcms/cms/issues/4363))

--- a/docs/testing/testing-craft/fixtures.md
+++ b/docs/testing/testing-craft/fixtures.md
@@ -20,9 +20,13 @@ A by-product of this is that some heavy lifting is required if element types are
 defined in a single fixture and data file. For this reason support is provided 
 out of the box for setting up various element types. 
 
+Provide your own custom element type? 
+You can extend `craft\test\fixtures\elements\ElementFixture` to provide developers using your module/plugin support 
+for their testing code - or just provide yourself support for testing your own module/plugin.  
+
 ::: tip
 Craft's element fixtures are based on the excellent team over at [robuust](https://robuust.digital/) 
-and their `craft-fixtures`  [plugin](https://github.com/robuust/craft-fixtures). 
+and their `craft-fixtures`  [plugin](https://github.com/robuust/craft-fixtures).
 :::
 
 ### `Asset fixtures`
@@ -159,6 +163,53 @@ return [
 
 The primary keys are: `siteId`, `username` and `email`.
 
+### Element fixture field layout and content. 
+
+If you pass a `fieldLayoutType` into any class that extends the base `ElementFixture` class Craft 
+will automatically try to find that the field layout associated with the type you passed in and link this field 
+layout to the new Element you are creating. 
+
+If you want to set custom field values you can simply include those into your fixture data file (the examples as shown above). 
+Here's an example of a fixture data file that is creating an entry with a title and some custom fields: 
+
+````php
+<?php
+return [
+    [
+        // Standard `craft\elements\Entry` fields. 
+        'authorId' => '1',
+        'sectionId' => '1000',
+        'typeId' => '1000',
+        'title' => 'Theories of matrix',
+        
+        // Set a  field layout
+        'fieldLayoutType' => 'field_layout_with_matrix_and_normal_fields',
+        
+        // Set field values
+        'aPlainTextFieldHandle' => 'value of text field',
+        'anotherPlainTextFieldHandle' => 'another valu',
+        
+        // If your field layout defines matrix fields - you can set those too!
+        'matrixFirst' => [
+            'new1' => [
+                'type' => 'aBlock',
+                'fields' => [
+                    'firstSubfield' => 'Some text'
+    
+                ],
+            ],
+            'new2' => [
+                'type' => 'aBlock',
+                'fields' => [
+                    'firstSubfield' => 'Some text'
+                ],
+            ],
+        ],
+    ]
+];
+
+````
+
 ### Field layout fixtures
 Another Craft specific concept is field layouts. Field layouts consist 
 of 
@@ -178,28 +229,74 @@ containing at least the following keys (including the nested position)
 
 ```php
 <?php
+use craft\fields\Matrix;
 
 return [
     [
-            'type' => 'craft\test\Craft', // Required
-            'tabs' => [ // Required - Value can be set to an empty array[]
-                [
-                    'name' => 'Tab 1', // Required
-                    'fields' => [ // Required - Value can be set to an empty array[]
-                        [
-                            'layout-link' => [ // Required
-                                'required' => true // Required
-                            ],
-                            'field' => [
-                                'name' => 'Test field', // Required
-                                'handle' => 'testField2', // Required
-                                'fieldType' => SomeField::class, // Required
-                            ]
+        'type' => 'craft\test\Craft', // Required - can be set to whatever you want. 
+        'tabs' => [ // Required - Value can be set to an empty array[]
+            [
+                'name' => 'Tab 1', // Required
+                'fields' => [ // Required - Value can be set to an empty array[]
+                    [
+                        'layout-link' => [ // Required
+                            'required' => true // Required
                         ],
-                    ]
+                        'field' => [
+                            'name' => 'Test field', // Required
+                            'handle' => 'testField2', // Required
+                            'fieldType' => SomeField::class, // Required
+                        ]
+                    ],
+                    // Even matrix fields are supported in the following config: 
+                    [
+                        'layout-link' => [
+                            'required' => false
+                        ],
+                        'field' => [
+                            'name' => 'Matrix 1',
+                            'handle' => 'matrixFirst',
+                            'fieldType' => Matrix::class,
+                            'blockTypes' => [
+                                'new1' => [
+                                    'name' => "A Block",
+                                    'handle' => "aBlock",
+                                    'fields' => [
+                                        'new1' => [
+                                            'type' => SomeField::class,
+                                            'name' => 'First Subfield',
+                                            'handle' => 'firstSubfield',
+                                            'instructions' => '',
+                                            'required' => false,
+                                            'typesettings' => [
+                                                'multiline' => ''
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                'new2' => [
+                                    'name' => "Another Block",
+                                    'handle' => "another Block",
+                                    'fields' => [
+                                        'new1' => [
+                                            'type' => SomeField::class,
+                                            'name' => 'Another Subfield',
+                                            'handle' => 'anotherSubfield',
+                                            'instructions' => '',
+                                            'required' => false,
+                                            'typesettings' => [
+                                                'multiline' => ''
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
                 ]
             ]
         ]
+    ]
 ];
 ```
 

--- a/src/test/fixtures/FieldLayoutFixture.php
+++ b/src/test/fixtures/FieldLayoutFixture.php
@@ -18,6 +18,7 @@ use craft\fields\Matrix;
 use craft\helpers\ArrayHelper;
 use craft\models\FieldLayout;
 use craft\models\FieldLayoutTab;
+use craft\services\Fields;
 use craft\test\Fixture;
 use Throwable;
 use yii\base\Exception as YiiBaseException;
@@ -84,6 +85,7 @@ abstract class FieldLayoutFixture extends Fixture
                     }
 
                     // Create and add a field.
+                    /* @var Field $field*/
                     $field = new $class($field);
                     if (!Craft::$app->getFields()->saveField($field)) {
                         $this->throwModelError($field);
@@ -103,6 +105,8 @@ abstract class FieldLayoutFixture extends Fixture
                 }
             }
         }
+
+        Craft::$app->set('fields', new Fields());
     }
 
     /**

--- a/src/test/fixtures/FieldLayoutFixture.php
+++ b/src/test/fixtures/FieldLayoutFixture.php
@@ -131,6 +131,19 @@ abstract class FieldLayoutFixture extends Fixture
     }
 
     /**
+     * Unloading fixtures removes fields and possible tables - so we need to refresh the DB Schema before our parent calls.
+     * Craft::$app->getDb()->createCommand()->checkIntegrity(true);
+     *
+     * @throws \yii\base\NotSupportedException
+     */
+    public function afterUnload()
+    {
+        $this->db->getSchema()->refresh();
+
+        parent::afterUnload();
+    }
+
+    /**
      * Attempt to delete all fields and field layout by a field handle.
      *
      * 1. Get a field by handle

--- a/src/test/fixtures/FieldLayoutFixture.php
+++ b/src/test/fixtures/FieldLayoutFixture.php
@@ -14,6 +14,7 @@ use craft\base\Field;
 use craft\base\Model;
 use craft\db\Query;
 use craft\db\Table;
+use craft\fields\Matrix;
 use craft\helpers\ArrayHelper;
 use craft\models\FieldLayout;
 use craft\models\FieldLayoutTab;
@@ -74,10 +75,23 @@ abstract class FieldLayoutFixture extends Fixture
                     $class = $field['fieldType'];
                     unset($field['fieldType']);
 
+                    $blockTypes = [];
+                    if ($class instanceof Matrix) {
+                        if (isset($field['blockTypes'])) {
+                            $blockTypes = $field['blockTypes'];
+                            unset($field['blockTypes']);
+                        }
+                    }
+
                     // Create and add a field.
                     $field = new $class($field);
                     if (!Craft::$app->getFields()->saveField($field)) {
                         $this->throwModelError($field);
+                    }
+
+                    // Set any block types to the matrix.
+                    if ($field instanceof Matrix && $blockTypes) {
+                        $field->setBlockTypes($blockTypes);
                     }
 
                     // Link it

--- a/src/test/fixtures/FieldLayoutFixture.php
+++ b/src/test/fixtures/FieldLayoutFixture.php
@@ -5,9 +5,7 @@
  * @license   https://craftcms.github.io/license/
  */
 
-
 namespace craft\test\fixtures;
-
 
 use Craft;
 use craft\base\Field;

--- a/src/test/fixtures/elements/ElementFixture.php
+++ b/src/test/fixtures/elements/ElementFixture.php
@@ -95,13 +95,10 @@ abstract class ElementFixture extends ActiveFixture
                 unset($data['dateDeleted']);
             }
 
-            foreach ($data as $handle => $value) {
-                $element->$handle = $value;
-            }
-
             // Set the field layout
             if (isset($data['fieldLayoutType'])) {
                 $fieldLayoutType = $data['fieldLayoutType'];
+                unset($data['fieldLayoutType']);
 
                 $fieldLayout = Craft::$app->getFields()->getLayoutByType($fieldLayoutType);
                 if ($fieldLayout) {
@@ -109,6 +106,10 @@ abstract class ElementFixture extends ActiveFixture
                 } else {
                     codecept_debug("Field layout with type: $fieldLayoutType but this was not findable");
                 }
+            }
+
+            foreach ($data as $handle => $value) {
+                $element->$handle = $value;
             }
 
             if (!Craft::$app->getElements()->saveElement($element)) {

--- a/src/test/fixtures/elements/ElementFixture.php
+++ b/src/test/fixtures/elements/ElementFixture.php
@@ -84,6 +84,7 @@ abstract class ElementFixture extends ActiveFixture
         $this->data = [];
 
         foreach ($this->getData() as $alias => $data) {
+            /* @var Element $element */
             $element = $this->getElement();
 
             // If they want to add a date deleted. Store it but dont set that as an element property
@@ -96,6 +97,18 @@ abstract class ElementFixture extends ActiveFixture
 
             foreach ($data as $handle => $value) {
                 $element->$handle = $value;
+            }
+
+            // Set the field layout
+            if (isset($data['fieldLayoutType'])) {
+                $fieldLayoutType = $data['fieldLayoutType'];
+
+                $fieldLayout = Craft::$app->getFields()->getLayoutByType($fieldLayoutType);
+                if ($fieldLayout) {
+                    $element->fieldLayoutId = $fieldLayout->id;
+                } else {
+                    codecept_debug("Field layout with type: $fieldLayoutType but this was not findable");
+                }
             }
 
             if (!Craft::$app->getElements()->saveElement($element)) {

--- a/tests/fixtures/EntryWithFieldsFixture.php
+++ b/tests/fixtures/EntryWithFieldsFixture.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace crafttests\fixtures;
+
+use craft\test\fixtures\elements\EntryFixture as BaseEntriesFixture;
+
+/**
+ * Class EntryWithFieldsFixture
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @author Global Network Group | Giel Tettelaar <giel@yellowflash.net>
+ * @since 3.2
+ */
+class EntryWithFieldsFixture extends BaseEntriesFixture
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public $dataFile = __DIR__ . '/data/entries.php';
+
+    /**
+     * @inheritdoc
+     */
+    public $depends = [FieldLayoutFixture::class, SectionsFixture::class, EntryTypeFixture::class];
+}

--- a/tests/fixtures/EntryWithFieldsFixture.php
+++ b/tests/fixtures/EntryWithFieldsFixture.php
@@ -24,7 +24,7 @@ class EntryWithFieldsFixture extends BaseEntriesFixture
     /**
      * @inheritdoc
      */
-    public $dataFile = __DIR__ . '/data/entries.php';
+    public $dataFile = __DIR__ . '/data/entry-with-fields.php';
 
     /**
      * @inheritdoc

--- a/tests/fixtures/data/entries.php
+++ b/tests/fixtures/data/entries.php
@@ -73,27 +73,5 @@ return [
         'typeId' => '1005',
         'title' => 'Single entry'
     ],
-    [
-        'authorId' => '1',
-        'sectionId' => '1000',
-        'typeId' => '1000',
-        'title' => 'Theories of matrix',
-        'fieldLayoutType' => 'field_layout_with_matrix_and_normal_fields',
-        'matrixFirst' => [
-            'new1' => [
-                'type' => 'aBlock',
-                'fields' => [
-                    'firstSubfield' => 'Some text'
-
-                ],
-            ],
-            'new2' => [
-                'type' => 'aBlock',
-                'fields' => [
-                    'firstSubfield' => 'Some text'
-                ],
-            ],
-        ],
-    ],
 
 ];

--- a/tests/fixtures/data/entries.php
+++ b/tests/fixtures/data/entries.php
@@ -73,4 +73,27 @@ return [
         'typeId' => '1005',
         'title' => 'Single entry'
     ],
+    [
+        'authorId' => '1',
+        'sectionId' => '1000',
+        'typeId' => '1000',
+        'title' => 'Theories of matrix',
+        'fieldLayoutType' => 'field_layout_with_matrix_and_normal_fields',
+        'matrixFirst' => [
+            'new1' => [
+                'type' => 'aBlock',
+                'fields' => [
+                    'firstSubfield' => 'Some text'
+
+                ],
+            ],
+            'new2' => [
+                'type' => 'aBlock',
+                'fields' => [
+                    'firstSubfield' => 'Some text'
+                ],
+            ],
+        ],
+    ],
+
 ];

--- a/tests/fixtures/data/entry-with-fields.php
+++ b/tests/fixtures/data/entry-with-fields.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    [
+        'authorId' => '1',
+        'sectionId' => '1000',
+        'typeId' => '1000',
+        'title' => 'Theories of matrix',
+        'fieldLayoutType' => 'field_layout_with_matrix_and_normal_fields',
+        'matrixFirst' => [
+            'new1' => [
+                'type' => 'aBlock',
+                'fields' => [
+                    'firstSubfield' => 'Some text'
+
+                ],
+            ],
+            'new2' => [
+                'type' => 'aBlock',
+                'fields' => [
+                    'firstSubfield' => 'Some text'
+                ],
+            ],
+        ],
+    ],
+];

--- a/tests/fixtures/data/field-layout.php
+++ b/tests/fixtures/data/field-layout.php
@@ -6,6 +6,8 @@
  */
 
 use craft\fields\Number;
+use craft\fields\Matrix;
+use craft\fields\PlainText;
 
 return [
     [
@@ -21,6 +23,57 @@ return [
                         'field' => [
                             'name' => 'Test field',
                             'handle' => 'testField2',
+                            'fieldType' => Number::class,
+                        ]
+                    ],
+                ]
+            ]
+        ]
+    ],
+    [
+        'type' => 'field_layout_with_matrix_and_normal_fields',
+        'tabs' => [
+            [
+                'name' => 'Tab 1',
+                'fields' => [
+                    // MATRIX FIELD 1
+                    [
+                        'layout-link' => [
+                            'required' => false
+                        ],
+                        'field' => [
+                            'name' => 'Matrix 1',
+                            'handle' => 'matrixFirst',
+                            'fieldType' => Matrix::class,
+                            'blockTypes' => [
+                                'new1' => [
+                                    'name' => "A Block",
+                                    'handle' => "aBlock",
+                                    'fields' => [
+                                        'new1' => [
+                                            'type' => PlainText::class,
+                                            'name' => 'First Subfield',
+                                            'handle' => 'firstSubfield',
+                                            'instructions' => '',
+                                            'required' => false,
+                                            'typesettings' => [
+                                                'multiline' => ''
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+
+                    // PLAIN TEXT FIELD TWO
+                    [
+                        'layout-link' => [
+                            'required' => true
+                        ],
+                        'field' => [
+                            'name' => 'Plain Text Field',
+                            'handle' => 'plainTextField',
                             'fieldType' => Number::class,
                         ]
                     ],

--- a/tests/unit/test/FieldLayoutTest.php
+++ b/tests/unit/test/FieldLayoutTest.php
@@ -10,8 +10,8 @@ namespace crafttests\unit;
 use Codeception\Test\Unit;
 use Craft;
 use craft\db\Query;
-use crafttests\fixtures\EntryFixture;
-use crafttests\fixtures\FieldLayoutFixture;
+use crafttests\fixtures\EntryWithFieldsFixture;
+use UnitTester;
 
 /**
  * Unit tests for App
@@ -22,18 +22,32 @@ use crafttests\fixtures\FieldLayoutFixture;
  */
 class FieldLayoutTest extends Unit
 {
+    // Public Properties
+    // =========================================================================
+
+    /**
+     * @var UnitTester
+     */
+    protected $tester;
+
+    // Public Methods
+    // =========================================================================
+
     public function _fixtures()
     {
         return [
-            'fieldlayout' => [
-                'class' => FieldLayoutFixture::class
-            ],
-            'entry' => [
-                'class' => EntryFixture::class
+            'entry-with-fields' => [
+                'class' => EntryWithFieldsFixture::class
             ]
         ];
     }
 
+    // Tests
+    // =========================================================================
+
+    /**
+     * @throws \yii\base\NotSupportedException
+     */
     public function testFieldLayoutMatrix()
     {
         $tableNames = Craft::$app->getDb()->getSchema()->tableNames;

--- a/tests/unit/test/FieldLayoutTest.php
+++ b/tests/unit/test/FieldLayoutTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace crafttests\unit;
+
+use Codeception\Test\Unit;
+use Craft;
+use craft\db\Query;
+use crafttests\fixtures\EntryFixture;
+use crafttests\fixtures\FieldLayoutFixture;
+
+/**
+ * Unit tests for App
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @author Global Network Group | Giel Tettelaar <giel@yellowflash.net>
+ * @since 3.2
+ */
+class FieldLayoutTest extends Unit
+{
+    public function _fixtures()
+    {
+        return [
+            'fieldlayout' => [
+                'class' => FieldLayoutFixture::class
+            ],
+            'entry' => [
+                'class' => EntryFixture::class
+            ]
+        ];
+    }
+
+    public function testFieldLayoutMatrix()
+    {
+        $tableNames = Craft::$app->getDb()->getSchema()->tableNames;
+        $matrixTableName = Craft::$app->getDb()->tablePrefix.'matrixcontent_matrixfirst';
+
+        $this->assertContains($matrixTableName, $tableNames);
+
+        $matrixRows = (new Query())
+            ->select('*')->from($matrixTableName)->all();
+
+        foreach ($matrixRows as $row) {
+            $this->assertSame('Some text',$row['field_aBlock_firstSubfield']);
+        }
+    }
+}

--- a/tests/unit/test/FieldLayoutTest.php
+++ b/tests/unit/test/FieldLayoutTest.php
@@ -58,6 +58,8 @@ class FieldLayoutTest extends Unit
         $matrixRows = (new Query())
             ->select('*')->from($matrixTableName)->all();
 
+        $this->assertCount(2, $matrixRows);
+        
         foreach ($matrixRows as $row) {
             $this->assertSame('Some text',$row['field_aBlock_firstSubfield']);
         }


### PR DESCRIPTION
@andris-sevcenko Needed this for his tests.

It's a nice addition to the test suite to be able to create matrix fields AND to be able to set content of matrix fields and other custom fields to elements when performing tests.  