### PR TITLE
Get rid of excess revisions on resave

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -6,8 +6,10 @@
 - Added the `enableGql` config setting. ([#4836](https://github.com/craftcms/cms/issues/4836))
 - Added the `children` field to the `EntryInterface` and `CategoryInterface` GraphQL types. ([#4843](https://github.com/craftcms/cms/issues/4843))
 - Added the `markdown` GraphQL directive. ([#4832](https://github.com/craftcms/cms/issues/4832))
+- Added the `craft\services\Revisions::pruneExcessRevisions()`.
 
 ### Changed
+- Craft will now prune excess revisions when resaving elements. ([#4851](https://github.com/craftcms/cms/issues/4851))
 - Preview target URIs can now be set to environment variables (e.g. `$NEWS_INDEX`) or URLs that begin with an alias (e.g. `@rootUrl/news` or `@rootUrl/news/{slug}`).
 - Templates passed to `craft\web\View::renderString()` and `renderObjectTemplate()` can now incude front-end templates.
 - Element queries with the `revisions` param set will now return revisions ordered by `num DESC` by default. ([#4825](https://github.com/craftcms/cms/issues/4825))

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -548,7 +548,7 @@ class Elements extends Component
                         $this->saveElement($element);
 
                         // Get rid of revisions?
-                        if (!$element->getIsRevision() && !$element->getIsDraft()) {
+                        if (!ElementHelper::isDraftOrRevision($element)) {
                             $revisionService->pruneExcessRevisions($element);
                         }
                     } catch (\Throwable $e) {

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -506,6 +506,8 @@ class Elements extends Component
             ]));
         }
 
+        $revisionService = Craft::$app->getRevisions();
+        $errorHandler = Craft::$app->getErrorHandler();
         $position = 0;
 
         try {
@@ -544,11 +546,16 @@ class Elements extends Component
                 if ($e === null) {
                     try {
                         $this->saveElement($element);
+
+                        // Get rid of revisions?
+                        if (!$element->getIsRevision() && !$element->getIsDraft()) {
+                            $revisionService->pruneExcessRevisions($element);
+                        }
                     } catch (\Throwable $e) {
                         if (!$continueOnError) {
                             throw $e;
                         }
-                        Craft::$app->getErrorHandler()->logException($e);
+                        $errorHandler->logException($e);
                     }
                 }
 

--- a/src/services/Revisions.php
+++ b/src/services/Revisions.php
@@ -185,6 +185,21 @@ class Revisions extends Component
 
         $mutex->release($lockKey);
 
+        $this->pruneExcessRevisions($source);
+
+        return $revision;
+    }
+
+    /**
+     * Prunes any excess revisions on the element.
+     *
+     * @param Element $source
+     * @throws \Throwable
+     */
+    public function pruneExcessRevisions(Element $source)
+    {
+        $elementsService = Craft::$app->getElements();
+
         // Prune any excess revisions
         $maxRevisions = Craft::$app->getConfig()->getGeneral()->maxRevisions;
         if ($maxRevisions > 0) {
@@ -201,8 +216,6 @@ class Revisions extends Component
                 $elementsService->deleteElement($extraRevision, true);
             }
         }
-
-        return $revision;
     }
 
     /**


### PR DESCRIPTION
Propsal for #4851

Not sure if bundling the purging of revisions to the resave process is the direction you want to go in however seeing as the [search index updating](https://github.com/craftcms/cms/issues/3698#issuecomment-503317402) is now also bundled to resaving it seemed appropriate. 