### PR TITLE
fix: return 200 instead of 302 if ajax request

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -445,9 +445,13 @@ class UsersController extends Controller
         $user->setScenario(User::SCENARIO_PASSWORD);
 
         if (!Craft::$app->getElements()->saveElement($user)) {
-            Craft::$app->getSession()->setError(Craft::t('app', 'Couldn’t update password.'));
-
             $errors = $user->getErrors('newPassword');
+
+            if (Craft::$app->getRequest()->getAcceptsJson()) {
+                return $this->asErrorJson(implode(', ', $errors));
+            }
+
+            Craft::$app->getSession()->setError(Craft::t('app', 'Couldn’t update password.'));
 
             return $this->_renderSetPasswordTemplate($user, [
                 'errors' => $errors,

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -470,6 +470,10 @@ class UsersController extends Controller
         // Maybe automatically log them in
         $this->_maybeLoginUserAfterAccountActivation($user);
 
+        if (Craft::$app->getRequest()->getAcceptsJson()) {
+            return $this->asJson(['success' => true]);
+        }
+
         // Can they access the CP?
         if ($user->can('accessCp')) {
             // Send them to the CP login page
@@ -478,10 +482,6 @@ class UsersController extends Controller
             // Send them to the 'setPasswordSuccessPath'.
             $setPasswordSuccessPath = Craft::$app->getConfig()->getGeneral()->getSetPasswordSuccessPath();
             $url = UrlHelper::siteUrl($setPasswordSuccessPath);
-        }
-
-        if (Craft::$app->getRequest()->getAcceptsJson()) {
-            return $this->asJson(['success' => true]);
         }
 
         return $this->redirect($url);

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -468,6 +468,10 @@ class UsersController extends Controller
                 $url = UrlHelper::siteUrl($setPasswordSuccessPath);
             }
 
+            if (Craft::$app->getRequest()->getAcceptsJson()) {
+                return $this->asJson(['success' => true]);
+            }
+
             return $this->redirect($url);
         }
 


### PR DESCRIPTION
### Description

In our headless setup we POST to the actionSetPassword from our frontend app. This is working as intended except that on success, Craft returns a 302 response as per:

https://github.com/craftcms/cms/blob/edbcd4a67755ef367b86be2217647371110c1327/src/controllers/UsersController.php#L471

It could be better to check if the request accepts JSON and return a 200 with success = true in these instances

