### PR TITLE
Improve downloading assets from stream

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -1054,7 +1054,10 @@ class AssetsController extends Controller
         if (count($assets) === 1) {
             $asset = reset($assets);
             return $this->response
-                ->sendStreamAsFile($asset->stream, $asset->filename);
+                ->sendStreamAsFile($asset->stream, $asset->filename, [
+                    'fileSize' => $asset->size,
+                    'mimeType' => $asset->mimeType,
+                ]);
         }
 
         // Otherwise create a zip of all the selected assets


### PR DESCRIPTION
Sometimes downloading an asset results in an error like `yii\base\ErrorException: fseek(): stream does not support seeking in /app/vendor/yiisoft/yii2/web/Response.php:586`

We know the Asset size and mimeType so we can just feed them as options to the `sendStreamAsFile` method.
By not having to guess the filesize and mimetype we can improve the stream stability. 