### PR TITLE
[Feature] Pass error code on error template render

### DIFF
--- a/src/controllers/TemplatesController.php
+++ b/src/controllers/TemplatesController.php
@@ -241,6 +241,7 @@ class TemplatesController extends Controller
             'code' => $exception->getCode(),
             'file' => $exception->getFile(),
             'line' => $exception->getLine(),
+            'statuscode' => $statusCode,
         ], get_object_vars($exception));
 
         // If this is a PHP error and html_errors (http://php.net/manual/en/errorfunc.configuration.php#ini.html-errors)

--- a/src/controllers/TemplatesController.php
+++ b/src/controllers/TemplatesController.php
@@ -241,7 +241,7 @@ class TemplatesController extends Controller
             'code' => $exception->getCode(),
             'file' => $exception->getFile(),
             'line' => $exception->getLine(),
-            'statuscode' => $statusCode,
+            'statusCode' => $statusCode,
         ], get_object_vars($exception));
 
         // If this is a PHP error and html_errors (http://php.net/manual/en/errorfunc.configuration.php#ini.html-errors)


### PR DESCRIPTION
## In reference to issue 5273

[https://github.com/craftcms/cms/issues/5273](https://github.com/craftcms/cms/issues/5273)

Allow HTML Error codes to be passed to error template