### PR TITLE
Allow hard-deletion of trashed elements through the CP

### DIFF
--- a/CHANGELOG-v3.2.md
+++ b/CHANGELOG-v3.2.md
@@ -42,6 +42,7 @@
 - It’s now possible for plugins and modules to define custom actions on console controllers.
 - Added a testing framework for Craft and plugins, powered by Codeception. ([#3382](https://github.com/craftcms/cms/pull/3382), [#1485](https://github.com/craftcms/cms/issues/1485), [#944](https://github.com/craftcms/cms/issues/944))
 - Added `craft\base\BlockElementInterface`.
+- Added `craft\elements\actions\HardDelete`.
 - Added `craft\base\Element::EVENT_AFTER_PROPAGATE`.
 - Added `craft\base\Element::EVENT_REGISTER_PREVIEW_TARGETS`.
 - Added `craft\base\Element::previewTargets()`.

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added the `{% dd %}` Twig tag. ([#4399](https://github.com/craftcms/cms/issues/4399))
+- Added `craft\elements\actions\HardDelete`.
 
 ### Changed
 - `craft\web\twig\variables\CraftVariable` no longer triggers the `defineComponents` event. ([#4416](https://github.com/craftcms/cms/issues/4416))

--- a/docs/extend/element-types.md
+++ b/docs/extend/element-types.md
@@ -509,6 +509,12 @@ All element types are [soft-deletable](soft-deletes.md) out of the box, however 
 
 To make an element restorable, just add the <api:craft\elements\actions\Restore> action to the array returned by your static `defineActions()` method. Craft will automatically hide it during normal index views, and show it when someone selects the “Trashed” status option.
 
+### Hard Delete Action
+
+Any [soft-deleted](soft-deletes.md) elements can be individually hard-deleted via the CP. 
+
+To enable hard-deletion, just add the <api:craft\elements\actions\HardDelete> action to the array returned by your static `defineActions()` method. The hard-delete button will, exactly as the restore action above, only be visible if someone selects the "trashed" status option. 
+
 ### Sort Options
 
 You can define the sort options for your element indexes by adding a protected static `defineSortOptions()` method to your element class:

--- a/docs/extend/soft-deletes.md
+++ b/docs/extend/soft-deletes.md
@@ -56,6 +56,8 @@ public function init()
 
 [hardDelete()](api:craft\services\Gc::hardDelete()) method will delete any rows with a `dateDeleted` value set to a timestamp that’s older than the <config:softDeleteDuration> config setting. 
 
+If you want to support hard-deleting your element from the CP add the [Hard Delete Action](element-types.md#hard-delete-action) to the array returned by your `defineActions()` method. 
+
 ::: tip
 If you need to check multiple tables for stale rows, you can pass an array of table names into [hardDelete()](api:craft\services\Gc::hardDelete()) instead.
 :::

--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -483,10 +483,10 @@ class ElementIndexesController extends BaseElementsController
 
             // Determine the actions to be displayed/hidden if we are showing trashed/non-trashed elements.
             if ($this->elementQuery->trashed) {
-                if (!in_array(get_class($action), [Restore::class, HardDelete::class], true)) {
+                if (!$action instanceof Restore && !$action instanceof HardDelete) {
                     unset($actions[$i]);
                 }
-            } else if (in_array(get_class($action), [Restore::class, HardDelete::class], true)) {
+            } else if ($action instanceof Restore || $action instanceof HardDelete) {
                 unset($actions[$i]);
             }
         }

--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -481,11 +481,12 @@ class ElementIndexesController extends BaseElementsController
                 }
             }
 
+            // Determine the actions to be displayed/hidden if we are showing trashed/non-trashed elements.
             if ($this->elementQuery->trashed) {
-                if (!$action instanceof Restore && !$action instanceof HardDelete) {
+                if (!in_array(get_class($action), [Restore::class, HardDelete::class], true)) {
                     unset($actions[$i]);
                 }
-            } else if ($action instanceof Restore && $action instanceof HardDelete) {
+            } else if (in_array(get_class($action), [Restore::class, HardDelete::class], true)) {
                 unset($actions[$i]);
             }
         }

--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -482,10 +482,10 @@ class ElementIndexesController extends BaseElementsController
             }
 
             if ($this->elementQuery->trashed) {
-                if (!$action instanceof Restore || !$action instanceof HardDelete) {
+                if (!$action instanceof Restore && !$action instanceof HardDelete) {
                     unset($actions[$i]);
                 }
-            } else if ($action instanceof Restore || $action instanceof HardDelete) {
+            } else if ($action instanceof Restore && $action instanceof HardDelete) {
                 unset($actions[$i]);
             }
         }

--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -12,6 +12,7 @@ use craft\base\Element;
 use craft\base\ElementAction;
 use craft\base\ElementActionInterface;
 use craft\base\ElementInterface;
+use craft\elements\actions\HardDelete;
 use craft\elements\actions\Restore;
 use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
@@ -481,10 +482,10 @@ class ElementIndexesController extends BaseElementsController
             }
 
             if ($this->elementQuery->trashed) {
-                if (!$action instanceof Restore) {
+                if (!$action instanceof Restore || !$action instanceof HardDelete) {
                     unset($actions[$i]);
                 }
-            } else if ($action instanceof Restore) {
+            } else if ($action instanceof Restore || $action instanceof HardDelete) {
                 unset($actions[$i]);
             }
         }

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -18,6 +18,7 @@ use craft\elements\actions\DeleteAssets;
 use craft\elements\actions\DownloadAssetFile;
 use craft\elements\actions\Edit;
 use craft\elements\actions\EditImage;
+use craft\elements\actions\HardDelete;
 use craft\elements\actions\PreviewAsset;
 use craft\elements\actions\RenameFile;
 use craft\elements\actions\ReplaceFile;
@@ -270,9 +271,11 @@ class Asset extends Element
                 $actions[] = EditImage::class;
             }
 
+            // TODO: Do we need to do a checkPermission in HardDelete for assets? It's done above. Why does the DeleteAssets class do this?
             // Delete
             if ($userSession->checkPermission('deleteFilesAndFoldersInVolume:' . $volume->uid)) {
                 $actions[] = DeleteAssets::class;
+                $actions[] = HardDelete::class;
             }
         }
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -271,7 +271,6 @@ class Asset extends Element
                 $actions[] = EditImage::class;
             }
 
