### PR TITLE
Add export events to modify exports

### DIFF
--- a/src/events/ExportEvent.php
+++ b/src/events/ExportEvent.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+
+/**
+ * Export event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.0
+ */
+class ExportEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    public $header;
+    public $results;
+    public $format;
+    public $elementType;
+    public $sourceKey;
+    public $criteria;
+    public $query;
+    public $contents;
+    public $filename;
+    public $mimeType;
+
+}


### PR DESCRIPTION
We'd like to modify the output of exports, including the original query. I'm wondering if the amount of information we're passing to the event is overkill, but figure you might as well pass as much as you can.

I've added two events, one to just modify the element query, the other to modify the output once the query has been fetched.

Our use-case is modifying Commerce Orders to export line-items as rows.

Thoughts?