### PR TITLE
Add missing allSites PHPDoc property

### DIFF
--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -39,7 +39,7 @@ use yii\db\Exception as DbException;
  * Sites service.
  * An instance of the Sites service is globally accessible in Craft via [[\craft\base\ApplicationTrait::getSites()|`Craft::$app->sites`]].
  *
- * @property Site[] $allSites all of the sites
+ * @property-read Site[] $allSites all of the sites
  * @property int[] $allSiteIds all of the site IDs
  * @property Site|null $currentSite the current site
  * @property int[] $editableSiteIds all of the site IDs that are editable by the current user

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -39,6 +39,7 @@ use yii\db\Exception as DbException;
  * Sites service.
  * An instance of the Sites service is globally accessible in Craft via [[\craft\base\ApplicationTrait::getSites()|`Craft::$app->sites`]].
  *
+ * @property Site[] $allSites all of the sites
  * @property int[] $allSiteIds all of the site IDs
  * @property Site|null $currentSite the current site
  * @property int[] $editableSiteIds all of the site IDs that are editable by the current user


### PR DESCRIPTION
PHPStorm shows a magic method warning due to the missing documentation.