### PR TITLE
Allow setting the storage path via constant

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -93,7 +93,13 @@ $rootPath = $findConfigPath('CRAFT_BASE_PATH', 'basePath') ?: dirname($vendorPat
 // By default the remaining directories will be in the base directory
 $configPath = $findConfigPath('CRAFT_CONFIG_PATH', 'configPath') ?: $rootPath . DIRECTORY_SEPARATOR . 'config';
 $contentMigrationsPath = $findConfigPath('CRAFT_CONTENT_MIGRATIONS_PATH', 'contentMigrationsPath') ?: $rootPath . DIRECTORY_SEPARATOR . 'migrations';
-$storagePath = $findConfigPath('CRAFT_STORAGE_PATH', 'storagePath') ?: $rootPath . DIRECTORY_SEPARATOR . 'storage';
+
+if (!defined('CRAFT_STORAGE_PATH')) {
+    $storagePath = $findConfigPath('CRAFT_STORAGE_PATH', 'storagePath') ?: $rootPath . DIRECTORY_SEPARATOR . 'storage';
+} else {
+    $storagePath = CRAFT_STORAGE_PATH;
+}
+
 $templatesPath = $findConfigPath('CRAFT_TEMPLATES_PATH', 'templatesPath') ?: $rootPath . DIRECTORY_SEPARATOR . 'templates';
 $translationsPath = $findConfigPath('CRAFT_TRANSLATIONS_PATH', 'translationsPath') ?: $rootPath . DIRECTORY_SEPARATOR . 'translations';
 


### PR DESCRIPTION
Adds a check to see if `CRAFT_STORAGE_PATH` is already defined, if it is defined then it will use the value defined in the constant.