### PR TITLE
Fixtures: Use relations as primary key

### DIFF
--- a/src/test/fixtures/elements/ElementFixture.php
+++ b/src/test/fixtures/elements/ElementFixture.php
@@ -183,7 +183,14 @@ abstract class ElementFixture extends ActiveFixture
             }
 
             if ($this->isPrimaryKey($key)) {
-                $query = $query->$key(addcslashes($value, ','));
+                if (is_array($value)) {
+                    $query = $query->relatedTo([
+                        'targetElement' => $value,
+                        'field' => $key,
+                    ]);
+                } else {
+                    $query = $query->$key(addcslashes($value, ','));
+                }
             }
         }
 


### PR DESCRIPTION
A relation field is always passed as an array (of id's or elements), never a scalar.

Had this in #5929 but reverted it, thinking it wasn't needed anymore. I was wrong.