### PR TITLE
Override `evaluateDynamicContent()` to prevent unintended code eval

### DIFF
--- a/CHANGELOG-v3.5.md
+++ b/CHANGELOG-v3.5.md
@@ -21,6 +21,7 @@
 - Added the `allowedGraphqlOrigins` config setting. ([#5933](https://github.com/craftcms/cms/issues/5933))
 - Added the `brokenImagePath` config setting. ([#5877](https://github.com/craftcms/cms/issues/5877))
 - Added the `cpHeadTags` config setting, making it possible to give the control panel a custom favicon. ([#4003](https://github.com/craftcms/cms/issues/4003))
+- Added the `enableDynamicContentEvaluation` config setting.
 - Added the `siteToken` config setting.
 - Added the `install/check` command. ([#5810](https://github.com/craftcms/cms/issues/5810))
 - Added the `plugin/install`, `plugin/uninstall`, `plugin/enable`, and `plugin/disable` commands. ([#5817](https://github.com/craftcms/cms/issues/5817))
@@ -273,6 +274,7 @@
 - `craft\services\Gql` now fires a `registerGqlMutations` event that allows for plugins to register their own GraphQL mutations.
 - `craft\services\Sites::getAllSiteIds()`, `getSiteByUid()`, `getAllSites()`, `getSitesByGroupId()`, `getSiteById()`, and `getSiteByHandle()` now have `$withDisabled` arguments.
 - `craft\services\TemplateCaches::startTemplateCache()` no longer has a `$key` argument.
+- `craft\web\View::evaluateDynamicContent()` now requires the `$enableDynamicContentEvaluation` config setting to be explicitly enabled, to prevent unintended execution of untrusted code.
 - Improved `data`/`aria` tag normalization via `craft\helpers\Html::parseTagAttributes()` and `normalizeTagAttributes()`.
 - Control panel form input macros and templates that accept a `class` variable can now pass it as an array of class names.
 - Control panel templates can now set a `formActions` variable, which registers alternative Save menu actions, optionally with associated keyboard shortcuts.

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -347,6 +347,11 @@ class GeneralConfig extends BaseObject
      */
     public $enableGql = true;
     /**
+     * @var bool Whether Craft should allow the View to eval dynamic PHP code via [[\craft\web\View::evaluateDynamicContent()]]
+     * @since 3.5.0
+     */
+    public $enableDynamicContentEvaluation = false;
+    /**
      * @var mixed The amount of time a user’s elevated session will last, which is required for some sensitive actions (e.g. user group/permission assignment).
      *
      * Set to `0` to disable elevated session support.

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -1602,6 +1602,25 @@ JS;
         parent::endPage($ajaxMode);
     }
 
+    /**
+     * Evaluates the given PHP statements, if allowed by the General Config
+     *
+     * (This method is used internally by Yii's View component. Craft overrides it as a no-op by default
+     * to prevent unintended runtime evaluation of untrusted code.)
+     *
+     * @param string $statements the PHP statements to be evaluated.
+     * @return mixed the return value of the PHP statements.
+     * @throws Exception if `enableDynamicContentEvaluation` not allowed via the General Config
+     */
+    public function evaluateDynamicContent($statements)
+    {
+        if (Craft::$app->getConfig()->getGeneral()->enableDynamicContentEvaluation)
+        {
+            return parent::evaluateDynamicContent($statements);
+        }
+        Craft::$app->getDeprecator()->log('evaluateDynamicContent', 'craft\\web\\View::evaluateDynamicContent() was invoked, but $enableDynamicContentEvaluation is not enabled in the General Config.');
+    }
+
     // Events
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
This short-circuits some potential security vulnerabilities at the source, by overriding `View::evaluateDynamicContent()` as a no-op, unless the environment explicitly permits dynamic evaluation via the `enableDynamicContentEvaluation` config setting.

(Prevents _unintended_ execution of untrusted code, but still keeps the API intact for the [brave souls](https://gist.github.com/elfacht/bc2c8a997c1801c45d29e4e374cd550a) who are utilizing that method already.)