### PR TITLE
Fix ArgumentCountError

### DIFF
--- a/src/services/Categories.php
+++ b/src/services/Categories.php
@@ -730,7 +730,7 @@ class Categories extends Component
      */
     public function applyBranchLimitToCategories(array &$categories, int $branchLimit)
     {
-        Craft::$app->getStructures()->applyBranchLimitToElements($categories);
+        Craft::$app->getStructures()->applyBranchLimitToElements($categories, $branchLimit);
     }
 
     /**


### PR DESCRIPTION
### Description

Fix ArgumentCountError: Too few arguments to function craft\services\Structures::applyBranchLimitToElements(), 1 passed and exactly 2 expected
