### PR TITLE
Fix infinite loop in setUniqueUri for entries  with duplicated long slugs

### DIFF
--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -82,8 +82,10 @@ class ElementHelper
         for ($i = 0; $i < $maxSlugIncrement; $i++) {
             $testSlug = $element->slug;
 
+            $suffixLength = 0;
             if ($i > 0) {
                 $testSlug .= $slugWordSeparator . $i;
+                $suffixLength = mb_strlen($slugWordSeparator . $i);
             }
 
             $originalSlug = $element->slug;
@@ -94,7 +96,7 @@ class ElementHelper
             // Make sure we're not over our max length.
             if (mb_strlen($testUri) > 255) {
                 // See how much over we are.
-                $overage = mb_strlen($testUri) - 255;
+                $overage = mb_strlen($testUri) + $suffixLength - 255;
 
                 // Do we have anything left to chop off?
                 if ($overage < mb_strlen($element->slug)) {
@@ -114,7 +116,6 @@ class ElementHelper
                 // OMG!
                 $element->slug = $testSlug;
                 $element->uri = $testUri;
-
                 return;
             }
 


### PR DESCRIPTION
### Description
In situations where the entry slug or the generated one based on title is really long (255+), an infinite loop will occur if one try to save another entry with the same slug.

For instance, having an existing entry with slug
`arrêté-du-24-décembre-2020-portant-modification-de-larrêté-du-4-décembre-2020-fixant-la-liste-des-personnes-autorisées-à-exercer-en-france-la-profession-de-médecin-dans-la-spécialité-gériatrie-en-application-des-dispositions-de-larti`
Trying to publish a new entry with the same slug (or in real case, auto generated slug based on the title) will end up in an infinite loop issue.
This is because the setUniqueUri does not calculate the `overage` value based on the added suffix.
The fix prevent such case by chopping the overage amount including the length of the added suffix.
