### PR TITLE
Allow users with administrateUsers permissions to choose if verification mail should be sent.

### DIFF
--- a/src/templates/users/_edit.html
+++ b/src/templates/users/_edit.html
@@ -75,7 +75,7 @@
 
                 {{ forms.textField({
                     label: "Email"|t('app'),
-                    instructions: (requireEmailVerification and not currentUser.admin ? 'A verification email will be sent automatically.'|t('app')),
+                    instructions: (requireEmailVerification and not currentUser.admin and not currentUser.can('administrateUsers') ? 'A verification email will be sent automatically.'|t('app')),
                     id: 'email',
                     name: 'email',
                     value: user.email,
@@ -84,7 +84,7 @@
                     errors: user.getErrors('email')|merge(user.getErrors('unverifiedEmail'))
                 }) }}
 
-                {% if requireEmailVerification and currentUser.admin %}
+                {% if requireEmailVerification and currentUser.admin or currentUser.can('administrateUsers') %}
                     {{ forms.checkboxField({
                         label: "Send an activation email now?"|t('app'),
                         name: 'sendVerificationEmail',


### PR DESCRIPTION
Users with the permission "administrateUsers" should be allowed to choose if a verification mail should be sent when creating a new user.

A typical use case would be that users will be created for a frontend login and have custom fields with documents and co and the creator does not have all information to give access to the user but still wants to create the user and later at some points wants to send the activation mail.
