### PR TITLE
Document translation message placeholders

### DIFF
--- a/docs/static-translations.md
+++ b/docs/static-translations.md
@@ -55,7 +55,22 @@ Now open `site.php` in a text editor, and have it return an array that maps the 
 
 return [
     'Contact us' => 'Kontaktiere uns',
+    'Welcome back' => 'Willkommen zurück {name}',
 ];
 ```
 
 Now, when Craft is processing the message translation for a German site, “Contact us” will be replaced with  “Kontaktiere uns”.
+
+### Message Parameters
+
+Translated messages can have [placeholder values](https://www.yiiframework.com/doc/guide/2.0/en/tutorial-i18n#message-parameters). For example, the 'Welcome back' message in the above `site.php` contains a placeholder for a person's name.
+
+To pass values to placeholders inside a template, use the `params` paramter.
+
+::: code
+```twig
+<p>{{ 'Welcome back'|t(params={
+  name: 'currentUser.friendlyName'
+}) }}</p>
+```
+:::

--- a/docs/static-translations.md
+++ b/docs/static-translations.md
@@ -24,10 +24,10 @@ The first step is to run all of your static messages through the translator. If 
 ```
 ```php
 // old
-$label = 'Contact us';
+echo 'Contact us';
 
 // new
-$label = Craft::t('site', 'Contact us');
+echo Craft::t('site', 'Contact us');
 ```
 :::
 
@@ -55,7 +55,6 @@ Now open `site.php` in a text editor, and have it return an array that maps the 
 
 return [
     'Contact us' => 'Kontaktiere uns',
-    'Welcome back' => 'Willkommen zurück {name}',
 ];
 ```
 
@@ -63,14 +62,27 @@ Now, when Craft is processing the message translation for a German site, “Cont
 
 ### Message Parameters
 
-Translated messages can have [placeholder values](https://www.yiiframework.com/doc/guide/2.0/en/tutorial-i18n#message-parameters). For example, the 'Welcome back' message in the above `site.php` contains a placeholder for a person's name.
+Static messages can have [placeholder values](https://www.yiiframework.com/doc/guide/2.0/en/tutorial-i18n#message-parameters). For example:
 
-To pass values to placeholders inside a template, use the `params` paramter.
+```php
+<?php
+
+return [
+    'Welcome back, {name}' => 'Willkommen zurück {name}',
+];
+```
+
+To replace the placeholder values with dynamic values when translating the message, pass the `params` argument when using the [translate](dev/filters.md#translate-or-t) filter or calling [Craft::t()](api:yii\BaseYii::t()):
 
 ::: code
 ```twig
-<p>{{ 'Welcome back'|t(params={
-  name: 'currentUser.friendlyName'
-}) }}</p>
+<a href="/contact">{{ 'Welcome back, {name}'|t(params={
+    'name' => currentUser.friendlyName,
+}) }}</a>
+```
+```php
+echo Craft::t('site', 'Welcome back, {name}', [
+    'name' => Craft::$app->user->identity->friendlyName,
+]);
 ```
 :::


### PR DESCRIPTION
This would have saved me the time I spent:

- Reading the yiiframework documentation about the feature
- Digging through craft source code to find how the translation filter is invoked and the parameter names used

Please assume this is a draft, I just wanted to open a pull request while everything was still fresh in my mind.
I don't have much experience writing docs, so a review or taking over the pull request is welcome.