### PR TITLE
Adds console command for Bulk plugin actions

### DIFF
--- a/CHANGELOG-v3.2.md
+++ b/CHANGELOG-v3.2.md
@@ -42,6 +42,7 @@
 - Added the `_special/sitepicker` template.
 - It’s now possible for plugins and modules to define custom actions on console controllers.
 - Added a testing framework for Craft and plugins, powered by Codeception. ([#3382](https://github.com/craftcms/cms/pull/3382), [#1485](https://github.com/craftcms/cms/issues/1485), [#944](https://github.com/craftcms/cms/issues/944))
+- Added `craft\console\PluginsController`
 - Added `craft\base\BlockElementInterface`.
 - Added `craft\base\Element::EVENT_AFTER_PROPAGATE`.
 - Added `craft\base\Element::EVENT_REGISTER_PREVIEW_TARGETS`.

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -5,6 +5,7 @@
 ### Added
 - Added the `{% dd %}` Twig tag. ([#4399](https://github.com/craftcms/cms/issues/4399))
 - Asset, category, entry, and user indexes can now have “UID” columns. ([#4433](https://github.com/craftcms/cms/issues/4433))
+- Added `craft\console\PluginsController`
 
 ### Changed
 - `craft\web\twig\variables\CraftVariable` no longer triggers the `defineComponents` event. ([#4416](https://github.com/craftcms/cms/issues/4416))

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -79,7 +79,7 @@ class PluginsController extends Controller
      *
      * @return int
      */
-    public function actionBulk()
+    public function actionBulk() : int
     {
         $action = $this->select('What bulk actions do you want to perform?' . PHP_EOL, [
             'Uninstall' => 'This will Uninstall this plugin',
@@ -128,7 +128,7 @@ class PluginsController extends Controller
      * @param string $actionablePluginHandle
      * @return int
      */
-    protected function _processPluginAction(string $actionablePluginHandle, string $action)
+    protected function _processPluginAction(string $actionablePluginHandle, string $action) : int
     {
         $pluginsService = Craft::$app->getPlugins();
 

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\console\controllers;
+
+use Craft;
+use craft\console\Controller;
+use craft\helpers\Console;
+use yii\console\ExitCode;
+
+/**
+ * The PluginsController allows management of plugins through the CLI.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @author Global Network Group | Giel Tettelaar <giel@yellowflash.net>
+ * @since 3.2
+ */
+class PluginsController extends Controller
+{
+    // Public functions
+    // =========================================================================
+
+    public function actionUninstall(string $param = null)
+    {
+        if ($param === 'all') {
+            if (!$this->stdout('Are you sure? This will uninstall ALL plugins and their associated data?')) {
+                $this->stdout('Cancelling');
+                return ExitCode::OK;
+            }
+
+            $this->stdout('Uninstalling all plugins'.PHP_EOL);
+
+            foreach (Craft::$app->getPlugins()->getAllPlugins() as $plugin) {
+                Craft::$app->getPlugins()->uninstallPlugin($plugin->getHandle());
+            }
+
+            $this->stdout('Uninstalled all plugins');
+        }
+
+        $plugin = Craft::$app->getPlugins()->getPlugin($param);
+
+        if (!$plugin) {
+            $this->stdout('No plugin');
+            return ExitCode::OK;
+        }
+
+        Craft::$app->getPlugins()->uninstallPlugin($plugin);
+
+        $this->stdout('Plugin uninstalled');
+        return ExitCode::OK;
+    }
+}

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -42,35 +42,9 @@ class PluginsController extends Controller
      * @return int
      * @throws InvalidPluginException
      */
-    public function actionView(string $pluginHandle = null) : int
+    public function actionView() : int
     {
-        $pluginsService = Craft::$app->getPlugins();
         $plugins = $this->_assemblePlugins();
-
-        // Single plugin display
-        if ($pluginHandle) {
-            $plugin = $pluginsService->getComposerPluginInfo($pluginHandle);
-            if (!$plugin) {
-                $this->stderr('No plugin exists by that handle.'.PHP_EOL);
-                return ExitCode::UNSPECIFIED_ERROR;
-            }
-
-            $this->stdout('Plugin with name: '.$plugin['name'].''.PHP_EOL.PHP_EOL);
-
-            foreach ($plugin as $propName => $value) {
-                if (is_array($value)) {
-                    $value = implode(', ', $value);
-                }
-
-                $this->stdout("$propName: $value" . PHP_EOL);
-            }
-
-            $isInstalled = $pluginsService->isPluginInstalled($pluginHandle) ? 'Yes': 'No';
-            $this->stdout("Is installed: $isInstalled".PHP_EOL);
-            $this->stdout(PHP_EOL);
-
-            return ExitCode::OK;
-        }
 
         $this->stdout('We are able to detect the following plugins: '.PHP_EOL);
 

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -15,6 +15,7 @@ use craft\helpers\ArrayHelper;
 use craft\helpers\Console;
 use craft\helpers\StringHelper;
 use craft\services\Plugins;
+use yii\base\InvalidArgumentException;
 use yii\console\ExitCode;
 
 /**
@@ -155,7 +156,7 @@ class PluginsController extends Controller
             }
         }
 
-        $this->prompt('All actions processed successfully.');
+        $this->stdout('All actions processed successfully.'.PHP_EOL);
         return ExitCode::OK;
     }
 
@@ -190,22 +191,31 @@ class PluginsController extends Controller
         try {
             switch ($action) {
                 case 'Uninstall':
+                    $this->stdout("Uninstalling plugin: $actionablePluginHandle...".PHP_EOL);
+
                     if (!$pluginsService->uninstallPlugin($actionablePluginHandle)) {
                         return $this->_handleFailedPluginAction($actionablePluginHandle, $action);
                     }
                     break;
                 case 'Install':
                     $edition = $this->prompt('Which edition must the plugin be installed?');
+
+                    $this->stdout("Installing plugin: $actionablePluginHandle...".PHP_EOL);
+
                     if (!$pluginsService->installPlugin($actionablePluginHandle, $edition)) {
                         return $this->_handleFailedPluginAction($actionablePluginHandle, $action);
                     }
                     break;
                 case 'Disable':
+                    $this->stdout("Disabling plugin: $actionablePluginHandle...".PHP_EOL);
+
                     if (!$pluginsService->disablePlugin($actionablePluginHandle)) {
                         return $this->_handleFailedPluginAction($actionablePluginHandle, $action);
                     }
                     break;
                 case 'Enable':
+                    $this->stdout("Enabling plugin: $actionablePluginHandle...".PHP_EOL);
+
                     if (!$pluginsService->enablePlugin($actionablePluginHandle)) {
                         return $this->_handleFailedPluginAction($actionablePluginHandle, $action);
                     }
@@ -229,10 +239,10 @@ class PluginsController extends Controller
         $composerInfo = Craft::$app->getPlugins()->getComposerPluginInfo();
 
         foreach ($composerInfo as $handle => $composerPlugin) {
-            if ($pluginsService->isPluginInstalled($handle)) {
-                $plugins[] = $pluginsService->getPlugin($handle);
-            } else {
-                $plugins[] = $pluginsService->createPlugin($handle);
+            $plugins[] = $plugin = $pluginsService->createPlugin($handle);
+            
+            if (!$plugin) {
+                throw new InvalidArgumentException("Unable to create a plugin by handle: $handle");
             }
         }
 

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -86,7 +86,7 @@ class PluginsController extends Controller
         ]);
 
         $actionablePlugins = $this->prompt(
-            'Enter plugins seperated by comma.'
+            'Enter plugins seperated by a comma.'
         );
 
         if (!$actionablePlugins) {

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -10,6 +10,7 @@ namespace craft\console\controllers;
 use Craft;
 use craft\base\Plugin;
 use craft\console\Controller;
+use craft\helpers\ArrayHelper;
 use craft\helpers\Console;
 use craft\helpers\StringHelper;
 use craft\services\Plugins;
@@ -35,11 +36,34 @@ class PluginsController extends Controller
     /**
      * @return int
      */
-    public function actionView() : int
+    public function actionView(string $pluginHandle = null) : int
     {
-        $this->stdout('We are able to detect the following plugins: '.PHP_EOL);
-
         $plugins = $this->_assemblePlugins();
+
+        if ($pluginHandle) {
+            $plugin = ArrayHelper::where(
+                $plugins,
+                'handle',
+                $pluginHandle
+            );
+            $plugin = ArrayHelper::firstValue($plugin);
+
+            foreach ($plugin as $propName => $value) {
+                if (is_array($value)) {
+                    $value = implode(', ', $value);
+                }
+
+                if (is_object($value) && !method_exists($value, '__toString')) {
+                    $value = 'Unkown';
+                }
+                
+                $this->stdout("$propName: $value" . PHP_EOL);
+            }
+
+            return ExitCode::OK;
+        }
+
+        $this->stdout('We are able to detect the following plugins: '.PHP_EOL);
 
         if (!$plugins) {
             $this->stdout('No plugins detected'.PHP_EOL);

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -65,7 +65,6 @@ class PluginsController extends Controller
             $enabled = $pluginService->isPluginEnabled($plugin->handle);
             $disabled = $pluginService->isPluginDisabled($plugin->handle);
 
-            $status = 'Unkown';
             if ($enabled) {
                 $status = 'Enabled';
             } else if ($disabled) {

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -173,11 +173,12 @@ class PluginsController extends Controller
         $pluginsService = Craft::$app->getPlugins();
 
         // Ensure we know what they want.
-        $action = $this->select("What do you want to do to $actionablePluginHandle?".PHP_EOL, [
+        $action = $this->select("What do you want to do to: $actionablePluginHandle?".PHP_EOL, [
             'Uninstall' => 'Uninstall',
             'Install' => 'Install',
             'Disable' => 'Disable',
             'Enable' => 'Enable',
+            'No Action' => 'No Action'
         ]);
 
         $isInstalled = $pluginsService->isPluginInstalled($actionablePluginHandle);
@@ -220,11 +221,15 @@ class PluginsController extends Controller
                         return $this->_handleFailedPluginAction($actionablePluginHandle, $action);
                     }
                     break;
+                case 'No Action':
+                    $this->stdout("No action taken. Proceeding to next plugin...".PHP_EOL);
+                    break;
             }
         } catch (\Throwable $exception) {
             return $this->_handleFailedPluginAction($actionablePluginHandle, $action, $exception->getMessage());
         }
 
+        $this->stdout(PHP_EOL);
         return ExitCode::OK;
     }
 
@@ -240,7 +245,7 @@ class PluginsController extends Controller
 
         foreach ($composerInfo as $handle => $composerPlugin) {
             $plugins[] = $plugin = $pluginsService->createPlugin($handle);
-            
+
             if (!$plugin) {
                 throw new InvalidArgumentException("Unable to create a plugin by handle: $handle");
             }

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -27,13 +27,16 @@ use yii\console\ExitCode;
  */
 class PluginsController extends Controller
 {
-    // Public functions
+    // Properties
     // =========================================================================
 
     /**
      * @inheritdoc
      */
     public $defaultAction = 'view';
+
+    // Public Methods
+    // =========================================================================
 
     /**
      * View basic information about all plugins or all information about one plugin.
@@ -118,7 +121,7 @@ class PluginsController extends Controller
         return ExitCode::OK;
     }
 
-    // Protected functions
+    // Protected Methods
     // =========================================================================
 
     /**

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -86,7 +86,7 @@ class PluginsController extends Controller
         ]);
 
         $actionablePlugins = $this->prompt(
-            'Enter plugins seperated by a comma.'
+            'Enter the applicable plugin handles seperated by a comma.'
         );
 
         if (!$actionablePlugins) {

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -125,22 +125,11 @@ class PluginsController extends Controller
      * @param string $actionablePluginHandle
      * @return int
      */
-    protected function _processPluginAction(string $actionablePluginHandle, string $action = null)
+    protected function _processPluginAction(string $actionablePluginHandle, string $action)
     {
         $pluginsService = Craft::$app->getPlugins();
 
         $this->stdout(PHP_EOL);
-
-        if (!$action) {
-            // Ensure we know what they want.
-            $action = $this->select("What do you want to do to: $actionablePluginHandle?" . PHP_EOL, [
-                'Uninstall' => 'This will Uninstall this plugin',
-                'Install' => 'This will Install this plugin',
-                'Disable' => 'This will Disable this plugin',
-                'Enable' => 'This will Enable this plugin',
-                'No Action' => 'No Action will be taken. We will move to the next plugin.'
-            ]);
-        }
 
         $isInstalled = $pluginsService->isPluginInstalled($actionablePluginHandle);
 
@@ -181,9 +170,6 @@ class PluginsController extends Controller
                     if (!$pluginsService->enablePlugin($actionablePluginHandle)) {
                         return $this->_handleFailedPluginAction($actionablePluginHandle, $action);
                     }
-                    break;
-                case 'No Action':
-                    $this->stdout("No action taken. Proceeding to next plugin...".PHP_EOL);
                     break;
             }
         } catch (\Throwable $exception) {

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -36,6 +36,8 @@ class PluginsController extends Controller
     public $defaultAction = 'view';
 
     /**
+     * View basic information about all plugins or all information about one plugin.
+     *
      * @param string|null $pluginHandle
      * @return int
      * @throws InvalidPluginException
@@ -145,7 +147,10 @@ class PluginsController extends Controller
 
                 $result = $this->select(
                     "$pluginName - $handle - $version",
-                    ['Yes' => 'Yes', 'No' => 'No']
+                    [
+                        'Yes' => 'This will proceed to allow you to select what action you want to perform (I.E. Install or Enable a plugin)',
+                        'No' => 'This will skip to the next plugin without performing actions on this one. '
+                    ]
                 );
 
                 if ($result === 'Yes') {
@@ -172,13 +177,15 @@ class PluginsController extends Controller
     {
         $pluginsService = Craft::$app->getPlugins();
 
+        $this->stdout(PHP_EOL);
+
         // Ensure we know what they want.
         $action = $this->select("What do you want to do to: $actionablePluginHandle?".PHP_EOL, [
-            'Uninstall' => 'Uninstall',
-            'Install' => 'Install',
-            'Disable' => 'Disable',
-            'Enable' => 'Enable',
-            'No Action' => 'No Action'
+            'Uninstall' => 'This will Uninstall this plugin',
+            'Install' => 'This will Install this plugin',
+            'Disable' => 'This will Disable this plugin',
+            'Enable' => 'This will Enable this plugin',
+            'No Action' => 'No Action will be taken. We will move to the next plugin.'
         ]);
 
         $isInstalled = $pluginsService->isPluginInstalled($actionablePluginHandle);

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -103,6 +103,12 @@ class PluginsController extends Controller
         }
 
         foreach ($actionablePlugins as $actionablePlugin) {
+            $composerInfo = Craft::$app->getPlugins()->getComposerPluginInfo($actionablePlugin);
+            if (!$composerInfo) {
+                $this->stderr("Invalid plugin handle: $actionablePlugin".PHP_EOL);
+                return ExitCode::UNSPECIFIED_ERROR;
+            }
+
             if (($result = $this->_processPluginAction($actionablePlugin, $action)) !== 0) {
                 return $result;
             }

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -47,6 +47,7 @@ class PluginsController extends Controller
      */
     public function actionView() : int
     {
+        $pluginService = Craft::$app->getPlugins();
         $plugins = $this->_assemblePlugins();
 
         $this->stdout('We are able to detect the following plugins: '.PHP_EOL);
@@ -61,9 +62,20 @@ class PluginsController extends Controller
             $pluginName = $plugin->name;
             $handle = $plugin->getHandle();
             $version = $plugin->getVersion();
+            $enabled = $pluginService->isPluginEnabled($plugin->handle);
+            $disabled = $pluginService->isPluginDisabled($plugin->handle);
+
+            $status = 'Unkown';
+            if ($enabled) {
+                $status = 'Enabled';
+            } else if ($disabled) {
+                $status = 'Disabled';
+            } else {
+                $status = 'Not installed';
+            }
 
             $result = $this->stdout(
-                "$pluginName - $handle - $version" . PHP_EOL
+                "$pluginName - $handle - $version - $status" . PHP_EOL
             );
 
             if ($result) {

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -10,6 +10,7 @@ namespace craft\console\controllers;
 use Craft;
 use craft\base\Plugin;
 use craft\console\Controller;
+use craft\errors\InvalidPluginException;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Console;
 use craft\helpers\StringHelper;
@@ -34,31 +35,35 @@ class PluginsController extends Controller
     public $defaultAction = 'view';
 
     /**
+     * @param string|null $pluginHandle
      * @return int
+     * @throws InvalidPluginException
      */
     public function actionView(string $pluginHandle = null) : int
     {
         $plugins = $this->_assemblePlugins();
 
+        // Single plugin display
         if ($pluginHandle) {
-            $plugin = ArrayHelper::where(
-                $plugins,
-                'handle',
-                $pluginHandle
-            );
-            $plugin = ArrayHelper::firstValue($plugin);
+            $plugin = Craft::$app->getPlugins()->getComposerPluginInfo($pluginHandle);
+            if (!$plugin) {
+                $this->stderr('No plugin exists by that handle.'.PHP_EOL);
+                return ExitCode::UNSPECIFIED_ERROR;
+            }
+
+            $this->stdout('Plugin with name: '.$plugin['name'].''.PHP_EOL.PHP_EOL);
 
             foreach ($plugin as $propName => $value) {
                 if (is_array($value)) {
                     $value = implode(', ', $value);
                 }
 
-                if (is_object($value) && !method_exists($value, '__toString')) {
-                    $value = 'Unkown';
-                }
-                
                 $this->stdout("$propName: $value" . PHP_EOL);
             }
+
+            $isInstalled = Craft::$app->getPlugins()->isPluginInstalled($pluginHandle) ? 'Yes': 'No';
+            $this->stdout("Is installed: $isInstalled".PHP_EOL);
+            $this->stdout(PHP_EOL);
 
             return ExitCode::OK;
         }
@@ -96,14 +101,15 @@ class PluginsController extends Controller
      * Enabling them
      *
      * @return int
+     * @throws InvalidPluginException
      */
     public function actionManage() : int
     {
         $pluginsService = Craft::$app->getPlugins();
 
-        if (($actionablePlugins = $this->prompt(
-            'Enter plugins seperated by comma. Enter "No" if you want a list of plugins and the option to select from that list.'.PHP_EOL)
-            ) !== 'No') {
+        if ($actionablePlugins = $this->prompt(
+            'Enter plugins seperated by comma. Enter nothing if you want a list of plugins and the option to select from that list.')
+            ) {
             $actionablePlugins = StringHelper::split($actionablePlugins, ',');
 
             // Hmmm.
@@ -138,7 +144,7 @@ class PluginsController extends Controller
         }
 
         foreach ($actionablePlugins as $actionablePlugin) {
-            $isInstalled = Craft::$app->getPlugins()->isPluginInstalled($actionablePlugin);
+            $isInstalled = $pluginsService->isPluginInstalled($actionablePlugin);
 
             // Hmmm.
             if (!$isInstalled) {
@@ -157,23 +163,23 @@ class PluginsController extends Controller
             try {
                 switch ($action) {
                     case 'Uninstall':
-                        if (!Craft::$app->getPlugins()->uninstallPlugin($actionablePlugin)) {
+                        if (!$pluginsService->uninstallPlugin($actionablePlugin)) {
                             return $this->_handleFailedPluginAction($actionablePlugin, $action);
                         }
                         break;
                     case 'Install':
                         $edition = $this->prompt('Which edition must the plugin be installed?');
-                        if (!Craft::$app->getPlugins()->installPlugin($actionablePlugin, $edition)) {
+                        if (!$pluginsService->installPlugin($actionablePlugin, $edition)) {
                             return $this->_handleFailedPluginAction($actionablePlugin, $action);
                         }
                         break;
                     case 'Disable':
-                        if (!Craft::$app->getPlugins()->disablePlugin($actionablePlugin)) {
+                        if (!$pluginsService->disablePlugin($actionablePlugin)) {
                             return $this->_handleFailedPluginAction($actionablePlugin, $action);
                         }
                         break;
                     case 'Enable':
-                        if (!Craft::$app->getPlugins()->enablePlugin($actionablePlugin)) {
+                        if (!$pluginsService->enablePlugin($actionablePlugin)) {
                             return $this->_handleFailedPluginAction($actionablePlugin, $action);
                         }
                         break;

--- a/src/console/controllers/PluginsController.php
+++ b/src/console/controllers/PluginsController.php
@@ -263,7 +263,7 @@ class PluginsController extends Controller
     {
         $this->stderr("We were unable to $action $plugin" . PHP_EOL);
         if ($exceptionMessage) {
-            $this->stderr("Additionally an exception was thrown: $exceptionMessage");
+            $this->stderr("Additionally an exception was thrown: $exceptionMessage".PHP_EOL);
         }
 
         return ExitCode::OK;


### PR DESCRIPTION
Proposal to resolve #2405. 

This PR adds `craft\console\PluginsController` and `plugins/*` console command. Adds support for doing the following via the CLI
- Bulk Installing Plugins
- Bulk Enabling Plugins
- Bulk Disabling Plugins
- Bulk Uninstalling Plugins

As well as viewing the currently installed plugins in the System. 