### PR TITLE
Add meta and settings hooks to edit Entries template

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 ### Added
-- Added the `cp.entries.edit.meta` and `cp.entries.edit.settings` template hooks to the Edit Entry page.
 - Added the `ignorePlaceholders` element query param.
+- Added the `cp.entries.edit.meta` and `cp.entries.edit.settings` template hooks to the Edit Entry page.
 - Added `craft\base\ElementInterface::getSource()`.
 
 ### Changed

--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added the `cp.entries.edit.meta` and `cp.entries.edit.settings` template hooks to the Edit Entry page.
+
 ### Changed
 - Improved the Control Panel header styling for mobile and on pages with long titles. ([#4548](https://github.com/craftcms/cms/issues/4548))
 - Element references in the Control Panel now reveal the site the element was fetched from in their tooltips, on multi-site installs. ([#4690](https://github.com/craftcms/cms/issues/4690))

--- a/src/templates/entries/_edit.html
+++ b/src/templates/entries/_edit.html
@@ -131,6 +131,14 @@
     {% endif %}
 
     {{ parent() }}
+    {# Give plugins a chance to add other things here #}
+    {% hook "cp.entries.edit.settings" %}
+{% endblock %}
+
+{% block meta %}
+    {{ parent() }}
+    {# Give plugins a chance to add other things here #}
+    {% hook "cp.entries.edit.meta" %}
 {% endblock %}
 
 {% block details %}


### PR DESCRIPTION
Adds two new hooks to supplement the existing `cp.entries.edit.details` hook. This allows plugin developers more control over where extra HTML is rendered, in particular when adding a new field or meta information.