### PR TITLE
Avoide to call _getMatchedElementRoute when UrlManager uses in console

### DIFF
--- a/src/web/UrlManager.php
+++ b/src/web/UrlManager.php
@@ -222,6 +222,10 @@ class UrlManager extends \yii\web\UrlManager
             return $this->_matchedElement;
         }
 
+        if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+            return false;
+        }
+
         $this->_getMatchedElementRoute(Craft::$app->getRequest());
         return $this->_matchedElement;
     }

--- a/src/web/UrlManager.php
+++ b/src/web/UrlManager.php
@@ -222,11 +222,13 @@ class UrlManager extends \yii\web\UrlManager
             return $this->_matchedElement;
         }
 
-        if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+        $request = Craft::$app->getRequest();
+
+        if ($request->getIsConsoleRequest()) {
             return false;
         }
 
-        $this->_getMatchedElementRoute(Craft::$app->getRequest());
+        $this->_getMatchedElementRoute($request);
         return $this->_matchedElement;
     }
 


### PR DESCRIPTION
### Description

When you're using the `Craft::$app->getView()->renderTemplate()` the below error will be occurred.

> Exception 'TypeError' with message 'Argument 1 passed to craft\web\UrlManager::_getMatchedElementRoute() must be an instance of craft\web\Request, instance of craft\console\Request given, called in www\nova\vendor\craftcms\cms\src\web\UrlManager.php on line 229'

So the PR will avoid to call the `_getMatchedElementRoute()`

### Related issues
https://github.com/craftcms/cms/issues/6945
