### PR TITLE
Improved Sendmail mail adapter

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -932,6 +932,12 @@ class GeneralConfig extends BaseObject
     public $verifyEmailSuccessPath = '';
 
     /**
+     * @var string The sendmail command, used as alternative for the php.ini setting
+     * @since 3.3.22
+     */
+    public $sendmailPath;
+
+    /**
      * @var array Stores any custom config settings
      */
     private $_customSettings = [];

--- a/src/mail/transportadapters/Sendmail.php
+++ b/src/mail/transportadapters/Sendmail.php
@@ -34,7 +34,11 @@ class Sendmail extends BaseTransportAdapter
      */
     public function defineTransport()
     {
-        $sendmailCommand = ini_get('sendmail_path');
+        $sendmailCommand = \Craft::$app->getConfig()->getGeneral()->sendmailPath;
+        if (empty($sendmailCommand)) {
+            $sendmailCommand = ini_get('sendmail_path');
+        }
+
         if (!empty($sendmailCommand)) {
 
             return [

--- a/src/mail/transportadapters/Sendmail.php
+++ b/src/mail/transportadapters/Sendmail.php
@@ -34,6 +34,15 @@ class Sendmail extends BaseTransportAdapter
      */
     public function defineTransport()
     {
+        $sendmailCommand = ini_get('sendmail_path');
+        if (!empty($sendmailCommand)) {
+
+            return [
+                'class'   => \Swift_SendmailTransport::class,
+                'command' => $sendmailCommand,
+            ];
+        }
+
         return [
             'class' => \Swift_SendmailTransport::class,
         ];


### PR DESCRIPTION
Since the command behind the sendmail adapter is coming from Swiftmailer.
It should respect the php.ini sendmail_path setting, but it doesn't. 
And besides that, I think it would be nice to even overwrite that via the general config.

Since it's not possible for a plugin to hook in on this (plugin will be loaded to late)

Let me know your thoughts :-)