### PR TITLE
Added `craft\events\SetElementSearchKeywordsEvent`

### DIFF
--- a/CHANGELOG-v3.md
+++ b/CHANGELOG-v3.md
@@ -5,6 +5,7 @@
 ### Added
 - Added the “Allow self relations” advanced setting to relational fields. ([#6113](https://github.com/craftcms/cms/issues/6113))
 - Added `craft\helpers\Assets::scaledDimensions()`.
+- Added `craft\events\SetElementSearchKeywordsEvent`.
 
 ### Changed
 - Asset thumbnails now use the same aspect ratio as the source image. ([#5518](https://github.com/craftcms/cms/issues/5518), [#5515](https://github.com/craftcms/cms/issues/5515))

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -224,7 +224,7 @@ abstract class Element extends Component implements ElementInterface
      *     $element = $e->sender;
      *     
      *     if ($e->attribute === 'productTitle') {
-     *         $e->keywords = $element->getProduct()->title;
+     *         $e->value = $element->getProduct()->title;
      *     }
      * });
      * ```

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -221,8 +221,10 @@ abstract class Element extends Component implements ElementInterface
      *
      * ```php
      * Event::on(craft\elements\Entry::class, craft\base\Element::EVENT_SET_SEARCH_KEYWORDS, function(craft\events\SetElementSearchKeywordsEvent $e) {
+     *     $element = $e->sender;
+     *     
      *     if ($e->attribute === 'productTitle') {
-     *         $e->keywords = $this->getProduct()->title;
+     *         $e->keywords = $element->getProduct()->title;
      *     }
      * });
      * ```

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -1598,11 +1598,12 @@ abstract class Element extends Component implements ElementInterface
     {
         // Give plugins a chance to modify them
         $event = new SetElementSearchKeywordsEvent([
-            'attribute' => $this->$attribute,
+            'attribute' => $attribute,
+            'value' => $this->$attribute,
         ]);
         $this->trigger(self::EVENT_SET_SEARCH_KEYWORDS, $event);
 
-        return StringHelper::toString($event->keywords);
+        return StringHelper::toString($event->value);
     }
 
     /**

--- a/src/events/SetElementSearchKeywordsEvent.php
+++ b/src/events/SetElementSearchKeywordsEvent.php
@@ -23,7 +23,7 @@ class SetElementSearchKeywordsEvent extends Event
     public $attribute;
 
     /**
-     * @var mixed The attribute's keywords that should be indexed for the element.
+     * @var mixed The value that should be indexed for the element.
      */
-    public $keywords;
+    public $value;
 }

--- a/src/events/SetElementSearchKeywordsEvent.php
+++ b/src/events/SetElementSearchKeywordsEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+
+/**
+ * SetElementSearchKeywordsEvent class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.4.21
+ */
+class SetElementSearchKeywordsEvent extends Event
+{
+    /**
+     * @var string The attribute that should be indexed for the element.
+     */
+    public $attribute;
+
+    /**
+     * @var mixed The attribute's keywords that should be indexed for the element.
+     */
+    public $keywords;
+}


### PR DESCRIPTION
So you can do i.e.

```php
// Register variant search attributes
Event::on(Variant::class, Variant::EVENT_REGISTER_SEARCHABLE_ATTRIBUTES, function (RegisterElementSearchableAttributesEvent $e) {
    $e->attributes[] = 'productLine';
});

// Register variant search keywords
Event::on(Variant::class, Variant::EVENT_SET_SEARCH_KEYWORDS, function (SetElementSearchKeywordsEvent $e) {
    $variant = $e->sender;
    $product = $variant->getProduct();

    if ($product->getType()->handle == 'trampoline' && $e->attribute === 'productLine') {
        $e->value = $product->productLine[0]->title;
    }
});
```

This allows for more custom search keywords control than just defining an attribute