### PR TITLE
Display search box if tableData has a length

### DIFF
--- a/src/web/assets/admintable/src/App.vue
+++ b/src/web/assets/admintable/src/App.vue
@@ -16,7 +16,7 @@
                     </admin-table-action-button>
                 </div>
 
-                <div v-if="search && !tableData.length" class="flex-grow texticon search icon clearable">
+                <div v-if="search && tableData.length" class="flex-grow texticon search icon clearable">
                     <input
                         class="text fullwidth"
                         type="text"


### PR DESCRIPTION
Currently, adding `search: true` does not display the search box in the Admin table. 

new Craft.VueAdminTable({
  ...
  search: true,
  ...
});