### PR TITLE
Set enabledForSite=false when querying for disabled in element indices

### DIFF
--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -450,6 +450,11 @@ class ElementIndexesController extends BaseElementsController
             Craft::configure($query, $criteria);
         }
 
+        // Override enabledForSite when querying for disabled
+        if ($query->status === Element::STATUS_DISABLED) {
+            $query->enabledForSite = false;
+        }
+
         // Exclude descendants of the collapsed element IDs
         $collapsedElementIds = $request->getParam('collapsedElementIds');
 


### PR DESCRIPTION
See https://github.com/craftcms/redactor/issues/236#issuecomment-650264753 for more context.

Basically, it seems that currently anything using an element index needs to also set `enabledForSite=false` for disabled filtering to work properly in a multi-site.

I'm not 💯 this is the right place to do this, but it seems better than making all implementations set `enabledForSite=false` to get things working as expected.

Furthermore, I'm setting this to `false` as that is what the param seems to expect, but the other exceptions for this seem to set it to `null`…but I'm not sure why (https://github.com/craftcms/cms/blob/6c579f86de714350a2af4b9e7adb956b54bf3bcf/src/web/assets/cp/CpAsset.php#L288, https://github.com/craftcms/cms/blob/6c579f86de714350a2af4b9e7adb956b54bf3bcf/src/fields/BaseRelationField.php#L852)