### PR TITLE
make first draft name translatable

### DIFF
--- a/src/services/Drafts.php
+++ b/src/services/Drafts.php
@@ -188,7 +188,7 @@ class Drafts extends Component
     public function saveElementAsDraft(ElementInterface $element, int $creatorId, string $name = null, string $notes = null): bool
     {
         if ($name === null) {
-            $name = 'First draft';
+            $name = Craft::t('app', 'First draft');
         }
 
         // Create the draft row

--- a/src/translations/de/app.php
+++ b/src/translations/de/app.php
@@ -418,6 +418,7 @@ return [
     'Find and Replace' => 'Suchen und ersetzen',
     'Finish up' => 'Vervollständigen',
     'Finishing up…' => 'Wird vervollständigt…',
+    'First draft' => 'Erster Entwurf',
     'First Name' => 'Vorname',
     'Fit' => 'Anpassen',
     'Flash' => 'Flash',


### PR DESCRIPTION
The "First draft" name was not translatable, so we fixed that and added the German translation :)