### PR TITLE
Clear existing user groups and field layouts

### DIFF
--- a/src/services/ProjectConfig.php
+++ b/src/services/ProjectConfig.php
@@ -889,7 +889,10 @@ class ProjectConfig extends Component
             'config' => $configData,
         ]);
         $this->trigger(self::EVENT_REBUILD, $event);
-
+        
+        // Remove any existing user groups and fieldlayouts from $currentConfig
+        unset($currentConfig['users']['groups'], $currentConfig['users']['fieldLayouts']);
+        
         // Merge the new data over the existing one.
         $configData = array_replace_recursive([
             'system' => $currentConfig['system'],


### PR DESCRIPTION
This avoids leaving orphaned/duplicated user groups in project config on `project-config/rebuild`