### PR TITLE
Allow changing template that will be loaded in "before" web View events

### DIFF
--- a/src/web/View.php
+++ b/src/web/View.php
@@ -1332,7 +1332,7 @@ JS;
      * @param array &$variables The variables that should be available to the template
      * @return bool Whether the template should be rendered
      */
-    public function beforeRenderTemplate(string $template, array &$variables): bool
+    public function beforeRenderTemplate(string &$template, array &$variables): bool
     {
         // Fire a 'beforeRenderTemplate' event
         $event = new TemplateEvent([
@@ -1341,6 +1341,7 @@ JS;
         ]);
         $this->trigger(self::EVENT_BEFORE_RENDER_TEMPLATE, $event);
         $variables = $event->variables;
+        $template = $event->template;
         return $event->isValid;
     }
 
@@ -1372,7 +1373,7 @@ JS;
      * @param array &$variables The variables that should be available to the template
      * @return bool Whether the template should be rendered
      */
-    public function beforeRenderPageTemplate(string $template, array &$variables): bool
+    public function beforeRenderPageTemplate(string &$template, array &$variables): bool
     {
         // Fire a 'beforeRenderPageTemplate' event
         $event = new TemplateEvent([
@@ -1381,6 +1382,7 @@ JS;
         ]);
         $this->trigger(self::EVENT_BEFORE_RENDER_PAGE_TEMPLATE, $event);
         $variables = $event->variables;
+        $template = $event->template;
         return $event->isValid;
     }
 


### PR DESCRIPTION
Enhancement to web View events `EVENT_BEFORE_RENDER_TEMPLATE` and `EVENT_BEFORE_RENDER_PAGE_TEMPLATE`, allowing the developer to replace the template that will be rendered. This allows a variety of creative solutions where routing may not be appropriate.

Before this, you cannot change the template about to be rendered, requiring the template to process and then overwriting the `$output` of the "after" events. With the suggested change, you can now prevent rendering of the undesired template with something along the lines of:
```
Event::on(
    View::class,
    View::EVENT_BEFORE_RENDER_TEMPLATE,
    function(TemplateEvent $event){
    	$event->template = 'something-else';
    }
);
```

If #4570 gets merged in and this causes a conflict, happy to resubmit.