### PR TITLE
Make basic Craft email work better with dark modes

### DIFF
--- a/src/templates/_special/email.html
+++ b/src/templates/_special/email.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-    <div style="max-width: 500px; font-size: 13px; line-height: 18px; font-family: HelveticaNeue, sans-serif; color: #29323d; background: #fff;">
+    <div style="max-width: 500px; font-size: 13px; line-height: 18px; font-family: HelveticaNeue, sans-serif;">
         {{ body }}
     </div>
 </body>


### PR DESCRIPTION
I use dark mode on the Mac, and found that (at least for Spark Mail), having a hardcoded HTML email body text color was causing HTML emails coming from Craft to be difficult to read - could become more of an issue when iOS 13 and its dark mode come:

![image](https://user-images.githubusercontent.com/273266/59367835-eaccf200-8d0a-11e9-81b0-2482fb16d0f3.png)

Thinking that leaving it up the email client will provide the best compatibility for coping with dark mode settings, or any other manual overrides a user might have (the same might go for setting pixel-specific font size and line-heights, but will leave that up to you).