### PR TITLE
Fixes #6351

### DIFF
--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -261,6 +261,11 @@ class FileHelper extends \yii\helpers\FileHelper
         if ($checkExtension && ($mimeType === null || !static::canTrustMimeType($mimeType))) {
             return static::getMimeTypeByExtension($file, $magicFile) ?? $mimeType;
         }
+        
+        // Handle invalid SVG mime type reported by PHP (https://bugs.php.net/bug.php?id=79045)
+        if ($mimeType === 'image/svg') {
+            return 'image/svg+xml';
+        }
 
         return $mimeType;
     }


### PR DESCRIPTION
Relates to #6351.

This change seems rather brute force to me, I’ll admit, however, I’m not sure how else you might go about this.

`image/svg` is not a valid mime type ([IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)). Browsers cannot display it and Craft cannot read/replace assets with this mime type assigned.

As content managers cannot be expected to ensure all SVGs have the XML declaration and because most software (Adobe Illustrator, SVGOMG, et al.) now omit this when preparing for web, we should fix this in Craft.