### PR TITLE
Added guest required twig tag.

### DIFF
--- a/src/web/Controller.php
+++ b/src/web/Controller.php
@@ -263,6 +263,8 @@ abstract class Controller extends \yii\web\Controller
 
     /**
      * Redirects the user to the account template if they are logged in.
+     *
+     * @since 3.4.0
      */
     public function requireGuest()
     {

--- a/src/web/Controller.php
+++ b/src/web/Controller.php
@@ -269,9 +269,7 @@ abstract class Controller extends \yii\web\Controller
         $userSession = Craft::$app->getUser();
 
         if (!$userSession->getIsGuest()) {
-            return Craft::$app
-                ->getResponse()
-                ->redirect(Craft::$app->user->returnUrl);
+            $userSession->guestRequired();
             Craft::$app->end();
         }
     }

--- a/src/web/Controller.php
+++ b/src/web/Controller.php
@@ -262,6 +262,21 @@ abstract class Controller extends \yii\web\Controller
     }
 
     /**
+     * Redirects the user to the account template if they are logged in.
+     */
+    public function requireGuest()
+    {
+        $userSession = Craft::$app->getUser();
+
+        if (!$userSession->getIsGuest()) {
+            return Craft::$app
+                ->getResponse()
+                ->redirect(Craft::$app->user->returnUrl);
+            Craft::$app->end();
+        }
+    }
+
+    /**
      * Throws a 403 error if the current user is not an admin.
      *
      * @param bool $requireAdminChanges Whether the [[\craft\config\GeneralConfig::$allowAdminChanges|`allowAdminChanges`]]

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -194,6 +194,21 @@ class User extends \yii\web\User
     }
 
     /**
+     * Redirects the user browser away from a guest page.
+     *
+     * @return Response the redirection response
+     * @throws ForbiddenHttpException the "Access Denied" HTTP exception if redirect is acceptable
+     * not applicable.
+     */
+    public function guestRequired()
+    {
+        if ($this->returnUrl !== null && $this->checkRedirectAcceptable()) {
+            return Craft::$app->getResponse()->redirect($this->returnUrl);
+        }
+        throw new ForbiddenHttpException(Craft::t('Craft', 'Guest Required'));
+    }
+
+    /**
      * Returns how many seconds are left in the current user session.
      *
      * @return int The seconds left in the session, or -1 if their session will expire when their HTTP session ends.

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -197,15 +197,15 @@ class User extends \yii\web\User
      * Redirects the user browser away from a guest page.
      *
      * @return Response the redirection response
-     * @throws ForbiddenHttpException the "Access Denied" HTTP exception if redirect is acceptable
-     * not applicable.
+     * @throws ForbiddenHttpException if the request doesn’t accept a redirect response
+     * @since 3.4.0
      */
     public function guestRequired()
     {
-        if ($this->returnUrl !== null && $this->checkRedirectAcceptable()) {
-            return Craft::$app->getResponse()->redirect($this->returnUrl);
+        if (!$this->checkRedirectAcceptable()) {
+            throw new ForbiddenHttpException(Craft::t('app', 'Guest Required'));
         }
-        throw new ForbiddenHttpException(Craft::t('Craft', 'Guest Required'));
+        return Craft::$app->getResponse()->redirect($this->getReturnUrl());
     }
 
     /**

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -40,6 +40,7 @@ use craft\web\twig\tokenparsers\RequireAdminTokenParser;
 use craft\web\twig\tokenparsers\RequireEditionTokenParser;
 use craft\web\twig\tokenparsers\RequireLoginTokenParser;
 use craft\web\twig\tokenparsers\RequirePermissionTokenParser;
+use craft\web\twig\tokenparsers\RequireGuestTokenParser;
 use craft\web\twig\tokenparsers\SwitchTokenParser;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\View;
@@ -136,6 +137,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new RequireAdminTokenParser(),
             new RequireEditionTokenParser(),
             new RequireLoginTokenParser(),
+            new RequireGuestTokenParser(),
             new RequirePermissionTokenParser(),
             new SwitchTokenParser(),
 

--- a/src/web/twig/nodes/RequireGuestNode.php
+++ b/src/web/twig/nodes/RequireGuestNode.php
@@ -12,25 +12,25 @@ use Twig\Compiler;
 use Twig\Node\Node;
 
 /**
- * Class RequireLoginNode
+ * Class RequireGuestNode
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 3.0
+ * @since 3.4.0
  */
 class RequireGuestNode extends Node
 {
-  // Public Methods
-  // =========================================================================
+    // Public Methods
+    // =========================================================================
 
-  /**
-   * Compiles a RequireLoginNode into PHP.
-   *
-   * @param Compiler $compiler
-   */
-  public function compile(Compiler $compiler)
-  {
-    $compiler
-        ->addDebugInfo($this)
-        ->write(Craft::class . "::\$app->controller->requireGuest();\n");
-  }
+    /**
+     * Compiles a RequireGuestNode into PHP.
+     *
+     * @param Compiler $compiler
+     */
+    public function compile(Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write(Craft::class . "::\$app->controller->requireGuest();\n");
+    }
 }

--- a/src/web/twig/nodes/RequireGuestNode.php
+++ b/src/web/twig/nodes/RequireGuestNode.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\web\twig\nodes;
+
+use Craft;
+use Twig\Compiler;
+use Twig\Node\Node;
+
+/**
+ * Class RequireLoginNode
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.0
+ */
+class RequireGuestNode extends Node
+{
+  // Public Methods
+  // =========================================================================
+
+  /**
+   * Compiles a RequireLoginNode into PHP.
+   *
+   * @param Compiler $compiler
+   */
+  public function compile(Compiler $compiler)
+  {
+    $compiler
+        ->addDebugInfo($this)
+        ->write(Craft::class . "::\$app->controller->requireGuest();\n");
+  }
+}

--- a/src/web/twig/tokenparsers/RequireGuestTokenParser.php
+++ b/src/web/twig/tokenparsers/RequireGuestTokenParser.php
@@ -13,36 +13,36 @@ use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
 /**
- * Class RequireLoginTokenParser
+ * Class RequireGuestTokenParser
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 3.0
+ * @since 3.4.0
  */
 class RequireGuestTokenParser extends AbstractTokenParser
 {
-  // Public Methods
-  // =========================================================================
+    // Public Methods
+    // =========================================================================
 
-  /**
-   * @inheritdoc
-   */
-  public function parse(Token $token)
-  {
-    $lineno = $token->getLine();
-    /** @var Parser $parser */
-    $parser = $this->parser;
-    $stream = $parser->getStream();
+    /**
+     * @inheritdoc
+     */
+    public function parse(Token $token)
+    {
+        $lineno = $token->getLine();
+        /** @var Parser $parser */
+        $parser = $this->parser;
+        $stream = $parser->getStream();
 
-    $stream->expect(Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
-    return new RequireGuestNode([], [], $lineno, $this->getTag());
-  }
+        return new RequireGuestNode([], [], $lineno, $this->getTag());
+    }
 
-  /**
-   * @inheritdoc
-   */
-  public function getTag()
-  {
-    return 'requireGuest';
-  }
+    /**
+     * @inheritdoc
+     */
+    public function getTag()
+    {
+        return 'requireGuest';
+    }
 }

--- a/src/web/twig/tokenparsers/RequireGuestTokenParser.php
+++ b/src/web/twig/tokenparsers/RequireGuestTokenParser.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\web\twig\tokenparsers;
+
+use craft\web\twig\nodes\RequireGuestNode;
+use Twig\Parser;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+/**
+ * Class RequireLoginTokenParser
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.0
+ */
+class RequireGuestTokenParser extends AbstractTokenParser
+{
+  // Public Methods
+  // =========================================================================
+
+  /**
+   * @inheritdoc
+   */
+  public function parse(Token $token)
+  {
+    $lineno = $token->getLine();
+    /** @var Parser $parser */
+    $parser = $this->parser;
+    $stream = $parser->getStream();
+
+    $stream->expect(Token::BLOCK_END_TYPE);
+
+    return new RequireGuestNode([], [], $lineno, $this->getTag());
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getTag()
+  {
+    return 'requireGuest';
+  }
+}


### PR DESCRIPTION
While creating the account and login pages for a craft project I used `{% requireLogin %}` on account pages but there is nothing similar to redirect an authenticated user away from a login page. 

When adding `{% requireGuest %}` to login/register templates, authenticated users will get redirected away. 