-            // TODO: Do we need to do a checkPermission in HardDelete for assets? It's done above. Why does the DeleteAssets class do this?
             // Delete
             if ($userSession->checkPermission('deleteFilesAndFoldersInVolume:' . $volume->uid)) {
                 $actions[] = DeleteAssets::class;

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -274,7 +274,11 @@ class Asset extends Element
             // Delete
             if ($userSession->checkPermission('deleteFilesAndFoldersInVolume:' . $volume->uid)) {
                 $actions[] = DeleteAssets::class;
-                $actions[] = HardDelete::class;
+                $actions[] = Craft::$app->getElements()->createAction([
+                    'type' => HardDelete::class,
+                    'confirmationMessage' => Craft::t('app', 'Are you sure you want to delete the selected assets?'),
+                    'successMessage' => Craft::t('app', 'Assets deleted.'),
+                ]);
             }
         }
 

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -16,6 +16,7 @@ use craft\elements\actions\DeepDuplicate;
 use craft\elements\actions\Delete;
 use craft\elements\actions\Duplicate;
 use craft\elements\actions\Edit;
+use craft\elements\actions\HardDelete;
 use craft\elements\actions\NewChild;
 use craft\elements\actions\Restore;
 use craft\elements\actions\SetStatus;
@@ -216,6 +217,12 @@ class Category extends Element
             // Delete
             $actions[] = $elementsService->createAction([
                 'type' => Delete::class,
+                'confirmationMessage' => Craft::t('app', 'Are you sure you want to delete the selected categories?'),
+                'successMessage' => Craft::t('app', 'Categories deleted.'),
+            ]);
+
+            $actions[] = $elementsService->createAction([
+                'type' => HardDelete::class,
                 'confirmationMessage' => Craft::t('app', 'Are you sure you want to delete the selected categories?'),
                 'successMessage' => Craft::t('app', 'Categories deleted.'),
             ]);

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -16,6 +16,7 @@ use craft\elements\actions\DeepDuplicate;
 use craft\elements\actions\Delete;
 use craft\elements\actions\Duplicate;
 use craft\elements\actions\Edit;
