### PR TITLE
Loading `project.yaml` and Fixtures

### DIFF
--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -166,6 +166,17 @@ class Craft extends Yii2
             return;
         }
 
+        $db = \Craft::createObject(
+            App::dbConfig(self::createDbConfig())
+        );
+
+        \Craft::$app->set('db', $db);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function loadFixtures($test) {
         // Re-apply project config
         if ($projectConfig = $this->_getConfig('projectConfig')) {
             // Tests just beginning. . Reset the project config to its original state.
@@ -189,11 +200,7 @@ class Craft extends Yii2
             }
         }
 
-        $db = \Craft::createObject(
-            App::dbConfig(self::createDbConfig())
-        );
-
-        \Craft::$app->set('db', $db);
+        return parent::loadFixtures($test);
     }
 
     /**


### PR DESCRIPTION
It is currently impossible to utilize the project.yaml _and_ fixtures in a test scenario. I'm not sure if this is something you'd like to support because it's non-trivial to add, but I figured I'd open a PR with some suggestions for your consideration.

First, the motivation for this is to implement TDD (or any testing) on a front-end only build of a website within Craft. E.g., imagine a developer working entirely in the template layer and the Craft admin. They may create several sections, add fields to those sections, configure some globals, etc. Additionally they may have some "boilerplate" entries that define things like a representative blog post or the scaffolding of the homepage.

Currently, the above developer would have to save everything out as a `project.yaml` file so they could sync configuration between production and staging. But for testing they would then have to redefine the section and entry type configuration in a second place, in fixtures, because they load too late in the test setup.

The attached fix moves the `project.yaml` setup out of the `_before` flow and moves it deeper in to the `loadFixutres` flow directly. This ensures it loads _before_ the fixtures but not before the app is initialized.

The _major_ downside to this approach is that the current `loadFixtures` method is `private` as defined in the Yii2 Codeception module. That means the attached won't actually work. If this seems feasible, though, I'm happy to open a PR over there for consideration of the upstream update.

If this doesn't make any sense and there's a better way to do this I'm all ears, but I couldn't find anything in my reading of the docs or my perusal of the source.