### PR TITLE
Configurable route variables from request

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -219,7 +219,7 @@ class AssetsController extends Controller
 
         $assetId = $this->request->getRequiredParam('assetId');
         $siteId = $this->request->getBodyParam('siteId');
-        $assetVariable = $this->request->getBodyParam('assetVariable', 'asset');
+        $assetVariable = $this->request->getValidatedBodyParam('assetVariable', 'asset');
 
         /** @var Asset|null $asset */
         $asset = Asset::find()

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -219,6 +219,7 @@ class AssetsController extends Controller
 
         $assetId = $this->request->getRequiredParam('assetId');
         $siteId = $this->request->getBodyParam('siteId');
+        $assetVariable = $this->request->getBodyParam('assetVariable', 'asset');
 
         /** @var Asset|null $asset */
         $asset = Asset::find()
@@ -259,7 +260,7 @@ class AssetsController extends Controller
 
             // Send the asset back to the template
             Craft::$app->getUrlManager()->setRouteParams([
-                'asset' => $asset
+                $assetVariable => $asset
             ]);
 
             return null;

--- a/src/controllers/CategoriesController.php
+++ b/src/controllers/CategoriesController.php
@@ -430,7 +430,7 @@ class CategoriesController extends Controller
         $this->requirePostRequest();
 
         $category = $this->_getCategoryModel();
-        $categoryVariable = $this->request->getBodyParam('categoryVariable', 'category');
+        $categoryVariable = $this->request->getValidatedBodyParam('categoryVariable', 'category');
         // Permission enforcement
         $this->_enforceEditCategoryPermissions($category);
 

--- a/src/controllers/CategoriesController.php
+++ b/src/controllers/CategoriesController.php
@@ -430,6 +430,7 @@ class CategoriesController extends Controller
         $this->requirePostRequest();
 
         $category = $this->_getCategoryModel();
+        $categoryVariable = $this->request->getBodyParam('categoryVariable', 'category');
         // Permission enforcement
         $this->_enforceEditCategoryPermissions($category);
 
@@ -483,7 +484,7 @@ class CategoriesController extends Controller
 
             // Send the category back to the template
             Craft::$app->getUrlManager()->setRouteParams([
-                'category' => $category
+                $categoryVarible => $category
             ]);
 
             return null;

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -300,7 +300,7 @@ class EntriesController extends BaseEntriesController
         $this->requirePostRequest();
 
         $entry = $this->_getEntryModel();
-        $entryVariable = $this->request->getBodyParam('entryVariable', 'entry');
+        $entryVariable = $this->request->getValidatedBodyParam('entryVariable', 'entry');
         // Permission enforcement
         $this->enforceSitePermission($entry->getSite());
         $this->enforceEditEntryPermissions($entry, $duplicate);

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -300,6 +300,7 @@ class EntriesController extends BaseEntriesController
         $this->requirePostRequest();
 
         $entry = $this->_getEntryModel();
+        $entryVariable = $this->request->getBodyParam('entryVariable', 'entry');
         // Permission enforcement
         $this->enforceSitePermission($entry->getSite());
         $this->enforceEditEntryPermissions($entry, $duplicate);
@@ -385,7 +386,7 @@ class EntriesController extends BaseEntriesController
 
             // Send the entry back to the template
             Craft::$app->getUrlManager()->setRouteParams([
-                'entry' => $entry
+                $entryVariable => $entry
             ]);
 
             return null;

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -938,7 +938,7 @@ class UsersController extends Controller
         $generalConfig = Craft::$app->getConfig()->getGeneral();
         $userSettings = Craft::$app->getProjectConfig()->get('users') ?? [];
         $requireEmailVerification = $userSettings['requireEmailVerification'] ?? true;
-        $userVariable = $this->request->getBodyParam('userVariable', 'user');
+        $userVariable = $this->request->getValidatedBodyParam('userVariable', 'user');
 
         // Get the user being edited
         // ---------------------------------------------------------------------

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -938,6 +938,7 @@ class UsersController extends Controller
         $generalConfig = Craft::$app->getConfig()->getGeneral();
         $userSettings = Craft::$app->getProjectConfig()->get('users') ?? [];
         $requireEmailVerification = $userSettings['requireEmailVerification'] ?? true;
+        $userVariable = $this->request->getBodyParam('userVariable', 'user');
 
         // Get the user being edited
         // ---------------------------------------------------------------------
@@ -1145,7 +1146,7 @@ class UsersController extends Controller
 
             // Send the account back to the template
             Craft::$app->getUrlManager()->setRouteParams([
-                'user' => $user
+                $userVariable => $user
             ]);
 
             return null;


### PR DESCRIPTION
Listen in the request for parms to configure route variables to avoid template conflicts.

I did it for every element you can potentially save from the frontend, so `entryVariable`, `userVariable`, `categoryVariable`, `assetVariable`.

Fixes https://github.com/craftcms/cms/issues/6240

/cc @piotrpog