### PR TITLE
Throw UnauthorizedHttpException for guest users

### DIFF
--- a/src/web/Controller.php
+++ b/src/web/Controller.php
@@ -18,6 +18,7 @@ use yii\base\InvalidConfigException;
 use yii\base\UserException;
 use yii\web\BadRequestHttpException;
 use yii\web\ForbiddenHttpException;
+use yii\web\UnauthorizedHttpException;
 use yii\web\HttpException;
 use yii\web\JsonResponseFormatter;
 use yii\web\Response as YiiResponse;
@@ -151,7 +152,7 @@ abstract class Controller extends \yii\web\Controller
                 $this->requireLogin();
                 $this->requirePermission('accessCp');
             } else if (Craft::$app->getUser()->getIsGuest()) {
-                throw new ServiceUnavailableHttpException();
+                throw new UnauthorizedHttpException();
             }
 
             // If the system is offline, make sure they have permission to access the CP/site


### PR DESCRIPTION
When a guest tries to access an action which doesn't allow anonymous access, and doesn't `requireLogin()` we get a `ServiceUnavailableException`.

To reproduce we used:

```php
class FooController extends \craft\web\Controller
{
    public function actionBar()
    {
        return $this->asJson(['foo' => 'bar']);
    }
}
```

The CraftCMS docs say:

> You can easily control whether the controller should allow anonymous access by overriding $allowAnonymous . (An active user session is required by default).

This PR aligns the error with the requirements in the docs.