### PR TITLE
GQL: Add asset uploader

### DIFF
--- a/src/gql/arguments/elements/Asset.php
+++ b/src/gql/arguments/elements/Asset.php
@@ -81,6 +81,11 @@ class Asset extends ElementArguments
                 'name' => 'withTransforms',
                 'type' => Type::listOf(Type::string()),
                 'description' => 'A list of transform handles to preload.'
+            ],
+            'uploader' => [
+                'name' => 'uploader',
+                'type' => QueryArgument::getType(),
+                'description' => 'Narrows the query results based on the user the assets were uploaded by, per the user’s ID.'
             ]
         ]);
     }

--- a/src/gql/arguments/mutations/Asset.php
+++ b/src/gql/arguments/mutations/Asset.php
@@ -34,6 +34,11 @@ class Asset extends ElementMutationArguments
                 'name' => 'newFolderId',
                 'description' => 'ID of the new folder for this asset',
                 'type' => Type::id()
+            ],
+            'uploaderId' => [
+                'name' => 'uploaderId',
+                'description' => 'The ID of the user who first added this asset (if known).',
+                'type' => Type::id()
             ]
         ]);
     }

--- a/src/gql/interfaces/elements/Asset.php
+++ b/src/gql/interfaces/elements/Asset.php
@@ -12,6 +12,7 @@ use craft\gql\arguments\elements\User as UserArguments;
 use craft\gql\arguments\Transform;
 use craft\gql\GqlEntityRegistry;
 use craft\gql\interfaces\Element;
+use craft\gql\interfaces\elements\User as UserInterface;
 use craft\gql\TypeManager;
 use craft\gql\types\DateTime;
 use craft\gql\types\generators\AssetType;
@@ -150,7 +151,7 @@ class Asset extends Element
             ],
             'uploader' => [
                 'name' => 'uploader',
-                'type' => User::getType(),
+                'type' => UserInterface::getType(),
                 'args' => UserArguments::getArguments(),
                 'description' => 'The ID of the user who first added this asset (if known).'
             ],

--- a/src/gql/interfaces/elements/Asset.php
+++ b/src/gql/interfaces/elements/Asset.php
@@ -149,12 +149,6 @@ class Asset extends Element
                 'type' => DateTime::getType(),
                 'description' => 'The date the asset file was last modified.'
             ],
-            'uploader' => [
-                'name' => 'uploader',
-                'type' => UserInterface::getType(),
-                'args' => UserArguments::getArguments(),
-                'description' => 'The ID of the user who first added this asset (if known).'
-            ],
             'prev' => [
                 'name' => 'prev',
                 'type' => self::getType(),
@@ -168,5 +162,29 @@ class Asset extends Element
                 'description' => 'Returns the next element relative to this one, from a given set of criteria. CAUTION: Applying arguments to this field severely degrades the performance of the query.',
             ],
         ]), self::getName());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected static function getConditionalFields(): array
+    {
+        if (Gql::canQueryUsers()) {
+            return [
+                'uploaderId' => [
+                    'name' => 'uploaderId',
+                    'type' => Type::int(),
+                    'description' => 'The ID of the user who first added this asset (if known).'
+                ],
+                'uploader' => [
+                    'name' => 'uploader',
+                    'type' => User::getType(),
+                    'args' => UserArguments::getArguments(),
+                    'description' => 'The user who first added this asset (if known).'
+                ],
+            ];
+        }
+
+        return [];
     }
 }

--- a/src/gql/interfaces/elements/Asset.php
+++ b/src/gql/interfaces/elements/Asset.php
@@ -8,6 +8,7 @@
 namespace craft\gql\interfaces\elements;
 
 use craft\gql\arguments\elements\Asset as AssetArguments;
+use craft\gql\arguments\elements\User as UserArguments;
 use craft\gql\arguments\Transform;
 use craft\gql\GqlEntityRegistry;
 use craft\gql\interfaces\Element;
@@ -146,6 +147,12 @@ class Asset extends Element
                 'name' => 'dateModified',
                 'type' => DateTime::getType(),
                 'description' => 'The date the asset file was last modified.'
+            ],
+            'uploader' => [
+                'name' => 'uploader',
+                'type' => User::getType(),
+                'args' => UserArguments::getArguments(),
+                'description' => 'The ID of the user who first added this asset (if known).'
             ],
             'prev' => [
                 'name' => 'prev',


### PR DESCRIPTION
Adds uploader to GQL asset arguments, interfaces, and mutations.

Note: based on how other things are structured, the `uploader` argument should probably be `uploaderId`? I'll leave that to you, since I didn't want to add the method to `AssetQuery` in this PR.