### PR TITLE
Fix typo in Elements service

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -761,7 +761,7 @@ class Elements extends Component
         $mainClone->clearErrors('uri');
 
         if ($mainClone->hasErrors()) {
-            throw new InvalidElementException($mainClone, 'Element ' . $element->id . ' could not be duplicated because it doens\'t validate.');
+            throw new InvalidElementException($mainClone, 'Element ' . $element->id . ' could not be duplicated because it doesn\'t validate.');
         }
 
         $transaction = Craft::$app->getDb()->beginTransaction();


### PR DESCRIPTION
"doens't" => "doesn't"