### PR TITLE
urlencode asset path

### DIFF
--- a/src/helpers/Assets.php
+++ b/src/helpers/Assets.php
@@ -82,7 +82,7 @@ class Assets
     public static function generateUrl(VolumeInterface $volume, Asset $asset, $uri = null): string
     {
         $baseUrl = $volume->getRootUrl();
-        $folderPath = $asset->getFolder()->path;
+        $folderPath = urlencode($asset->getFolder()->path);
         $appendix = static::urlAppendix($volume, $asset);
 
         return $baseUrl . $folderPath . ($uri ?? $asset->filename) . $appendix;


### PR DESCRIPTION
Asset folder path can contain chars that should be urlencoded.

Here's an example of a failing link generated by Craft that has no urlencoding:

https://cloud-cube-eu.s3.amazonaws.com/h5hefxygz0g8/users/info+demolid@clubee.nl/_72x72_crop_center-center_none/ABC_Company_logo.png?mtime=20200320124425&focal=none

Here's the same link urlencoded, working:

https://cloud-cube-eu.s3.amazonaws.com/h5hefxygz0g8/users/info%2Bdemolid@clubee.nl/_72x72_crop_center-center_none/ABC_Company_logo.png?mtime=20200320124425&focal=none