### PR TITLE
Fix error in job queue example

### DIFF
--- a/docs/extend/updating-plugins.md
+++ b/docs/extend/updating-plugins.md
@@ -904,7 +904,7 @@ class MyJob extends BaseJob
     public function execute($queue)
     {
         $totalSteps = 5;
-        for ($step = 0; $step < $steps; $step++)
+        for ($step = 0; $step < $totalSteps; $step++)
         {
             $this->setProgress($queue, $step / $totalSteps);
             // do something...


### PR DESCRIPTION
Noticed that the example task gets stuck, even thought it’s fairly simple. Turns out there was a typo.