### PR TITLE
Add docker-compose.yaml for tests

### DIFF
--- a/tests/.env.example.mysql
+++ b/tests/.env.example.mysql
@@ -1,8 +1,8 @@
 # Set in accordance to your environment
 
-DB_DSN="mysql:host=localhost;port=3306;dbname=craft-test"
-DB_USER="root"
-DB_PASSWORD=""
+DB_DSN="mysql:host=127.0.0.1;port=33060;dbname=craft-test"
+DB_USER="craft"
+DB_PASSWORD="craft"
 DB_TABLE_PREFIX=""
 
 SECURITY_KEY="abcde12345"

--- a/tests/.env.example.mysql
+++ b/tests/.env.example.mysql
@@ -1,6 +1,8 @@
 # Set in accordance to your environment
 
-DB_DSN="mysql:host=127.0.0.1;port=33060;dbname=craft-test"
+DB_DSN="mysql:host=localhost;port=3306;dbname=craft-test"
+# if you are using the docker-compose.yaml file use these
+# DB_DSN="mysql:host=127.0.0.1;port=33060;dbname=craft-test"
 DB_USER="craft"
 DB_PASSWORD="craft"
 DB_TABLE_PREFIX=""

--- a/tests/.env.example.mysql
+++ b/tests/.env.example.mysql
@@ -2,9 +2,11 @@
 
 DB_DSN="mysql:host=localhost;port=3306;dbname=craft-test"
 # if you are using the docker-compose.yaml file use these
-# DB_DSN="mysql:host=127.0.0.1;port=33060;dbname=craft-test"
+#DB_DSN="mysql:host=127.0.0.1;port=33060;dbname=craft-test"
 DB_USER="craft"
-DB_PASSWORD="craft"
+DB_PASSWORD=""
+# if you are using the docker-compose.yaml file, the password is defined in the file
+#DB_PASSWORD="craft"
 DB_TABLE_PREFIX=""
 
 SECURITY_KEY="abcde12345"

--- a/tests/.env.example.pgsql
+++ b/tests/.env.example.pgsql
@@ -4,7 +4,9 @@ DB_DSN="pgsql:host=localhost;port=5432;dbname=craft-test"
 # if you are using the docker-compose.yaml file use these
 # DB_DSN="pgsql:host=127.0.0.1;port=54320;dbname=craft-test"
 DB_USER="craft"
-DB_PASSWORD="craft"
+DB_PASSWORD=""
+# if you are using the docker-compose.yaml file, the password is defined in the file
+#DB_PASSWORD="craft"
 DB_SCHEMA="public"
 DB_TABLE_PREFIX=""
 

--- a/tests/.env.example.pgsql
+++ b/tests/.env.example.pgsql
@@ -1,8 +1,8 @@
 # Set in accordance to your environment
 
-DB_DSN="pgsql:host=localhost;port=5432;dbname=craft-test"
-DB_USER="postgres"
-DB_PASSWORD=""
+DB_DSN="pgsql:host=127.0.01;port=54320;dbname=craft-test"
+DB_USER="craft"
+DB_PASSWORD="craft"
 DB_SCHEMA="public"
 DB_TABLE_PREFIX=""
 

--- a/tests/.env.example.pgsql
+++ b/tests/.env.example.pgsql
@@ -1,6 +1,8 @@
 # Set in accordance to your environment
 
-DB_DSN="pgsql:host=127.0.01;port=54320;dbname=craft-test"
+DB_DSN="pgsql:host=localhost;port=5432;dbname=craft-test"
+# if you are using the docker-compose.yaml file use these
+# DB_DSN="pgsql:host=127.0.0.1;port=54320;dbname=craft-test"
 DB_USER="craft"
 DB_PASSWORD="craft"
 DB_SCHEMA="public"

--- a/tests/CraftTest.php
+++ b/tests/CraftTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class CraftTest extends TestCase
+{
+    public function testParseEnv()
+    {
+        // Arrange
+        putenv("CRAFT_TEST=testing");
+
+        // Act
+        $env = Craft::parseEnv('$CRAFT_TEST');
+
+        // Assert
+        $this->assertEquals('testing', $env);
+    }
+}

--- a/tests/CraftTest.php
+++ b/tests/CraftTest.php
@@ -14,5 +14,34 @@ class CraftTest extends TestCase
 
         // Assert
         $this->assertEquals('testing', $env);
+        putenv('CRAFT_TEST');
+    }
+
+    public function testParseEnvReturnsTrue()
+    {
+        // Arrange
+        putenv("CRAFT_TEST=true");
+
+        // Act
+        $env = Craft::parseEnv('$CRAFT_TEST');
+
+        // Assert
+        $this->assertEquals(true, $env);
+        $this->assertIsBool($env);
+        putenv('CRAFT_TEST');
+    }
+
+    public function testParseEnvReturnsFalse()
+    {
+        // Arrange
+        putenv("CRAFT_TEST=false");
+
+        // Act
+        $env = Craft::parseEnv('$CRAFT_TEST');
+
+        // Assert
+        $this->assertEquals(false, $env);
+        $this->assertIsBool($env);
+        putenv('CRAFT_TEST');
     }
 }

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -9,8 +9,6 @@ services:
       MYSQL_DATABASE: craft-test
       MYSQL_USER: craft
       MYSQL_PASSWORD: craft
-    tmpfs:
-      - /var/lib/mysql:rw,noexec,nosuid,size=1024m
   postgres:
     image: postgres:11-alpine
     ports:
@@ -19,6 +17,3 @@ services:
       POSTGRES_PASSWORD: craft
       POSTGRES_USER: craft
       POSTGRES_DB: craft-test
-    tmpfs:
-      - /var/lib/postgresql/data:rw,noexec,nosuid,size=1024m
-

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: "3.6"
+services:
+  mysql:
+    image: mysql:5.7
+    ports:
+      - 33060:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: craft
+      MYSQL_DATABASE: craft-test
+      MYSQL_USER: craft
+      MYSQL_PASSWORD: craft
+    tmpfs:
+      - /var/lib/mysql:rw,noexec,nosuid,size=1024m
+  postgres:
+    image: postgres:11-alpine
+    ports:
+      - 54320:5432
+    environment:
+      POSTGRES_PASSWORD: craft
+      POSTGRES_USER: craft
+      POSTGRES_DB: craft-test
+    tmpfs:
+      - /var/lib/postgresql/data:rw,noexec,nosuid,size=1024m
+


### PR DESCRIPTION
Added a `docker-compose.yaml` in `tests` that contains databases for quick setup.

