### PR TITLE
Remove warning log when removing local image source

### DIFF
--- a/src/services/AssetTransforms.php
+++ b/src/services/AssetTransforms.php
@@ -903,9 +903,7 @@ class AssetTransforms extends Component
             if (!$volume instanceof LocalVolumeInterface) {
                 if (!is_file($imageSourcePath) || filesize($imageSourcePath) === 0) {
                     // Delete it just in case it's a 0-byter
-                    if (!FileHelper::unlink($imageSourcePath)) {
-                        Craft::warning("Unable to delete the file \"$imageSourcePath\".", __METHOD__);
-                    }
+                    FileHelper::unlink($imageSourcePath);
 
                     $prefix = pathinfo($asset->filename, PATHINFO_FILENAME) . '.delimiter.';
                     $extension = $asset->getExtension();


### PR DESCRIPTION
This PR removes the warning log which is logged when attempting to unlink an image source which doesn't exist prior to retrieving a local image source.

I can replicate this by loading the assets in CP; waiting for the the thumbnails to load and searching my logs for the warning.