### PR TITLE
Remove |e filter to render permissions properly

### DIFF
--- a/src/templates/_includes/permissions.html
+++ b/src/templates/_includes/permissions.html
@@ -31,7 +31,7 @@
 
             <li>
                 {{ checkbox({
-                    label: props.label|e,
+                    label: props.label,
                     name: 'permissions[]',
                     value: permissionName,
                     checked: checked,

--- a/src/templates/graphql/schemas/_edit.html
+++ b/src/templates/graphql/schemas/_edit.html
@@ -28,7 +28,7 @@
 
             <li>
                 {{ checkbox({
-                    label: props.label|e,
+                    label: props.label,
                     name: 'permissions[]',
                     value: permissionName,
                     checked: checked,


### PR DESCRIPTION
Not sure why the label here was being escaped initially, but it screwed up the output when the label has an unescaped character (e.g. **&**):

![Screen Shot 2020-08-03 at 1 13 31 PM](https://user-images.githubusercontent.com/18329/89209038-882c5a80-d58b-11ea-9dee-b640efc9020f.png)
