### PR TITLE
Add fieldsLocation param to UsersController and GlobalsController

### DIFF
--- a/src/controllers/GlobalsController.php
+++ b/src/controllers/GlobalsController.php
@@ -246,7 +246,8 @@ class GlobalsController extends Controller
             $this->requirePermission('editSite:' . $site->uid);
         }
 
-        $globalSet->setFieldValuesFromRequest('fields');
+        $fieldsLocation = $this->request->getParam('fieldsLocation', 'fields');
+        $globalSet->setFieldValuesFromRequest($fieldsLocation);
         $globalSet->setScenario(Element::SCENARIO_LIVE);
 
         if (!Craft::$app->getElements()->saveElement($globalSet)) {

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1222,7 +1222,8 @@ class UsersController extends Controller
         }
 
         // If this is Craft Pro, grab any profile content from post
-        $user->setFieldValuesFromRequest('fields');
+        $fieldsLocation = $this->request->getParam('fieldsLocation', 'fields');
+        $user->setFieldValuesFromRequest($fieldsLocation);
 
         // Validate and save!
         // ---------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the ability to rename the param that defines the custom field values to update in the `UsersController` and `GlobalsController` by adding the `fieldsLocation` param. This brings the controller behaviour in line with the `EntriesController`, `CategoriesController` and `AssetsController`.

The arguments for making the behaviour the same are consistency and reducing the chances of errors when working with submitted fields in front-end forms.

```php
// Get fields sent to the UsersController.
$fields = Craft::$app->request->getBodyParam('fields');
```

```php
// Get fields sent to the EntriesController.
$fieldsLocation = Craft::$app->request->getBodyParam('fieldsLocation', 'fields');
$fields = Craft::$app->request->getBodyParam($fieldsLocation);
```

The differences in code are especially critical when performing any sort of security checks such as allowed/disallowed fields in front-end form submissions. An example can be seen [in this Gist](https://gist.github.com/bencroker/87a4b9337543f9c2b232225936e3920b).