### PR TITLE
Ensure DB connection is closed and PDO references are dropped

### DIFF
--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -1083,6 +1083,9 @@ class Db
      */
     public static function reset()
     {
+        if (self::$_db) {
+            self::$_db->close();
+        }
         self::$_db = null;
     }
 


### PR DESCRIPTION
### Description

Idle database connections are left open and aren't collected during GC when running unit tests:

```
MariaDB [test_db]> show full processlist;
+-------+-------------+-----------+---------------+---------+------+--------------------------+-----------------------+----------+
| Id    | User        | Host      | db            | Command | Time | State                    | Info                  | Progress |
+-------+-------------+-----------+---------------+---------+------+--------------------------+-----------------------+----------+
| 19736 | user        | localhost | test_db       | Sleep   |   36 |                          | NULL                  |    0.000 |
| 19737 | user        | localhost | test_db       | Sleep   |   33 |                          | NULL                  |    0.000 |
| 19738 | user        | localhost | test_db       | Sleep   |   31 |                          | NULL                  |    0.000 |
| 19739 | user        | localhost | test_db       | Sleep   |   29 |                          | NULL                  |    0.000 |
| 19740 | user        | localhost | test_db       | Sleep   |   27 |                          | NULL                  |    0.000 |
| 19741 | user        | localhost | test_db       | Sleep   |   24 |                          | NULL                  |    0.000 |
| 19742 | user        | localhost | test_db       | Sleep   |   22 |                          | NULL                  |    0.000 |
| 19743 | user        | localhost | test_db       | Sleep   |   20 |                          | NULL                  |    0.000 |
| 19744 | user        | localhost | test_db       | Sleep   |   18 |                          | NULL                  |    0.000 |
| 19745 | user        | localhost | test_db       | Sleep   |   15 |                          | NULL                  |    0.000 |
| 19746 | user        | localhost | test_db       | Sleep   |   13 |                          | NULL                  |    0.000 |
| 19747 | user        | localhost | test_db       | Sleep   |   11 |                          | NULL                  |    0.000 |
| 19748 | user        | localhost | test_db       | Sleep   |    9 |                          | NULL                  |    0.000 |
| 19749 | user        | localhost | test_db       | Sleep   |    6 |                          | NULL                  |    0.000 |
| 19750 | user        | localhost | test_db       | Sleep   |    4 |                          | NULL                  |    0.000 |
| 19751 | user        | localhost | test_db       | Sleep   |    2 |                          | NULL                  |    0.000 |
| 19752 | user        | localhost | test_db       | Sleep   |    0 |                          | NULL                  |    0.000 |
| 19753 | user        | localhost | test_db       | Sleep   |    0 |                          | NULL                  |    0.000 |
+-------+-------------+-----------+---------------+---------+------+--------------------------+-----------------------+----------+
```

This eventually cause tests to start failing when the database server starts rejecting new connections.

To replicate with MySQL, set `max_connections` to something low like 10, and run a test suite which has more than 10 tests.

This PR removes the static PDO reference from the memoized database connection before clearing the connection which enables GC to collect the PDO connection and close it. 



