### PR TITLE
Fix bug where asset preview modals can be left orphaned

### DIFF
--- a/src/elements/actions/PreviewAsset.php
+++ b/src/elements/actions/PreviewAsset.php
@@ -74,7 +74,7 @@ class PreviewAsset extends ElementAction
                 settings.startingWidth = \$selectedItems.find('.element').data('image-width');
                 settings.startingHeight = \$selectedItems.find('.element').data('image-height');
             }
-            var modal = new Craft.PreviewFileModal(\$selectedItems.find('.element').data('id'), \$selectedItems, settings);
+            var modal = new Craft.PreviewFileModal(\$selectedItems.find('.element').data('id'), Craft.elementIndex.view.elementSelect, settings);
         }
     });
 })();


### PR DESCRIPTION
Currently, if you preview an asset in Craft via the Element Action, the modal is initialized with the incorrect parameter for the ElementSelect instance. This results in two issues:
- Error thrown in CP when the modal is closed:
`Craft.js:17921 Uncaught TypeError: this.elementSelect.focusItem is not a function`
- The modal is never destroyed on close

The asset preview works as expected when previewing via the keyboard shortcut since the instance is created correctly in the AssetIndex (https://github.com/craftcms/cms/blob/develop/src/web/assets/cp/src/js/AssetIndex.js#L1039)