### PR TITLE
Don't apply enabledForSite condition when querying for disabled

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1408,7 +1408,7 @@ class ElementQuery extends Query implements ElementQueryInterface
             $this->subQuery->andWhere(Db::parseParam('elements_sites.uri', $this->uri, '=', true));
         }
 
-        if ($this->enabledForSite) {
+        if ($this->enabledForSite && $this->status !== Element::STATUS_DISABLED) {
             $this->subQuery->andWhere(['elements_sites.enabled' => true]);
         }
 


### PR DESCRIPTION
Fixes https://github.com/craftcms/cms/issues/6273 and https://github.com/craftcms/redactor/issues/236

If this makes sense, you may also want to review the other spots where Craft _is_ explicitly passing `enabledForSite: null`, which, perhaps coincidentally, is allowing it to work as expected in those spots:

- https://github.com/craftcms/cms/blob/6c579f86de714350a2af4b9e7adb956b54bf3bcf/src/web/assets/cp/CpAsset.php#L288
- https://github.com/craftcms/cms/blob/6c579f86de714350a2af4b9e7adb956b54bf3bcf/src/fields/BaseRelationField.php#L852