### PR TITLE
Adds the missing param to method call "applyBranchLimitToElements"

### DIFF
--- a/src/services/Categories.php
+++ b/src/services/Categories.php
@@ -730,7 +730,7 @@ class Categories extends Component
      */
     public function applyBranchLimitToCategories(array &$categories, int $branchLimit)
     {
-        Craft::$app->getStructures()->applyBranchLimitToElements($categories);
+        Craft::$app->getStructures()->applyBranchLimitToElements($categories, $branchLimit);
     }
 
     /**


### PR DESCRIPTION
### Description
https://sentry.io/share/issue/ce5cadf67e4f4bab98244be7e063fd76/

The method requires 2 params, but only 1 of them is passed in. Causing relational fields to error.


### Related issues

