### PR TITLE
Eager loads Author in Recent Entries widget

### DIFF
--- a/src/widgets/RecentEntries.php
+++ b/src/widgets/RecentEntries.php
@@ -180,6 +180,7 @@ class RecentEntries extends Widget
         $query->sectionId($targetSectionId);
         $query->editable(true);
         $query->limit($this->limit ?: 100);
+        $query->with(['author']);
         $query->orderBy('elements.dateCreated desc');
 
         return $query->all();


### PR DESCRIPTION
Currently the Recent Entries widget does two queries on entry.author for every entry in Recent Entries - this gets it to properly eager-load the author and keeps queries constant.