### PR TITLE
Improved asset previews

### DIFF
--- a/src/assetpreviews/HtmlPreview.php
+++ b/src/assetpreviews/HtmlPreview.php
@@ -49,7 +49,8 @@ class HtmlPreview extends AssetPreview
     /**
      * @inheritDoc
      */
-    public function getModalHtml(): string {
+    public function getModalHtml(): string
+    {
         return $this->template;
     }
 

--- a/src/assetpreviews/HtmlPreview.php
+++ b/src/assetpreviews/HtmlPreview.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ * @since 3.4.0
+ */
+
+namespace craft\assetpreviews;
+
+use Craft;
+use craft\base\AssetPreview;
+use craft\elements\Asset;
+
+/**
+ * Provides functionality to preview text files as HTML
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.3.0
+ */
+class HtmlPreview extends AssetPreview
+{
+
+    private $template = '';
+    private $foot = '';
+
+    // Public Methods
+    // =========================================================================
+
+    public function init()
+    {
+        $localCopy = $this->asset->getCopyOfFile();
+        $content = htmlspecialchars(file_get_contents($localCopy));
+        unlink($localCopy);
+        $language = $this->asset->kind === Asset::KIND_HTML ? 'markup' : $this->asset->kind;
+        $view = Craft::$app->getView();
+        $this->template = $view->renderTemplate('assets/_previews/html', [
+            'asset' => $this->asset,
+            'language' => $language,
+            'content' => $content
+        ]);
+
+        $this->foot = $view->getBodyHtml();
+
+        parent::init();
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getModalHtml(): string {
+        return $this->template;
+    }
+
+    public function getFootHtml()
+    {
+        return $this->foot;
+    }
+}

--- a/src/assetpreviews/HtmlPreview.php
+++ b/src/assetpreviews/HtmlPreview.php
@@ -16,7 +16,7 @@ use craft\elements\Asset;
  * Provides functionality to preview text files as HTML
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 3.3.0
+ * @since 3.4.0
  */
 class HtmlPreview extends AssetPreview
 {

--- a/src/assetpreviews/ImagePreview.php
+++ b/src/assetpreviews/ImagePreview.php
@@ -26,9 +26,11 @@ class ImagePreview extends AssetPreview
     /**
      * @inheritDoc
      */
-    public function getModalHtml(): string {
+    public function getModalHtml(): string
+    {
 
         $volume = $this->asset->getVolume();
+
         if ($volume->hasUrls) {
             $assetUrl = $this->asset->getUrl();
         } else {

--- a/src/assetpreviews/ImagePreview.php
+++ b/src/assetpreviews/ImagePreview.php
@@ -15,7 +15,7 @@ use craft\base\AssetPreview;
  * Provides functionality to preview images
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 3.3.0
+ * @since 3.4.0
  */
 class ImagePreview extends AssetPreview
 {

--- a/src/assetpreviews/ImagePreview.php
+++ b/src/assetpreviews/ImagePreview.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ * @since 3.4.0
+ */
+
+namespace craft\assetpreviews;
+
+use Craft;
+use craft\base\AssetPreview;
+
+/**
+ * Provides functionality to preview images
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.3.0
+ */
+class ImagePreview extends AssetPreview
+{
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritDoc
+     */
+    public function getModalHtml(): string {
+
+        $volume = $this->asset->getVolume();
+        if ($volume->hasUrls) {
+            $assetUrl = $this->asset->getUrl();
+        } else {
+            $source = $this->asset->getTransformSource();
+            $assetUrl = Craft::$app->getAssetManager()->getPublishedUrl($source, true);
+        }
+
+        $view = Craft::$app->getView();
+        return $view->renderTemplate('assets/_previews/image', [
+            'asset' => $this->asset,
+            'assetUrl' => $assetUrl
+        ]);
+    }
+}

--- a/src/assetpreviews/NoPreview.php
+++ b/src/assetpreviews/NoPreview.php
@@ -27,7 +27,8 @@ class NoPreview extends AssetPreview
     /**
      * @inheritDoc
      */
-    public function getModalHtml(): string {
+    public function getModalHtml(): string
+    {
         $view = Craft::$app->getView();
         return $view->renderTemplate('assets/_previews/no_preview');
     }

--- a/src/assetpreviews/NoPreview.php
+++ b/src/assetpreviews/NoPreview.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ * @since 3.4.0
+ */
+
+namespace craft\assetpreviews;
+
+use Craft;
+use craft\base\AssetPreview;
+
+/**
+ * When there's no preview available
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.4.0
+ */
+class NoPreview extends AssetPreview
+{
+
+    // Public Methods
+    // =========================================================================
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getModalHtml(): string {
+        $view = Craft::$app->getView();
+        return $view->renderTemplate('assets/_previews/no_preview');
+    }
+}

--- a/src/assetpreviews/PdfPreview.php
+++ b/src/assetpreviews/PdfPreview.php
@@ -26,9 +26,11 @@ class PdfPreview extends AssetPreview
     /**
      * @inheritDoc
      */
-    public function getModalHtml(): string {
+    public function getModalHtml(): string
+    {
 
         $volume = $this->asset->getVolume();
+
         if ($volume->hasUrls) {
             $assetUrl = $this->asset->getUrl();
         } else {

--- a/src/assetpreviews/PdfPreview.php
+++ b/src/assetpreviews/PdfPreview.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\assetpreviews;
+
+use Craft;
+use craft\base\AssetPreview;
+
+/**
+ * Provides functionality to preview PDFs
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.4.0
+ */
+class PdfPreview extends AssetPreview
+{
+
+    // Public Methods
+    // =========================================================================
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getModalHtml(): string {
+
+        $volume = $this->asset->getVolume();
+        if ($volume->hasUrls) {
+            $assetUrl = $this->asset->getUrl();
+        } else {
+            $assetUrl = $this->asset->getCopyOfFile();
+        }
+
+        $view = Craft::$app->getView();
+        return $view->renderTemplate('assets/_previews/pdf', [
+            'asset' => $this->asset,
+            'assetUrl' => $assetUrl
+        ]);
+    }
+}

--- a/src/base/AssetPreview.php
+++ b/src/base/AssetPreview.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ * @since 3.4.0
+ */
+
+namespace craft\base;
+
+
+use craft\elements\Asset;
+
+/**
+ * An AssetPreview provides functionality to preview an arbitrary Asset element
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.3.0
+ */
+abstract class AssetPreview extends Component implements AssetPreviewInterface
+{
+    use AssetPreviewTrait;
+
+    /**
+     * AssetPreview constructor.
+     * @param Asset $asset
+     */
+    public function __construct(Asset $asset)
+    {
+        parent::__construct([
+            'asset' => $asset
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFootHtml()
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getHeadHtml()
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getModalHtml()
+    {
+        return false;
+    }
+
+}

--- a/src/base/AssetPreview.php
+++ b/src/base/AssetPreview.php
@@ -15,7 +15,7 @@ use craft\elements\Asset;
  * An AssetPreview provides functionality to preview an arbitrary Asset element
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 3.3.0
+ * @since 3.4.0
  */
 abstract class AssetPreview extends Component implements AssetPreviewInterface
 {

--- a/src/base/AssetPreviewInterface.php
+++ b/src/base/AssetPreviewInterface.php
@@ -12,7 +12,7 @@ namespace craft\base;
  * The AssetPreview interface dictates the requirements to register Asset Preview handlers with Craft
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 3.3.0
+ * @since 3.4.0
  */
 interface AssetPreviewInterface
 {

--- a/src/base/AssetPreviewInterface.php
+++ b/src/base/AssetPreviewInterface.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ * @since 3.4.0
+ */
+
+namespace craft\base;
+
+/**
+ * The AssetPreview interface dictates the requirements to register Asset Preview handlers with Craft
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.3.0
+ */
+interface AssetPreviewInterface
+{
+
+    // Public Methods
+    // =========================================================================
+
+
+    /**
+     * Returns the preview's modal HTML.
+     *
+     * @return string|false The preview’s modal HTML
+     */
+    public function getModalHtml();
+
+    /**
+     * Returns HTML to be added to the head of the page on preview
+     *
+     * @return string|false the preview's head HTML
+     */
+    public function getHeadHtml();
+
+    /**
+     * Returns HTML to be added at the end of the page before the closing body tag
+     *
+     * @return string|false the preview's head HTML
+     */
+    public function getFootHtml();
+}

--- a/src/base/AssetPreviewTrait.php
+++ b/src/base/AssetPreviewTrait.php
@@ -12,8 +12,10 @@ namespace craft\base;
 use craft\elements\Asset;
 
 /**
- * Trait AssetPreviewTrait
- * @package craft\base
+ * An AssetPreview provides functionality to preview an arbitrary Asset element
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.4.0
  */
 trait AssetPreviewTrait
 {

--- a/src/base/AssetPreviewTrait.php
+++ b/src/base/AssetPreviewTrait.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ * @since 3.4.0
+ */
+
+namespace craft\base;
+
+
+use craft\elements\Asset;
+
+/**
+ * Trait AssetPreviewTrait
+ * @package craft\base
+ */
+trait AssetPreviewTrait
+{
+    /** @var Asset $asset */
+    public $asset;
+}

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1021,6 +1021,8 @@ class Asset extends Element
      */
     public function getSupportsPreview(): bool
     {
+        Craft::$app->getDeprecator()->log(self::class . '::getSupportsPreview()', self::class . '::getSupportsPreview() has been deprecated. Use \craft\services\Assets::getAssetPreview() instead.');
+
         return \in_array($this->kind, [self::KIND_IMAGE, self::KIND_HTML, self::KIND_JAVASCRIPT, self::KIND_JSON], true);
     }
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1017,6 +1017,7 @@ class Asset extends Element
      * Returns whether this asset can be previewed.
      *
      * @return bool
+     * @deprecated in 3.4.0. Use [[\craft\services\Assets::getAssetPreview]] instead.
      */
     public function getSupportsPreview(): bool
     {

--- a/src/events/AssetPreviewEvent.php
+++ b/src/events/AssetPreviewEvent.php
@@ -16,7 +16,7 @@ use yii\base\Event;
  * Asset preview event class.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 3.3.0
+ * @since 3.4.0
  */
 class AssetPreviewEvent extends Event
 {

--- a/src/events/AssetPreviewEvent.php
+++ b/src/events/AssetPreviewEvent.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ * @since 3.4.0
+ */
+
+namespace craft\events;
+
+use craft\base\AssetPreviewInterface;
+use craft\elements\Asset;
+use yii\base\Event;
+
+/**
+ * Asset preview event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.3.0
+ */
+class AssetPreviewEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var Asset|null The asset model associated with the event.
+     */
+    public $asset;
+
+    /**
+     * @var AssetPreviewInterface $previewHandler
+     */
+    public $previewHandler;
+}

--- a/src/events/AssetPreviewEvent.php
+++ b/src/events/AssetPreviewEvent.php
@@ -24,11 +24,12 @@ class AssetPreviewEvent extends Event
     // =========================================================================
 
     /**
-     * @var Asset|null The asset model associated with the event.
+     * @var Asset|null The asset Element associated with the event.
      */
     public $asset;
 
     /**
+     * An AssetPreview handler
      * @var AssetPreviewInterface $previewHandler
      */
     public $previewHandler;

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -92,7 +92,7 @@ class Assets extends Component
     /**
      * @event AssetPreviewEvent The event that is triggered when an asset is previewed
      */
-    const EVENT_GET_PREVIEW_TEMPLATE = 'getPreviewTemplate';
+    const EVENT_GET_ASSET_PREVIEW = 'getAssetPreview';
 
     // Properties
     // =========================================================================
@@ -1050,8 +1050,8 @@ class Assets extends Component
         $event = new AssetPreviewEvent(['asset' => $asset]);
 
         // Give plugins a chance to register their own preview handlers
-        if ($this->hasEventHandlers(self::EVENT_GET_PREVIEW_TEMPLATE)) {
-            $this->trigger(self::EVENT_GET_PREVIEW_TEMPLATE, $event);
+        if ($this->hasEventHandlers(self::EVENT_GET_ASSET_PREVIEW)) {
+            $this->trigger(self::EVENT_GET_ASSET_PREVIEW, $event);
         }
 
         $preview = $event->previewHandler;

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -1063,6 +1063,8 @@ class Assets extends Component
         switch($asset->kind) {
             case Asset::KIND_IMAGE:
                 return new ImagePreview($asset);
+            case Asset::KIND_PDF:
+                return new PdfPreview($asset);
             case Asset::KIND_HTML:
             case Asset::KIND_JSON:
             case Asset::KIND_JAVASCRIPT:

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -1055,6 +1055,7 @@ class Assets extends Component
         }
 
         $preview = $event->previewHandler;
+
         if ($preview instanceof AssetPreview) {
             return $preview;
         }

--- a/src/templates/assets/_previews/html.html
+++ b/src/templates/assets/_previews/html.html
@@ -1,0 +1,23 @@
+<div class="highlight {{ asset.kind }}">
+    <pre><code class="language-{{ language }}">{{ content|raw }}</code></pre>
+</div>
+{% js %}
+var $instance = Craft.PreviewFileModal.openInstance;
+var $highlight = $instance.find('.highlight');
+
+if ($highlight.length && $highlight.hasClass('json')) {
+    var $target = $highlight.find('code');
+    $target.html(JSON.stringify(JSON.parse($target.html()), undefined, 4));
+}
+
+if ($highlight.length) {
+    Prism.highlightElement($highlight.find('code').get(0));
+}
+
+$instance.base();
+
+$instance.find('.highlight')
+    .height($instance.height())
+    .width($instance.width())
+    .css({'overflow': 'auto'});
+{% endjs %}

--- a/src/templates/assets/_previews/image.html
+++ b/src/templates/assets/_previews/image.html
@@ -1,0 +1,65 @@
+<img src="{{ assetUrl }}" width="{{ asset.width }}" height="{{ asset.height }}" data-maxWidth="{{ asset.width }}" data-maxHeight="{{ asset.height }}" />
+{% js %}
+    var $instance = Craft.PreviewFileModal.openInstance;
+    var containerHeight = Garnish.$win.height() * 0.66;
+    var containerWidth = Math.min(containerHeight / 3 * 4, Garnish.$win.width() - $instance.settings.minGutter * 2);
+    containerHeight = containerWidth / 4 * 3;
+
+    if (startingWidth && startingHeight) {
+        var ratio = startingWidth / startingHeight;
+        containerWidth =  Math.min(startingWidth, Garnish.$win.width() - $instance.settings.minGutter * 2);
+        containerHeight = Math.min(containerWidth / ratio, Garnish.$win.height() - $instance.settings.minGutter * 2);
+        containerWidth = containerHeight * ratio;
+
+        // This might actually have put width over the viewport limits, so doublecheck
+        if (containerWidth > Math.min(startingWidth, Garnish.$win.width() - $instance.settings.minGutter * 2)) {
+            containerWidth =  Math.min(startingWidth, Garnish.$win.width() - $instance.settings.minGutter * 2);
+            containerHeight = containerWidth / ratio;
+        }
+    }
+
+    $instance.find('img').css({
+        width: containerWidth,
+        height: containerHeight
+    });
+    var $img = $instance.find('img');
+
+    if ($instance.loaded && $img.length) {
+        // Make sure we maintain the ratio
+
+        var maxWidth = $img.data('maxwidth'),
+            maxHeight = $img.data('maxheight'),
+            imageRatio = maxWidth / maxHeight,
+            desiredWidth = $instance.desiredWidth ? $instance.desiredWidth : $instance.width(),
+            desiredHeight = $instance.desiredHeight ? $instance.desiredHeight : $instance.height(),
+            width = Math.min(desiredWidth, maxWidth),
+            height = Math.round(Math.min(maxHeight, width / imageRatio));
+
+        width = Math.round(height * imageRatio);
+
+        $img.css({'width': width, 'height': height});
+        $instance._resizeContainer(width, height);
+
+        $instance.desiredWidth = width;
+        $instance.desiredHeight = height;
+    }
+
+    $instance.base();
+
+    if ($instance.loaded && $img.length) {
+        // Correct anomalities
+        var containerWidth = Math.round(Math.min(Math.max($img.height() * imageRatio), Garnish.$win.width() - ($instance.settings.minGutter * 2))),
+            containerHeight = Math.round(Math.min(Math.max(containerWidth / imageRatio), Garnish.$win.height() - ($instance.settings.minGutter * 2)));
+        containerWidth = Math.round(containerHeight * imageRatio);
+
+        // This might actually have put width over the viewport limits, so doublecheck that
+        if (containerWidth > Math.min(containerWidth, Garnish.$win.width() - $instance.settings.minGutter * 2)) {
+            containerWidth =  Math.min(containerWidth, Garnish.$win.width() - $instance.settings.minGutter * 2);
+            containerHeight = containerWidth / imageRatio;
+        }
+
+        $instance._resizeContainer(containerWidth, containerHeight);
+
+        $img.css({'width': containerWidth, 'height': containerHeight});
+    }
+{% endjs %}

--- a/src/templates/assets/_previews/no_preview.html
+++ b/src/templates/assets/_previews/no_preview.html
@@ -1,0 +1,1 @@
+<p class="nopreview centeralign" style="top: calc(50% - 10px) !important; position: relative;">{{ 'Preview not available.'|t('app') }}</p>

--- a/src/templates/assets/_previews/pdf.html
+++ b/src/templates/assets/_previews/pdf.html
@@ -1,0 +1,1 @@
+<iframe width="100%" height="100%" src="{{ assetUrl }}"></iframe>

--- a/src/web/assets/cp/src/js/PreviewFileModal.js
+++ b/src/web/assets/cp/src/js/PreviewFileModal.js
@@ -135,24 +135,8 @@ Craft.PreviewFileModal = Garnish.Modal.extend(
 
                         this.loaded = true;
                         this.$container.append(response.modalHtml);
-
-                        var $highlight = this.$container.find('.highlight');
-
-                        if ($highlight.length && $highlight.hasClass('json')) {
-                            var $target = $highlight.find('code');
-                            $target.html(JSON.stringify(JSON.parse($target.html()), undefined, 4));
-                        }
-
-                        if ($highlight.length) {
-                            Prism.highlightElement($highlight.find('code').get(0));
-                        } else {
-                            this.$container.find('img').css({
-                                width: containerWidth,
-                                height: containerHeight
-                            });
-                        }
-
-                        this.updateSizeAndPosition();
+                        Craft.appendHeadHtml(response.headHtml);
+                        Craft.appendFootHtml(response.footHtml);
                     } else {
                         alert(response.error);
 
@@ -160,62 +144,6 @@ Craft.PreviewFileModal = Garnish.Modal.extend(
                     }
                 }
             }.bind(this));
-        },
-
-        /**
-         * Override default logic with some extra shenanigans
-         */
-        updateSizeAndPosition: function() {
-            if (!this.loaded) {
-                return;
-            }
-
-            var $img = this.$container.find('img');
-
-            if (this.loaded && $img.length) {
-                // Make sure we maintain the ratio
-
-                var maxWidth = $img.data('maxwidth'),
-                    maxHeight = $img.data('maxheight'),
-                    imageRatio = maxWidth / maxHeight,
-                    desiredWidth = this.desiredWidth ? this.desiredWidth : this.$container.width(),
-                    desiredHeight = this.desiredHeight ? this.desiredHeight : this.$container.height(),
-                    width = Math.min(desiredWidth, maxWidth),
-                    height = Math.round(Math.min(maxHeight, width / imageRatio));
-
-                width = Math.round(height * imageRatio);
-
-                $img.css({'width': width, 'height': height});
-                this._resizeContainer(width, height);
-
-                this.desiredWidth = width;
-                this.desiredHeight = height;
-
-            }
-
-            this.base();
-
-            if (this.loaded && $img.length) {
-                // Correct anomalities
-                var containerWidth = Math.round(Math.min(Math.max($img.height() * imageRatio), Garnish.$win.width() - (this.settings.minGutter * 2))),
-                    containerHeight = Math.round(Math.min(Math.max(containerWidth / imageRatio), Garnish.$win.height() - (this.settings.minGutter * 2)));
-                    containerWidth = Math.round(containerHeight * imageRatio);
-
-                // This might actually have put width over the viewport limits, so doublecheck that
-                if (containerWidth > Math.min(containerWidth, Garnish.$win.width() - this.settings.minGutter * 2)) {
-                    containerWidth =  Math.min(containerWidth, Garnish.$win.width() - this.settings.minGutter * 2);
-                    containerHeight = containerWidth / imageRatio;
-                }
-
-                this._resizeContainer(containerWidth, containerHeight);
-
-                $img.css({'width': containerWidth, 'height': containerHeight});
-            } else if (this.loaded) {
-                this.$container.find('.highlight')
-                    .height(this.$container.height())
-                    .width(this.$container.width())
-                    .css({'overflow': 'auto'});
-            }
         },
 
         /**


### PR DESCRIPTION
This was more of a fun experiment that I was working on this weekend, but I thought I'd submit a draft PR since it's functional and clean and is _nearly_ production ready if desired.

I've implemented the following changes:
- Moved Asset previewability out of the Asset Element and into the Assets service, deprecating `getSupportsPreview`
- Moved preview generation logic out of the `AssetsController`
- Added concept of an `AssetPreview` via an abstract class, trait, and interface, which is responsible for returning modal HTML given an Asset
- Removed inline HTML for previews and replaced with Twig templates and corresponding AssetPreview concrete classes
- Added event for overriding and supplying AssetPreviews via `Assets::EVENT_GET_ASSET_PREVIEW`
- Allow AssetPreviews to register their own head and footer Javascript, allowing us to remove preview-specific logic from `PreviewFileModal.js` and into the appropriate Twig template.

![image](https://user-images.githubusercontent.com/3810939/67216599-7b21ee80-f3f1-11e9-9b48-345c7396703a.png)

I won't be offended if this isn't the direction you want to go, but hopefully it at least gives you ideas, as I think this is code that needs to be refactored at some point.

(Closes #3402)