### PR TITLE
Set test env

### DIFF
--- a/src/test/TestSetup.php
+++ b/src/test/TestSetup.php
@@ -213,6 +213,7 @@ class TestSetup
                 'components' => [
                     'config' => [
                         'class' => Config::class,
+                        'env' => 'test',
                         'configDir' => CRAFT_CONFIG_PATH,
                         'appDefaultsDir' => $srcPath . '/config/defaults',
                     ],


### PR DESCRIPTION
`Config::$env` is `null` when running tests. This makes it use the `*` environmental config values, and you can't set specific `test` config values.

This fixes that.

However I also feel that maybe https://github.com/craftcms/cms/blob/develop/src/test/TestSetup.php#L214-L218 could be merged with https://github.com/craftcms/cms/blob/develop/src/test/TestSetup.php#L247-L250 somehow (which already has the `test` env)