### PR TITLE
Helper class for getting CSRF token name & value

### DIFF
--- a/src/helpers/Csrf.php
+++ b/src/helpers/Csrf.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\helpers;
+
+use Craft;
+
+/**
+ * Class Csrf
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.1
+ */
+class Csrf
+{
+    /**
+     * Get the CSRF token name.
+     *
+     * @return string
+     */
+    public static function tokenName(): string
+    {
+        return Craft::$app->getConfig()->getGeneral()->csrfTokenName;
+    }
+
+    /**
+     * Get the CSRF token value.
+     *
+     * @return string
+     */
+    public static function tokenValue(): string
+    {
+        return Craft::$app->getRequest()->getCsrfToken();
+    }
+}


### PR DESCRIPTION
Getting a CSRF token name & value the traditional way is clunky and difficult to remember...

```php
$csrfTokenName  = Craft::$app->getConfig()->getGeneral()->csrfTokenName;
$csrfTokenValue = Craft::$app->getRequest()->getCsrfToken();
```

I find it to be nearly impossible to remember where those two pieces of data live.

**I propose this simple helper class:**

```php
$csrfTokenName  = Csrf::tokenName();
$csrfTokenValue = Csrf::tokenValue();
```

This would make it _much_ easier to register CSRF tokens via PHP...

```php
use craft\helpers\Csrf;

$view = Craft::$app->getView();
$view->registerJs('
    window.csrfTokenName  = "'.Csrf::tokenName().'";
    window.csrfTokenValue = "'.Csrf::tokenValue().'";
', $view::POS_END);
```

If possible, I'd love to make it just as accessible via Twig tags. But I wasn't sure the best way to approach the Twig stuff.

Let me know if you have any suggestions!