### PR TITLE
Clarify Project Config in testing docs

### DIFF
--- a/docs/testing/framework/config-options.md
+++ b/docs/testing/framework/config-options.md
@@ -22,6 +22,7 @@ The `projectConfig` setting accepts an object with the following parameters:
 `CRAFT_CONFIG_PATH` but instead the file whose contents will be copied into the `project.yml` file 
 located here. 
 
+For the `projectConfig` option to work correctly please ensure you enable the [useProjectConfigFile](../../config/config-settings.md#useprojectconfigfile) config setting in `general.php`. 
 ::: warning
 If you have enabled `projectConfig`, regular DB based fixtures for Project Config data (i.e sections) may cause syncing issues. It is recommended
  to setup your environment using the `project.yml` file only. 


### PR DESCRIPTION
Based on #4711 it's probably smart to add a note stating that the `useProjectConfigFile` general config option must be enabled for project config to work. 