### PR TITLE
Fixed typo in variable (3.4)

### DIFF
--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -257,7 +257,7 @@ class Sites extends Component
             $group->uid = Db::uidById(Table::SITEGROUPS, $group->id);
         }
 
-        $projectConfig->set(self::CONFIG_SITEGROUP_KEY . '.' . $group->uid, $configDat, "Save the “$group->name” site group");
+        $projectConfig->set(self::CONFIG_SITEGROUP_KEY . '.' . $group->uid, $configData, "Save the “$group->name” site group");
 
         // Now that we have an ID, save it on the model
         if ($isNewGroup) {


### PR DESCRIPTION
I tried renaming a site group on a 3.4 beta install and noticed that it crashed on this.