### PR TITLE
Added wrapper to make button containers consistent

### DIFF
--- a/src/templates/_layouts/element.html
+++ b/src/templates/_layouts/element.html
@@ -189,7 +189,9 @@
         {% endif %}
     {% elseif isDraft %}
         {% if canUpdateSource and saveSourceAction %}
-            <input type="submit" class="btn submit" value="{{ 'Publish changes'|t('app') }}">
+            <div id="publish-changes-btn-container">
+                <input type="submit" class="btn submit" value="{{ 'Publish changes'|t('app') }}">
+            </div>
         {% endif %}
     {% elseif isRevision %}
         {% if canUpdateSource and revertSourceAction %}


### PR DESCRIPTION
This PR adds a button container with an ID to make it consistent with the `#save-btn-container` and provide a hook for plugins like https://github.com/spicywebau/craft-fieldlabels 

In fact this change may be required to fix https://github.com/spicywebau/craft-fieldlabels/issues/51

