### PR TITLE
[3.3] Allow custom attributes and elements in the `svg()` function

### DIFF
--- a/CHANGELOG-v3.3.md
+++ b/CHANGELOG-v3.3.md
@@ -2,7 +2,7 @@
 
 ## Changed
 - You can now use handles in Global set reference tags. ([#4645](https://github.com/craftcms/cms/issues/4645))
-- It is now possible to specify any attribute when using the SVG function. ([#4660](https://github.com/craftcms/cms/issues/4660))
+- Improved the `svg()` function to allow custom attributes and elements. ([#4660](https://github.com/craftcms/cms/issues/4660), [#3937](https://github.com/craftcms/cms/issues/3937))
 
 ## Deprecated
 - You can no longer pass a `string $class` argument to the twig svg function. Pass `array $attributes` instead. 

--- a/CHANGELOG-v3.3.md
+++ b/CHANGELOG-v3.3.md
@@ -5,4 +5,4 @@
 - Improved the `svg()` function to allow custom attributes and elements. ([#4660](https://github.com/craftcms/cms/issues/4660), [#3937](https://github.com/craftcms/cms/issues/3937))
 
 ## Deprecated
-- You can no longer pass a `string $class` argument to the twig svg function. Pass `array $attributes` instead. 
+- You can no longer pass a `string $class` argument to the twig `svg()` function. Pass `array $attributes` instead. 

--- a/CHANGELOG-v3.3.md
+++ b/CHANGELOG-v3.3.md
@@ -2,7 +2,7 @@
 
 ## Changed
 - You can now use handles in Global set reference tags. ([#4645](https://github.com/craftcms/cms/issues/4645))
-- Improved the `svg()` function to allow custom attributes and elements. ([#4660](https://github.com/craftcms/cms/issues/4660), [#3937](https://github.com/craftcms/cms/issues/3937))
+- Improved the `svg()` function to allow custom elements. ([#3937](https://github.com/craftcms/cms/issues/3937))
 
 ## Deprecated
-- You can no longer pass a `string $class` argument to the twig `svg()` function. Pass `array $attr` instead. 
+- Passing a `string $class` argument into twig `svg()` function is deprecated. Use the `|attr` filter instead. 

--- a/CHANGELOG-v3.3.md
+++ b/CHANGELOG-v3.3.md
@@ -2,3 +2,7 @@
 
 ## Changed
 - You can now use handles in Global set reference tags. ([#4645](https://github.com/craftcms/cms/issues/4645))
+- It is now possible to specify any attribute when using the SVG function. ([#4660](https://github.com/craftcms/cms/issues/4660))
+
+## Deprecated
+- You can no longer pass a `$class` argument to the twig svg function. Pass `$attributes` instead. 

--- a/CHANGELOG-v3.3.md
+++ b/CHANGELOG-v3.3.md
@@ -5,4 +5,4 @@
 - It is now possible to specify any attribute when using the SVG function. ([#4660](https://github.com/craftcms/cms/issues/4660))
 
 ## Deprecated
-- You can no longer pass a `$class` argument to the twig svg function. Pass `$attributes` instead. 
+- You can no longer pass a `string $class` argument to the twig svg function. Pass `array $attributes` instead. 

--- a/CHANGELOG-v3.3.md
+++ b/CHANGELOG-v3.3.md
@@ -5,4 +5,4 @@
 - Improved the `svg()` function to allow custom attributes and elements. ([#4660](https://github.com/craftcms/cms/issues/4660), [#3937](https://github.com/craftcms/cms/issues/3937))
 
 ## Deprecated
-- You can no longer pass a `string $class` argument to the twig `svg()` function. Pass `array $attributes` instead. 
+- You can no longer pass a `string $class` argument to the twig `svg()` function. Pass `array $attr` instead. 

--- a/docs/dev/functions.md
+++ b/docs/dev/functions.md
@@ -346,8 +346,8 @@ By default, if you pass an asset or raw markup into the function, the SVG will b
 {{ svg(image, sanitize=false, namespace=false) }}
 ```
 
-You can specify custom attributes that should be added the root `<svg>` element using the `$attributes` argument. 
-The `$attributes` argument accepts an array where the `key` is name of the attribute the `value` is it's value: 
+You can specify custom attributes that should be added the root `<svg>` element using the `$attr` argument. 
+The `$attr` argument accepts an array where the `key` is name of the attribute the `value` is it's value: 
 
 ```twig
 {{ svg('@webroot/icons/lemon.svg', attributes={class: 'lemon-icon', 'aria-labelledby': 'title'}) }}
@@ -358,7 +358,7 @@ The `$elements` argument requires a nested array where the child arrays contain 
 - The name of the element
 - The content of the element
 - An array containing the key value pairs listing any attributes of this element, 
-in the same format as required when using the `$attributes` argument.
+in the same format as required when using the `$attr` argument.
 
 So doing this: 
 

--- a/docs/dev/functions.md
+++ b/docs/dev/functions.md
@@ -346,11 +346,14 @@ By default, if you pass an asset or raw markup into the function, the SVG will b
 {{ svg(image, sanitize=false, namespace=false) }}
 ```
 
-You can specify custom attributes that should be added the root `<svg>` element using the `$attr` argument. 
-The `$attr` argument accepts an array where the `key` is name of the attribute the `value` is it's value: 
+If you want to specify custom attributes you can use the [|attr](#attr) filter as follows: 
 
 ```twig
-{{ svg('@webroot/icons/lemon.svg', attributes={class: 'lemon-icon', 'aria-labelledby': 'title'}) }}
+{{ svg('@webroot/icons/lemon.svg')|attr({
+    class: 'icon',
+    role: 'img',
+    'aria-labelledby': 'title desc'
+}) }}
 ```
 
 It is also possible to specify custom elements that should be added as children of the root svg element (i.e. a `<title>`). This can be done  via the `$elements` argument. 

--- a/docs/dev/functions.md
+++ b/docs/dev/functions.md
@@ -347,7 +347,7 @@ By default, if you pass an asset or raw markup into the function, the SVG will b
 ```
 
 You can also specify a custom attributes that should be added the root `<svg>` node using the `$attributes` argument. 
-The `$attributes` argument accepts an array where the `key` is the attribute and the `value` is the value of the argument. 
+The `$attributes` argument accepts an array where the `key` is the attributes name and the `value` is the attributes value: 
 
 ```twig
 {{ svg('@webroot/icons/lemon.svg', attributes={class: 'lemon-icon', 'aria-labelledby': 'title'}) }}

--- a/docs/dev/functions.md
+++ b/docs/dev/functions.md
@@ -354,7 +354,7 @@ The `$attributes` argument accepts an array where the `key` is name of the attri
 ```
 
 It is also possible to specify custom elements that should be added as children of the root svg element (i.e. a `<title>`). This can be done  via the `$elements` argument. 
-The `$elements` argument requires a nested array where the child array contains three items: 
+The `$elements` argument requires a nested array where the child arrays contain these three items: 
 - The name of the element
 - The content of the element
 - An array containing the key value pairs listing any attributes of this element, 

--- a/docs/dev/functions.md
+++ b/docs/dev/functions.md
@@ -346,11 +346,37 @@ By default, if you pass an asset or raw markup into the function, the SVG will b
 {{ svg(image, sanitize=false, namespace=false) }}
 ```
 
-You can also specify a custom attributes that should be added the root `<svg>` node using the `$attributes` argument. 
-The `$attributes` argument accepts an array where the `key` is the attributes name and the `value` is the attributes value: 
+You can specify custom attributes that should be added the root `<svg>` element using the `$attributes` argument. 
+The `$attributes` argument accepts an array where the `key` is name of the attribute the `value` is it's value: 
 
 ```twig
 {{ svg('@webroot/icons/lemon.svg', attributes={class: 'lemon-icon', 'aria-labelledby': 'title'}) }}
+```
+
+It is also possible to specify custom elements that should be added as children of the root svg element (i.e. a `<title>`). This can be done  via the `$elements` argument. 
+The `$elements` argument requires a nested array where the child array contains three items: 
+- The name of the element
+- The content of the element
+- An array containing the key value pairs listing any attributes of this element, 
+in the same format as required when using the `$attributes` argument.
+
+So doing this: 
+
+```twig
+{{ svg('<svg><circle></circle></svg>', elements=[['title', 'Some circle', {attribute: 'round'}]]) }}
+```
+
+would render: 
+
+```twig
+<svg>
+    <title attribute="round">
+        Some circle
+    </title>
+    <circle>
+    </circle>
+</svg>
+
 ```
 
 ## `source`

--- a/docs/dev/functions.md
+++ b/docs/dev/functions.md
@@ -346,10 +346,11 @@ By default, if you pass an asset or raw markup into the function, the SVG will b
 {{ svg(image, sanitize=false, namespace=false) }}
 ```
 
-You can also specify a custom class name that should be added to the root `<svg>` node using the `class` argument:
+You can also specify a custom attributes that should be added the root `<svg>` node using the `$attributes` argument. 
+The `$attributes` argument accepts an array where the `key` is the attribute and the `value` is the value of the argument. 
 
 ```twig
-{{ svg('@webroot/icons/lemon.svg', class='lemon-icon') }}
+{{ svg('@webroot/icons/lemon.svg', attributes={class: 'lemon-icon', 'aria-labelledby': 'title'}) }}
 ```
 
 ## `source`

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -951,7 +951,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [], array $elements = [], string $class = '')
     {
-        // Deprecate the $class argument
+        // Deprecate the $class argument. Allow both svg(class='class') and svg('', true, true, 'class')
         $oldClass = is_string($attributes) ? $attributes : $class;
         if ($oldClass) {
             $attributes = ['class' => $oldClass];

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1026,11 +1026,15 @@ class Extension extends AbstractExtension implements GlobalsInterface
         // Load up the attributes
         foreach ($attributes as $key => $value) {
             if (is_string($key) && is_string($value)) {
-                $svg = preg_replace('/(<svg\b[^>]+\b' . $key . '=([\'"])[^\'"]+)(\\2)/i', "$1 {$value}$3", $svg, 1, $count);
+                $encKey = Html::encode($key);
+                $encVal = Html::encode($value);
+
+                $svg = preg_replace('/(<svg\b[^>]+\b' . $encKey . '=([\'"])[^\'"]+)(\\2)/i', "$1 {$encVal}$3", $svg, 1, $count);
                 if ($count === 0) {
-                    $svg = preg_replace('/<svg\b/i', "$0 {$key}=\"{$value}\"", $svg, 1);
+                    $svg = preg_replace('/<svg\b/i', "$0 {$encKey}=\"{$encVal}\"", $svg, 1);
                 }
             }
+
         }
 
         return TemplateHelper::raw($svg);

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -944,17 +944,15 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * @param bool|null $namespace Whether class names and IDs within the SVG
      * should be namespaced to avoid conflicts with other elements in the DOM.
      * By default the SVG will only be namespaced if an asset or markup is passed in.
-     * @param string|null $class Deprecated - use $attributes instead.
-     * @param array|null $attr A list of attributes that should be added to the root `<svg>` element.
+     * @param string|null $class Deprecated - use |attr instead.
      * @param array|null $elements Any elements that should be added under the  root`svg` element
      * @return Markup|string
      */
-    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, string $class = null, array $attr = [], array $elements = [])
+    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, string $class = null, array $elements = [])
     {
-        // Deprecate the $class argument. Allow both svg(class='class') and svg('', true, true, 'class')
+        // Deprecate the $class argument.
         if ($class) {
-            $attr['class'] = isset($attr['class']) ? $attr['class'] . ' ' . $class : $class;
-            Craft::$app->getDeprecator()->log("svg(class=$class)", 'Passing a string $class argument is deprecated. Pass an array with a `class` key instead.');
+            Craft::$app->getDeprecator()->log("svg(class=$class)", 'Passing a string $class argument is deprecated. Use the `|attr` filter.');
         }
 
         if ($svg instanceof Asset) {
@@ -1025,16 +1023,11 @@ class Extension extends AbstractExtension implements GlobalsInterface
             }
         }
 
-        // Load up the attributes
-        foreach ($attr as $key => $value) {
-            if (is_string($key) && is_string($value)) {
-                $encKey = Html::encode($key);
-                $encVal = Html::encode($value);
-
-                $svg = preg_replace('/(<svg\b[^>]+\b' . $encKey . '=([\'"])[^\'"]+)(\\2)/i', "$1 {$encVal}$3", $svg, 1, $count);
-                if ($count === 0) {
-                    $svg = preg_replace('/<svg\b/i', "$0 {$encKey}=\"{$encVal}\"", $svg, 1);
-                }
+        // Class functionality.
+        if ($class !== null) {
+            $svg = preg_replace('/(<svg\b[^>]+\bclass=([\'"])[^\'"]+)(\\2)/i', "$1 {$class}$3", $svg, 1, $count);
+            if ($count === 0) {
+                $svg = preg_replace('/<svg\b/i', "$0 class=\"{$class}\"", $svg, 1);
             }
         }
 

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1037,7 +1037,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             }
         }
 
-        // Render the tags...
+        // Render the elements...
         $elementValue = '';
         foreach ($elements as $elementConfig) {
             // Dont allow empty name
@@ -1047,7 +1047,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
 
             // Empty content or no attributes is allowed...
             $elementName = $elementConfig[0];
-            $tag = Html::tag(
+            $element = Html::tag(
                 $elementName ,
                 $elementConfig[1] ?? '',
                 $elementConfig[2] ?? []
@@ -1055,11 +1055,11 @@ class Extension extends AbstractExtension implements GlobalsInterface
 
             // Add it back...
             $encName = Html::encode($elementName);
-            $svg = preg_replace('/<'.$encName.'>.*?<\/'.$encName.'>\s*/is', $tag, $svg, 1, $count);
+            $svg = preg_replace('/<'.$encName.'>.*?<\/'.$encName.'>\s*/is', $element, $svg, 1, $count);
 
             // If it didn't exist - we save it to add later.
             if ($count === 0) {
-                $elementValue .= $tag;
+                $elementValue .= $element;
             }
         }
         $svg = preg_replace('/<\s*svg[^>]*>/', "$0 $elementValue", $svg, 1);

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1046,13 +1046,16 @@ class Extension extends AbstractExtension implements GlobalsInterface
             }
 
             // Empty content or no attributes is allowed...
+            $elementName = $elementConfig[0];
             $tag = Html::tag(
-                $elementConfig[0] ,
+                $elementName ,
                 $elementConfig[1] ?? '',
                 $elementConfig[2] ?? []
             );
 
-            $svg = preg_replace('/<title>.*?<\/title>\s*/is', $tag, $svg, 1, $count);
+            // Add it back...
+            $encName = Html::encode($elementName);
+            $svg = preg_replace('/<'.$encName.'>.*?<\/'.$encName.'>\s*/is', $tag, $svg, 1, $count);
 
             // If it didn't exist - we add it later.
             if ($count === 0) {

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -949,10 +949,10 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [])
     {
-        // Deprate the $class argument
+        // Deprecate the $class argument
         if (is_string($attributes)) {
             $attributes = ['class' => $attributes];
-            Craft::$app->getDeprecator()->log('app', 'Passing a string $class argument is deprecated.');
+            Craft::$app->getDeprecator()->log('Extension::svgFunction()', 'Passing a string $class argument is deprecated. Pass an array with a `class` key instead.');
         }
 
         if ($svg instanceof Asset) {

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -948,7 +948,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * @param array|null $elements Any elements that should be added under the  root`svg` element
      * @return Markup|string
      */
-    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [], array $elements = null)
+    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [], array $elements = [])
     {
         // Deprecate the $class argument
         if (is_string($attributes)) {

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -946,13 +946,15 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * By default the SVG will only be namespaced if an asset or markup is passed in.
      * @param array|string|null $attributes A list of attributes that should be added to the root `<svg>` element.
      * @param array|null $elements Any elements that should be added under the  root`svg` element
+     * @param string|null $class Deprecated - use $attributes instead.
      * @return Markup|string
      */
-    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [], array $elements = [])
+    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [], array $elements = [], string $class = '')
     {
         // Deprecate the $class argument
-        if (is_string($attributes)) {
-            $attributes = ['class' => $attributes];
+        $oldClass = is_string($attributes) ? $attributes : $class;
+        if ($oldClass) {
+            $attributes = ['class' => $oldClass];
             Craft::$app->getDeprecator()->log('Extension::svgFunction()', 'Passing a string $class argument is deprecated. Pass an array with a `class` key instead.');
         }
 

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -944,8 +944,8 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * @param bool|null $namespace Whether class names and IDs within the SVG
      * should be namespaced to avoid conflicts with other elements in the DOM.
      * By default the SVG will only be namespaced if an asset or markup is passed in.
-     * @param array|string|null $attributes A list of attributes that should be added to the `<svg>` element.
-     * @param array|null $elements Any elements that should be added under the `svg` element
+     * @param array|string|null $attributes A list of attributes that should be added to the root `<svg>` element.
+     * @param array|null $elements Any elements that should be added under the  root`svg` element
      * @return Markup|string
      */
     public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [], array $elements = null)

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -947,7 +947,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * @param array|string|null $attributes A list of attributes that should be added to the `<svg>` element.
      * @return Markup|string
      */
-    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [], array $tags = [])
+    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [])
     {
         // Deprate the $class argument
         if (is_string($attributes)) {
@@ -1030,14 +1030,6 @@ class Extension extends AbstractExtension implements GlobalsInterface
                 $svg = preg_replace('/<svg\b/i', "$0 {$key}=\"{$value}\"", $svg, 1);
             }
         }
-
-        // Render the tags...
-        $tagContent = '';
-        foreach ($tags as $value) {
-            $tagContent .= Html::tag($value[0], $value[1], $value[2]);
-        }
-
-        $svg = preg_replace('/<\s*svg[^>]*>/', "$0 $tagContent", $svg, 1);
 
         return TemplateHelper::raw($svg);
     }

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1025,6 +1025,10 @@ class Extension extends AbstractExtension implements GlobalsInterface
 
         // Load up the attributes
         foreach ($attributes as $key => $value) {
+            if (!is_string($key) || !is_string($value)) {
+                continue;
+            }
+
             $svg = preg_replace('/(<svg\b[^>]+\b'.$key.'=([\'"])[^\'"]+)(\\2)/i', "$1 {$value}$3", $svg, 1, $count);
             if ($count === 0) {
                 $svg = preg_replace('/<svg\b/i', "$0 {$key}=\"{$value}\"", $svg, 1);

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -944,18 +944,17 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * @param bool|null $namespace Whether class names and IDs within the SVG
      * should be namespaced to avoid conflicts with other elements in the DOM.
      * By default the SVG will only be namespaced if an asset or markup is passed in.
-     * @param array|string|null $attributes A list of attributes that should be added to the root `<svg>` element.
-     * @param array|null $elements Any elements that should be added under the  root`svg` element
      * @param string|null $class Deprecated - use $attributes instead.
+     * @param array|string|null $attr A list of attributes that should be added to the root `<svg>` element.
+     * @param array|null $elements Any elements that should be added under the  root`svg` element
      * @return Markup|string
      */
-    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, $attributes = [], array $elements = [], string $class = '')
+    public function svgFunction($svg, bool $sanitize = null, bool $namespace = null, string $class = null, array $attr = [], array $elements = [])
     {
         // Deprecate the $class argument. Allow both svg(class='class') and svg('', true, true, 'class')
-        $oldClass = is_string($attributes) ? $attributes : $class;
-        if ($oldClass) {
-            $attributes = ['class' => $oldClass];
-            Craft::$app->getDeprecator()->log('Extension::svgFunction()', 'Passing a string $class argument is deprecated. Pass an array with a `class` key instead.');
+        if ($class) {
+            $attr['class'] = isset($attr['class']) ? $attr['class'] . ' ' . $class : $class;
+            Craft::$app->getDeprecator()->log("svg(class=$class)", 'Passing a string $class argument is deprecated. Pass an array with a `class` key instead.');
         }
 
         if ($svg instanceof Asset) {
@@ -1027,7 +1026,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
         }
 
         // Load up the attributes
-        foreach ($attributes as $key => $value) {
+        foreach ($attr as $key => $value) {
             if (is_string($key) && is_string($value)) {
                 $encKey = Html::encode($key);
                 $encVal = Html::encode($value);

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1057,7 +1057,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             $encName = Html::encode($elementName);
             $svg = preg_replace('/<'.$encName.'>.*?<\/'.$encName.'>\s*/is', $tag, $svg, 1, $count);
 
-            // If it didn't exist - we add it later.
+            // If it didn't exist - we save it to add later.
             if ($count === 0) {
                 $elementValue .= $tag;
             }

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1025,13 +1025,11 @@ class Extension extends AbstractExtension implements GlobalsInterface
 
         // Load up the attributes
         foreach ($attributes as $key => $value) {
-            if (!is_string($key) || !is_string($value)) {
-                continue;
-            }
-
-            $svg = preg_replace('/(<svg\b[^>]+\b'.$key.'=([\'"])[^\'"]+)(\\2)/i', "$1 {$value}$3", $svg, 1, $count);
-            if ($count === 0) {
-                $svg = preg_replace('/<svg\b/i', "$0 {$key}=\"{$value}\"", $svg, 1);
+            if (is_string($key) && is_string($value)) {
+                $svg = preg_replace('/(<svg\b[^>]+\b' . $key . '=([\'"])[^\'"]+)(\\2)/i', "$1 {$value}$3", $svg, 1, $count);
+                if ($count === 0) {
+                    $svg = preg_replace('/<svg\b/i', "$0 {$key}=\"{$value}\"", $svg, 1);
+                }
             }
         }
 

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -945,7 +945,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * should be namespaced to avoid conflicts with other elements in the DOM.
      * By default the SVG will only be namespaced if an asset or markup is passed in.
      * @param string|null $class Deprecated - use $attributes instead.
-     * @param array|string|null $attr A list of attributes that should be added to the root `<svg>` element.
+     * @param array|null $attr A list of attributes that should be added to the root `<svg>` element.
      * @param array|null $elements Any elements that should be added under the  root`svg` element
      * @return Markup|string
      */

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1023,7 +1023,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             }
         }
 
-        // Load up attributes
+        // Load up the attributes
         foreach ($attributes as $key => $value) {
             $svg = preg_replace('/(<svg\b[^>]+\b'.$key.'=([\'"])[^\'"]+)(\\2)/i', "$1 {$value}$3", $svg, 1, $count);
             if ($count === 0) {


### PR DESCRIPTION
Proposal to resolve #4660 and #3937. 

Not sure if it's required for the old `string $class` argument to go through a deprecation phase until `4.0` so I can remove that if it's unnecessary. 