### PR TITLE
Add fix for 6140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed a bug where renaming an empty volume folder would create a subfolder inside it. ([#7721](https://github.com/craftcms/cms/issues/7721))
 - Fixed a bug where simultaneously-executed MySQL backups could result in a `my.cnf` conflict. ([#7801](https://github.com/craftcms/cms/issues/7801))
 - Fixed a bug where radio button labels weren’t including custom container attributes passed to the input.
-
+- Improved performance for asset query's that have a local volume attached, fixes ([#6140](https://github.com/craftcms/cms/issues/6140))
 ## 3.6.12 - 2021-04-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Fixed a bug where renaming an empty volume folder would create a subfolder inside it. ([#7721](https://github.com/craftcms/cms/issues/7721))
 - Fixed a bug where simultaneously-executed MySQL backups could result in a `my.cnf` conflict. ([#7801](https://github.com/craftcms/cms/issues/7801))
 - Fixed a bug where radio button labels weren’t including custom container attributes passed to the input.
-- Fixed a bug where Assets would cause n+1 queries even when eager-loaded on local volumes. ([#6140](https://github.com/craftcms/cms/issues/6140))
+- Fixed a bug where the `migrate/all` command was attempting to re-apply old content migrations when updating from Craft 3.4 or earlier. ([
+ #7818](https://github.com/craftcms/cms/issues/7818))
+ - Fixed a bug where Assets would cause n+1 queries even when eager-loaded on local volumes. ([#6140](https://github.com/craftcms/cms/issues/6140))
 
 ## 3.6.12 - 2021-04-13
 

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -608,7 +608,7 @@ class Assets extends Component
         if ($index->fileExists) {
             // For local volumes, really make sure
             $volume = $asset->getVolume();
-            $transformPath = $asset->getFolder()->path . $assetTransforms->getTransformSubpath($asset, $index);
+            $transformPath = $asset->folderPath . $assetTransforms->getTransformSubpath($asset, $index);
 
             if ($volume instanceof LocalVolumeInterface && !$volume->fileExists($transformPath)) {
                 $index->fileExists = false;


### PR DESCRIPTION
### Description
Fixed an edge case where asset-queries would still query folders for their paths, even though these are available on the asset model. Fixed #6140 