### PR TITLE
Use systemName over siteName in emails

### DIFF
--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -1113,7 +1113,7 @@ return [
     'You’re running Craft {edition} with a Craft {licensedEdition} license.' => 'You’re running Craft {edition} with a Craft {licensedEdition} license.',
     'account_activation_body' => 'Hey {{user.friendlyName}},
 
-Thanks for creating an account with {{siteName}}! To activate your account, click the following link:
+Thanks for creating an account with {{systemName}}! To activate your account, click the following link:
 
 <{{link}}>
 
@@ -1131,7 +1131,7 @@ If you were not expecting this email, just ignore it.',
     'folders and files' => 'folders and files',
     'forgot_password_body' => 'Hey {{user.friendlyName}},
 
-To reset your {{siteName}} password, click on this link:
+To reset your {{systemName}} password, click on this link:
 
 <{{link}}>
 


### PR DESCRIPTION
`systemName` might make more sense than `siteName` here, as users aren't site-specific.