### PR TITLE
Adds static translations for Heading and Tip field layout elements

### DIFF
--- a/src/fieldlayoutelements/Heading.php
+++ b/src/fieldlayoutelements/Heading.php
@@ -62,6 +62,6 @@ HTML;
      */
     public function formHtml(ElementInterface $element = null, bool $static = false)
     {
-        return Html::tag('h2', Html::encode($this->heading));
+        return Html::tag('h2', Html::encode(Craft::t('site', $this->heading)));
     }
 }

--- a/src/fieldlayoutelements/Tip.php
+++ b/src/fieldlayoutelements/Tip.php
@@ -80,7 +80,7 @@ HTML;
     public function formHtml(ElementInterface $element = null, bool $static = false)
     {
         $noteClass = $this->_isTip() ? self::STYLE_TIP : self::STYLE_WARNING;
-        $tip = Markdown::process(Html::encode($this->tip));
+        $tip = Markdown::process(Html::encode(Craft::t('site', $this->tip)));
 
         return <<<HTML
 <div class="readable">


### PR DESCRIPTION
### Description

Adds missing static translation (using the `'site'` translation category) for Heading and Tip field layout elements' values in the new field layout designer.

### Related issues

