### PR TITLE
Remove checkerboard from small thumbs when img present

### DIFF
--- a/src/web/assets/cp/src/css/_main.scss
+++ b/src/web/assets/cp/src/css/_main.scss
@@ -2046,7 +2046,7 @@ $elementInnerSpacing: 5px;
     display: inline-block;
   }
 
-  &.small,
+  &.small:not(.hasthumb),
   &.large:not(.hasthumb) {
     display: inline-block;
     padding: $baseElementSidePadding;


### PR DESCRIPTION
In the user listing, small thumbnail images showed a checkerboard pattern in their transparent area instead of the solid background color.

### Description

Here is a screenshot of the proposed change. https://share.jmx2.com/cgv9zQ

I could fix it in my CSS directly, but since you're using SCSS, I've attempted to track down the spot in the SCSS that created the CSS line as shown here: https://share.jmx2.com/W0nqES
