### PR TITLE
Update TestSetup.php

### DIFF
--- a/src/test/TestSetup.php
+++ b/src/test/TestSetup.php
@@ -344,6 +344,7 @@ class TestSetup
         Craft::setAlias('@vendor', $vendorPath);
         Craft::setAlias('@lib', $libPath);
         Craft::setAlias('@craft', $srcPath);
+        Craft::setAlias('@appicons', $srcPath . DIRECTORY_SEPARATOR . 'icons');
         Craft::setAlias('@config', $configPath);
         Craft::setAlias('@contentMigrations', $contentMigrationsPath);
         Craft::setAlias('@storage', $storagePath);


### PR DESCRIPTION
Add `appicons` alias

### Description
While running some functional tests that involve the CP I got an error related to the `@appicons` alias. 

```                                                                                                                                         
  [Twig\Error\RuntimeError] An exception has been thrown during the rendering of a template ("Invalid path alias: @appicons/c-outline.svg").  
```

It looks like this alias just wasn't ported over to `TestSetup.php` when it was added in 8335098e548ca2fb4e90cea1cc0da189f676a141
