### PR TITLE
mysql8 requires an additional attr for mysqldump

### DIFF
--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -154,7 +154,8 @@ class Schema extends \yii\db\mysql\Schema
             ' --no-autocommit' .
             ' --routines' .
             ' --set-charset' .
-            ' --triggers';
+            ' --triggers' . 
+            '--column-statistics=0';
 
         $ignoreTableArgs = [];
         foreach (Craft::$app->getDb()->getIgnoredBackupTables() as $table) {


### PR DESCRIPTION
mysql8 will fail on mysqldump without the --column-statistics=0 flag