### PR TITLE
Add hover style to improve contrast of Craft version info

### DIFF
--- a/src/web/assets/cp/src/css/_cp.scss
+++ b/src/web/assets/cp/src/css/_cp.scss
@@ -380,6 +380,11 @@ $systemInfoHoverBgColor: darken($grey800, 10%);
 #version {
   margin-top: 4px;
   font-size: 12px;
+
+  &:hover {
+    color: $white;
+    transition: color linear 100ms 500ms;
+  }
 }
 
 #devmode {


### PR DESCRIPTION
### Description

I have a hard time reading Craft's version info in the control panel. This PR adds a hover style to increase contrast. I added a delay to the transition to prevent flickering when moving the pointer over.

default state (like now)
![Screenshot-2020-10-02-at-13 01 37](https://user-images.githubusercontent.com/3640237/94916912-d25c8a00-04af-11eb-95d8-4991b4f77cf8.png)

hover state
![Screenshot-2020-10-02-at-13 01 42](https://user-images.githubusercontent.com/3640237/94916909-d1c3f380-04af-11eb-9f32-e943db244981.png)
