### PR TITLE
Fix error when running project-config/rebuild

### DIFF
--- a/src/console/controllers/ProjectConfigController.php
+++ b/src/console/controllers/ProjectConfigController.php
@@ -105,12 +105,13 @@ class ProjectConfigController extends Controller
      */
     public function actionRebuild(): int
     {
+        $projectConfig = Craft::$app->getProjectConfig();
+        
         if (!file_exists(Craft::$app->getPath()->getProjectConfigFilePath())) {
             $this->stdout('No project.yaml file found. Generating one from internal config ... ', Console::FG_YELLOW);
             $projectConfig->regenerateYamlFromConfig();
         }
-
-        $projectConfig = Craft::$app->getProjectConfig();
+        
         $this->stdout('Rebuilding the project config from the current state ... ', Console::FG_YELLOW);
 
         try {


### PR DESCRIPTION
If no project config file existed, running rebuild would result in an error:

```
./craft project-config/rebuild
No project.yaml file found. Generating one from internal config ... 
                                                                                                                        
 [ERROR] Undefined variable: projectConfig                                                                              
                                                                                                                        
         yii\base\ErrorException                                                                                        
                                                                                                                        
         in /vendor/craftcms/cms/src/console/controllers/ProjectConfigController.php: 110      
                                                                                                                        

▓                                                                                                                       
▓  Stack trace:                                                                                                         
▓                                                                                                                       
▓  #0 /vendor/craftcms/cms/src/console/controllers/ProjectConfigController.php(110):                                    
▓  yii\base\ErrorHandler->handleError(8, 'Undefined varia...', '/Users/tdavis/s...', 110, Array)                        
▓  #1 [internal function]: craft\console\controllers\ProjectConfigController->actionRebuild()                           
▓  #2 /vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)                                
▓  #3 /vendor/yiisoft/yii2/base/Controller.php(157): yii\base\InlineAction->runWithParams(Array)                        
▓  #4 /vendor/yiisoft/yii2/console/Controller.php(164): yii\base\Controller->runAction('rebuild', Array)                
▓  #5 /vendor/craftcms/cms/src/console/Controller.php(187): yii\console\Controller->runAction('rebuild', Array)         
▓  #6 /vendor/yiisoft/yii2/base/Module.php(528): craft\console\Controller->runAction('rebuild', Array)                  
▓  #7 /vendor/yiisoft/yii2/console/Application.php(180): yii\base\Module->runAction('project-config/...', Array)        
▓  #8 /vendor/craftcms/cms/src/console/Application.php(87): yii\console\Application->runAction('project-config/...',    
▓  Array)                                                                                                               
▓  #9 /vendor/yiisoft/yii2/console/Application.php(147): craft\console\Application->runAction('project-config/...',     
▓  Array)                                                                                                               
▓  #10 /vendor/yiisoft/yii2/base/Application.php(386):                                                                  
▓  yii\console\Application->handleRequest(Object(craft\console\Request))                                                
▓  #11 /craft(22): yii\base\Application->run()                                                                          
▓  #12 {main}   
```