### PR TITLE
Fixed trailing slash returned from siteUrl twig function.

### DIFF
--- a/src/web/assets/installer/src/install.scss
+++ b/src/web/assets/installer/src/install.scss
@@ -162,6 +162,7 @@ input.hidden {
 
   .centeralign {
     margin-top: 35px;
+    margin-bottom: 70px !important;
   }
 }
 


### PR DESCRIPTION
Fixes #5675 by trimming the trailing / from the baseUrl