### PR TITLE
Create uid index on elements table

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -766,6 +766,7 @@ class Install extends Migration
         $this->createIndex(null, Table::CONTENT, ['title'], false);
         $this->createIndex(null, Table::DEPRECATIONERRORS, ['key', 'fingerprint'], true);
         $this->createIndex(null, Table::ELEMENTINDEXSETTINGS, ['type'], true);
+        $this->createIndex(null, Table::ELEMENTS, ['uid'], false);
         $this->createIndex(null, Table::ELEMENTS, ['dateDeleted'], false);
         $this->createIndex(null, Table::ELEMENTS, ['fieldLayoutId'], false);
         $this->createIndex(null, Table::ELEMENTS, ['type'], false);

--- a/src/migrations/m200605_145232_Add_elements_uid_idx.php
+++ b/src/migrations/m200605_145232_Add_elements_uid_idx.php
@@ -1,0 +1,33 @@
+
+<?php
+
+namespace craft\contentmigrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\helpers\MigrationHelper;
+use craft\db\Table;
+
+/**
+ * m200605_145232_Add_elements_uid_idx migration.
+ */
+class m200605_145232_Add_elements_uid_idx extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        if (!MigrationHelper::doesIndexExist(Table::ELEMENTS, 'uid', false)) {
+            $this->createIndex(null, Table::ELEMENTS, 'uid', false);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        MigrationHelper::dropIndexIfExists(Table::ELEMENTS, 'uid', false);
+    }
+}


### PR DESCRIPTION
This PR adds an index for the uid column on the elements table.

Some operations fetch elements by UID, for example, in Craft Commerce (3.0.1) when canceling a subscription, the uid is used, this results in a query similar to:

```sql
SELECT `elements`.`id`, `elements`.`fieldLayoutId`, `elements`.`uid`
FROM (SELECT `elements`.`id` AS `elementsId`, `elements_sites`.`id` AS `elementsSitesId`, `content`.`id` AS `contentId`
FROM `craft_elements` `elements`
INNER JOIN `craft_commerce_subscriptions` `commerce_subscriptions` ON `commerce_subscriptions`.`id` = `elements`.`id`
INNER JOIN `craft_users` `users` ON `commerce_subscriptions`.`userId` = `users`.`id`
INNER JOIN `craft_elements_sites` `elements_sites` ON `elements_sites`.`elementId` = `elements`.`id`
INNER JOIN `craft_content` `content` ON `content`.`elementId` = `elements`.`id`
WHERE (`elements`.`uid`='<uid>') AND (`elements`.`archived`=FALSE) AND (`elements`.`dateDeleted` IS NULL) AND (`elements`.`draftId` IS NULL) AND (`elements`.`revisionId` IS NULL)
ORDER BY `commerce_subscriptions`.`dateCreated` DESC) `subquery`
INNER JOIN `craft_commerce_subscriptions` `commerce_subscriptions` ON `commerce_subscriptions`.`id` = `subquery`.`elementsId`
INNER JOIN `craft_elements` `elements` ON `elements`.`id` = `subquery`.`elementsId`
INNER JOIN `craft_elements_sites` `elements_sites` ON `elements_sites`.`id` = `subquery`.`elementsSitesId`
INNER JOIN `craft_content` `content` ON `content`.`id` = `subquery`.`contentId`
ORDER BY `commerce_subscriptions`.`dateCreated` DESC
;
```

With over 3 million records, the query takes > 4s to execute.

After adding this index, it brings it down to a few milliseconds.
