### PR TITLE
Unset ID if null to avoid Postgres throwing an error.

### DIFF
--- a/src/db/ActiveRecord.php
+++ b/src/db/ActiveRecord.php
@@ -93,6 +93,12 @@ abstract class ActiveRecord extends \yii\db\ActiveRecord
             if ($this->hasAttribute('uid') && !isset($this->uid)) {
                 $this->uid = StringHelper::UUID();
             }
+            
+            // Unset ID if null to avoid Postgres throwing an error.
+            if (Craft::$app->getDb()->getIsPgsql() && $this->hasAttribute('id') && $this->id === null) {
+                unset($this->id);
+            }
+        }
         } else if (
             !empty($this->getDirtyAttributes()) &&
             $this->hasAttribute('dateUpdated')


### PR DESCRIPTION
This PR unsets the ID of all ActiveRecord classes if null to avoid Postgres throwing an error.

This will eliminate the need to do this manually in various places, including plugins:
https://github.com/craftcms/cms/blob/3.4.10.1/src/services/AssetIndexer.php#L415-L416