### PR TITLE
Fix the 'score' check to handle arrays with more than one item

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -2565,10 +2565,10 @@ class ElementQuery extends Query implements ElementQueryInterface
      */
     private function _applyOrderByParams(Connection $db)
     {
+        $hasScore = is_array($this->orderBy) && array_key_exists('score', $this->orderBy);
         if (
             $this->orderBy === null ||
-            $this->orderBy === ['score' => SORT_ASC] ||
-            $this->orderBy === ['score' => SORT_DESC] ||
+            $hasScore ||
             !empty($this->query->orderBy)
         ) {
             return;


### PR DESCRIPTION
Since updating to Craft 3.4 searching for entries fails with the following error:

```
error: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'score' in 'order clause'
The SQL being executed was: SELECT `elements`.`id`
FROM (SELECT `elements`.`id` AS `elementsId`, `elements_sites`.`id` AS `elementsSitesId`, `content`.`id` AS `contentId`
FROM `elements` `elements`
INNER JOIN `entries` `entries` ON `entries`.`id` = `elements`.`id`
INNER JOIN `elements_sites` `elements_sites` ON `elements_sites`.`elementId` = `elements`.`id`
INNER JOIN `content` `content` ON (`content`.`elementId` = `elements`.`id`) AND (`content`.`siteId` = `elements_sites`.`siteId`)
INNER JOIN `structureelements` `structureelements` ON (`structureelements`.`elementId` = `elements`.`id`) AND (`structureelements`.`structureId`=1)
WHERE (`entries`.`sectionId` IN ('19', '32', '22', '24', '25', '3', '29', '30', '31', '1', '23', '27', '28', '18', '20')) AND (`entries`.`sectionId`='1') AND (`elements_sites`.`siteId`='1') AND (`elements`.`archived`=FALSE) AND (`elements`.`dateDeleted` IS NULL) AND (`elements`.`draftId` IS NULL) AND (`elements`.`revisionId` IS NULL)
ORDER BY `score` DESC, `elements`.`id` DESC) `subquery`
INNER JOIN `entries` `entries` ON `entries`.`id` = `subquery`.`elementsId`
INNER JOIN `elements` `elements` ON `elements`.`id` = `subquery`.`elementsId`
INNER JOIN `elements_sites` `elements_sites` ON `elements_sites`.`id` = `subquery`.`elementsSitesId`
INNER JOIN `content` `content` ON `content`.`id` = `subquery`.`contentId`
INNER JOIN `structureelements` `structureelements` ON (`structureelements`.`elementId` = `subquery`.`elementsId`) AND (`structureelements`.`structureId`=1)
ORDER BY `score` DESC, `elements`.`id` DESC
```

After doing some digging it turns out that $this->orderBy can contain more than one item, an example being 
```
array(2) {
  ["score"]=>
  int(3)
  ["elements.id"]=>
  int(3)
}
```

The problem with this is that the check for 'score' (provided below) only works when there is a single sort parameter
```
if (
            $this->orderBy === null ||
            $this->orderBy === ['score' => SORT_ASC] ||
            $this->orderBy === ['score' => SORT_DESC] ||
            !empty($this->query->orderBy)
        )
```

My patch fixes the check to be able to handle multiple items in $this->orderBy which fixes entry searching on my Craft install 