### PR TITLE
Fix file type regex on GraphQL asset mutations

### DIFF
--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -177,7 +177,7 @@ class Asset extends ElementMutationResolver
             $dataString = $fileInformation['fileData'];
             $fileData = null;
 
-            if (preg_match('/^data:((?<type>[a-z0-9]+\/[a-z0-9\+]+);)?base64,(?<data>.+)/i', $dataString, $matches)) {
+            if (preg_match('/^data:((?<type>[a-z0-9]+\/[a-z0-9\+\.\-]+);)?base64,(?<data>.+)/i', $dataString, $matches)) {
                 // Decode the file
                 $fileData = base64_decode($matches['data']);
             }


### PR DESCRIPTION
### Description

Following on from https://github.com/craftcms/cms/issues/7327, I modified the regex and ran some tests, and it seems to all be working correctly now.

### Related issues

https://github.com/craftcms/cms/issues/7327