### PR TITLE
Fixed redirection when field layout is submitted

### DIFF
--- a/src/templates/settings/users/fields.html
+++ b/src/templates/settings/users/fields.html
@@ -8,7 +8,6 @@
 {% block content %}
     <form method="post" accept-charset="UTF-8" data-saveshortcut data-confirm-unload>
         {{ actionInput('users/save-field-layout') }}
-        {{ redirectInput('settings') }}
         {{ csrfInput() }}
 
         {{ forms.fieldLayoutDesignerField({


### PR DESCRIPTION
### Description

When we submit the Field layout form, we are redirected to the main settings page. It's not user friendly when you want to do many changes.

I opened a new PR (the old one is here: https://github.com/craftcms/cms/pull/7131)

### Related issues

N/A