### PR TITLE
Hotfix/date time field a11y

### DIFF
--- a/src/web/assets/cp/src/css/_cp.scss
+++ b/src/web/assets/cp/src/css/_cp.scss
@@ -1007,12 +1007,6 @@ $toolbarIconColor: darken($inputColor, 10%);
       }
     }
 
-    .text::placeholder,
-    .datewrapper .text:placeholder-shown + div[data-icon],
-    .timewrapper .text:placeholder-shown + div[data-icon] {
-      color: $grey300;
-    }
-
     .ui-datepicker {
       @include margin(0, 0, 0, -8px);
     }

--- a/src/web/assets/cp/src/css/_main.scss
+++ b/src/web/assets/cp/src/css/_main.scss
@@ -4643,17 +4643,12 @@ fieldset {
       top: calc(50% - 10px);
       @include left(14px);
       z-index: 0;
-      color: $lightTextColor;
 
       &,
       &:before {
         user-select: none;
         pointer-events: none;
         z-index: 1;
-      }
-
-      #details & {
-        color: $darkHairlineColor;
       }
     }
 

--- a/src/web/assets/cp/src/css/_main.scss
+++ b/src/web/assets/cp/src/css/_main.scss
@@ -4611,7 +4611,7 @@ fieldset {
     width: 20px;
     @include margin-left(4px);
     cursor: pointer;
-    color: $darkHairlineColor;
+    color: $lightTextColor;
     border: none;
     padding: 0;
     background: transparent;
@@ -4622,7 +4622,7 @@ fieldset {
     }
 
     &:hover {
-      color: $mediumTextColor;
+      color: $errorColor;
     }
   }
 }

--- a/src/web/assets/cp/src/js/Craft.js
+++ b/src/web/assets/cp/src/js/Craft.js
@@ -2027,6 +2027,7 @@ $.extend($.fn,
                                 type: 'button',
                                 class: 'clear-btn',
                                 title: Craft.t('app', 'Clear'),
+                                ['aria-label']: Craft.t('app', 'Clear'),
                             })
                                 .appendTo($wrapper)
                                 .on('click', () => {


### PR DESCRIPTION
### Description
- [ ] Calendar picker doesn't seem to be keyboard-accessible. [Deque suggestion for improving jQuery UI datepicker a11y](https://www.deque.com/blog/accessible-jquery-ui-datepicker/)
- [ ] It's not clear what format or constraints the date should be in when typed directly into the text input. Note: the format depends on the user's (formatting) locale settings. Validation.
- [ ] Inputs are not associated with labels. For the date-only and time-only fields, the visible label can be its label. This will also put the input into focus when the label is clicked. For the date/time fields, the date field and time field should have aria-label to indicate one is for date and one is for time.

- Increase contrast for x/remove icon/button, and make hover color consistent with other similar instances (e.g. categories, users)
- Add aria-label for remove button
- Increase contrast for date field icons in details sidebar


### Related issues
Closes #7321
