### PR TITLE
Add `tableId` attribute to AdminTable component

### DIFF
--- a/src/web/assets/admintable/src/App.vue
+++ b/src/web/assets/admintable/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="vue-admin-table" :class="{ 'vue-admin-table-padded': padded }">
+    <div :id="tableId" class="vue-admin-table" :class="{ 'vue-admin-table-padded': padded }">
         <div v-show="showToolbar" class="toolbar">
             <div class="flex">
 
@@ -136,6 +136,9 @@
         },
 
         props: {
+            container: {
+                type: String,
+            },
             actions: {
                 type: Array,
                 default: () => { return [] },
@@ -374,6 +377,15 @@
         },
 
         computed: {
+            tableId() {
+                // Replace either `#` or `.` from the container selector
+                if (this.container) {
+                    return this.container.replace(/[#.]/g,'');
+                }
+                
+                return '';
+            },
+            
             apiUrl() {
                 if (!this.tableDataEndpoint) {
                     return '';


### PR DESCRIPTION
This is mostly to make admin tables compatible with [Cloner](https://github.com/verbb/cloner).

For example, take the section index HTML:

```
<div id="sections-vue-admin-table"></div>
```

This is completely replaced when the component is mounted to this element. I actually didn't think this replaced all attributes on the HTML element, but it does, resulting in:

```
<div class="vue-admin-table">
    <div class="toolbar" style="display: none;">
    <div class="flex">
    ...
```

This adds back the original container ID, so you'll get:
```
<div id="sections-vue-admin-table" class="vue-admin-table">
    <div class="toolbar" style="display: none;">
    <div class="flex">
    ...
```

From this, I can target the table and go from there!