### PR TITLE
Use CRAFT_BASE_PATH as dir for @webroot creation

### DIFF
--- a/src/console/Request.php
+++ b/src/console/Request.php
@@ -35,7 +35,7 @@ class Request extends \yii\console\Request
         // Set the @webroot and @web aliases, in case they are needed
         if (Craft::getRootAlias('@webroot') === false) {
             // see if it's any of the usual suspects
-            $dir = dirname($this->getScriptFile());
+            $dir = realpath(CRAFT_BASE_PATH);
             foreach (['web', 'public', 'public_html', 'html'] as $folder) {
                 if (is_dir($dir . DIRECTORY_SEPARATOR . $folder)) {
                     $dir .= DIRECTORY_SEPARATOR . $folder;


### PR DESCRIPTION
We moved our `craft` executable to `bin/craft` which meant the `@webroot` alias could not be automatically determined when running a console command becuase `$dir` was the `bin` directory.

This PR replaces `$this->getScriptFile()` with the `CRAFT_BASE_PATH` constant which in our case is `define('CRAFT_BASE_PATH', __DIR__.'/..');`