### PR TITLE
Skip eager-loading this segment if there is no filtered elements

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1976,6 +1976,11 @@ class Elements extends Component
                 } else {
                     $filteredElements = $elements;
                 }
+                
+                if (count($filteredElements) === 0) {
+                    // Skip eager-loading this segment if there is no filtered elements
+                    continue;
+                }
 
                 // Get the eager-loading map from the source element type
                 /** @var ElementInterface|string $elementType */


### PR DESCRIPTION
### Description
If the filtered elements is empty, it causes an exception.

### Related issues
Issue described here:
https://github.com/craftcms/cms/issues/6849
