### PR TITLE
Check if command is run in interactive mode before asking for input

### DIFF
--- a/src/console/controllers/GcController.php
+++ b/src/console/controllers/GcController.php
@@ -51,7 +51,7 @@ class GcController extends Controller
     {
         $gc = Craft::$app->getGc();
         $deleteAllTrashed = $gc->deleteAllTrashed;
-        $gc->deleteAllTrashed = ($this->deleteAllTrashed || $this->confirm('Delete all trashed items?'));
+        $gc->deleteAllTrashed = ($this->deleteAllTrashed || ($this->interactive && $this->confirm('Delete all trashed items?')));
         $this->stdout('Running garbage collection ... ', Console::FG_YELLOW);
         $gc->run(true);
         $this->stdout('done' . PHP_EOL, Console::FG_GREEN);


### PR DESCRIPTION
### Description
If the Garbage Collector is not run in interactive mode, non eligible sofe-deletes wil not be deleted


### Related issues
#7280 
