### PR TITLE
[Docs] Fix twig error

### DIFF
--- a/docs/static-translations.md
+++ b/docs/static-translations.md
@@ -77,7 +77,7 @@ To replace the placeholder values with dynamic values when translating the messa
 ::: code
 ```twig
 <a href="/contact">{{ 'Welcome back, {name}'|t(params={
-    'name' => currentUser.friendlyName,
+    'name' : currentUser.friendlyName,
 }) }}</a>
 ```
 ```php

--- a/docs/static-translations.md
+++ b/docs/static-translations.md
@@ -76,8 +76,8 @@ To replace the placeholder values with dynamic values when translating the messa
 
 ::: code
 ```twig
-<a href="/contact">{{ 'Welcome back, {name}'|t(params={
-    'name' : currentUser.friendlyName,
+<a href="/contact">{{ 'Welcome back, {name}'|t(params = {
+    name: currentUser.friendlyName,
 }) }}</a>
 ```
 ```php


### PR DESCRIPTION
Twig Syntax Error – Twig\Error\SyntaxError
A hash key must be followed by a colon (:). Unexpected token "arrow function" of value "=>" ("punctuation" expected with value ":").