### PR TITLE
Adding new checks to old migrations scripts

### DIFF
--- a/src/migrations/m181112_203955_sequences_table.php
+++ b/src/migrations/m181112_203955_sequences_table.php
@@ -15,6 +15,7 @@ class m181112_203955_sequences_table extends Migration
      */
     public function safeUp()
     {
+        $this->dropTableIfExists(Table::SEQUENCES);
         $this->createTable(Table::SEQUENCES, [
             'name' => $this->string()->notNull(),
             'next' => $this->integer()->unsigned()->notNull()->defaultValue(1),

--- a/src/migrations/m190312_152740_element_revisions.php
+++ b/src/migrations/m190312_152740_element_revisions.php
@@ -18,6 +18,8 @@ class m190312_152740_element_revisions extends Migration
     public function safeUp()
     {
         // drafts and revisions tables
+        $this->dropTableIfExists(Table::DRAFTS);
+        $this->dropTableIfExists(Table::REVISIONS);
         $this->createTable(Table::DRAFTS, [
             'id' => $this->primaryKey(),
             'sourceId' => $this->integer()->notNull(),
@@ -48,6 +50,8 @@ class m190312_152740_element_revisions extends Migration
         $this->addForeignKey(null, Table::ELEMENTS, ['revisionId'], Table::REVISIONS, ['id'], 'CASCADE', null);
 
         // add error tables for old entry draft and version migration
+        $this->dropTableIfExists('{{%entryversionerrors}}');
+        $this->dropTableIfExists('{{%entrydrafterrors}}');
         $this->createTable('{{%entrydrafterrors}}', [
             'id' => $this->primaryKey(),
             'draftId' => $this->integer(),

--- a/src/migrations/m190617_164400_add_gqlschemas_table.php
+++ b/src/migrations/m190617_164400_add_gqlschemas_table.php
@@ -15,6 +15,7 @@ class m190617_164400_add_gqlschemas_table extends Migration
      */
     public function safeUp()
     {
+        $this->dropTableIfExists(Table::GQLSCHEMAS);
         $this->createTable(Table::GQLSCHEMAS, [
             'id' => $this->primaryKey(),
             'name' => $this->string()->notNull(),


### PR DESCRIPTION
I was running into some existing table errors during core craft upgrades.  The following tables were already included
in the Install.php script and thus were causing an error during the DB Migration Process:

  Table::DRAFTS
  Table::REVISIONS
  Table::GQLSCHEMAS
  Table::SEQUENCES
  {{%entryversionerrors}}
  {{%entrydrafterrors}}

Steps to reproduce:
You will need to trigger one of the affected migrations. this entails rolling back to a snapshot from a previous craft version or removing the respective entry from the craft migration table.
With your composer version pointed to the latest craft release, Remove the entire vendor directory and run a fresh composer install.
Go to the /admin install page and click 'Finish Up'.
You see migration run for awhile before breaking on the error "craft_xxxx" table already exists.

Why this should work:
It is a standard pattern in the migration scripts to run `dropTableIfExists` on a table before running `createTable`.  This will allow the migration process to continue for tables that are created as part of Install.php.