### PR TITLE
Ctrl/Cmd + Shift + S: save field settings and go back

### DIFF
--- a/src/templates/settings/fields/_edit.html
+++ b/src/templates/settings/fields/_edit.html
@@ -7,6 +7,11 @@
         shortcut: true,
         retainScroll: true,
     },
+    {
+        label: 'Save'|t('app'),
+        shortcut: true,
+        shift: true,
+    },
 ] %}
 
 {% import "_includes/forms" as forms %}


### PR DESCRIPTION
Add a new shortcut for the old behavior of the field settings "Save" button: Ctrl/Cmd + Shift + S will save the field settings and take you back to the list of fields.

### Description
#2872 Requested a new behavior for the Ctrl/Cmd + S on edit field settings page. This PR adds a shortcut for the previous behavior: save and go back to the list of fields.