### PR TITLE
Adds the ability for plugins/modules to intercept an entries keywords before saving

### DIFF
--- a/src/events/ElementKeywordsEvent.php
+++ b/src/events/ElementKeywordsEvent.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use craft\base\ElementInterface;
+use yii\base\Event;
+
+/**
+ * Element keywords event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.0.0
+ */
+class ElementKeywordsEvent extends Event
+{
+    /**
+     * @var string List of keywords to be saved to the index.
+     */
+    public $keywords;
+
+    public $element;
+
+    public $field;
+
+}


### PR DESCRIPTION
### Description
After discussing with Oli over email, it was decided that the "cleanest" way for users to be able to manipulate keyword data would be to introduce a new event that works like others such as `RegisterComponentTypesEvent::class`

**This PR is really a proof-of-concept, and not completely polished yet, e.g. hense no code comments etc - It is here as a bit of an RFC to discuss how to move forward**

The naming and location of the events might need changing etc, e.g. Maybe the event should be `SearchKeywordsEvent` for example rather than `ElementKeywordsEvent` etc.

In a nut shell, this PR adds the ability via an Event for users to intercept the keywords that will be saved for `field`.

This gives them the opportunity to overwrite or manipulate them in anyway, such as appending author names, or other information into the keywords via an automated and seamless method.

Example usage:


```php
Event::on(Search::class, Search::EVENT_ELEMENT_KEYWORDS, function (ElementKeywordsEvent $event) {
    $event->keywords = 'overwrite the default keywords with this';
    return $event;
});
```

