### PR TITLE
Fix GraphQL save asset mutations

### DIFF
--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -227,7 +227,7 @@ class Asset extends ElementMutationResolver
         }
 
         $asset->tempFilePath = $tempPath;
-        $asset->newFilename = $filename;
+        $asset->filename = $filename;
         $asset->avoidFilenameConflicts = true;
 
         return true;


### PR DESCRIPTION
### Description

Hi,

When running a save asset mutation such as:

```
mutation($file: FileInput!) {
  save_uploads_Asset(
    _file: $file
    newFolderId: 1
  ) {
    id
  }
}

// variables
{
  "file": {
    "fileData": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
    "filename": "test.png"
  }
}
```

I'm receiving the following error:

```json
{
  "errors": [
    {
      "message": "Filename cannot be blank.\nKind cannot be blank.",
      "category": "user",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "save_uploads_Asset"
      ]
    }
  ],
  "data": {
    "save_uploads_Asset": null
  }
}
```

Changing it so the filename is passed to `$asset->filename` instead of `$asset->newFilename` seems to have fixed the issue for me.

Thanks!

### Related issues

