### PR TITLE
Small typo in group filter example

### DIFF
--- a/docs/dev/filters.md
+++ b/docs/dev/filters.md
@@ -337,7 +337,7 @@ Groups the items of an array together based on common properties.
 
 ```twig
 {% set allEntries = craft.entries.section('blog').all() %}
-{% set allEntriesByYear = allEntries|group('postDate|date('Y')') %}
+{% set allEntriesByYear = allEntries|group('postDate|date("Y")') %}
 
 {% for year, entriesInYear in allEntriesByYear %}
     <h2>{{ year }}</h2>


### PR DESCRIPTION
Running the code sample as-is results in an error. I swapped the single quotes around the Y to double quotes and now it works.