### PR TITLE
Fix SVG scaling bug when using transform with only one dimension value

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -749,7 +749,10 @@ class Asset extends Element
             return null;
         }
 
-        if ($this->getMimeType() === 'image/gif' && !Craft::$app->getConfig()->getGeneral()->transformGifs) {
+        if (
+            ($this->getMimeType() === 'image/gif' && !Craft::$app->getConfig()->getGeneral()->transformGifs) ||
+            ($this->getMimeType() === 'image/svg+xml')
+        ){
             return AssetsHelper::generateUrl($volume, $this);
         }
 


### PR DESCRIPTION
Patches an error (see below) that occurs when using an image transform that only has a defined height (or width) on an SVG asset.

Argument 1 passed to craft\image\Svg::scaleToFit() must be of the type integer, null given, called in ../vendor/craftcms/cms/src/services/AssetTransforms.php on line 1424