### PR TITLE
Added `html` to the usual suspects in console/Request

### DIFF
--- a/src/console/Request.php
+++ b/src/console/Request.php
@@ -36,7 +36,7 @@ class Request extends \yii\console\Request
         if (Craft::getRootAlias('@webroot') === false) {
             // see if it's any of the usual suspects
             $dir = dirname($this->getScriptFile());
-            foreach (['web', 'public', 'public_html'] as $folder) {
+            foreach (['web', 'public', 'public_html', 'html'] as $folder) {
                 if (is_dir($dir . DIRECTORY_SEPARATOR . $folder)) {
                     $dir .= DIRECTORY_SEPARATOR . $folder;
                     break;


### PR DESCRIPTION
Added `html` to the usual suspects for when the `@webroot` alias is set dynamically in the console request. 

This is after realising (after lots of troubleshooting for a client) that the webroot was defaulting to the base path because the folder which was named `html` was not being picked up automatically. I guess a second request would be to document that the `@webroot` alias should be explicitly set for console requests to work as expected if the folder is not named as one of the "usual suspects":
https://github.com/craftcms/cms/blob/3.3.9/src/console/Request.php#L35-L47