### PR TITLE
Adding a progress count to the output of the resave console commands.

### DIFF
--- a/src/console/controllers/ResaveController.php
+++ b/src/console/controllers/ResaveController.php
@@ -281,10 +281,10 @@ class ResaveController extends Controller
         $elementsService = Craft::$app->getElements();
         $fail = false;
 
-        $beforeCallback = function(BatchElementActionEvent $e) use ($query) {
+        $beforeCallback = function(BatchElementActionEvent $e) use ($query, $count) {
             if ($e->query === $query) {
                 $element = $e->element;
-                $this->stdout("    - Resaving {$element} ({$element->id}) ... ");
+                $this->stdout("    - Resaving ({$e->position}/{$count}) {$element} ({$element->id}) ... ");
             }
         };
 

--- a/src/console/controllers/ResaveController.php
+++ b/src/console/controllers/ResaveController.php
@@ -284,7 +284,7 @@ class ResaveController extends Controller
         $beforeCallback = function(BatchElementActionEvent $e) use ($query, $count) {
             if ($e->query === $query) {
                 $element = $e->element;
-                $this->stdout("    - Resaving ({$e->position}/{$count}) {$element} ({$element->id}) ... ");
+                $this->stdout("    - [{$e->position}/{$count}] Resaving {$element} ({$element->id}) ... ");
             }
         };
 


### PR DESCRIPTION
Pulling in the query count to the `beforeCallback` and using the `BatchElementActionEvent` position property to display a progress count in the console when resaving elements. 

Example:
```
- Resaving (32/1341) Graphic Design (283204) ... done
```