### PR TITLE
adding periods to the commands

### DIFF
--- a/src/console/controllers/BackupController.php
+++ b/src/console/controllers/BackupController.php
@@ -27,7 +27,7 @@ class BackupController extends Controller
     public $defaultAction = 'db';
 
     /**
-     * Creates a new database backup
+     * Creates a new database backup.
      *
      * @param string|null The path the database backup should be created at.
      * Can be any of the following:

--- a/src/console/controllers/ClearCachesController.php
+++ b/src/console/controllers/ClearCachesController.php
@@ -56,7 +56,7 @@ class ClearCachesController extends Controller
     }
 
     /**
-     * Clear all caches
+     * Clear all caches.
      *
      * @return int
      * @throws InvalidRouteException

--- a/src/console/controllers/GraphqlController.php
+++ b/src/console/controllers/GraphqlController.php
@@ -55,7 +55,7 @@ class GraphqlController extends Controller
     }
 
     /**
-     * Print out a given GraphQL schema
+     * Print out a given GraphQL schema.
      *
      * @return int
      */
@@ -73,7 +73,7 @@ class GraphqlController extends Controller
     }
 
     /**
-     * Dump out a given GraphQL schema to a file
+     * Dump out a given GraphQL schema to a file.
      *
      * @return int
      */

--- a/src/console/controllers/InstallController.php
+++ b/src/console/controllers/InstallController.php
@@ -84,7 +84,7 @@ class InstallController extends Controller
     }
 
     /**
-     * Runs the install migration
+     * Runs the install migration.
      *
      * @return int
      */
@@ -179,7 +179,7 @@ class InstallController extends Controller
     }
 
     /**
-     * Installs a plugin
+     * Installs a plugin.
      *
      * @param string $handle
      * @return int

--- a/src/console/controllers/RestoreController.php
+++ b/src/console/controllers/RestoreController.php
@@ -13,7 +13,7 @@ use craft\helpers\Console;
 use yii\console\ExitCode;
 
 /**
- * Creates a new database backup
+ * Restores a database from backup.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.1.29

--- a/src/queue/Command.php
+++ b/src/queue/Command.php
@@ -76,7 +76,7 @@ class Command extends \yii\queue\cli\Command
     }
 
     /**
-     * Runs all jobs in the queue
+     * Runs all jobs in the queue.
      *
      * @return int
      */


### PR DESCRIPTION
This is rather nitpicky, but I was working on a plugin that focuses on console commands and noticed some inconsistencies with the use of periods on the command descriptions. 

