### PR TITLE
Track whether an element is a source element explicitly

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '3.4.13',
-    'schemaVersion' => '3.5.0',
+    'schemaVersion' => '3.5.1',
     'minVersionRequired' => '2.6.2788',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -2425,7 +2425,7 @@ class ElementQuery extends Query implements ElementQueryInterface
                 $this->subQuery->andWhere(['drafts.creatorId' => $this->draftCreator]);
             }
         } else {
-            $this->subQuery->andWhere($this->_placeholderCondition(['elements.draftId' => null]));
+            $this->subQuery->andWhere($this->_placeholderCondition(['elements.isSource' => true]));
         }
 
         if ($this->revisions) {

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -248,6 +248,7 @@ class Install extends Migration
             'revisionId' => $this->integer(),
             'fieldLayoutId' => $this->integer(),
             'type' => $this->string()->notNull(),
+            'isSource' => $this->boolean()->notNull()->defaultValue(true),
             'enabled' => $this->boolean()->notNull()->defaultValue(true),
             'archived' => $this->boolean()->notNull()->defaultValue(false),
             'dateCreated' => $this->dateTime()->notNull(),
@@ -771,8 +772,9 @@ class Install extends Migration
         $this->createIndex(null, Table::ELEMENTS, ['fieldLayoutId'], false);
         $this->createIndex(null, Table::ELEMENTS, ['type'], false);
         $this->createIndex(null, Table::ELEMENTS, ['enabled'], false);
-        $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateCreated'], false);
-        $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateDeleted', 'draftId', 'revisionId'], false);
+        $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateDeleted', 'draftId'], false);
+        $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateCreated', 'revisionId'], false);
+        $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateDeleted', 'isSource'], false);
         $this->createIndex(null, Table::ELEMENTS_SITES, ['elementId', 'siteId'], true);
         $this->createIndex(null, Table::ELEMENTS_SITES, ['siteId'], false);
         $this->createIndex(null, Table::ELEMENTS_SITES, ['slug', 'siteId'], false);

--- a/src/migrations/m200406_125325_draft_revision_bools.php
+++ b/src/migrations/m200406_125325_draft_revision_bools.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace craft\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Table;
+use craft\helpers\MigrationHelper;
+
+/**
+ * m200406_125325_draft_revision_bools migration.
+ */
+class m200406_125325_draft_revision_bools extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->addColumn(Table::ELEMENTS, 'isSource', $this->boolean()->notNull()->defaultValue(true)->after('type'));
+
+        MigrationHelper::dropIndexIfExists(Table::ELEMENTS, ['archived', 'dateCreated'], false);
+        MigrationHelper::dropIndexIfExists(Table::ELEMENTS, ['archived', 'dateDeleted', 'draftId', 'revisionId'], false);
+
+        $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateDeleted', 'draftId'], false);
+        $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateCreated', 'revisionId'], false);
+        $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateDeleted', 'isSource'], false);
+
+        $this->update(Table::ELEMENTS, ['isSource' => false], [
+            'or',
+            ['not', ['draftId' => null]],
+            ['not', ['revisionId' => null]],
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m200406_125325_draft_revision_bools cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/records/Element.php
+++ b/src/records/Element.php
@@ -18,6 +18,7 @@ use craft\db\Table;
  * @property int|null $revisionId Revision ID
  * @property int $fieldLayoutId ID
  * @property string $type Type
+ * @property bool $isSource Is source element
  * @property bool $enabled Enabled
  * @property bool $archived Archived
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -376,7 +376,9 @@ class Elements extends Component
         if (version_compare($schemaVersion, '3.1.0', '>=')) {
             $query->andWhere(['elements.dateDeleted' => null]);
         }
-        if (version_compare($schemaVersion, '3.2.6', '>=')) {
+        if (version_compare($schemaVersion, '3.5.1', '>=')) {
+            $query->andWhere(['elements.isSource' => true]);
+        } else if (version_compare($schemaVersion, '3.2.6', '>=')) {
             $query->andWhere([
                 'elements.draftId' => null,
                 'elements.revisionId' => null,
@@ -2015,6 +2017,7 @@ class Elements extends Component
                 $elementRecord->draftId = (int)$element->draftId ?: null;
                 $elementRecord->revisionId = (int)$element->revisionId ?: null;
                 $elementRecord->fieldLayoutId = $element->fieldLayoutId = (int)($element->fieldLayoutId ?? $element->getFieldLayout()->id ?? 0) ?: null;
+                $elementRecord->isSource = !($element->draftId || $element->revisionId);
                 $elementRecord->enabled = (bool)$element->enabled;
                 $elementRecord->archived = (bool)$element->archived;
 


### PR DESCRIPTION
This PR adds a new `isSource` boolean column to the `elements` table, which will be `true` if the element is not a draft or revision.

With that in place, source element queries can start searching for `isSource = true` rather than `draftId is null and revisionId is null`, which isn’t very performant.

Would resolve #5891.