+use craft\elements\actions\HardDelete;
 use craft\elements\actions\NewChild;
 use craft\elements\actions\Restore;
 use craft\elements\actions\SetStatus;
@@ -381,6 +382,12 @@ class Entry extends Element
                 ) {
                     $actions[] = $elementsService->createAction([
                         'type' => Delete::class,
+                        'confirmationMessage' => Craft::t('app', 'Are you sure you want to delete the selected entries?'),
+                        'successMessage' => Craft::t('app', 'Entries deleted.'),
+                    ]);
+
+                    $actions[] = $elementsService->createAction([
+                        'type' => HardDelete::class,
                         'confirmationMessage' => Craft::t('app', 'Are you sure you want to delete the selected entries?'),
                         'successMessage' => Craft::t('app', 'Entries deleted.'),
                     ]);

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -13,6 +13,7 @@ use craft\db\Query;
 use craft\db\Table;
 use craft\elements\actions\DeleteUsers;
 use craft\elements\actions\Edit;
+use craft\elements\actions\HardDelete;
 use craft\elements\actions\Restore;
 use craft\elements\actions\SuspendUsers;
 use craft\elements\actions\UnsuspendUsers;
@@ -229,6 +230,13 @@ class User extends Element implements IdentityInterface
         if (Craft::$app->getUser()->checkPermission('deleteUsers')) {
             // Delete
             $actions[] = DeleteUsers::class;
+
+            $actions[] = $elementsService->createAction([
+                'type' => HardDelete::class,
+                'successMessage' => Craft::t('app', 'Users deleted.'),
+                'partialSuccessMessage' => Craft::t('app', 'Some users deleted.'),
+                'failMessage' => Craft::t('app', 'Users not deleted.'),
+            ]);
         }
 
         // Restore

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -234,8 +234,7 @@ class User extends Element implements IdentityInterface
             $actions[] = $elementsService->createAction([
                 'type' => HardDelete::class,
                 'successMessage' => Craft::t('app', 'Users deleted.'),
-                'partialSuccessMessage' => Craft::t('app', 'Some users deleted.'),
-                'failMessage' => Craft::t('app', 'Users not deleted.'),
+                'confirmationMessage' => Craft::t('app', 'Are you sure you want to delete the users?'),
             ]);
         }
 

--- a/src/elements/actions/HardDelete.php
+++ b/src/elements/actions/HardDelete.php
@@ -11,7 +11,6 @@ use Craft;
 use craft\base\ElementAction;
 use craft\elements\Asset;
 use craft\elements\db\ElementQueryInterface;
