### PR TITLE
Supported sites event

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -127,7 +127,7 @@ abstract class Element extends Component implements ElementInterface
 
     /**
      * @event RegisterElementSupportedSitesEvent The event that is triggered when registering the sites this element is associated with.
-     * @since ctrl_find_replace_this_for_since_supported_sites
+     * @since find_replace_this_for_since_supported_sites
      */
     const EVENT_REGISTER_SUPPORTED_SITES = 'registerSupportedSites';
 
@@ -496,7 +496,7 @@ abstract class Element extends Component implements ElementInterface
      *
      * @return int[]|array
      * @see getSupportedSites()
-     * @since ctrl_find_replace_this_for_since_supported_sites
+     * @since find_replace_this_for_since_supported_sites
      */
     protected function defineSupportedSites(): array
     {

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -498,7 +498,7 @@ abstract class Element extends Component implements ElementInterface
      * @see getSupportedSites()
      * @since ctrl_find_replace_this_for_since_supported_sites
      */
-    protected static function defineSupportedSites(): array
+    protected function defineSupportedSites(): array
     {
         if (static::isLocalized()) {
             return Craft::$app->getSites()->getAllSiteIds();
@@ -1458,7 +1458,7 @@ abstract class Element extends Component implements ElementInterface
      */
     public function getSupportedSites(): array
     {
-        $sites = static::defineSupportedSites();
+        $sites = $this->defineSupportedSites();
 
         // Give plugins a chance to modify them
         $event = new RegisterElementSupportedSitesEvent([

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -484,12 +484,17 @@ interface ElementInterface extends ComponentInterface
     public function getFieldLayout();
 
     /**
-     * Returns the sites this element is associated with.
+     * Returns the [sites](https://docs.craftcms.com/v3/sites.html) this element is associated with.
      *
-     * The function can either return an array of site IDs, or an array of sub-arrays,
+     * The sites can either return an array of site IDs, or an array of sub-arrays,
      * each with the keys `siteId` (int) and `enabledByDefault` (boolean).
      *
-     * @return int[]|array
+     * ::: tip
+     * Element types that extend [[\craft\base\Element]] should override [[\craft\base\Element::defineSupportedSites()]]
+     * instead of this method.
+     * :::
+     *
+     * @return int[]|array The sites this element is associated with.
      */
     public function getSupportedSites(): array;
 

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -710,7 +710,7 @@ class Entry extends Element
     /**
      * @inheritdoc
      */
-    public function getSupportedSites(): array
+    public function defineSupportedSites(): array
     {
         $section = $this->getSection();
         /** @var Site[] $allSites */

--- a/src/elements/MatrixBlock.php
+++ b/src/elements/MatrixBlock.php
@@ -243,7 +243,7 @@ class MatrixBlock extends Element implements BlockElementInterface
     /**
      * @inheritdoc
      */
-    public function getSupportedSites(): array
+    public function defineSupportedSites(): array
     {
         try {
             $owner = $this->getOwner();

--- a/src/events/RegisterElementSupportedSitesEvent.php
+++ b/src/events/RegisterElementSupportedSitesEvent.php
@@ -14,7 +14,7 @@ use yii\base\Event;
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @author PixelDeluxe | Tim van Dijkhuizen <tim@pixeldeluxe.nl>
- * @since ctrl_find_replace_this_for_since_supported_sites
+ * @since find_replace_this_for_since_supported_sites
  */
 class RegisterElementSupportedSitesEvent extends Event
 {

--- a/src/events/RegisterElementSupportedSitesEvent.php
+++ b/src/events/RegisterElementSupportedSitesEvent.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+
+/**
+ * RegisterElementSupportedSitesEvent class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @author PixelDeluxe | Tim van Dijkhuizen <tim@pixeldeluxe.nl>
+ * @since ctrl_find_replace_this_for_since_supported_sites
+ */
+class RegisterElementSupportedSitesEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var array List of registered sites for the element type.
+     */
+    public $sites = [];
+}


### PR DESCRIPTION
See this FR for more info: https://github.com/craftcms/cms/issues/4483

I don't know which release this would be in if it got accepted so replace this string to set the version for all `@since` tags: `find_replace_this_for_since_supported_sites`