### PR TITLE
Add `ElementIndexAvailableTableAttributesEvent` event

### DIFF
--- a/src/events/ElementIndexAvailableTableAttributesEvent.php
+++ b/src/events/ElementIndexAvailableTableAttributesEvent.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+
+/**
+ * ElementIndexAvailableTableAttributesEvent event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.4.9
+ */
+class ElementIndexAvailableTableAttributesEvent extends Event
+{
+    /**
+     * @var array The element type.
+     */
+    public $elementType;
+
+    /**
+     * @var bool Whether or not to include fields.
+     */
+    public $includeFields;
+
+    /**
+     * @var array The collection of available table attributes.
+     */
+    public $attributes;
+}


### PR DESCRIPTION
I know that event name is a bit of a mouthful, but wanted to prefix the event name so it relates to an element index event.

This adds an event to give plugins a chance to modify the available table attributes of any element. In my use-case, this is for [Events](https://verbb.io/craft-plugins/events), where one element type, a Purchased Ticket actually uses the custom fields of another element, the Ticket, so that they're actually linked. If you remove a field from Ticket element's field layout, it goes from the Purchased Ticket.

As-is, this function to generate the available table attributes assumes you want to get element attributes and custom fields from the same element. This is most commonly the case, but adding this function allows us to modify this behaviour.

If I could do this in the Purchased Ticket element, I would, but table functions are static, and are more for attributes, than this later step where it amalgamates attributes and custom fields.