### PR TITLE
Remove expiryDate from actionCreateToken

### DIFF
--- a/src/controllers/LivePreviewController.php
+++ b/src/controllers/LivePreviewController.php
@@ -65,8 +65,7 @@ class LivePreviewController extends Controller
             ]
         ];
 
-        $expiryDate = (new \DateTime())->add(new \DateInterval('P1D'));
-        $token = Craft::$app->getTokens()->createToken($route, null, $expiryDate);
+        $token = Craft::$app->getTokens()->createToken($route);
 
         if (!$token) {
             throw new ServerErrorHttpException('Could not create a Live Preview token.');


### PR DESCRIPTION
Shared URL's will automatically expire after 24 hours (`P1D`). 

This PR removed the `expiryDate` from the createToken method call. Doing so will change the expiration of the preview token to make it match with the `defaultTokenDuration` config setting. 

This defaultTokenDuration config value has a default value of 86400 / 1 day, thus only those who have altered this value will have a different behaviour. 