### PR TITLE
Adds details hook to assets edit template

### DIFF
--- a/src/templates/assets/_edit.html
+++ b/src/templates/assets/_edit.html
@@ -40,6 +40,8 @@
 {% block details %}
     {{ previewHtml|raw }}
     {{ parent() }}
+    {# Give plugins a chance to add other things here #}
+    {% hook "cp.assets.edit.details" %}
 {% endblock %}
 
 {% block settings %}


### PR DESCRIPTION
Mirrors the functionality plugins have on entry edit templates.

Specifically, looking to extend the Sequential Edit plugin to assets now that they have laudable URLs in the CP just like entries!