### PR TITLE
Update or insert searchindex, instead of only inserting, which can fail.

### DIFF
--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -396,7 +396,7 @@ SQL;
 
         // Insert/update the row in searchindex
         $db->createCommand()
-            ->insert(Table::SEARCHINDEX, $columns, false)
+            ->upsert(Table::SEARCHINDEX, $columns, false)
             ->execute();
     }
 


### PR DESCRIPTION
The current `searchindex` fails if there is a duplicate entry, it should be an [`upsert()`](https://www.yiiframework.com/doc/api/2.0/yii-db-querybuilder#upsert()-detail) so that the current record is updated instead of just failing.
```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '349095-slug-0-1' for key 'PRIMARY'
The SQL being executed was: INSERT INTO `searchindex` (`elementId`, `attribute`, `fieldId`, `siteId`, `keywords`) VALUES (349095, 'slug', 0, 1, ' coming soon pop icons bill nye ')
```