### PR TITLE
Add InterceptTokenRouteEvent to craft\web\UrlManager::_getRequestRoute

### DIFF
--- a/src/events/InterceptTokenRouteEvent.php
+++ b/src/events/InterceptTokenRouteEvent.php
@@ -21,5 +21,6 @@ class InterceptTokenRouteEvent extends Event
     // =========================================================================
 
     public $useTokenRoute = true;
+    public $useReturnedRoute = false;
     public $route = null;
 }

--- a/src/events/InterceptTokenRouteEvent.php
+++ b/src/events/InterceptTokenRouteEvent.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+
+/**
+ * RegisterUrlRulesEvent class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.0
+ */
+class InterceptTokenRouteEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    public $useTokenRoute = true;
+    public $route = null;
+}


### PR DESCRIPTION
This event makes it possible for a plugin to override a token Route in further releases of 3.1, so that a route previously registered can be used in desired cases.

It's intended to be used for 3.1 share requests. If desired, we could further restrict this implementation to only apply on those cases.

This implementation also includes ability to override the token Route, still bypassing ordinary routing. It's an option not actually used for current plugin, so it would be fine to take this action out if undesirable.

Ref: offline conversation which this should put a close to.
