### PR TITLE
Fix example code for displaying Matrix block contents

### DIFF
--- a/docs/dev/element-queries/matrix-block-queries.md
+++ b/docs/dev/element-queries/matrix-block-queries.md
@@ -39,7 +39,7 @@ We can display content from all the Matrix blocks of an element by doing the fol
 {% set matrixBlocks = myMatrixBlockQuery.all() %}
 
 {# Display their contents #}
-{% for block in blocks %}
+{% for block in matrixBlocks %}
     <p>{{ block.text }}</p>
 {% endfor %}
 ```


### PR DESCRIPTION
Need to loop through `matrixBlocks` not `blocks`