### PR TITLE
Adds a console command for testing email settings

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -7,7 +7,7 @@
 - Added `craft\base\ElementInterface::getIsDraft()`.
 - Added `craft\base\ElementInterface::getIsRevision()`.
 - Added `craft\services\Users::canImpersonate()`.
-- Added the `tests/email-settings` console command to test your email settings ([#4020](https://github.com/craftcms/cms/issues/4020))
+- Added the `tests/email-settings` console command to test system email settings. ([#4020](https://github.com/craftcms/cms/issues/4020))
 
 ### Fixed
 - Fixed a bug where entry drafts weren’t getting updated slug values once their initial slug had been saved, if their entry type had a custom title format. ([#4373](https://github.com/craftcms/cms/issues/4373))

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -5,6 +5,7 @@
 ### Added
 - Added `craft\base\ElementInterface::getIsDraft()`.
 - Added `craft\base\ElementInterface::getIsRevision()`.
+- Added the `tests/email-settings` console command to test your email settings ([#4020](https://github.com/craftcms/cms/issues/4020))
 
 ### Fixed
 - Fixed a bug where entry drafts weren’t getting updated slug values once their initial slug had been saved, if their entry type had a custom title format. ([#4373](https://github.com/craftcms/cms/issues/4373))

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -73,14 +73,16 @@ class TestsController extends Controller
             return $this->_testEmailSending($message);
         }
 
-
         // Otherwise we let the user decide....
         $transportAdapters = [
+            $settingsModel->transportType,
             Smtp::class,
             Gmail::class,
             Sendmail::class,
             'Other'
         ];
+        $transportAdapters = array_unique($transportAdapters);
+
         $selectedOption = null;
 
         foreach ($transportAdapters as $transportAdapter) {

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -8,6 +8,7 @@
 namespace craft\console\controllers;
 
 use Craft;
+use craft\helpers\Component;
 use craft\console\Controller;
 use craft\helpers\App;
 use craft\helpers\Console;
@@ -92,11 +93,14 @@ class TestsController extends Controller
             $selectedOption = $this->prompt("Which transport type do you want to use?");
         }
 
-        /* @var BaseTransportAdapter $transport */
-        $transport = new $selectedOption();
-
-        if (!$transport instanceof BaseTransportAdapter) {
-            $this->stderr("$selectedOption is not an instance of " . BaseTransportAdapter::class . "");
+        // Create the mailer
+        try {
+            /* @var BaseTransportAdapter $transport */
+            $transport = Component::createComponent([
+                'class' => $selectedOption
+            ], BaseTransportAdapter::class);
+        } catch (\Throwable $exception) {
+            $this->stderr("The following problem occured: $exception");
             return ExitCode::OK;
         }
 

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -341,7 +341,7 @@ class TestsController extends Controller
         if ($message->send()) {
             $this->stdout('Email sent successfully! Check your inbox.'.PHP_EOL.PHP_EOL);
         } else {
-            $this->stderr('There was an error testing your email settings.'.PHP_EOL.PHP_EOL);
+            $this->stderr('There was an error testing your email settings. Please check the Craft log files.'.PHP_EOL.PHP_EOL);
         }
 
         return ExitCode::OK;

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -98,7 +98,7 @@ class TestsController extends Controller
         try {
             /* @var BaseTransportAdapter $transport */
             $transport = Component::createComponent([
-                'class' => $selectedOption
+                'type' => $selectedOption
             ], BaseTransportAdapter::class);
         } catch (\Throwable $exception) {
             $this->stderr("The following problem occured when creating the mailer: $exception");
@@ -107,7 +107,13 @@ class TestsController extends Controller
 
         // What do they want to use?
         foreach ($transport->settingsAttributes() as $property) {
-            $transport->$property = $this->prompt("What must $property be set to?");
+            // Try and find a default.
+            $default = null;
+            if (isset($settingsModel->transportSettings[$property])) {
+                $default = $settingsModel->transportSettings[$property];
+            }
+
+            $transport->$property = $this->prompt("What must $property be set to?", ['default' => $default]);
         }
 
         // Save the new stuff to the settings

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -75,31 +75,38 @@ class TestsController extends Controller
 
         // Otherwise we let the user decide....
         $transportAdapters = [
-            $settingsModel->transportType,
-            Smtp::class,
-            Gmail::class,
-            Sendmail::class,
-            'A custom transport adapter'
+            $settingsModel->transportType::displayName() => $settingsModel->transportType,
+            'Smtp' => Smtp::class,
+            'Gmail' => Gmail::class,
+            'Sendmail'=> Sendmail::class,
+            'Other' => 'Other'
         ];
         $transportAdapters = array_unique($transportAdapters);
 
+        $userInput = $this->select('Which transport type do you want to use?', $transportAdapters);
+
         $selectedOption = null;
-
-        foreach ($transportAdapters as $transportAdapter) {
-            if ($this->confirm("Do you want to use {$transportAdapter}?")) {
-                $selectedOption = $transportAdapter;
+        switch ($userInput) {
+            case 'Smtp':
+                $selectedOption = Smtp::class;
                 break;
-            }
-        }
-
-        if ($selectedOption === 'A custom transport adapter') {
-            $selectedOption = $this->prompt("Which transport type do you want to use?");
+            case 'Gmail':
+                $selectedOption = Gmail::class;
+                break;
+            case 'Sendmail':
+                $selectedOption = Sendmail::class;
+                break;
+            case 'Other':
+                $selectedOption = $this->prompt("Which transport type do you want to use?");
+            default:
+                $this->stderr('You have entered an invalid transport type.');
+                return ExitCode::OK;
         }
 
         if (!$selectedOption) {
             $selectedOption = $this->prompt("You have not entered a custom transport type - please enter one now.");
         }
-        
+
         // Create the mailer
         try {
             /* @var BaseTransportAdapter $transport */

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -25,7 +25,8 @@ use yii\console\ExitCode;
 use craft\elements\User as UserElement;
 
 /**
- * Various support resources for testing Craft.
+ * The TestsController provides various support resources for testing both Craft's own services and your implementation of
+ * Craft within your project.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @author Global Network Group | Giel Tettelaar <giel@yellowflash.net>

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -299,30 +299,35 @@ class TestsController extends Controller
     // =========================================================================
 
     /**
-     * @param MailSettings $settings
-     * @param $adapter
+     * @param MailSettings|null $settings
+     * @param null $adapter
      * @return string
      */
-    protected function _renderMailSettingsString(MailSettings $settings, $adapter) : string
+    protected function _renderMailSettingsString(MailSettings $settings = null, $adapter = null) : string
     {
         // Compose the settings list as HTML
         $settingsList = '';
 
-        foreach (['fromEmail', 'fromName', 'template'] as $name) {
-            if (!empty($settings->$name)) {
-                $settingsList .= '- **' . $settings->getAttributeLabel($name) . ':** ' . $settings->$name . "\n";
+        if ($settings) {
+            foreach (['fromEmail', 'fromName', 'template'] as $name) {
+                if (!empty($settings->$name)) {
+                    $settingsList .= '- **' . $settings->getAttributeLabel($name) . ':** ' . $settings->$name . "\n";
+                }
             }
         }
 
-        $settingsList .= '- **' . 'Transport Type' . ':** ' . $adapter::displayName() . "\n";
 
-        $security = Craft::$app->getSecurity();
+        if ($adapter) {
+            $settingsList .= '- **' . 'Transport Type' . ':** ' . $adapter::displayName() . "\n";
 
-        foreach ($adapter->settingsAttributes() as $name) {
-            if (!empty($adapter->$name)) {
-                $label = $adapter->getAttributeLabel($name);
-                $value = $security->redactIfSensitive($name, $adapter->$name);
-                $settingsList .= "- **{$label}:** {$value}\n";
+            $security = Craft::$app->getSecurity();
+
+            foreach ($adapter->settingsAttributes() as $name) {
+                if (!empty($adapter->$name)) {
+                    $label = $adapter->getAttributeLabel($name);
+                    $value = $security->redactIfSensitive($name, $adapter->$name);
+                    $settingsList .= "- **{$label}:** {$value}\n";
+                }
             }
         }
 

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -82,7 +82,7 @@ class TestsController extends Controller
         $selectedOption = null;
 
         foreach ($transportAdapters as $transportAdapter) {
-            if ($this->confirm("Do you want to user {$transportAdapter}?".PHP_EOL)) {
+            if ($this->confirm("Do you want to use {$transportAdapter}?" . PHP_EOL)) {
                 $selectedOption = $transportAdapter;
                 break;
             }

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -79,7 +79,7 @@ class TestsController extends Controller
             Smtp::class,
             Gmail::class,
             Sendmail::class,
-            'Other'
+            'A custom transport adapter'
         ];
         $transportAdapters = array_unique($transportAdapters);
 
@@ -92,10 +92,14 @@ class TestsController extends Controller
             }
         }
 
-        if ($selectedOption === 'Other') {
+        if ($selectedOption === 'A custom transport adapter') {
             $selectedOption = $this->prompt("Which transport type do you want to use?");
         }
 
+        if (!$selectedOption) {
+            $selectedOption = $this->prompt("You have not entered a custom transport type - please enter one now.");
+        }
+        
         // Create the mailer
         try {
             /* @var BaseTransportAdapter $transport */

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -42,7 +42,7 @@ class TestsController extends Controller
      *
      * 1. Testing the default settings used in Craft::$app->getMailer()->send();
      * 2. Test sending according to email settings used in a custom config defined through app.php
-     * 3. Define your own custom Transport adapter and test using one off settings.
+     * 3. Choose your own custom Transport adapter and test using once off settings.
      *
      * @return int
      * @throws \craft\errors\MissingComponentException

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -43,7 +43,7 @@ class TestsController extends Controller
      */
     public function actionEmailSettings()
     {
-        $recieverEmail = $this->prompt('Which email address must we send this test email to?');
+        $recieverEmail = $this->prompt(PHP_EOL.'Which email address must we send this test email to?');
 
         $mailParams = [
             'user' => new UserElement([
@@ -55,7 +55,7 @@ class TestsController extends Controller
         $settingsModel = App::mailSettings();
 
         // Default settings?
-        if ($this->confirm('Do you want to test using the current email settings?')) {
+        if ($this->confirm(PHP_EOL.'Do you want to test using the current email settings?')) {
             $adapter = MailerHelper::createTransportAdapter(
                 $settingsModel->transportType,
                 $settingsModel->transportSettings
@@ -83,7 +83,7 @@ class TestsController extends Controller
         ];
         $transportAdapters = array_unique($transportAdapters);
 
-        $userInput = $this->select('Which transport type do you want to use?', $transportAdapters);
+        $userInput = $this->select(PHP_EOL.'Which transport type do you want to use?', $transportAdapters);
 
         $selectedOption = null;
         switch ($userInput) {
@@ -97,14 +97,15 @@ class TestsController extends Controller
                 $selectedOption = Sendmail::class;
                 break;
             case 'Other':
-                $selectedOption = $this->prompt("Which transport type do you want to use?");
+                $selectedOption = $this->prompt(PHP_EOL.'Which custom transport type do you want to use?');
+                break;
             default:
-                $this->stderr('You have entered an invalid transport type.');
+                $this->stderr(PHP_EOL.'You have entered an invalid transport type.');
                 return ExitCode::OK;
         }
 
         if (!$selectedOption) {
-            $selectedOption = $this->prompt("You have not entered a custom transport type - please enter one now.");
+            $selectedOption = $this->prompt(PHP_EOL."You have not entered a custom transport type - please enter one now.");
         }
 
         // Create the mailer
@@ -115,7 +116,7 @@ class TestsController extends Controller
             ], BaseTransportAdapter::class);
         } catch (\Throwable $exception) {
             $message = $exception->getMessage();
-            $this->stderr("The following problem occured when creating the mailer: $message".PHP_EOL, Console::FG_RED);
+            $this->stderr(PHP_EOL."The following problem occured when creating the mailer: $message", Console::FG_RED);
             return ExitCode::OK;
         }
 

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -100,7 +100,6 @@ class TestsController extends Controller
 
             Craft::$app->set('mailer', $mailer);
 
-            // TODO: Is there a way to extract the MailSettings and TransportAdapter settings from Craft::$app->getMailer()
             $mailParams['settings'] = '';
 
             return $this->_testEmailSending($mailParams, $receiverEmail);

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -100,7 +100,7 @@ class TestsController extends Controller
                 'class' => $selectedOption
             ], BaseTransportAdapter::class);
         } catch (\Throwable $exception) {
-            $this->stderr("The following problem occured: $exception");
+            $this->stderr("The following problem occured when creating the mailer: $exception");
             return ExitCode::OK;
         }
 

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -41,7 +41,7 @@ class TestsController extends Controller
      * @throws \craft\errors\MissingComponentException
      * @throws \yii\base\InvalidConfigException
      */
-    public function actionTestEmailSettings()
+    public function actionEmailSettings()
     {
         $recieverEmail = $this->prompt('Which email address must we send this test email to?');
 
@@ -55,7 +55,7 @@ class TestsController extends Controller
         $settingsModel = App::mailSettings();
 
         // Default settings?
-        if ($this->confirm('Do you want to test Crafts default email settings?')) {
+        if ($this->confirm('Do you want to test using the current email settings?')) {
             $adapter = MailerHelper::createTransportAdapter(
                 $settingsModel->transportType,
                 $settingsModel->transportSettings
@@ -86,7 +86,7 @@ class TestsController extends Controller
         $selectedOption = null;
 
         foreach ($transportAdapters as $transportAdapter) {
-            if ($this->confirm("Do you want to use {$transportAdapter}?" . PHP_EOL)) {
+            if ($this->confirm("Do you want to use {$transportAdapter}?")) {
                 $selectedOption = $transportAdapter;
                 break;
             }
@@ -103,7 +103,8 @@ class TestsController extends Controller
                 'type' => $selectedOption
             ], BaseTransportAdapter::class);
         } catch (\Throwable $exception) {
-            $this->stderr("The following problem occured when creating the mailer: $exception");
+            $message = $exception->getMessage();
+            $this->stderr("The following problem occured when creating the mailer: $message".PHP_EOL, Console::FG_RED);
             return ExitCode::OK;
         }
 
@@ -115,7 +116,7 @@ class TestsController extends Controller
                 $default = $settingsModel->transportSettings[$property];
             }
 
-            $transport->$property = $this->prompt("What must $property be set to?", ['default' => $default]);
+            $transport->$property = $this->prompt(PHP_EOL."What must $property be set to?", ['default' => $default]);
         }
 
         // Save the new stuff to the settings

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -9,10 +9,19 @@ namespace craft\console\controllers;
 
 use Craft;
 use craft\console\Controller;
+use craft\helpers\App;
 use craft\helpers\Console;
 use craft\helpers\FileHelper;
+use craft\helpers\MailerHelper;
+use craft\mail\Message;
+use craft\mail\transportadapters\BaseTransportAdapter;
+use craft\mail\transportadapters\Gmail;
+use craft\mail\transportadapters\Sendmail;
+use craft\mail\transportadapters\Smtp;
+use craft\models\MailSettings;
 use yii\base\InvalidArgumentException;
 use yii\console\ExitCode;
+use craft\elements\User as UserElement;
 
 /**
  * Various support resources for testing Craft.
@@ -27,6 +36,101 @@ class TestsController extends Controller
     // =========================================================================
 
     /**
+     * @return int
+     * @throws \craft\errors\MissingComponentException
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function actionTestEmailSettings()
+    {
+        $recieverEmail = $this->prompt('Which email address must we send this test email to?');
+
+        $mailParams = [
+            'user' => new UserElement([
+                'email' => $recieverEmail,
+                'username' => $recieverEmail
+            ])
+        ];
+
+        $settingsModel = App::mailSettings();
+
+        // Default settings?
+        if ($this->confirm('Do you want to test Crafts default email settings?')) {
+            $adapter = MailerHelper::createTransportAdapter(
+                $settingsModel->transportType,
+                $settingsModel->transportSettings
+            );
+
+            $mailParams['settings'] = $this->_renderMailSettingsString(
+                App::mailSettings(),
+                $adapter
+            );
+
+            $message = Craft::$app->getMailer()
+                ->composeFromKey('test_email', $mailParams)
+                ->setTo($recieverEmail);
+
+            return $this->_testEmailSending($message);
+        }
+
+        // Otherwise we let the user decide....
+        $transportAdapters = [
+            Smtp::class,
+            Gmail::class,
+            Sendmail::class,
+            'Other'
+        ];
+        $selectedOption = null;
+
+        foreach ($transportAdapters as $transportAdapter) {
+            if ($this->confirm("Do you want to user {$transportAdapter}?".PHP_EOL)) {
+                $selectedOption = $transportAdapter;
+                break;
+            }
+        }
+
+        if ($selectedOption === 'Other') {
+            $selectedOption = $this->prompt("Which transport type do you want to use?");
+        }
+
+        /* @var BaseTransportAdapter $transport */
+        $transport = new $selectedOption();
+
+        if (!$transport instanceof BaseTransportAdapter) {
+            $this->stderr("$selectedOption is not an instance of " . BaseTransportAdapter::class . "");
+            return ExitCode::OK;
+        }
+
+        // What do they want to use?
+        foreach ($transport->settingsAttributes() as $property) {
+            $transport->$property = $this->prompt("What must $property be set to?");
+        }
+
+        // Save the new stuff to the settings
+        $settingsModel->transportType = $transport::displayName();
+        $settingsModel->transportSettings = $transport->getSettings();
+
+        // Too easy?
+        if (!$transport->validate()) {
+            $this->stderr('Your email settings are invalid.');
+            return ExitCode::OK;
+        }
+
+        // Setup the mailer.
+        $mailer = Craft::$app->getMailer();
+        $mailer->transport = $transport->defineTransport();
+
+        // For the template
+        $mailParams['settings'] = $this->_renderMailSettingsString($settingsModel, $transport);
+
+        $message = $mailer
+            ->composeFromKey('test_email', $mailParams)
+            ->setTo($recieverEmail);
+
+        // FOR... SPARTAAA!
+        return $this->_testEmailSending($message);
+    }
+
+    /**
      * Sets up a test suite for the current project.
      *
      * @param string|null $dst The folder that the test suite should be generated in.
@@ -39,7 +143,7 @@ class TestsController extends Controller
             $dst = getcwd();
         }
 
-        $src = dirname(__DIR__, 2). DIRECTORY_SEPARATOR . 'test' . DIRECTORY_SEPARATOR . 'internal' . DIRECTORY_SEPARATOR . 'example-test-suite';
+        $src = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'test' . DIRECTORY_SEPARATOR . 'internal' . DIRECTORY_SEPARATOR . 'example-test-suite';
 
         // Figure out the plan and check for conflicts
         $plan = [];
@@ -129,6 +233,55 @@ class TestsController extends Controller
         }
 
         $this->outputCommand('An output command');
+
+        return ExitCode::OK;
+    }
+
+    // Protected functions
+    // =========================================================================
+
+    /**
+     * @param MailSettings $settings
+     * @param $adapter
+     * @return string
+     */
+    protected function _renderMailSettingsString(MailSettings $settings, $adapter) : string
+    {
+        // Compose the settings list as HTML
+        $settingsList = '';
+
+        foreach (['fromEmail', 'fromName', 'template'] as $name) {
+            if (!empty($settings->$name)) {
+                $settingsList .= '- **' . $settings->getAttributeLabel($name) . ':** ' . $settings->$name . "\n";
+            }
+        }
+
+        $settingsList .= '- **' . 'Transport Type' . ':** ' . $adapter::displayName() . "\n";
+
+        $security = Craft::$app->getSecurity();
+
+        foreach ($adapter->settingsAttributes() as $name) {
+            if (!empty($adapter->$name)) {
+                $label = $adapter->getAttributeLabel($name);
+                $value = $security->redactIfSensitive($name, $adapter->$name);
+                $settingsList .= "- **{$label}:** {$value}\n";
+            }
+        }
+
+        return $settingsList;
+    }
+
+    /**
+     * @param Message $message
+     * @return int
+     */
+    protected function _testEmailSending(Message $message) : int
+    {
+        if ($message->send()) {
+            $this->stdout('Email sent successfully! Check your inbox.'.PHP_EOL.PHP_EOL);
+        } else {
+            $this->stderr('There was an error testing your email settings.'.PHP_EOL.PHP_EOL);
+        }
 
         return ExitCode::OK;
     }

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -67,12 +67,8 @@ class TestsController extends Controller
                 $settingsModel,
                 $adapter
             );
-
-            $message = Craft::$app->getMailer()
-                ->composeFromKey('test_email', $mailParams)
-                ->setTo($recieverEmail);
-
-            return $this->_testEmailSending($message);
+            
+            return $this->_testEmailSending($mailParams, $recieverEmail);
         }
 
         // Environment settings
@@ -98,11 +94,7 @@ class TestsController extends Controller
 
             $mailParams['settings'] = '';
 
-            $message = Craft::$app->getMailer()
-                ->composeFromKey('test_email', $mailParams)
-                ->setTo($recieverEmail);
-
-            return $this->_testEmailSending($message);
+            return $this->_testEmailSending($mailParams, $recieverEmail);
         }
 
         // Otherwise we let the user decide....
@@ -180,12 +172,8 @@ class TestsController extends Controller
         // For the template
         $mailParams['settings'] = $this->_renderMailSettingsString($settingsModel, $transport);
 
-        $message = $mailer
-            ->composeFromKey('test_email', $mailParams)
-            ->setTo($recieverEmail);
-
         // FOR... SPARTAAA!
-        return $this->_testEmailSending($message);
+        return $this->_testEmailSending($mailParams, $recieverEmail);
     }
 
     /**
@@ -335,11 +323,17 @@ class TestsController extends Controller
     }
 
     /**
-     * @param Message $message
+     * @param array $mailParams
+     * @param $reciever
      * @return int
+     * @throws \yii\base\InvalidConfigException
      */
-    protected function _testEmailSending(Message $message) : int
+    protected function _testEmailSending(array $mailParams, $reciever) : int
     {
+        $message = Craft::$app->getMailer()
+            ->composeFromKey('test_email', $mailParams)
+            ->setTo($reciever);
+
         if ($message->send()) {
             $this->stdout('Email sent successfully! Check your inbox.'.PHP_EOL.PHP_EOL);
         } else {

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -106,7 +106,7 @@ class TestsController extends Controller
         }
 
         if (!$selectedOption) {
-            $selectedOption = $this->prompt(PHP_EOL."You have not entered a custom transport type - please enter one now.");
+            $selectedOption = $this->prompt(PHP_EOL.'You have not entered a custom transport type - please enter one now.');
         }
 
         // Create the mailer

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -291,6 +291,8 @@ class TestsController extends Controller
     // =========================================================================
 
     /**
+     * Copied from `craft\controllers\SystemSettingsController::actionTestEmailSettings()`
+     *
      * @param MailSettings|null $settings
      * @param null $adapter
      * @return string

--- a/src/console/controllers/TestsController.php
+++ b/src/console/controllers/TestsController.php
@@ -62,7 +62,7 @@ class TestsController extends Controller
             );
 
             $mailParams['settings'] = $this->_renderMailSettingsString(
-                App::mailSettings(),
+                $settingsModel,
                 $adapter
             );
 
@@ -72,6 +72,7 @@ class TestsController extends Controller
 
             return $this->_testEmailSending($message);
         }
+
 
         // Otherwise we let the user decide....
         $transportAdapters = [


### PR DESCRIPTION
Resolves #4020

Not entirely sure what the original FR meant with the `multi-env` setup in `app.php` point. Will double check there - PR is still WIP for now. 

For now, this command allows you to test the default Craft email settings OR test custom settings based on any custom user input. You can select custom transport adapters and configure those to send a test email through the console 