### PR TITLE
Remove unused re-registration of Yii autoloader

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -198,10 +198,6 @@ $srcPath = $cmsPath . DIRECTORY_SEPARATOR . 'src';
 require $libPath . DIRECTORY_SEPARATOR . 'yii2' . DIRECTORY_SEPARATOR . 'Yii.php';
 require $srcPath . DIRECTORY_SEPARATOR . 'Craft.php';
 
-// Move Yii's autoloader to the end (Composer's is faster when optimized)
-spl_autoload_unregister(['Yii', 'autoload']);
-spl_autoload_register(['Yii', 'autoload'], true, false);
-
 // Set aliases
 Craft::setAlias('@root', $rootPath);
 Craft::setAlias('@lib', $libPath);


### PR DESCRIPTION
Re-registration was added in 2.x (f4cd1510f31924363e0f17705a60e89fe786e17c), but became unused with 7ceee8b6aa6f1de9018054aae8e7432d71ebc3d9.

This PR proposes a slight cleanup of the bootstrap-code.