### PR TITLE
Do not use references when recursively packing arrays

### DIFF
--- a/src/helpers/ProjectConfig.php
+++ b/src/helpers/ProjectConfig.php
@@ -220,11 +220,11 @@ class ProjectConfig
     {
         // Deal with the nested values first
         if ($recursive) {
-            foreach ($array as &$value) {
-                if (is_array($value)) {
-                    $value = static::packAssociativeArray($value, true);
-                }
-            }
+            $array = array_map(function($value) {
+                return is_array($value)
+                   ? static::packAssociativeArray($value, true)
+                   : $value;
+            }, $array);
         }
 
         // Only pack this array if its keys are not in numerical order


### PR DESCRIPTION
### Description

It looks like ProjectConfig::packAssociativeArray copies the first found recursive value into all subsequent child nodes with recursive arrays.

### Related issues

This resolves #6320
