### PR TITLE
Disable caching of compiled templates when `devMode` is enabled

### DIFF
--- a/src/web/View.php
+++ b/src/web/View.php
@@ -1871,6 +1871,7 @@ JS;
         if (YII_DEBUG) {
             $this->_twigOptions['debug'] = true;
             $this->_twigOptions['strict_variables'] = true;
+            $this->_twigOptions['cache'] = false;
         }
 
         return $this->_twigOptions;


### PR DESCRIPTION
This PR disables caching of compiled templates when `devMode` is enabled, for a better local development experience. https://twig.symfony.com/doc/3.x/api.html#environment-options