### PR TITLE
Update test plugin config options

### DIFF
--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -225,12 +225,15 @@ class Craft extends Yii2
     {
         ob_start();
         try {
+            $dbSetupConfig = $this->_getConfig('dbSetup');
+
             // Prevent's a static properties bug.
-            ProjectConfig::reset();
+            // Only reset PC when cleaning
+            if (isset($dbSetupConfig['clean']) && $dbSetupConfig['clean'] === true) {
+                ProjectConfig::reset();
+            }
 
             App::maxPowerCaptain();
-
-            $dbSetupConfig = $this->_getConfig('dbSetup');
 
             // Setup the project config from the passed file.
             if ($projectConfig = TestSetup::useProjectConfig()) {

--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -226,27 +226,29 @@ class Craft extends Yii2
         ob_start();
         try {
             $dbSetupConfig = $this->_getConfig('dbSetup');
+            $clean = (isset($dbSetupConfig['clean']) && $dbSetupConfig['clean'] === true);
+            $setupCraft = (isset($dbSetupConfig['setupCraft']) && $dbSetupConfig['setupCraft'] == true);
 
             // Prevents a static properties bug.
             // Only reset PC when cleaning
-            if (isset($dbSetupConfig['clean']) && $dbSetupConfig['clean'] === true) {
+            if ($clean) {
                 ProjectConfig::reset();
             }
 
             App::maxPowerCaptain();
 
             // Setup the project config from the passed file.
-            if ($projectConfig = TestSetup::useProjectConfig()) {
+            if (($clean && $setupCraft) && $projectConfig = TestSetup::useProjectConfig()) {
                 TestSetup::setupProjectConfig();
             }
 
             // Get rid of everything.
-            if (isset($dbSetupConfig['clean']) && $dbSetupConfig['clean'] === true) {
+            if ($clean) {
                 TestSetup::cleanseDb(\Craft::$app->getDb());
             }
 
             // Install the db from install.php
-            if (isset($dbSetupConfig['setupCraft']) && $dbSetupConfig['setupCraft'] === true) {
+            if ($setupCraft) {
                 TestSetup::setupCraftDb(\Craft::$app->getDb());
             }
 
@@ -265,12 +267,9 @@ class Craft extends Yii2
             }
 
             // Add any plugins
-            if ($plugins = $this->_getConfig('plugins')) {
+            if (($clean && $setupCraft) && $plugins = $this->_getConfig('plugins')) {
                 foreach ($plugins as $plugin) {
-                    // Assume plugins need to be installed by default or check the `install` key
-                    if (!isset($plugin['install']) || (isset($plugin['install']) && $plugin['install'] === true)) {
-                        $this->installPlugin($plugin);
-                    }
+                    $this->installPlugin($plugin);
                 }
             }
 

--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -267,7 +267,10 @@ class Craft extends Yii2
             // Add any plugins
             if ($plugins = $this->_getConfig('plugins')) {
                 foreach ($plugins as $plugin) {
-                    $this->installPlugin($plugin);
+                    // Assume plugins need to be installed by default or check the `install` key
+                    if (!isset($plugin['install']) || (isset($plugin['install']) && $plugin['install'] === true)) {
+                        $this->installPlugin($plugin);
+                    }
                 }
             }
 

--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -227,7 +227,7 @@ class Craft extends Yii2
         try {
             $dbSetupConfig = $this->_getConfig('dbSetup');
 
-            // Prevent's a static properties bug.
+            // Prevents a static properties bug.
             // Only reset PC when cleaning
             if (isset($dbSetupConfig['clean']) && $dbSetupConfig['clean'] === true) {
                 ProjectConfig::reset();

--- a/tests/_envs/installed.yml
+++ b/tests/_envs/installed.yml
@@ -1,0 +1,8 @@
+# `installed` environment config
+# This environment can be used after a full test has been run once.
+# It expects that the database has been setup and everything installed.
+# Cleanup and setup will be skipped
+modules:
+  config:
+    \craft\test\Craft:
+      dbSetup: {clean: false, setupCraft: false}


### PR DESCRIPTION
### Description
To allow for more rapid testing Commerce will be adding an `installed` Codeception test environment.

This environment disables the cleaning and craft setup during tests. It significantly reduces the time it takes to run the tests as it doesn't have to nuke and re-setup the database at the start of the tests process.

One slight gotcha is that `\craft\test\Craft` was still trying to install the plugin during the test set-up process and during that process due to Project Config being reset the plugin data would be removed.

~This PR adds the ability to add an `install` key to each plugin in the Codeception YAML allowing control over whether or not the plugin should be installed during the process. Leaving out the `install` key will still mean the plugin is installed as is the current behaviour.~

This PR updates the Craft test bootstrap to base setup checks around `clean` and `setupCraft` keys.

As a real-world example, the Commerce Codeception YAML currently looks like the follow:

<details>
<summary>Commerce Codeception YAML</summary>

```yaml
actor: Tester
paths:
  tests: tests
  log: tests/_output
  data: tests/_data
  support: tests/_support
  envs: tests/_envs
bootstrap: _bootstrap.php
coverage:
  enabled: true
  include:
    - src/*
  exclude:
    - src/etc/*
    - src/migrations/*
    - src/templates/*
    - src/translations/*
    - src/web/assets/*
    - docs/*
    - templates/*
    - tests/*
    - vendor/*
params:
  - env
  - tests/.env
modules:
  config:
    \craft\test\Craft:
      configFile: 'tests/_craft/config/test.php'
      entryUrl: 'http://test.craftcms.test/index.php'
      projectConfig: {}
      migrations: []
      plugins:
        commerce:
          class: '\craft\commerce\Plugin'
          handle: commerce
      cleanup: true
      transaction: true
      dbSetup: {clean: true, setupCraft: true}
      fullMock: false
groups:
  elements: [tests/unit/elements]
  models: [tests/unit/models]
  services: [tests/unit/services]
  gql: [tests/unit/gql]
```
</details>

Running the command `codecept run unit` will run all the unit tests as normal cleaning and setting up the database as expected.

Creating a [Codeception environment](https://codeception.com/docs/07-AdvancedUsage#Environments) `installed` with the following config allows us to then run `codecept run unit --env installed`. This takes the root config and merges it over the top. This will prevent the cleaning, setup and prevent the attempt to install the Commerce plugin.

```yaml
modules:
  config:
    \craft\test\Craft:
      dbSetup: {clean: false, setupCraft: false}
```

~It would have been a little easier to reset the whole `plugins` key but unfortunately passing `plugins: []` doesn't work due to the way that Codeception merges the data. The `install` key also gives a little finer controller if there were multiple plugins listed.~

## TODO
- [x] Allow running of tests with `clean` and `craftSetup` set to `false`
- [ ] ~Add `install` key to plugin config options~
- [x] Created `installed` codeception environment
- [x] Check all tests run correctly under `installed` environment
- [ ] ~Document `install` key (if required)~