### PR TITLE
Fix bug in HTML::_namespaceAttributes to allow multiple url() calls in one line of CSS

### DIFF
--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -618,7 +618,7 @@ class Html extends \yii\helpers\Html
 
         // ID references in url() calls
         $html = preg_replace_callback(
-            "/(?<=url\\(#)[^'\"\s]*(?=\\))/i",
+            "/(?<=url\\(#)[^'\"\s\)]*(?=\\))/i",
             function(array $match) use ($namespace, $ids): string {
                 if (isset($ids[$match[0]])) {
                     return $namespace . '-' . $match[0];

--- a/tests/unit/helpers/HtmlHelperTest.php
+++ b/tests/unit/helpers/HtmlHelperTest.php
@@ -420,6 +420,7 @@ class HtmlHelperTest extends Unit
             ['<style>.foo-bar{}</style>', '<style>.bar{}</style>', 'foo', true],
             ['<style>.foo-bar{content: \'.baz\'}</style>', '<style>.bar{content: \'.baz\'}</style>', 'foo', true],
             ['<linearGradient id="foo-bar"></linearGradient><path fill="url(#foo-bar)"></path>', '<linearGradient id="bar"></linearGradient><path fill="url(#bar)"></path>', 'foo', false],
+            ['<style>.foo-st4{mask:url(#foo-bar);fill-rule:evenodd;fill:url(#foo-bla);}</style><mask id="foo-bar"></mask><linearGradient id="foo-bla"></linearGradient>', '<style>.st4{mask:url(#bar);fill-rule:evenodd;fill:url(#bla);}</style><mask id="bar"></mask><linearGradient id="bla"></linearGradient>', 'foo', true],
             ['<circle id="foo-bar"></circle><use xlink:href="#foo-bar"></use>', '<circle id="bar"></circle><use xlink:href="#bar"></use>', 'foo', false],
         ];
     }


### PR DESCRIPTION
I had an issue with a SVG file where a CSS rule with multiple url() calls in one line. The rule didn't add any namespace at all to this line. Here is my line of CSS, that didn't work:

```css
.st4{mask:url(#mask-4_1_);fill-rule:evenodd;clip-rule:evenodd;fill:url(#Fill-6_1_);}
```

I modified the regular expression to disallow closing brackets in the ID. As far as I know you can't use brackets in IDs. With this PR both url() calls are handled by the regex callback separately.