### PR TITLE
Fixing typing for craft\records\Site::baseUrl

### DIFF
--- a/src/records/Site.php
+++ b/src/records/Site.php
@@ -23,7 +23,7 @@ use yii\db\ActiveQueryInterface;
  * @property bool $primary Primary
  * @property bool $enabled Enabled
  * @property bool $hasUrls Has URLs
- * @property bool $baseUrl Base URL
+ * @property string $baseUrl Base URL
  * @property int $sortOrder Sort order
  * @property SiteGroup $group Group
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>


### PR DESCRIPTION
### Description
Should be string, not boolean. Just a typing issue.


### Related issues

