### PR TITLE
[testing] Fixes a functional test re-bootstrapping bug

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -25,6 +25,7 @@
 - Deprecated the `$checkToken` argument for `craft\gql\base\Query::getQueries()`. `craft\helpers\Gql::getFullAccessSchema()` should be used instead to ensure all queries are returned.
 
 ### Fixed
+- Fixed a bug that could occur when using plugin specific config files while running functional tests. ([#5137](https://github.com/craftcms/cms/pull/5137))
 - Fixed an error that occurred when loading a relational field’s selection modal, if no sources were visible.
 - Fixed a bug where required relational fields would get a validation error if only elements from other sites were selected. ([#5116](https://github.com/craftcms/cms/issues/5116))
 - Fixed a bug where the “Profile Twig templates when Dev Mode is disabled” admin preference wasn’t saving. ([#5118](https://github.com/craftcms/cms/pull/5118))

--- a/src/test/CraftConnector.php
+++ b/src/test/CraftConnector.php
@@ -98,7 +98,14 @@ class CraftConnector extends Yii2
             $moduleId = $module->id;
 
             if ($module instanceof Plugin) {
-                $module = Craft::$app->getPlugins()->createPlugin($moduleId);
+                $plugins = Craft::$app->getPlugins();
+
+                // Follow the same error handling as Craft does natively.
+                if (($info = $plugins->getStoredPluginInfo($moduleId)) === null) {
+                    throw new InvalidPluginException($moduleId);
+                }
+
+                $module = $plugins->createPlugin($moduleId, $info);
             } else {
                 $module = new $moduleClass($moduleId, Craft::$app);
             }


### PR DESCRIPTION
Plugins weren't being loaded with their specific configuration file on request reset causing obvious problems. 