### PR TITLE
Fixes a bug with functional tests returning 404

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -1,5 +1,16 @@
 # Release Notes for Craft CMS 3.x
 
+## Unreleased
+
+## Changed
+- `craft\test\TestSetup::setupProjectConfig()` will now throw an exception if it fails to write the `project.yml` file.
+
+## Fixed
+- Fixed a bug where where Functional tests could cause 404 errors ([#4472](https://github.com/craftcms/cms/issues/4472))
+
+## Removed
+- Removed the `$mergeExistingConfig` option on `craft\test\TestSetup::setupProjectConfig()` 
+
 ## 3.2.0-RC3 - 2019-07-02
 
 ### Added

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -6,10 +6,10 @@
 - `craft\test\TestSetup::setupProjectConfig()` will now throw an exception if it fails to write the `project.yml` file.
 
 ## Fixed
-- Fixed a bug where where Functional tests could cause 404 errors ([#4472](https://github.com/craftcms/cms/issues/4472))
+- Fixed a bug where where functional tests could cause 404 errors. ([#4472](https://github.com/craftcms/cms/issues/4472))
 
 ## Removed
-- Removed the `$mergeExistingConfig` option on `craft\test\TestSetup::setupProjectConfig()` 
+- Removed the `$mergeExistingConfig` option on `craft\test\TestSetup::setupProjectConfig()`.
 
 ## 3.2.0-RC3 - 2019-07-02
 

--- a/src/test/CraftConnector.php
+++ b/src/test/CraftConnector.php
@@ -12,6 +12,7 @@ use Codeception\Lib\Connector\Yii2;
 use Craft;
 use craft\base\Plugin;
 use craft\errors\InvalidPluginException;
+use craft\web\View;
 use yii\base\Module;
 use yii\mail\MessageInterface;
 use yii\web\Application;
@@ -86,6 +87,9 @@ class CraftConnector extends Yii2
     {
         parent::resetRequest($app);
         $app->getRequest()->setIsConsoleRequest(false);
+
+        // Reset the view object
+        $app->set('view', new View());
 
         /* @var Module $module */
         foreach (Craft::$app->getModules() as $module) {

--- a/src/test/TestSetup.php
+++ b/src/test/TestSetup.php
@@ -14,6 +14,7 @@ use craft\db\Migration;
 use craft\db\MigrationManager;
 use craft\feeds\Feeds;
 use craft\helpers\ArrayHelper;
+use craft\helpers\FileHelper;
 use craft\helpers\MigrationHelper;
 use craft\i18n\Locale;
 use craft\mail\Mailer;
@@ -332,7 +333,7 @@ class TestSetup
      * @param string $projectConfigFile
      * @param bool $mergeExistingConfig
      */
-    public static function setupProjectConfig(string $projectConfigFile, bool $mergeExistingConfig = false)
+    public static function setupProjectConfig(string $projectConfigFile)
     {
         if (!is_file($projectConfigFile)) {
             throw new InvalidArgumentException('Project config is not a file');
@@ -342,14 +343,8 @@ class TestSetup
         $contents = file_get_contents($projectConfigFile);
         $arrayContents = Yaml::parse($contents);
 
-        // Do we need to take into account the existing project config file?
-        if ($mergeExistingConfig === true && is_file($testSuiteProjectConfigPath)) {
-            $existingConfig = file_get_contents($testSuiteProjectConfigPath);
-            $arrayContents = array_merge($arrayContents, $existingConfig);
-        }
-
         // Write to the file.
-        file_put_contents($testSuiteProjectConfigPath, Yaml::dump($arrayContents));
+        FileHelper::writeToFile($testSuiteProjectConfigPath, Yaml::dump($arrayContents));
     }
 
     /**

--- a/src/test/TestSetup.php
+++ b/src/test/TestSetup.php
@@ -72,6 +72,7 @@ use craft\web\User;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionException;
 use Symfony\Component\Yaml\Yaml;
+use yii\base\ErrorException;
 use yii\base\Event;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
@@ -329,9 +330,8 @@ class TestSetup
     }
 
     /**
-     * @todo the $mergeExistingConfig is not being used by us - deprecate it?
      * @param string $projectConfigFile
-     * @param bool $mergeExistingConfig
+     * @throws ErrorException
      */
     public static function setupProjectConfig(string $projectConfigFile)
     {


### PR DESCRIPTION
Resolves #4472 

This bug was called if we tried using `ElementFixtures` with Functional tests where `craft\web\View::init()` was automatically setting the request to console and the template path to `TEMPLATE_MODE_CP` because the "order of operations" was following the expected path. 

<hr>

Without any fixtures the `init()` method would be called after the invocation of `craft\test\CraftConnector::resetRequest()` which set's the `_isConsoleRequest` property to false. All fine.

With fixtures the `init()` was being called before the `CraftConnecter` call. Leading `craft\web\View` to set it's `templateMode` to `cp`. 

This caused site requests would `404` as they would try to find templates in the CP directory - not the site directory if that was requested.

PR Also has some light cleanup work to be included before the `GA` release. 