### PR TITLE
Avoids a deadlock when multiple relations are updated concurrently

### DIFF
--- a/src/services/Relations.php
+++ b/src/services/Relations.php
@@ -61,9 +61,17 @@ class Relations extends Component
                 ];
             }
 
-            Craft::$app->getDb()->createCommand()
-                ->delete(Table::RELATIONS, $oldRelationConditions)
-                ->execute();
+            $existingIds = (new Query)
+                ->select('id')
+                ->from(Table::RELATIONS)
+                ->where($oldRelationConditions)
+                ->column();
+
+            if (count($existingIds)) {
+                Craft::$app->getDb()->createCommand()
+                    ->delete(Table::RELATIONS, ['id' => $existingIds])
+                    ->execute();
+            }
 
             // Add the new ones
             if (!empty($targetIds)) {


### PR DESCRIPTION
Spoiler alert: no idea if this is correct or something you all are worried about. Feel free to close if not.

--

I'm running in to an issue with Deadlocks when I try to mass import/save entries in Craft. This has come up twice recently, 1st I'm adding a bunch of fresh data via a custom console command and 2nd I'm resaving a bunch of data to ensure the internal search index is updated and the URIs are set.

In both these cases I'm looking to parallel the work so I don't have to wait for 2M rows to re-save serially but can do 100k or so at a time, in parallel. When I do that I end up with a bunch of Deadlock errors from MySQL.

The error is, _I think_ because `src/services/Relations.php` does two things in a transaction,

1. Deletes all the relations for a source/field
2. Re-saves all the relations for a source/field

Where it runs in to a deadlock is if you have two concurrent saves running. Both will try to delete all relations and both will try to re-add (mostly the same) relations. The deadlock is, then, a gap lock because the unique `craft_relations_fieldId_sourceId_sourceSiteId_targetId_unq_idx` key is hitting a gap lock for the deletion and re-saving. I'm a little fuzzy on all of this, but I think it boils down to:

1. Connection A tries to delete Source A, Field 1's relations
2. Connection B tries to delete Source B, Field 1's relations
3. Connection B tries to save Source B, Field 1's relations
4. Connection A tries to save Source A, Field 1's relations

In step 3 and 4, they're both trying to update the index in a very similar manner and lock each other infinitely. Our relations table is rather large and because of that lookups take a bit longer making the issue more pronounced.

I think this PR offers a fix for the issue (at least it does locally). The fix being that instead of blindly asking MySQL to delete all relations for a source/field it first asks for the primary ID of those relations and then deletes them by primary ID. This way MySQL doesn't have to lock as aggressively because it knows exactly what rows to deal with.

Curious your thoughts on this and if anyone else has reported anything similar. I don't have a reduced test case for this yet, but might be able to get one together if you need it.

```
------------------------
LATEST DETECTED DEADLOCK
------------------------
2020-03-01 09:41:51 0x700010549000
*** (1) TRANSACTION:
TRANSACTION 80920987, ACTIVE 2 sec inserting
mysql tables in use 1, locked 1
LOCK WAIT 22 lock struct(s), heap size 1136, 11 row lock(s), undo log entries 8
MySQL thread id 23808, OS thread handle 123145578795008, query id 5011216 localhost 127.0.0.1 root update
INSERT INTO `craft_relations` (`fieldId`, `sourceId`, `sourceSiteId`, `targetId`, `sortOrder`, `dateCreated`, `dateUpdated`, `uid`) VALUES (119, 9126199, NULL, 6062, 1, '2020-03-01 14:41:50', '2020-03-01 14:41:50', '25de6520-f47b-4bcb-b6bb-580d9c6a9603')
*** (1) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 156618 page no 131806 n bits 400 index craft_relations_fieldId_sourceId_sourceSiteId_targetId_unq_idx of table `craft_relations` trx id 80920987 lock_mode X locks gap before rec insert intention waiting
Record lock, heap no 2 PHYSICAL RECORD: n_fields 5; compact format; info bits 0
 0: len 4; hex 80000078; asc    x;;
 1: len 4; hex 80000614; asc     ;;
 2: SQL NULL;
 3: len 4; hex 80000611; asc     ;;
 4: len 4; hex 814fe373; asc  O s;;

*** (2) TRANSACTION:
TRANSACTION 80920806, ACTIVE 4 sec inserting
mysql tables in use 1, locked 1
23 lock struct(s), heap size 1136, 12 row lock(s), undo log entries 8
MySQL thread id 23776, OS thread handle 123145576288256, query id 5010806 localhost 127.0.0.1 root update
INSERT INTO `craft_relations` (`fieldId`, `sourceId`, `sourceSiteId`, `targetId`, `sortOrder`, `dateCreated`, `dateUpdated`, `uid`) VALUES (119, 9126189, NULL, 6061, 1, '2020-03-01 14:41:48', '2020-03-01 14:41:48', 'faca9232-df9e-44d0-b0e7-ce592c186219')
*** (2) HOLDS THE LOCK(S):
RECORD LOCKS space id 156618 page no 131806 n bits 400 index craft_relations_fieldId_sourceId_sourceSiteId_targetId_unq_idx of table `craft_relations` trx id 80920806 lock_mode X locks gap before rec
Record lock, heap no 2 PHYSICAL RECORD: n_fields 5; compact format; info bits 0
 0: len 4; hex 80000078; asc    x;;
 1: len 4; hex 80000614; asc     ;;
 2: SQL NULL;
 3: len 4; hex 80000611; asc     ;;
 4: len 4; hex 814fe373; asc  O s;;

*** (2) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 156618 page no 131806 n bits 400 index craft_relations_fieldId_sourceId_sourceSiteId_targetId_unq_idx of table `craft_relations` trx id 80920806 lock_mode X locks gap before rec insert intention waiting
Record lock, heap no 2 PHYSICAL RECORD: n_fields 5; compact format; info bits 0
 0: len 4; hex 80000078; asc    x;;
 1: len 4; hex 80000614; asc     ;;
 2: SQL NULL;
 3: len 4; hex 80000611; asc     ;;
 4: len 4; hex 814fe373; asc  O s;;

*** WE ROLL BACK TRANSACTION (1)
```