### PR TITLE
fix lightswitch id when id is available

### DIFF
--- a/src/templates/_includes/forms/lightswitch.html
+++ b/src/templates/_includes/forms/lightswitch.html
@@ -1,4 +1,4 @@
-{%- set id = id ?? 'lightswitch'~random() %}
+{%- set id = id ?? ('lightswitch'~random()) %}
 {%- set on = on ?? false %}
 {%- set indeterminate = not on and (indeterminate ?? false) %}
 {%- set value = value ?? '1' %}


### PR DESCRIPTION
it seems currently random() is added to end of lightswitch id even if id is available. this PR prevents this. 