### PR TITLE
Display author for "revisionCreator/Last Edited By" if no revisions yet

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1242,6 +1242,9 @@ class Entry extends Element
                     ($creator = $behavior->getCreator()) === null
                 ) {
                     return '';
+                    if (!$creator = $this->getAuthor()) {
+                        return '';
+                    }
                 }
                 return Craft::$app->getView()->renderTemplate('_elements/element', ['element' => $creator]);
         }


### PR DESCRIPTION
It seems like adding the "Last Edited By" column to the element table attributes should default to the author if there aren't yet any revisions.

This makes it analogous to how "Date Updated" works.

Or, if you wanted to get even more granular, there could be a new "Last Updated By" column with this value.