### PR TITLE
Add null check to URL field

### DIFF
--- a/src/fields/Url.php
+++ b/src/fields/Url.php
@@ -220,7 +220,7 @@ class Url extends Field implements PreviewableFieldInterface
 
             $typeOptions[] = ['label' => $label, 'value' => $type];
 
-            if ($value && $type === $valueType && $prefix) {
+            if (is_string($value) && $type === $valueType && $prefix) {
                 $value = StringHelper::removeLeft($value, $prefix);
             }
         }

--- a/src/fields/Url.php
+++ b/src/fields/Url.php
@@ -220,7 +220,7 @@ class Url extends Field implements PreviewableFieldInterface
 
             $typeOptions[] = ['label' => $label, 'value' => $type];
 
-            if ($type === $valueType && $prefix) {
+            if ($value && $type === $valueType && $prefix) {
                 $value = StringHelper::removeLeft($value, $prefix);
             }
         }


### PR DESCRIPTION
### Description
Adds a null check to `$value` before it goes into `StringHelper::removeLeft(string $value)`

### Related issues
Fixes error when the URL field is still empty on a fresh element, showing 
```craft\helpers\StringHelper::removeLeft(): Argument #1 ($str) must be of type string, null given, called in /app/user/vendor/craftcms/cms/src/fields/Url.php on line 224```
