### PR TITLE
Zip backups by default

### DIFF
--- a/src/console/controllers/BackupController.php
+++ b/src/console/controllers/BackupController.php
@@ -30,7 +30,7 @@ class BackupController extends Controller
      * @var bool Whether the backup should be saved as a zip file.
      * @since 3.5.0
      */
-    public $zip = false;
+    public $zip = true;
 
     /**
      * @var bool Whether to overwrite an existing backup file, if a specific file path is given.


### PR DESCRIPTION
This PR zips backups by default in the console controller action. This makes sense to save space on the server as the command will generally be run through scheduled cron jobs. It is also in-line with how backups are zipped in the utilities controller action:
https://github.com/craftcms/cms/blob/develop/src/controllers/UtilitiesController.php#L352-L353
