### PR TITLE
Prevent “node_modules” scan for template suggestions

### DIFF
--- a/src/web/twig/variables/Cp.php
+++ b/src/web/twig/variables/Cp.php
@@ -459,9 +459,13 @@ class Cp extends Component
         $files = [];
         $pathLengths = [];
 
+        $excludes = ['node_modules/'];
+
         foreach ($iterator as $file) {
             /** @var \SplFileInfo $file */
-            if (!$file->isDir() && $file->getFilename()[0] !== '.') {
+            if ($file->isDir()) continue;
+
+            if ($file->getFilename()[0] !== '.' && !StringHelper::containsAny($file->getPath(), $excludes)) {
                 $files[] = $file;
                 $pathLengths[] = strlen($file->getRealPath());
             }


### PR DESCRIPTION
Currently the "template suggestion" feature scans the `node_modules` folder if exists inside the template.

This slows down considerably the loading of the page (e.g. Edit of a Section) inside the control panel.

With this PR we can prevent the scanning of unwanted folders (like `node_modules`) speeding up the loading of the pages that use this feature.

I was thinking of moving the `$excludes` variable to a configuration file but I'm not sure which one is correct. Thoughts?