### PR TITLE
Respect slugWordSeparator for section URIs if configured

### DIFF
--- a/src/web/assets/cp/src/js/UriFormatGenerator.js
+++ b/src/web/assets/cp/src/js/UriFormatGenerator.js
@@ -22,7 +22,7 @@ Craft.UriFormatGenerator = Craft.BaseInputGenerator.extend(
             // Get the "words"
             var words = Craft.filterArray(sourceVal.split(/[^a-z0-9]+/));
 
-            var uriFormat = words.join('-');
+            var uriFormat = words.join(Craft.slugWordSeparator ? Craft.slugWordSeparator : '-');
 
             if (uriFormat && this.settings.suffix) {
                 uriFormat += this.settings.suffix;

--- a/tests/unit/helpers/StringHelperTest.php
+++ b/tests/unit/helpers/StringHelperTest.php
@@ -2390,7 +2390,6 @@ class StringHelperTest extends Unit
         $provider = [
             // One needle
             [false, 'Str contains foo bar', []],
-            [false, 'Str contains foo bar', ['']],
             // Multiple needles
             [true, 'Str contains foo bar', ['foo', 'bar']],
             [true, '12398!@(*%!@# @!%#*&^%', [' @!%#*', '&^%']],


### PR DESCRIPTION
I guess `slugWordSeparator` should be `uriWordSeperator` too?