### PR TITLE
Updates return type of `$serializedFieldValues`

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -79,7 +79,7 @@ use yii\validators\Validator;
  * @property Element|null $prevSibling The element’s previous sibling
  * @property string|null $ref The reference string to this element
  * @property mixed $route The route that should be used when the element’s URI is requested
- * @property string|null $serializedFieldValues Array of the element’s serialized custom field values, indexed by their handles
+ * @property array|null $serializedFieldValues Array of the element’s serialized custom field values, indexed by their handles
  * @property ElementQueryInterface $siblings All of the element’s siblings
  * @property Site $site Site the element is associated with
  * @property string|null $status The element’s status


### PR DESCRIPTION
While working on a client site I noticed that `serializedFieldValues` was throwing a warning because I was treating it like an array but PHPStorm thought it could be a string. This PR just updates return type  to be `array|null` instead of `string|null`. 

I don't believe `serializedFieldValues` is ever a string (especially since the description says it's an array), but it's possible I'm missing something. 