### PR TITLE
Fix Html::_namespaceInputs() to work with numbers as a namespace.

### DIFF
--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -545,7 +545,7 @@ class Html extends \yii\helpers\Html
      */
     private static function _namespaceInputs(string &$html, string $namespace)
     {
-        $html = preg_replace('/(?<![\w\-])(name=(\'|"))([^\'"\[\]]+)([^\'"]*)\2/i', '$1' . $namespace . '[$3]$4$2', $html);
+        $html = preg_replace('/(?<![\w\-])(name=(\'|"))([^\'"\[\]]+)([^\'"]*)\2/i', '${1}' . $namespace . '[$3]$4$2', $html);
     }
 
     /**


### PR DESCRIPTION
### Description

The `Html::_namespaceInputs()` function can't take numbers as a namespace, because they break the regex replacement pattern. Numbers get concatenated with the capture reference, which changes the reference number.

Problem: `'$1' . $namespace . '[$3]$4$2'` turns into `'$13[$3]$4$2'` when `$namespace = '3'`. The reference `$1` changed to `$13`.

This twig code

```twig
{{ '<input name="test">'|namespace('3')|raw }}
```

currently generates this html

```html
<input [test]">
```

More info from [php.net/manual/en/function.preg-replace](https://www.php.net/manual/en/function.preg-replace)

> When working with a replacement pattern where a backreference is immediately followed by another number (i.e.: placing a literal number immediately after a matched pattern), you cannot use the familiar \1 notation for your backreference. \11, for example, would confuse preg_replace() since it does not know whether you want the \1 backreference followed by a literal 1, or the \11 backreference followed by nothing. In this case the solution is to use ${1}1. This creates an isolated $1 backreference, leaving the 1 as a literal.

### Related issues

-/-