### PR TITLE
Fix display of long titles

### DIFF
--- a/src/templates/_layouts/cp.html
+++ b/src/templates/_layouts/cp.html
@@ -229,7 +229,7 @@
                         {% block header %}
                             {% block pageTitle %}
                                 {% if title is defined and title|length %}
-                                    <h1>{{ title }}</h1>
+                                    <h1><span>{{ title }}</span></h1>
                                 {% endif %}
                             {% endblock %}
                             {% block contextMenu %}{% endblock %}

--- a/src/web/assets/cp/dist/css/_cp.scss
+++ b/src/web/assets/cp/dist/css/_cp.scss
@@ -531,7 +531,7 @@ $sidebarLinkSecondaryColor: hsl($hue, 5%, 75%);
       display: flex;
       align-items: center;
       align-content: stretch;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       justify-content: space-between;
       position: relative;
       z-index: 2;
@@ -564,14 +564,18 @@ $sidebarLinkSecondaryColor: hsl($hue, 5%, 75%);
         line-height: 32px;
         margin-top: 0;
         margin-bottom: 0;
-        display: inline;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        min-width: 0;
 
         &:not(:last-child) {
           @include margin-right(24px !important);
         }
+      }
+      
+      h1 > span {
+        display: block;  
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .buttons,
@@ -898,6 +902,10 @@ $sidebarLinkSecondaryColor: hsl($hue, 5%, 75%);
 
   #main-container {
     #main {
+      #header {
+        flex-wrap: wrap;
+      }
+
       #main-content {
         flex-direction: column;
         max-height: none !important;


### PR DESCRIPTION
Resolves the issue described in #4548 by forcing the header to no wrap and apply the text overflow strategy as described here: https://css-tricks.com/flexbox-truncated-text/

![Bildschirmfoto 2019-07-31 um 12 22 52](https://user-images.githubusercontent.com/2273359/62204652-f4c7b480-b38d-11e9-8b06-b3f4a8d9f969.png)

The entry edit header is still too wide on smaller screens, but at least it does not break apart. Maybe we could:
- Rename "Save entry" to "Save"
- Move "Save as draft" to dropdown in the save button
- Remove labels of "Preview" and "Share" Buttons, the icons are unique enough
- Move "Preview", "Share" and "Save as Draft" to a menu