### PR TITLE
Fixed missing white space in install agreement.

### DIFF
--- a/src/web/assets/installer/src/install.scss
+++ b/src/web/assets/installer/src/install.scss
@@ -162,6 +162,7 @@ input.hidden {
 
   .centeralign {
     margin-top: 35px;
+    margin-bottom: 70px !important;
   }
 }
 


### PR DESCRIPTION
### Description

Fixed a missing space below the "got it" button in the license agreement.

I've attached screenshots:

**Before**
<img width="871" alt="Screenshot 2020-09-10 at 23 26 24" src="https://user-images.githubusercontent.com/1453384/92811766-09fb7900-f3bf-11ea-9d8d-e28bd47f9467.png">

**After**
<img width="914" alt="Screenshot 2020-09-10 at 23 26 41" src="https://user-images.githubusercontent.com/1453384/92811731-01a33e00-f3bf-11ea-9561-2e83030009cf.png">
