### PR TITLE
Use $event->query in `executeQuery`

### DIFF
--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -455,7 +455,7 @@ class Gql extends Component
         if ($event->result === null) {
             $cacheKey = $this->_getCacheKey(
                 $schema,
-                $query,
+                $event->$query,
                 $event->rootValue,
                 $event->context,
                 $event->variables,
@@ -465,13 +465,13 @@ class Gql extends Component
             if ($cacheKey && ($cachedResult = $this->getCachedResult($cacheKey)) !== null) {
                 $event->result = $cachedResult;
             } else {
-                $schemaDef = $this->getSchemaDef($schema, $debugMode || StringHelper::contains($query, '__schema'));
+                $schemaDef = $this->getSchemaDef($schema, $debugMode || StringHelper::contains($event->$query, '__schema'));
                 $elementsService = Craft::$app->getElements();
                 $elementsService->startCollectingCacheTags();
 
                 $event->result = GraphQL::executeQuery(
                     $schemaDef,
-                    $query,
+                    $event->$query,
                     $event->rootValue,
                     $event->context,
                     $event->variables,


### PR DESCRIPTION
### Description

Currently, we're unable to modify the query passed into `GraphQL::executeQuery`.

Although the `EVENT_BEFORE_EXECUTE_GQL_QUERY` trigger is being called, the variable passed into the function initially is being used to create the cache keys and run the query, rather than the modified query from `$event`.

### Related issues

