### PR TITLE
Fixed redirection when field layout is submitted

### DIFF
--- a/src/templates/settings/users/fields.html
+++ b/src/templates/settings/users/fields.html
@@ -8,7 +8,7 @@
 {% block content %}
     <form method="post" accept-charset="UTF-8" data-saveshortcut data-confirm-unload>
         {{ actionInput('users/save-field-layout') }}
-        {{ redirectInput('settings') }}
+        {{ redirectInput('settings/users/fields') }}
         {{ csrfInput() }}
 
         {{ forms.fieldLayoutDesignerField({


### PR DESCRIPTION
### Description

When we submit the Field layout form, we are redirected to the main settings page. It's not user friendly when you want to do many changes. 

### Related issues

N/A
