### PR TITLE
Adds before and after events for GraphQL execution

### DIFF
--- a/src/controllers/GraphqlController.php
+++ b/src/controllers/GraphqlController.php
@@ -9,6 +9,7 @@ namespace craft\controllers;
 
 use Craft;
 use craft\errors\GqlException;
+use craft\events\GraphqlBeforeExecuteEvent;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
@@ -30,6 +31,11 @@ use yii\web\Response;
  */
 class GraphqlController extends Controller
 {
+    /**
+     * @event GraphqlBeforeExecuteEvent The event that is triggered before the GraphQL request is executed.
+     */
+    const EVENT_BEFORE_GRAPHQL_EXECUTE = 'beforeGraphqlExecute';
+
     /**
      * @inheritdoc
      */
@@ -141,6 +147,15 @@ class GraphqlController extends Controller
 
         try {
             $schemaDef = $gqlService->getSchemaDef($schema, StringHelper::contains($query, '__schema'));
+
+            $beforeEvent = new GraphqlBeforeExecuteEvent();
+            $beforeEvent->schema = $schema;
+            $beforeEvent->query = $query;
+            $beforeEvent->variables = $variables;
+            $beforeEvent->operationName = $operationName;
+
+            $this->trigger(self::EVENT_BEFORE_GRAPHQL_EXECUTE, $beforeEvent);
+
             $result = GraphQL::executeQuery($schemaDef, $query, null, null, $variables, $operationName)
                 ->toArray(true);
         } catch (\Throwable $e) {

--- a/src/events/GraphqlAfterExecuteEvent.php
+++ b/src/events/GraphqlAfterExecuteEvent.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+
+/**
+ * Graphql after execute event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.3
+ */
+class GraphqlAfterExecuteEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var array The results of the GraphQL execute command.
+     */
+    public $result;
+}

--- a/src/events/GraphqlBeforeExecuteEvent.php
+++ b/src/events/GraphqlBeforeExecuteEvent.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+use Graphql\Type\Schema;
+use GraphQL\Language\AST\DocumentNode;
+
+/**
+ * Graphql before execute event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.3
+ */
+class GraphqlBeforeExecuteEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var Schema The GraphQL type system to use when validating and executing a query.
+     */
+    public $schema;
+
+    /**
+     * @var string|DocumentNode A GraphQL language formatted string representing the requested operation.
+     */
+    public $source;
+
+    /**
+     * @var mixed The value provided as the first argument to resolver functions on the top level type
+     * (e.g. the query object type).
+     */
+    public $rootValue;
+
+    /**
+     * @var mixed The value provided as the third argument to all resolvers.
+     * Use this to pass current session, user data, etc
+     */
+    public $context;
+
+    /**
+     * @var array|null A mapping of variable name to runtime value to use for all variables
+     * defined in the requestString.
+     */
+    public $variables;
+
+    /**
+     * @var string|null The name of the operation to use if requestString contains multiple
+     * possible operations. Can be omitted if requestString contains only
+     * one operation.
+     */
+    public $operationName;
+}


### PR DESCRIPTION
Adding events for before and after the execution of GraphQL execution. 

Spoke with @andris-sevcenko about this on Discord. These events can be used for caching the request from within another plugin.