### PR TITLE
Prevent stringy from updating past 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "craftcms/plugin-installer": "~1.5.3",
     "craftcms/server-check": "~1.1.0",
     "creocoder/yii2-nested-sets": "~0.9.0",
-    "voku/stringy": "^5.1.0",
+    "voku/stringy": "5.1.*",
     "elvanto/litemoji": "^1.3.1",
     "enshrined/svg-sanitize": "~0.9.0",
     "guzzlehttp/guzzle": "^6.3.0",


### PR DESCRIPTION
I was doing some local development on Craft and apparently when you symlink a package, `composer install` doesn't respect the composer-lock file in the repo. This resulted in Stringy 5.2.x being installed, which has breaking changes (removal of getLangSpecificCharsArray).

This change prevents Craft from updating to 5.2.0. (Note: The composer.lock file is locked at 5.1.1, which is currently the last 5.1 release of stringy.)