### PR TITLE
Add the impersonateUsers User permission

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -6,6 +6,8 @@
 - Added `craft\base\ElementInterface::getIsDraft()`.
 - Added `craft\base\ElementInterface::getIsRevision()`.
 - Added the `impersonateUsers` user permission.
+- Added `craft\services\UserPermissions::doesFirstUserHaveMorePermissions()`
+- Added `craft\services\UserPermissions::isImpersonationAllowed()`
 
 ### Fixed
 - Fixed a bug where entry drafts weren’t getting updated slug values once their initial slug had been saved, if their entry type had a custom title format. ([#4373](https://github.com/craftcms/cms/issues/4373))

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -3,11 +3,10 @@
 ## Unreleased (3.2)
 
 ### Added
+- Added the “Impersonate users” permission. ([#3501](https://github.com/craftcms/cms/issues/3501))
 - Added `craft\base\ElementInterface::getIsDraft()`.
 - Added `craft\base\ElementInterface::getIsRevision()`.
-- Added the `impersonateUsers` user permission.
-- Added `craft\services\UserPermissions::doesFirstUserHaveMorePermissions()`
-- Added `craft\services\UserPermissions::isImpersonationAllowed()`
+- Added `craft\services\Users::canImpersonate()`.
 
 ### Fixed
 - Fixed a bug where entry drafts weren’t getting updated slug values once their initial slug had been saved, if their entry type had a custom title format. ([#4373](https://github.com/craftcms/cms/issues/4373))

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -5,6 +5,7 @@
 ### Added
 - Added `craft\base\ElementInterface::getIsDraft()`.
 - Added `craft\base\ElementInterface::getIsRevision()`.
+- Added the `impersonateUsers` user permission.
 
 ### Fixed
 - Fixed a bug where entry drafts weren’t getting updated slug values once their initial slug had been saved, if their entry type had a custom title format. ([#4373](https://github.com/craftcms/cms/issues/4373))

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -180,7 +180,7 @@ class UsersController extends Controller
     public function actionImpersonate()
     {
         $this->requireLogin();
-        $this->requireAdmin(false);
+        $this->requirePermission('impersonateUsers');
         $this->requirePostRequest();
 
         $userSession = Craft::$app->getUser();
@@ -697,7 +697,7 @@ class UsersController extends Controller
             }
 
             if (!$isCurrentUser) {
-                if ($userSession->getIsAdmin()) {
+                if ($userSession->checkPermission('impersonateUsers')) {
                     $sessionActions[] = [
                         'action' => 'users/impersonate',
                         'label' => Craft::t('app', 'Login as {user}', ['user' => $user->getName()])

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -130,8 +130,7 @@ class UserPermissions extends Component
                         ],
                         'impersonateUsers' => [
                             'label' => Craft::t('app', 'Impersonate users'),
-                            'warning' => Craft::t('app', 'Once impersonated the user can perform all actions through a child account for which you have assigned them permissions.'),
-                        ]
+                        ],
                     ],
                 ],
                 'deleteUsers' => [
@@ -348,57 +347,6 @@ class UserPermissions extends Component
         }
 
         return $this->_permissionsByUserId[$userId];
-    }
-
-    /**
-     * Checks whether the $impersonator can impersonate the $userToImpersonate
-     *
-     * @param User $impersonator
-     * @param User $userToImpersonate
-     * @return bool
-     */
-    public function isImpersonationAllowed(User $impersonator, User $userToImpersonate) : bool
-    {
-        // Too easy
-        if ($impersonator->admin) {
-            return true;
-        }
-
-        // Is the impersonator not an admin but the impersonatee is - then no.
-        if ($userToImpersonate->admin) {
-            return false;
-        }
-
-        // Be gone!
-        if (!$impersonator->can('impersonateUsers')) {
-            return false;
-        }
-
-        // The user that is going to get impersonated cannot have more rights than the impersonator.
-        if ($this->doesFirstUserHaveMorePermissions($userToImpersonate->id, $impersonator->id)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Checks whether a user with id ($userId1) has more permissions than a user with id ($userId2)
-     *
-     * @param int $userId1 The user that should have more permissions
-     * @param int $userId2 - The user to compare against.
-     * @return bool
-     */
-    public function doesFirstUserHaveMorePermissions(int $userId1, int $userId2) : bool
-    {
-        // Get both their permissions
-        $mainUser = $this->getPermissionsByUserId($userId1);
-        $secondaryUser = $this->getPermissionsByUserId($userId2);
-
-        // Does $mainUser have more than $secondaryUser
-        $difference = array_diff($mainUser, $secondaryUser);
-
-        return $difference ? true : false;
     }
 
     /**

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -351,6 +351,8 @@ class UserPermissions extends Component
     }
 
     /**
+     * Checks whether the $impersonator can impersonate the $userToImpersonate
+     *
      * @param User $impersonator
      * @param User $userToImpersonate
      * @return bool

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -377,22 +377,23 @@ class UserPermissions extends Component
             return false;
         }
 
-        // Mkay
         return true;
     }
 
     /**
      * Checks whether a user with id ($userId1) has more permissions than a user with id ($userId2)
      *
-     * @param int $userId1
-     * @param int $userId2
+     * @param int $userId1 The user that should have more permissions
+     * @param int $userId2 - The user to compare against.
      * @return bool
      */
     public function doesFirstUserHaveMorePermissions(int $userId1, int $userId2) : bool
     {
+        // Get both their permissions
         $mainUser = $this->getPermissionsByUserId($userId1);
         $secondaryUser = $this->getPermissionsByUserId($userId2);
 
+        // Does $mainUser have more than $secondaryUser
         $difference = array_diff($mainUser, $secondaryUser);
 
         return $difference ? true : false;

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -129,7 +129,8 @@ class UserPermissions extends Component
                             'warning' => Craft::t('app', 'Accounts with this permission could use it to escalate their own permissions.'),
                         ],
                         'impersonateUsers' => [
-                            'label' => Craft::t('app', 'Impersonate users')
+                            'label' => Craft::t('app', 'Impersonate users'),
+                            'warning' => Craft::t('app', 'Once impersonated the user can perform all actions through a child account for which you have assigned them permissions.'),
                         ]
                     ],
                 ],

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -350,7 +350,7 @@ class UserPermissions extends Component
     }
 
     /**
-     * @param User $user
+     * @param User $impersonator
      * @param User $userToImpersonate
      * @return bool
      */

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -128,6 +128,9 @@ class UserPermissions extends Component
                             'info' => Craft::t('app', 'Includes activating user accounts, resetting passwords, and changing email addresses.'),
                             'warning' => Craft::t('app', 'Accounts with this permission could use it to escalate their own permissions.'),
                         ],
+                        'impersonateUsers' => [
+                            'label' => Craft::t('app', 'Impersonate users')
+                        ]
                     ],
                 ],
                 'deleteUsers' => [

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -1067,6 +1067,44 @@ class Users extends Component
         return true;
     }
 
+    /**
+     * Returns whether a user is allowed to impersonate another user.
+     *
+     * @param User $impersonator
+     * @param User $impersonatee
+     * @return bool
+     * @since 3.2
+     */
+    public function canImpersonate(User $impersonator, User $impersonatee): bool
+    {
+        // Admins can do whatever they want
+        if ($impersonator->admin) {
+            return true;
+        }
+
+        // Only admins are allowed to impersonate another admin
+        if ($impersonatee->admin) {
+            return false;
+        }
+
+        // impersonateUsers permission is obviously required
+        if (!$impersonator->can('impersonateUsers')) {
+            return false;
+        }
+
+        // Make sure the impersonator has at least all the same permissions as the impersonatee
+        $permissionsService = Craft::$app->getUserPermissions();
+        $impersonatorPermissions = array_flip($permissionsService->getPermissionsByUserId($impersonator->id));
+        $impersonateePermissions = $permissionsService->getPermissionsByUserId($impersonatee->id);
+
+        foreach ($impersonateePermissions as $permission) {
+            if (!isset($impersonatorPermissions[$permission])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /**
      * Prune a deleted field from user group layout.

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -253,6 +253,8 @@ class User extends \yii\web\User
                 ->one();
 
             // Ensure that the impersonator can also access this resource.
+            // TODO: This could cause a problem where if the IMPERSONATE_KEY wasn't flushed
+            // TODO: Then `checkPermission` could be unreliable. 
             if (!$impersonatingUser || !$impersonatingUser->can($permissionName)) {
                 return false;
             }

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -240,7 +240,7 @@ class User extends \yii\web\User
      *
      * @param string $permissionName
      * @return bool
-     * @throws \craft\errors\MissingComponentException
+     * @throws MissingComponentException
      */
     public function checkPermission(string $permissionName): bool
     {
@@ -253,6 +253,7 @@ class User extends \yii\web\User
                 ->id($previousUserId)
                 ->one();
 
+            // Ensure that the impersonator can also access this resource.
             if (!$user || !$user->can($permissionName)) {
                 return false;
             }

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -12,7 +12,6 @@ use craft\controllers\UsersController;
 use craft\db\Query;
 use craft\db\Table;
 use craft\elements\User as UserElement;
-use craft\errors\MissingComponentException;
 use craft\errors\UserLockedException;
 use craft\events\LoginFailureEvent;
 use craft\helpers\ConfigHelper;
@@ -20,7 +19,6 @@ use craft\helpers\Db;
 use craft\helpers\UrlHelper;
 use craft\helpers\User as UserHelper;
 use craft\validators\UserPasswordValidator;
-use yii\base\InvalidArgumentException;
 use yii\web\Cookie;
 
 /**
@@ -299,8 +297,6 @@ class User extends \yii\web\User
      * @param string $password the current user’s password
      * @return bool Whether the password was valid, and the user session has been elevated
      * @throws UserLockedException if the user is locked.
-     * @throws MissingComponentException
-     * @throws InvalidArgumentException
      */
     public function startElevatedSession(string $password): bool
     {

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -246,15 +246,14 @@ class User extends \yii\web\User
     {
         $user = $this->getIdentity();
 
-
         if ($previousUserId = Craft::$app->getSession()->get(UserElement::IMPERSONATE_KEY)) {
-            $user = UserElement::find()
+            $impersonatingUser = UserElement::find()
                 ->addSelect(['users.password'])
                 ->id($previousUserId)
                 ->one();
 
             // Ensure that the impersonator can also access this resource.
-            if (!$user || !$user->can($permissionName)) {
+            if (!$impersonatingUser || !$impersonatingUser->can($permissionName)) {
                 return false;
             }
         }
@@ -325,6 +324,7 @@ class User extends \yii\web\User
             $user = UserElement::find()
                 ->addSelect(['users.password'])
                 ->id($previousUserId)
+                ->admin(true)
                 ->one();
 
             // TODO: @brandonkelly - have a look at this. I removed the ->admin() call in favour of this.

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -324,7 +324,6 @@ class User extends \yii\web\User
             $user = UserElement::find()
                 ->addSelect(['users.password'])
                 ->id($previousUserId)
-                ->admin(true)
                 ->one();
 
             // TODO: @brandonkelly - have a look at this. I removed the ->admin() call in favour of this.

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -309,9 +309,11 @@ class User extends \yii\web\User
     /**
      * Starts an elevated user session for the current user.
      *
-     * @param string $password the current user’s password
-     * @return bool Whether the password was valid, and the user session has been elevated
-     * @throws UserLockedException if the user is locked.
+     * @param string $password
+     * @return bool
+     * @throws UserLockedException
+     * @throws MissingComponentException
+     * @throws InvalidArgumentException
      */
     public function startElevatedSession(string $password): bool
     {
@@ -322,8 +324,14 @@ class User extends \yii\web\User
             $user = UserElement::find()
                 ->addSelect(['users.password'])
                 ->id($previousUserId)
-                ->admin(true)
                 ->one();
+
+            // TODO: @brandonkelly - have a look at this. I removed the ->admin() call in favour of this.
+            // TODO: It seems more appropriate
+            if (!$user->can('impersonateUsers')) {
+                $this->_handleLoginFailure(UserElement::AUTH_INVALID_CREDENTIALS);
+                return false;
+            }
         } else {
             // Get the current user
             $user = $this->getIdentity();

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -248,13 +248,12 @@ class User extends \yii\web\User
 
         if ($previousUserId = Craft::$app->getSession()->get(UserElement::IMPERSONATE_KEY)) {
             $impersonatingUser = UserElement::find()
-                ->addSelect(['users.password'])
                 ->id($previousUserId)
                 ->one();
 
             // Ensure that the impersonator can also access this resource.
             // TODO: This could cause a problem where if the IMPERSONATE_KEY wasn't flushed
-            // TODO: Then `checkPermission` could be unreliable. 
+            // TODO: Then `checkPermission` could be unreliable.
             if (!$impersonatingUser || !$impersonatingUser->can($permissionName)) {
                 return false;
             }

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -326,13 +326,6 @@ class User extends \yii\web\User
                 ->addSelect(['users.password'])
                 ->id($previousUserId)
                 ->one();
-
-            // TODO: @brandonkelly - have a look at this. I removed the ->admin() call in favour of this.
-            // TODO: It seems more appropriate
-            if (!$user->can('impersonateUsers')) {
-                $this->_handleLoginFailure(UserElement::AUTH_INVALID_CREDENTIALS);
-                return false;
-            }
         } else {
             // Get the current user
             $user = $this->getIdentity();

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -238,8 +238,8 @@ class User extends \yii\web\User
     /**
      * Returns whether the current user has a given permission.
      *
-     * @param string $permissionName
-     * @return bool
+     * @param string $permissionName The name of the permission.
+     * @return bool Whether the current user has the permission.
      * @throws MissingComponentException
      */
     public function checkPermission(string $permissionName): bool
@@ -310,9 +310,9 @@ class User extends \yii\web\User
     /**
      * Starts an elevated user session for the current user.
      *
-     * @param string $password
-     * @return bool
-     * @throws UserLockedException
+     * @param string $password the current user’s password
+     * @return bool Whether the password was valid, and the user session has been elevated
+     * @throws UserLockedException if the user is locked.
      * @throws MissingComponentException
      * @throws InvalidArgumentException
      */

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -240,24 +240,10 @@ class User extends \yii\web\User
      *
      * @param string $permissionName The name of the permission.
      * @return bool Whether the current user has the permission.
-     * @throws MissingComponentException
      */
     public function checkPermission(string $permissionName): bool
     {
         $user = $this->getIdentity();
-
-        if ($previousUserId = Craft::$app->getSession()->get(UserElement::IMPERSONATE_KEY)) {
-            $impersonatingUser = UserElement::find()
-                ->id($previousUserId)
-                ->one();
-
-            // Ensure that the impersonator can also access this resource.
-            // TODO: This could cause a problem where if the IMPERSONATE_KEY wasn't flushed
-            // TODO: Then `checkPermission` could be unreliable.
-            if (!$impersonatingUser || !$impersonatingUser->can($permissionName)) {
-                return false;
-            }
-        }
 
         return ($user && $user->can($permissionName));
     }


### PR DESCRIPTION
Doh! Of all things, I didn't test #4401 via the CP - I changed the permission check in `actionEditUser()` to reflect the new permission so that the `Login as {user}` dropdown option is visible. Sorry bout that! 

Of what I can see `craft\web\User` has two references to the Impersonate functionality: `Line 306` & `Line 406` but they both deal with "If a user is using Craft whilst impersonating someone" not "Is this user allowed to impersonate other users" the latter is where this permission makes changes.

Resolves #1186 