### PR TITLE
Hide or override CSS icon content text for AT

### DIFF
--- a/src/templates/_components/fieldtypes/Matrix/input.html
+++ b/src/templates/_components/fieldtypes/Matrix/input.html
@@ -36,7 +36,7 @@
                     <div class="titlebar">
                         <div class="blocktype{% if block.hasErrors() %} error{% endif %}">
                             {{ block.getType().name|t('site') }}
-                            {% if block.hasErrors() %}<span data-icon="alert"></span>{% endif %}
+                            {% if block.hasErrors() %}<span data-icon="alert" aria-label="{{ 'Error'|t('app') }}"></span>{% endif %}
                         </div>
                         <div class="preview"></div>
                     </div>

--- a/src/templates/_components/fieldtypes/Matrix/settings.html
+++ b/src/templates/_components/fieldtypes/Matrix/settings.html
@@ -14,7 +14,7 @@
                                 <h4>
                                     {{ blockType.name }}
                                     {% if blockType.hasFieldErrors %}
-                                        <span data-icon="alert"></span>
+                                        <span data-icon="alert" aria-label="{{ 'Error'|t('app') }}"></span>
                                     {% endif %}
                                 </h4>
                                 <div class="smalltext light code">{{ blockType.handle }}</div>
@@ -48,7 +48,7 @@
                                         {%- else -%}
                                             <em class="light">{{ '(blank)'|t('app') }}</em>
                                         {%- endif -%}
-                                        {%- if field.hasErrors() %} <span data-icon="alert"></span>{% endif -%}
+                                        {%- if field.hasErrors() %} <span data-icon="alert" aria-label="{{ 'Error'|t('app') }}"></span>{% endif -%}
                                     </h4>
                                     <div class="smalltext light code">{{ field.handle }}</div>
                                 </div>

--- a/src/templates/_components/fieldtypes/PositionSelect/settings.html
+++ b/src/templates/_components/fieldtypes/PositionSelect/settings.html
@@ -13,7 +13,7 @@
                     }) }}
                 </td>
                 <td>
-                    <span data-icon="pos{{ option|replace('-', '') }}"></span>
+                    <span data-icon="pos{{ option|replace('-', '') }}" aria-hidden="true"></span>
                 </td>
                 <td class="code">
                     {{ option }}

--- a/src/templates/_elements/toolbar.html
+++ b/src/templates/_elements/toolbar.html
@@ -42,9 +42,9 @@
                 <ul class="padded">
                     {% set draftsExist = elementInstance.find().draftOf(false).anyStatus().siteId('*').limit(1).exists() %}
                     {% if draftsExist %}
-                        <li><a data-drafts><span class="icon" data-icon="draft"></span>{{ 'Drafts'|t('app') }}</a></li>
+                        <li><a data-drafts><span class="icon" data-icon="draft" aria-hidden="true"></span>{{ 'Drafts'|t('app') }}</a></li>
                     {% endif %}
-                    <li><a data-trashed><span class="icon" data-icon="trash"></span>{{ "Trashed"|t('app') }}</a></li>
+                    <li><a data-trashed><span class="icon" data-icon="trash" aria-hidden="true"></span>{{ "Trashed"|t('app') }}</a></li>
                 </ul>
             {% endif %}
         </div>

--- a/src/templates/_includes/forms/copytextbtn.html
+++ b/src/templates/_includes/forms/copytextbtn.html
@@ -13,7 +13,7 @@
         size: value|length,
         tabindex: '-1',
     }) }}
-    <span data-icon="clipboard"></span>
+    <span data-icon="clipboard" aria-hidden="true"></span>
 </div>
 
 {% js %}

--- a/src/templates/_layouts/components/global-sidebar.twig
+++ b/src/templates/_layouts/components/global-sidebar.twig
@@ -25,7 +25,7 @@
                 } %}
                 <li {{ attr(itemAttributes) }}>
                     <a {{ attr(linkAttributes) }}>
-                        <span class="icon icon-mask">
+                        <span class="icon icon-mask" aria-hidden="true">
                             {%- if item.icon is defined -%}
                                 {{ svg(item.icon, sanitize=true, namespace=true) }}
                             {%- elseif item.fontIcon is defined -%}

--- a/src/templates/_special/install/account.html
+++ b/src/templates/_special/install/account.html
@@ -3,7 +3,7 @@
 {% set useEmailAsUsername = craft.app.config.general.useEmailAsUsername %}
 
 <div id="account" class="screen hidden" data-inputs="username,email,password">
-    <div class="icon">{{ svg(userIcon, sanitize=false) }}</div>
+    <div class="icon" aria-hidden="true">{{ svg(userIcon, sanitize=false) }}</div>
     <h1>{{ "Create your account"|t('app') }}</h1>
 
     <form accept-charset="UTF-8">

--- a/src/templates/_special/install/db.html
+++ b/src/templates/_special/install/db.html
@@ -3,7 +3,7 @@
 {% set dbConfig = craft.app.config.db %}
 
 <div id="db" class="screen hidden" data-inputs="driver,server,port,user,password,database,schema,tablePrefix">
-    <div class="icon">{{ svg(dbIcon, sanitize=false) }}</div>
+    <div class="icon" aria-hidden="true">{{ svg(dbIcon, sanitize=false) }}</div>
     <h1>{{ "Connect the database"|t('app') }}</h1>
 
     <form accept-charset="UTF-8">

