### PR TITLE
Deprecate the `getFileMetadata` method on Volumes.

### DIFF
--- a/CHANGELOG-v3.6.md
+++ b/CHANGELOG-v3.6.md
@@ -160,7 +160,7 @@
 - Deprecated the `relatedToAll` GraphQL query argument.
 - Deprecated the `isUnsavedDraft` GraphQL field.
 - Deprecated `craft\base\Element::getIsUnsavedDraft()`. `getIsUnpublishedDraft()` should be used instead.
-- Deprecated `craft\base\VolumeInterface::getFileMetadata()`. `getFileSize()` and `getDateModified()` instead.
+- Deprecated `craft\base\VolumeInterface::getFileMetadata()`. `getFileSize()` and `getDateModified()` should be used instead.
 - Deprecated `craft\db\Connection::trimObjectName()`.
 - Deprecated `craft\gql\base\Resolver::getArrayableArguments()`.
 - Deprecated `craft\gql\base\Resolver::prepareArguments()`.

--- a/CHANGELOG-v3.6.md
+++ b/CHANGELOG-v3.6.md
@@ -31,6 +31,8 @@
 - Added `craft\base\ElementInterface::getIsUnpublishedDraft()`.
 - Added `craft\base\FieldInterface::includeInGqlSchema()`. ([#7244](https://github.com/craftcms/cms/pull/7244))
 - Added `craft\base\FieldInterface::useFieldset()`, which custom fields can override to return `true` if a `<fieldset>` and `<legend>` should be used, rather than a `<div>` and `<label>`.
+- Added `craft\base\VolumeInterface::getDateModified()`.
+- Added `craft\base\VolumeInterface::getFileSize()`.
 - Added `craft\base\VolumeTrait::$titleTranslationKeyFormat`.
 - Added `craft\base\VolumeTrait::$titleTranslationMethod`.
 - Added `craft\console\Controller::passwordPrompt()`.
@@ -158,6 +160,7 @@
 - Deprecated the `relatedToAll` GraphQL query argument.
 - Deprecated the `isUnsavedDraft` GraphQL field.
 - Deprecated `craft\base\Element::getIsUnsavedDraft()`. `getIsUnpublishedDraft()` should be used instead.
+- Deprecated `craft\base\VolumeInterface::getFileMetadata()`. `getFileSize()` and `getDateModified()` instead.
 - Deprecated `craft\db\Connection::trimObjectName()`.
 - Deprecated `craft\gql\base\Resolver::getArrayableArguments()`.
 - Deprecated `craft\gql\base\Resolver::prepareArguments()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Updated Yii to 2.0.40.
 
 ### Deprecated
-- Deprecated `craft\base\VolumeInterface::getFileMetadata()`. `getFileSize()` and `getDateModified()` instead.
+- Deprecated `craft\base\VolumeInterface::getFileMetadata()`. `getFileSize()` and `getDateModified()` should be used instead.
 - Deprecated `craft\helpers\Template::paginateCriteria()`. `paginateQuery()` should be used instead.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Added the `handleCasing` config setting, which determines the default casing that should be used when autogenerating component handles. ([#4276](https://github.com/craftcms/cms/issues/4276))
 - Added `craft\base\ApplicationTrait::getFormattingLocale()`, which returns the locale that should be used for date/time formatting.
 - Added `craft\base\FieldInterface::useFieldset()`, which custom fields can override to return `true` if a `<fieldset>` and `<legend>` should be used, rather than a `<div>` and `<label>`.
+- Added `craft\base\VolumeInterface::getDateModified()`.
+- Added `craft\base\VolumeInterface::getFileSize()`.
 - Added `craft\fieldlayoutelements\BaseField::useFieldset()`.
 - Added `craft\fields\Url::TYPE_EMAIL`.
 - Added `craft\fields\Url::TYPE_TEL`.
@@ -32,6 +34,7 @@
 
 ### Deprecated
 - Deprecated `craft\helpers\Template::paginateCriteria()`. `paginateQuery()` should be used instead.
+- Deprecated `craft\base\VolumeInterface::getFileMetadata()`. `getFileSize()` and `getDateModified()` instead.
 
 ### Removed
 - Removed the “Placeholder” setting from URL fields. ([#7303](https://github.com/craftcms/cms/issues/7303))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@
 - Updated Yii to 2.0.40.
 
 ### Deprecated
-- Deprecated `craft\helpers\Template::paginateCriteria()`. `paginateQuery()` should be used instead.
 - Deprecated `craft\base\VolumeInterface::getFileMetadata()`. `getFileSize()` and `getDateModified()` instead.
+- Deprecated `craft\helpers\Template::paginateCriteria()`. `paginateQuery()` should be used instead.
 
 ### Removed
 - Removed the “Placeholder” setting from URL fields. ([#7303](https://github.com/craftcms/cms/issues/7303))

--- a/src/base/FlysystemVolume.php
+++ b/src/base/FlysystemVolume.php
@@ -30,6 +30,11 @@ abstract class FlysystemVolume extends Volume
     protected $foldersHaveTrailingSlashes = true;
 
     /**
+     * @var array An array of cached metadata by path.
+     */
+    private $_cachedMetadata = [];
+
+    /**
      * @var AdapterInterface|null The Flysystem adapter, created by [[createAdapter()]]
      */
     private $_adapter;
@@ -54,11 +59,30 @@ abstract class FlysystemVolume extends Volume
      */
     public function getFileMetadata(string $uri): array
     {
-        try {
-            return $this->filesystem()->getMetadata($uri);
-        } catch (FileNotFoundException $e) {
-            throw new VolumeObjectNotFoundException($e->getMessage(), 0, $e);
-        }
+        Craft::$app->getDeprecator()->log('getFileMetadata', "The `getFileMetadata()` method has been deprecated. Use `getDateModified()` and `getFileSize()` instead.");
+
+        return $this->fetchFileMetadata($uri, true);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDateModified(string $uri)
+    {
+        $metadata = $this->fetchFileMetadata($uri);
+
+        return $metadata['timestamp'] ?? null;
+
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFileSize(string $uri)
+    {
+        $metadata = $this->fetchFileMetadata($uri);
+
+        return $metadata['size'] ?? null;
     }
 
     /**
@@ -342,5 +366,32 @@ abstract class FlysystemVolume extends Volume
     protected function visibility(): string
     {
         return $this->hasUrls ? AdapterInterface::VISIBILITY_PUBLIC : AdapterInterface::VISIBILITY_PRIVATE;
+    }
+
+    /**
+     * Fetch the file metadata from the volume, optionally caching the result.
+     *
+     * @param string $uri
+     * @param false $bypassCache
+     * @return array|false|mixed
+     * @throws VolumeObjectNotFoundException
+     */
+    protected function fetchFileMetadata(string $uri, $bypassCache = false)
+    {
+        if ($bypassCache || empty($this->_cachedMetadata[$uri])) {
+            try {
+                $metadata = $this->filesystem()->getMetadata($uri);
+            } catch (FileNotFoundException $e) {
+                throw new VolumeObjectNotFoundException($e->getMessage(), 0, $e);
+            }
+
+            if ($bypassCache) {
+                return $metadata;
+            }
+
+            $this->_cachedMetadata[$uri] = $metadata;
+        }
+
+        return $this->_cachedMetadata[$uri];
     }
 }

--- a/src/base/FlysystemVolume.php
+++ b/src/base/FlysystemVolume.php
@@ -66,7 +66,7 @@ abstract class FlysystemVolume extends Volume
     /**
      * @inheritdoc
      */
-    public function getDateModified(string $uri)
+    public function getDateModified(string $uri): ?int
     {
         $metadata = $this->fetchFileMetadata($uri);
         return $metadata['timestamp'] ?? null;
@@ -76,7 +76,7 @@ abstract class FlysystemVolume extends Volume
     /**
      * @inheritdoc
      */
-    public function getFileSize(string $uri)
+    public function getFileSize(string $uri): ?int
     {
         $metadata = $this->fetchFileMetadata($uri);
         return $metadata['size'] ?? null;

--- a/src/base/FlysystemVolume.php
+++ b/src/base/FlysystemVolume.php
@@ -60,7 +60,6 @@ abstract class FlysystemVolume extends Volume
     public function getFileMetadata(string $uri): array
     {
         Craft::$app->getDeprecator()->log('getFileMetadata', "The `getFileMetadata()` method has been deprecated. Use `getDateModified()` and `getFileSize()` instead.");
-
         return $this->fetchFileMetadata($uri, true);
     }
 
@@ -70,7 +69,6 @@ abstract class FlysystemVolume extends Volume
     public function getDateModified(string $uri)
     {
         $metadata = $this->fetchFileMetadata($uri);
-
         return $metadata['timestamp'] ?? null;
 
     }
@@ -81,7 +79,6 @@ abstract class FlysystemVolume extends Volume
     public function getFileSize(string $uri)
     {
         $metadata = $this->fetchFileMetadata($uri);
-
         return $metadata['size'] ?? null;
     }
 
@@ -375,6 +372,7 @@ abstract class FlysystemVolume extends Volume
      * @param false $bypassCache
      * @return array|false|mixed
      * @throws VolumeObjectNotFoundException
+     * @since 3.6.0
      */
     protected function fetchFileMetadata(string $uri, $bypassCache = false)
     {

--- a/src/base/VolumeInterface.php
+++ b/src/base/VolumeInterface.php
@@ -64,6 +64,7 @@ interface VolumeInterface extends SavableComponentInterface
      *
      * @param string $uri
      * @return mixed
+     * @since 3.6.0
      */
     public function getFileSize(string $uri);
 
@@ -72,6 +73,7 @@ interface VolumeInterface extends SavableComponentInterface
      *
      * @param string $uri
      * @return mixed
+     * @since 3.6.0
      */
     public function getDateModified(string $uri);
 

--- a/src/base/VolumeInterface.php
+++ b/src/base/VolumeInterface.php
@@ -55,12 +55,12 @@ interface VolumeInterface extends SavableComponentInterface
      * @param string $uri URI to the file on the volume
      * @return array
      * @throws VolumeObjectNotFoundException if the file cannot be found
-     * @deprecated in Craft 3.6.0. Use [[getFileSize]] and [[getDateModified]] instead.
+     * @deprecated in Craft 3.6.0. Use [[getFileSize()]] and [[getDateModified()]] instead.
      */
     public function getFileMetadata(string $uri): array;
 
     /**
-     * Return the file size.
+     * Returns the file size.
      *
      * @param string $uri
      * @return mixed
@@ -69,7 +69,7 @@ interface VolumeInterface extends SavableComponentInterface
     public function getFileSize(string $uri);
 
     /**
-     * Return the last time the file was modified.
+     * Returns the last time the file was modified.
      *
      * @param string $uri
      * @return mixed

--- a/src/base/VolumeInterface.php
+++ b/src/base/VolumeInterface.php
@@ -63,19 +63,19 @@ interface VolumeInterface extends SavableComponentInterface
      * Returns the file size.
      *
      * @param string $uri
-     * @return mixed
+     * @return int|null
      * @since 3.6.0
      */
-    public function getFileSize(string $uri);
+    public function getFileSize(string $uri): ?int;
 
     /**
      * Returns the last time the file was modified.
      *
      * @param string $uri
-     * @return mixed
+     * @return int|null
      * @since 3.6.0
      */
-    public function getDateModified(string $uri);
+    public function getDateModified(string $uri): ?int;
 
     /**
      * Creates a file.

--- a/src/base/VolumeInterface.php
+++ b/src/base/VolumeInterface.php
@@ -55,8 +55,25 @@ interface VolumeInterface extends SavableComponentInterface
      * @param string $uri URI to the file on the volume
      * @return array
      * @throws VolumeObjectNotFoundException if the file cannot be found
+     * @deprecated in Craft 3.6.0. Use [[getFileSize]] and [[getDateModified]] instead.
      */
     public function getFileMetadata(string $uri): array;
+
+    /**
+     * Return the file size.
+     *
+     * @param string $uri
+     * @return mixed
+     */
+    public function getFileSize(string $uri);
+
+    /**
+     * Return the last time the file was modified.
+     *
+     * @param string $uri
+     * @return mixed
+     */
+    public function getDateModified(string $uri);
 
     /**
      * Creates a file.

--- a/src/services/AssetIndexer.php
+++ b/src/services/AssetIndexer.php
@@ -375,7 +375,6 @@ class AssetIndexer extends Component
      */
     public function indexFile(VolumeInterface $volume, string $path, string $sessionId = '', bool $cacheImages = false, bool $createIfMissing = true)
     {
-        $fileInfo = $volume->getFileMetadata($path);
         $folderPath = dirname($path);
 
         if ($folderPath !== '.') {
@@ -386,8 +385,8 @@ class AssetIndexer extends Component
             'volumeId' => $volume->id,
             'sessionId' => $sessionId ?: $this->getIndexingSessionId(),
             'uri' => $path,
-            'size' => $fileInfo['size'],
-            'timestamp' => $fileInfo['timestamp'],
+            'size' => $volume->getFileSize($path),
+            'timestamp' => $volume->getDateModified($path),
             'inProgress' => true,
             'completed' => false
         ]);

--- a/src/services/AssetTransforms.php
+++ b/src/services/AssetTransforms.php
@@ -1531,8 +1531,7 @@ class AssetTransforms extends Component
 
         // Already created. Relax, grasshopper!
         if ($volume->fileExists($transformPath)) {
-            $metaData = $volume->getFileMetadata($transformPath);
-            $dateModified = $metaData['timestamp'];
+            $dateModified = $volume->getDateModified($transformPath);
             $dimensionChangeTime = $index->getTransform()->dimensionChangeTime;
 
             if (!$dimensionChangeTime || $dimensionChangeTime->getTimestamp() <= $dateModified) {

--- a/tests/unit/volumes/FlysysteVolumeTest.php
+++ b/tests/unit/volumes/FlysysteVolumeTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craftunit\gql;
+
+use Codeception\Stub\Expected;
+use Codeception\Test\Unit;
+use Craft;
+use craft\elements\Asset;
+use craft\elements\Asset as AssetElement;
+use craft\elements\Category as CategoryElement;
+use craft\elements\Entry as EntryElement;
+use craft\elements\GlobalSet as GlobalSetElement;
+use craft\elements\MatrixBlock as MatrixBlockElement;
+use craft\elements\User as UserElement;
+use craft\errors\GqlException;
+use craft\gql\types\elements\Asset as AssetGqlType;
+use craft\gql\types\elements\Category as CategoryGqlType;
+use craft\gql\types\elements\Entry as EntryGqlType;
+use craft\gql\types\elements\GlobalSet as GlobalSetGqlType;
+use craft\gql\types\elements\MatrixBlock as MatrixBlockGqlType;
+use craft\gql\types\elements\Tag as TagGqlType;
+use craft\gql\types\elements\User as UserGqlType;
+use craft\helpers\Json;
+use craft\helpers\StringHelper;
+use craft\models\CategoryGroup;
+use craft\models\EntryType;
+use craft\models\GqlSchema;
+use craft\models\MatrixBlockType;
+use craft\models\Section;
+use craft\models\UserGroup;
+use craft\services\Assets;
+use craft\services\Deprecator;
+use craft\volumes\Local;
+use GraphQL\Type\Definition\ResolveInfo;
+use League\Flysystem\Filesystem;
+
+class FlysysteVolumeTest extends Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+
+    protected function _before()
+    {
+    }
+
+    protected function _after()
+    {
+    }
+
+    /**
+     * Test deprecation and caching.
+     */
+    public function testFileMetadataDeprecation()
+    {
+        $deprecator = $this->make(Deprecator::class, [
+            'log' => Expected::once()
+        ]);
+
+        Craft::$app->set('deprecator', $deprecator);
+
+        /** @var Local $volume */
+        $volume = $this->make(Local::class, [
+            'filesystem' => $this->make(Filesystem::class, [
+                'getMetadata' => Expected::exactly(2, [
+                    'timestamp' => 123,
+                    'size' => 456
+                ])
+            ])
+        ]);
+
+        $this->assertEquals(['timestamp' => 123, 'size' => 456], $volume->getFileMetadata('path'));
+        $this->assertEquals(456, $volume->getFileSize('path'));
+        $this->assertEquals(123, $volume->getDateModified('path'));
+    }
+}


### PR DESCRIPTION
### Description

Flysystem V2 has removed the possibility to fetch all the metadata in one go - probably because it would incur multiple requests under the hood for some storage adapters.

To prepare for this `getFileMetadata()` becomes deprecated in 3.6.0, while adding `getFileSize()` and `getDateModified()` methods, that implement trivial caching to avoid performance hit.