-use yii\base\InvalidArgumentException;
 
 /**
  * HardDelete represents a Hard delete element action.

--- a/src/elements/actions/HardDelete.php
+++ b/src/elements/actions/HardDelete.php
@@ -9,7 +9,9 @@ namespace craft\elements\actions;
 
 use Craft;
 use craft\base\ElementAction;
+use craft\elements\Asset;
 use craft\elements\db\ElementQueryInterface;
+use yii\base\InvalidArgumentException;
 
 /**
  * HardDelete represents a Hard delete element action.
@@ -78,6 +80,13 @@ class HardDelete extends ElementAction
     {
         $elementsService = Craft::$app->getElements();
         foreach ($query->all() as $element) {
+            if ($element instanceof Asset) {
+                $volume = $element->getVolume();
+                if (!Craft::$app->getUser()->checkPermission('deleteFilesAndFoldersInVolume:' . $volume->uid)) {
+                    return true;
+                }
+            }
+
             $elementsService->deleteElement($element, true);
         }
 

--- a/src/elements/actions/HardDelete.php
+++ b/src/elements/actions/HardDelete.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\elements\actions;
+
+use Craft;
+use craft\base\ElementAction;
+use craft\elements\db\ElementQueryInterface;
+
+/**
+ * HardDelete represents a Hard delete element action.
+ *
+ * Unline craft\elements\actions\Delete this action **will** remove any rows of the element from the DB and skip (if applicable)
+ * the `trashed` state.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @author Global Network Group | Giel Tettelaar <giel@yellowflash.net>
+ * @since 3.2
+ */
+class HardDelete extends ElementAction
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var string|null The confirmation message that should be shown before the elements get hard-deleted
+     */
+    public $confirmationMessage;
+
+    /**
+     * @var string|null The message that should be shown after the elements get hard-deleted
+     */
+    public $successMessage;
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function getTriggerLabel(): string
+    {
+        return Craft::t('app', 'Hard delete');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function isDestructive(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getConfirmationMessage()
+    {
+        return $this->confirmationMessage;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function performAction(ElementQueryInterface $query): bool
+    {
+        $elementsService = Craft::$app->getElements();
+        foreach ($query->all() as $element) {
+            $elementsService->deleteElement($element, true);
+        }
+
+        $this->setMessage($this->successMessage);
+
+        return true;
+    }
+}

--- a/src/elements/actions/HardDelete.php
+++ b/src/elements/actions/HardDelete.php
@@ -50,6 +50,14 @@ class HardDelete extends ElementAction
     /**
      * @inheritdoc
      */
+    public function getTriggerHtml()
+    {
+        return '<div class="btn formsubmit">' . $this->getTriggerLabel() . '</div>';
+    }
+
+    /**
+     * @inheritdoc
+     */
     public static function isDestructive(): bool
     {
         return true;

--- a/src/elements/actions/HardDelete.php
+++ b/src/elements/actions/HardDelete.php
@@ -16,8 +16,8 @@ use craft\elements\db\ElementQueryInterface;
 /**
  * HardDelete represents a Hard delete element action.
  *
- * Unline craft\elements\actions\Delete this action **will** remove any rows of the element from the DB and skip (if applicable)
- * the `trashed` state.
+ * Unlike craft\elements\actions\Delete this action **will** remove any rows of the element from the DB.
+ * Elements MUST be `trashed` before HardDelete actually deletes the elements.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @author Global Network Group | Giel Tettelaar <giel@yellowflash.net>

--- a/src/elements/actions/HardDelete.php
+++ b/src/elements/actions/HardDelete.php
@@ -8,6 +8,7 @@
 namespace craft\elements\actions;
 
 use Craft;
+use craft\base\Element;
 use craft\base\ElementAction;
 use craft\elements\Asset;
 use craft\elements\db\ElementQueryInterface;
@@ -78,7 +79,14 @@ class HardDelete extends ElementAction
     public function performAction(ElementQueryInterface $query): bool
     {
         $elementsService = Craft::$app->getElements();
+
+        /* @var Element $element */
         foreach ($query->all() as $element) {
+            // Nope. Soft-deletion first.
+            if (!$element->trashed) {
+                return true;
+            }
+
             if ($element instanceof Asset) {
                 $volume = $element->getVolume();
                 if (!Craft::$app->getUser()->checkPermission('deleteFilesAndFoldersInVolume:' . $volume->uid)) {


### PR DESCRIPTION
Resolves #4420 

Adds a `craft\elements\actions\HardDelete` class for hard-deletion. Only trashed elements will actually be deleted by this class (non-trashed are ignored). Preventing any loop-holes in the existing workflow. 

The `craft\controllers\ElementIndexesController::availableActions()` is adjusted accordingly. 