### PR TITLE
Added `white-space: nowrap` to thin table cells

### DIFF
--- a/src/web/assets/cp/dist/css/_main.scss
+++ b/src/web/assets/cp/dist/css/_main.scss
@@ -1525,6 +1525,7 @@ table {
   th.thin,
   td.thin {
     width: 0.01% !important;
+    white-space: nowrap;
   }
 
   thead {


### PR DESCRIPTION
When `.thin` table cells contain text with spaces, the text is wrapped and looks quite ugly. This PR fixes that with `white-space: nowrap`.

Before:
![Screenshot 2020-03-03 at 08 39 19](https://user-images.githubusercontent.com/57572400/75753604-69e7d780-5d2b-11ea-9622-734d112a3879.png)

After:
![Screenshot 2020-03-03 at 08 39 49](https://user-images.githubusercontent.com/57572400/75753623-70764f00-5d2b-11ea-9c93-22271f74de35.png)