--- a/src/templates/_special/install/site.html
+++ b/src/templates/_special/install/site.html
@@ -1,7 +1,7 @@
 {% import "_includes/forms" as forms %}
 
 <div id="site" class="screen hidden" data-inputs="name,baseUrl,language">
-    <div class="icon">{{ svg(worldIcon, sanitize=false) }}</div>
+    <div class="icon" aria-hidden="true">{{ svg(worldIcon, sanitize=false) }}</div>
     <h1>{{ "Setup your site"|t('app') }}</h1>
 
     <form accept-charset="UTF-8">

--- a/src/templates/_special/missing-component.html
+++ b/src/templates/_special/missing-component.html
@@ -2,9 +2,9 @@
     <p class="error">{{ error }}</p>
     {% if showPlugin %}
         <div class="install-plugin">
-            <div class="icon">
+            <div class="icon" aria-hidden="true">
                 {% if iconUrl %}
-                    <img src="{{ iconUrl }}">
+                    <img src="{{ iconUrl }}" alt="">
                 {% else %}
                     {{ svg(iconSvg, sanitize=true, namespace=true) }}
                 {% endif %}

--- a/src/templates/dashboard/_index.html
+++ b/src/templates/dashboard/_index.html
@@ -10,7 +10,7 @@
                     {% for type, info in widgetTypes if info.selectable %}
                         <li>
                             <a data-type="{{ type }}" data-name="{{ info.name }}">
-                                <span class="icon">{{ svg(info.iconSvg, sanitize=false) }}</span>
+                                <span class="icon" aria-hidden="true">{{ svg(info.iconSvg, sanitize=false) }}</span>
                                 {{ info.name }}
                             </a>
                         </li>

--- a/src/templates/settings/index.html
+++ b/src/templates/settings/index.html
@@ -13,7 +13,7 @@
                 {% set icon = item.iconMask ?? item.icon %}
                 <li>
                     <a href="{% if item.url is defined %}{{ url(item.url) }}{% else %}{{ url('settings/'~handle) }}{% endif %}">
-                        <div class="icon{% if item.iconMask is defined %} icon-mask{% endif %}">
+                        <div class="icon{% if item.iconMask is defined %} icon-mask{% endif %}" aria-hidden="true">
                             {{ svg(icon, sanitize=true, namespace=true) }}
                         </div>
                         {{ item.label }}

--- a/src/templates/settings/plugins/index.html
+++ b/src/templates/settings/plugins/index.html
@@ -56,7 +56,7 @@
                                                     <a href="{{ config.documentationUrl }}" rel="noopener" target="_blank">{{ "Documentation"|t('app') }}</a>
                                                 {% endif %}
                                                 {% if config.hasCpSettings %}
-                                                    <a href="{{ url('settings/plugins/'~config.moduleId) }}"><span data-icon="settings"></span>{{ "Settings"|t('app') }}</a>
+                                                    <a href="{{ url('settings/plugins/'~config.moduleId) }}"><span data-icon="settings" aria-hidden="true"></span>{{ "Settings"|t('app') }}</a>
                                                 {% endif %}
                                                 {% endspaceless -%}
                                             </p>

--- a/src/templates/settings/sites/index.html
+++ b/src/templates/settings/sites/index.html
@@ -67,7 +67,7 @@
                             </th>
                             <td data-title="{{ 'Handle'|t('app') }}"><code>{{ site.handle }}</code></td>
                             <td data-title="{{ 'Language'|t('app') }}"><code>{{ site.language }}</code></td>
-                            <td data-title="{{ 'Primary'|t('app') }}">{% if site.primary %}<div data-icon="check"></div>{% endif %}</td>
+                            <td data-title="{{ 'Primary'|t('app') }}">{% if site.primary %}<div data-icon="check" aria-label="{{ 'Yes'|t('app') }}"></div>{% endif %}</td>
                             <td data-title="{{ 'Base URL'|t('app') }}"><code>{{ site.baseUrl }}</code></td>
                             {% if not group %}
                                 <td data-title="{{ 'Group'|t('app') }}">{{ site.group.name|t('site') }}</td>

--- a/src/templates/utilities/_index.html
+++ b/src/templates/utilities/_index.html
@@ -9,7 +9,7 @@
                 {% set selected = utility.id == id %}
                 <li>
                     <a class="{% if selected %}sel{% elseif utility.badgeCount %}has-badge{% endif %}" href="{{ url('utilities/'~utility.id) }}">
-                        <span class="icon icon-mask">{{ svg(utility.iconSvg, sanitize=false) }}</span>
+                        <span class="icon icon-mask" aria-hidden="true">{{ svg(utility.iconSvg, sanitize=false) }}</span>
                         <span class="label">{{ utility.displayName }}</span>
                         {% if not selected and utility.badgeCount %}
                             <span class="badge">{{ utility.badgeCount|number(decimals=0) }}</span>

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -1575,6 +1575,7 @@ return [
     'XML' => 'XML',
     'Years' => 'Years',
     'Yesterday' => 'Yesterday',
+    'Yes' => 'Yes',
     'You can only delete groups that have no sites.' => 'You can only delete groups that have no sites.',
     'You cannot access the control panel while the system is offline with that account.' => 'You cannot access the control panel while the system is offline with that account.',
     'You cannot access the control panel with that account.' => 'You cannot access the control panel with that account.',


### PR DESCRIPTION
### Description
The CSS `content` value used for icon fonts may be announced to screen readers.

I went through several instances of this and added aria-hidden where the icon was duplicating nearby text, and an overriding aria-label where it was standalone.

Also, I think the Position Select field type was deprecated, so not sure if its code is still needed in the repo.

