### PR TITLE
Fix issue with Globals redirect to first set where the array of sets might not be zero indexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - The GraphQL API now supports `variables` and `operationName` query string parameters. ([#6728](https://github.com/craftcms/cms/issues/6728))
 
+### Fixed
+- Fixed a bug where a user trying to access globals that does not have access to the alphabetical first global set would throw an `Undefined offset: 0` exception
+
 ## 3.5.7 - 2020-08-26
 
 ### Changed

--- a/src/controllers/GlobalsController.php
+++ b/src/controllers/GlobalsController.php
@@ -42,7 +42,7 @@ class GlobalsController extends Controller
             throw new ForbiddenHttpException('User not permitted to edit any global content');
         }
 
-        return $this->redirect('globals/' . $editableSets[0]->handle);
+        return $this->redirect('globals/' . array_values($editableSets)[0]->handle);
     }
 
     /**


### PR DESCRIPTION
# Description

If a user that does not have access to the alphabetically first global set clicks on "Globals" in the CMS nav, an exception will be thrown with the message `Undefined offset: 0`.

<img width="600" alt="Screen Shot 2020-08-26 at 12 16 34 PM" src="https://user-images.githubusercontent.com/3803475/91336111-0baa2780-e797-11ea-8892-169d4aba6f9c.png">

<img width="839" alt="Screen Shot 2020-08-26 at 12 17 59 PM" src="https://user-images.githubusercontent.com/3803475/91336121-106edb80-e797-11ea-9af7-ec9c2b876f53.png">

Digging into this, I found that the user group did not have access to the first global set alphabetically.

<img width="325" alt="Screen Shot 2020-08-26 at 12 18 33 PM" src="https://user-images.githubusercontent.com/3803475/91336183-27adc900-e797-11ea-9179-8f33c50c2058.png">

A dump of `$editableSets` revealed that the array index in this case did not start at `0`.

<img width="743" alt="Screen Shot 2020-08-26 at 12 19 32 PM" src="https://user-images.githubusercontent.com/3803475/91336250-4318d400-e797-11ea-8688-ec538dd780de.png">

<img width="579" alt="Screen Shot 2020-08-26 at 12 19 39 PM" src="https://user-images.githubusercontent.com/3803475/91336258-457b2e00-e797-11ea-9902-9ea21ac6b8ff.png">

Wrapping `$editableSets` with an `array_values` function produces the editable sets array with a 0 index, allowing the user access to the Global Sets they have access to.

<img width="473" alt="Screen Shot 2020-08-26 at 12 20 25 PM" src="https://user-images.githubusercontent.com/3803475/91336542-aefb3c80-e797-11ea-8eca-8a3b563ff5ad.png">