### PR TITLE
Fixes bug with token when params are empty

### DIFF
--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -1017,6 +1017,9 @@ class Request extends \yii\web\Request
 
         list($route, $params) = $result;
 
+        // Ensure params is an array
+        $params = is_array($params) ? $params : [];
+
         /** @noinspection AdditionOperationOnArraysInspection */
         return [$route, $params + $this->getQueryParams()];
     }


### PR DESCRIPTION
If a token is created without any params, for example:
```
Craft::$app->getTokens()->createToken('my/token/route');
```

and the token is later used, an `Unsupported operand types` error is generated because `$params` is `null`:
```
return [$route, $params + $this->getQueryParams()];
```

This PR ensures that `$params` is an array before applying the `+` operator.