### PR TITLE
 Added a limit to the pending image transform.

### DIFF
--- a/src/queue/jobs/GeneratePendingTransforms.php
+++ b/src/queue/jobs/GeneratePendingTransforms.php
@@ -8,6 +8,7 @@
 namespace craft\queue\jobs;
 
 use Craft;
+use craft\helpers\Queue;
 use craft\queue\BaseJob;
 
 /**
@@ -18,13 +19,15 @@ use craft\queue\BaseJob;
  */
 class GeneratePendingTransforms extends BaseJob
 {
+    public $limit;
+
     /**
      * @inheritdoc
      */
     public function execute($queue)
     {
         // Get all of the pending transform index IDs
-        $indexIds = Craft::$app->getAssetTransforms()->getPendingTransformIndexIds();
+        $indexIds = Craft::$app->getAssetTransforms()->getPendingTransformIndexIds($this->limit);
 
         $totalIndexes = count($indexIds);
         $assetTransformsService = Craft::$app->getAssetTransforms();
@@ -42,6 +45,12 @@ class GeneratePendingTransforms extends BaseJob
                 } catch (\Throwable $e) {
                 }
             }
+        }
+
+        $pendingImageTransformCount = Craft::$app->getAssetTransforms()->countPendingTransformIndexIds();
+
+        if ($pendingImageTransformCount > 0) {
+            Queue::push(new GeneratePendingTransforms(['limit' => $this->limit]));
         }
     }
 

--- a/src/services/AssetTransforms.php
+++ b/src/services/AssetTransforms.php
@@ -948,14 +948,32 @@ class AssetTransforms extends Component
     /**
      * Returns a list of pending transform index IDs.
      *
+     * @param int $limit
      * @return array
      */
-    public function getPendingTransformIndexIds(): array
+    public function getPendingTransformIndexIds($limit = 0): array
+    {
+        $query = $this->_createTransformIndexQuery()
+            ->select(['id'])
+            ->where(['fileExists' => false, 'inProgress' => false]);
+
+        if ($limit > 0) {
+            $query = $query->limit($limit);
+        }
+
+       return $query->column();
+    }
+
+    /**
+     * Counts pending transforms.
+     *
+     * @return int
+     */
+    public function countPendingTransformIndexIds(): int
     {
         return $this->_createTransformIndexQuery()
-            ->select(['id'])
             ->where(['fileExists' => false, 'inProgress' => false])
-            ->column();
+            ->count();
     }
 
     /**

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -94,6 +94,12 @@ class Assets extends Component
     const EVENT_REGISTER_PREVIEW_HANDLER = 'registerPreviewHandler';
 
     /**
+     * @var int limit's transform per queue operation
+     * @since 3.6.0
+     */
+    public int $generatePendingTransformsLimit = 0;
+
+    /**
      * @var
      */
     private $_foldersById = [];
@@ -626,7 +632,7 @@ class Assets extends Component
 
         // Queue up a new Generate Pending Transforms job
         if (!$this->_queuedGeneratePendingTransformsJob) {
-            Queue::push(new GeneratePendingTransforms());
+            Queue::push(new GeneratePendingTransforms(['limit' => $this->generatePendingTransformsLimit]));
             $this->_queuedGeneratePendingTransformsJob = true;
         }
 


### PR DESCRIPTION
### Description
Seeing the thread in #7360, there will be an option to stop the pending transform queue job to be fired. This will give problems with caching in twig templates. Because the cache is not saved of there are pending transforms. This will give problems if you are using source sets in your images or picture tags.

> Tip: The {% cache %} tag will detect if there are any ungenerated image transform URLs within it. If there are, it will hold off on caching the template until the next request, so those temporary image URLs won’t get cached. 

By adding the following code to the components in the config/app.php in combination with this pull request. The Job will only transform 10 images. If there are more images left the job will add a new job, until all the images are transformed.

`
 'assets' => [
   'generatePendingTransformsLimit' => 10,
 ],
`


### Related issues
#7360 