### PR TITLE
Add "Link" as a default column in the Assets table

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -415,6 +415,7 @@ class Asset extends Element
             'size',
             'dateModified',
             'uploader',
+            'link'
         ];
     }
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -415,7 +415,7 @@ class Asset extends Element
             'size',
             'dateModified',
             'uploader',
-            'link'
+            'link',
         ];
     }
 


### PR DESCRIPTION
This adds the "Link" column as a default column in the Assets table. I commonly add this to make it simple to grab links and view the asset directly (outside of the modal when previewing an image). This is also useful in the case when you want to grab the URL of an asset that isn't an image like a PDF, PPT, etc.

It's a small enough column to make this a nice quality-of-life update.

Related to #2944