### PR TITLE
Consider 'custom' translation method in craft\base\Field.getIsTranslatable()

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -313,6 +313,13 @@ abstract class Field extends SavableComponent implements FieldInterface
      */
     public function getIsTranslatable(ElementInterface $element = null): bool
     {
+        if(
+            $element !== null
+            && $this->translationMethod === self::TRANSLATION_METHOD_CUSTOM
+        ) {
+            return '1' !== $this->getTranslationKey($element);
+        }
+
         return ($this->translationMethod !== self::TRANSLATION_METHOD_NONE);
     }
 


### PR DESCRIPTION
### Description

The base class `craft\base\Field` will now consider a custom translation method in its method `getIsTranslatable()`.

### Related issues

#7647 
