### PR TITLE
add sitegroup handle & more defined template paths

### DIFF
--- a/src/controllers/SitesController.php
+++ b/src/controllers/SitesController.php
@@ -14,6 +14,7 @@ use craft\models\Site;
 use craft\models\SiteGroup;
 use craft\web\assets\sites\SitesAsset;
 use craft\web\Controller;
+use yii\helpers\Inflector;
 use yii\web\BadRequestHttpException;
 use yii\web\NotFoundHttpException;
 use yii\web\Response;

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -556,6 +556,7 @@ class Install extends Migration
         $this->createTable(Table::SITEGROUPS, [
             'id' => $this->primaryKey(),
             'name' => $this->string()->notNull(),
+            'handle' => $this->string()->notNull(),
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
             'dateDeleted' => $this->dateTime()->null(),
@@ -841,6 +842,7 @@ class Install extends Migration
         $this->createIndex(null, Table::SITES, ['handle'], false);
         $this->createIndex(null, Table::SITES, ['sortOrder'], false);
         $this->createIndex(null, Table::SITEGROUPS, ['name'], false);
+        $this->createIndex(null, Table::SITEGROUPS, ['handle'], true);
         $this->createIndex(null, Table::STRUCTUREELEMENTS, ['structureId', 'elementId'], true);
         $this->createIndex(null, Table::STRUCTUREELEMENTS, ['root'], false);
         $this->createIndex(null, Table::STRUCTUREELEMENTS, ['lft'], false);

--- a/src/migrations/m200806_084715_add_site_group_handle.php
+++ b/src/migrations/m200806_084715_add_site_group_handle.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace craft\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\db\Table;
+use yii\helpers\Inflector;
+
+/**
+ * m200806_084715_add_site_group_handle migration.
+ */
+class m200806_084715_add_site_group_handle extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        // Make table changes
+        $this->addColumn(Table::SITEGROUPS, 'handle', $this->string()->after('name'));
+
+        $this->createIndex(null, Table::SITEGROUPS, ['handle'], true);
+
+        // Update existing Site Groups handle
+        $siteGroups = (new Query())
+            ->select(['id', 'name'])
+            ->from(Table::SITEGROUPS)
+            ->all();
+
+        foreach($siteGroups as $siteGroup) {
+            $this->update(Table::SITEGROUPS, [
+                'handle' => Inflector::variablize($siteGroup['name'])
+            ], [
+                'id' => $siteGroup['id']
+            ], [], false);
+        }
+
+        // Set the new column to be NOT NULL
+        $this->alterColumn(Table::SITEGROUPS, 'handle', $this->string()->notNull());
+    }
+
+    public function safeDown()
+    {
+        echo "m200806_084715_add_site_group_handle cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/SiteGroup.php
+++ b/src/models/SiteGroup.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Model;
 use craft\helpers\ArrayHelper;
 use craft\records\SiteGroup as SiteGroupRecord;
+use craft\validators\HandleValidator;
 use craft\validators\UniqueValidator;
 
 /**
@@ -32,6 +33,11 @@ class SiteGroup extends Model
     public $name;
 
     /**
+     * @var string|null Handle
+     */
+    public $handle;
+
+    /**
      * @var string|null UID
      */
     public $uid;
@@ -43,6 +49,7 @@ class SiteGroup extends Model
     {
         return [
             'name' => Craft::t('app', 'Name'),
+            'handle' => Craft::t('app', 'Handle'),
         ];
     }
 
@@ -52,10 +59,16 @@ class SiteGroup extends Model
     protected function defineRules(): array
     {
         $rules = parent::defineRules();
-        $rules[] = [['id'], 'number', 'integerOnly' => true];
-        $rules[] = [['name'], 'string', 'max' => 255];
-        $rules[] = [['name'], UniqueValidator::class, 'targetClass' => SiteGroupRecord::class];
         $rules[] = [['name'], 'required'];
+        $rules[] = [['id'], 'number', 'integerOnly' => true];
+        $rules[] = [['name', 'handle'], 'string', 'max' => 255];
+        $rules[] = [['name'], UniqueValidator::class, 'targetClass' => SiteGroupRecord::class];
+        $rules[] = [['handle'], HandleValidator::class, 'reservedWords' => ['id', 'dateCreated', 'dateUpdated', 'uid', 'title']];
+
+        if (Craft::$app->getIsInstalled()) {
+            $rules[] = [['name', 'handle'], UniqueValidator::class, 'targetClass' => SiteGroupRecord::class];
+        }
+
         return $rules;
     }
 
@@ -99,6 +112,7 @@ class SiteGroup extends Model
     {
         return [
             'name' => $this->name,
+            'handle' => $this->handle,
         ];
     }
 }

--- a/src/records/SiteGroup.php
+++ b/src/records/SiteGroup.php
@@ -17,6 +17,7 @@ use yii\db\ActiveQueryInterface;
  *
  * @property int $id ID
  * @property string $name Name
+ * @property string $handle Handle
  * @property Site[] $sites Sites
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -35,6 +35,7 @@ use yii\base\Component;
 use yii\base\Exception;
 use yii\base\InvalidArgumentException;
 use yii\db\Exception as DbException;
+use yii\helpers\Inflector;
 
 /**
  * Sites service.
@@ -270,6 +271,7 @@ class Sites extends Component
         }
 
         $groupRecord->name = $data['name'];
+        $groupRecord->handle = Inflector::variablize($data['name']);
 
         if ($groupRecord->dateDeleted) {
             $groupRecord->restore();
@@ -1203,6 +1205,7 @@ class Sites extends Component
             ->select([
                 'id',
                 'name',
+                'handle',
                 'uid',
             ])
             ->from([Table::SITEGROUPS])

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -869,9 +869,18 @@ class View extends \yii\web\View
         // Should we be looking for a localized version of the template?
         if ($this->_templateMode === self::TEMPLATE_MODE_SITE && Craft::$app->getIsInstalled()) {
             /** @noinspection PhpUnhandledExceptionInspection */
-            $sitePath = $this->_templatesPath . DIRECTORY_SEPARATOR . Craft::$app->getSites()->getCurrentSite()->handle;
-            if (is_dir($sitePath)) {
-                $basePaths[] = $sitePath;
+            $currentSite = Craft::$app->getSites()->getCurrentSite();
+            $currentGroup = $currentSite->getGroup();
+            $sitePaths = [
+                $this->_templatesPath . DIRECTORY_SEPARATOR . $currentGroup->handle . DIRECTORY_SEPARATOR . $currentSite->handle,
+                $this->_templatesPath . DIRECTORY_SEPARATOR . $currentGroup->handle,
+                $this->_templatesPath . DIRECTORY_SEPARATOR . $currentSite->handle // legacy implementation
+            ];
+
+            foreach($sitePaths as $sitePath) {
+                if (is_dir($sitePath)) {
+                    $basePaths[] = $sitePath;
+                }
             }
         }
 


### PR DESCRIPTION
### Description
Simple implementation of Site specific templates inside of a specific SiteGroup.
Uses auto generated SiteGroup handles based on the group name.

```
.
└── templates/
    ├── SiteGroupHandle/
    │   ├── SiteHandle/
    │   │   └── index.twig ----> specific template for site with this handle in this group
    │   └── index.twig     ----> default template for all sites in this group
    └── index.twig.        ----> fallback for all other sites
```

### Related issues
#3101 
