### PR TITLE
Move login delay to failure handler

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -137,9 +137,6 @@ class UsersController extends Controller
         // Does a user exist with that username/email?
         $user = Craft::$app->getUsers()->getUserByUsernameOrEmail($loginName);
 
-        // Delay randomly between 0 and 1.5 seconds.
-        usleep(random_int(0, 1500000));
-
         if (!$user || $user->password === null) {
             // Delay again to match $user->authenticate()'s delay
             Craft::$app->getSecurity()->validatePassword('p@ss1w0rd', '$2y$13$nj9aiBeb7RfEfYP3Cum6Revyu14QelGGxwcnFUKXIrQUitSodEPRi');
@@ -1597,6 +1594,9 @@ class UsersController extends Controller
      */
     private function _handleLoginFailure(string $authError = null, User $user = null)
     {
+        // Delay randomly between 0 and 1.5 seconds.
+        usleep(random_int(0, 1500000));
+
         $message = UserHelper::getLoginFailureMessage($authError, $user);
 
         // Fire a 'loginFailure' event


### PR DESCRIPTION
This PR moves the random delay applied to all login attempts to the `_handleLoginFailure` method. 

As brute-force mitigation, I think it should only really necessary to add a delay to failed attempts and any successful login shouldn't be met with a potential delay.