### PR TITLE
Force plugin uninstallation

### DIFF
--- a/src/console/controllers/PluginController.php
+++ b/src/console/controllers/PluginController.php
@@ -21,6 +21,28 @@ use yii\console\ExitCode;
 class PluginController extends Controller
 {
     /**
+     * @var bool Whether the plugin uninstallation should be forced.
+     * @since 3.6.14
+     */
+    public $force = false;
+
+    /**
+     * @inheritdoc
+     */
+    public function options($actionID)
+    {
+        $options = parent::options($actionID);
+
+        switch ($actionID) {
+            case 'uninstall':
+                $options[] = 'force';
+                break;
+        }
+
+        return $options;
+    }
+
+    /**
      * @inheritdoc
      */
     public function beforeAction($action)
@@ -64,9 +86,13 @@ class PluginController extends Controller
         $start = microtime(true);
 
         try {
-            Craft::$app->plugins->uninstallPlugin($handle);
+            Craft::$app->plugins->uninstallPlugin($handle, $this->force);
         } catch (\Throwable $e) {
-            $this->stderr("*** failed to uninstall {$handle}: {$e->getMessage()}" . PHP_EOL . PHP_EOL, Console::FG_RED);
+            $this->stderr("*** failed to uninstall {$handle}: {$e->getMessage()}" . PHP_EOL, Console::FG_RED);
+            if (!$this->force) {
+                $this->stderr('Try again with --force.' . PHP_EOL);
+            }
+            $this->stderr(PHP_EOL);
             return ExitCode::UNSPECIFIED_ERROR;
         }
 

--- a/src/console/controllers/ProjectConfigController.php
+++ b/src/console/controllers/ProjectConfigController.php
@@ -322,21 +322,10 @@ class ProjectConfigController extends Controller
             $this->stdout(' ... ', Console::FG_YELLOW);
 
             ob_start();
+            $pluginsService->uninstallPlugin($handle, true);
+            ob_end_clean();
 
-            try {
-                $pluginsService->uninstallPlugin($handle);
-                ob_end_clean();
-                $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
-            } catch (\Throwable $e) {
-                ob_end_clean();
-                $this->stdout('error: ' . $e->getMessage() . PHP_EOL, Console::FG_RED);
-                Craft::$app->getErrorHandler()->logException($e);
-
-                // Just remove the row
-                Db::delete(Table::PLUGINS, [
-                    'handle' => $handle,
-                ]);
-            }
+            $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
         }
     }
 

--- a/src/controllers/ConfigSyncController.php
+++ b/src/controllers/ConfigSyncController.php
@@ -80,18 +80,7 @@ class ConfigSyncController extends BaseUpdaterController
     public function actionUninstallPlugin(): Response
     {
         $handle = array_shift($this->data['uninstallPlugins']);
-
-        try {
-            Craft::$app->getPlugins()->uninstallPlugin($handle);
-        } catch (\Throwable $e) {
-            Craft::warning("Could not uninstall plugin \"$handle\" that was removed from your project config YAML files: " . $e->getMessage());
-
-            // Just remove the row
-            Db::delete(Table::PLUGINS, [
-                'handle' => $handle,
-            ]);
-        }
-
+        Craft::$app->getPlugins()->uninstallPlugin($handle, true);
         return $this->sendNextAction($this->_nextApplyYamlAction());
     }
 

--- a/src/services/Plugins.php
+++ b/src/services/Plugins.php
@@ -582,35 +582,39 @@ class Plugins extends Component
      * Uninstalls a plugin by its handle.
      *
      * @param string $handle The plugin’s handle
+     * @param bool $force Whether to force the plugin uninstallation, even if it is disabled, its
+     * `uninstall()` method returns `false`, or its files aren’t present or its
      * @return bool Whether the plugin was uninstalled successfully
      * @throws InvalidPluginException if the plugin doesn’t exist
      * @throws \Throwable if reasons
      */
-    public function uninstallPlugin(string $handle): bool
+    public function uninstallPlugin(string $handle, bool $force = false): bool
     {
         $this->loadPlugins();
 
-        if (!$this->isPluginEnabled($handle)) {
-            // Don't allow uninstalling disabled plugins, because that could be buggy
-            // if the plugin was composer-updated while disabled, and its uninstall()
-            // function is out of sync with what's actually in the database
-            if ($this->isPluginInstalled($handle)) {
-                throw new InvalidPluginException($handle, 'Uninstalling disabled plugins is not allowed.');
-            }
+        if (!$this->isPluginInstalled($handle)) {
             // It's already uninstalled
             return true;
         }
+
+        if (!$force && !$this->isPluginEnabled($handle)) {
+            // Don't allow uninstalling disabled plugins, because that could be buggy
+            // if the plugin was composer-updated while disabled, and its uninstall()
+            // function is out of sync with what's actually in the database
+            throw new InvalidPluginException($handle, 'Uninstalling disabled plugins is not allowed.');
+        }
+
         // Temporarily allow changes to the project config even if it's supposed to be read only
         $projectConfig = Craft::$app->getProjectConfig();
         $readOnly = $projectConfig->readOnly;
         $projectConfig->readOnly = false;
 
-        if (($plugin = $this->getPlugin($handle)) === null) {
+        if (($plugin = $this->getPlugin($handle)) === null && !$force) {
             throw new InvalidPluginException($handle);
         }
 
         // Fire a 'beforeUninstallPlugin' event
-        if ($this->hasEventHandlers(self::EVENT_BEFORE_UNINSTALL_PLUGIN)) {
+        if ($plugin && $this->hasEventHandlers(self::EVENT_BEFORE_UNINSTALL_PLUGIN)) {
             $this->trigger(self::EVENT_BEFORE_UNINSTALL_PLUGIN, new PluginEvent([
                 'plugin' => $plugin,
             ]));
@@ -619,9 +623,8 @@ class Plugins extends Component
         $transaction = Craft::$app->getDb()->beginTransaction();
         try {
             // Let the plugin uninstall itself first
-            if ($plugin->uninstall() === false) {
+            if ($plugin && ($plugin->uninstall() === false) && !$force) {
                 $transaction->rollBack();
-
                 return false;
             }
 
@@ -648,11 +651,14 @@ class Plugins extends Component
             $projectConfig->remove(self::CONFIG_PLUGINS_KEY . '.' . $handle, "Uninstall the “{$handle}” plugin");
         }
 
-        $this->_unregisterPlugin($plugin);
+        if ($plugin) {
+            $this->_unregisterPlugin($plugin);
+        }
+
         unset($this->_enabledPluginInfo[$handle]);
 
         // Fire an 'afterUninstallPlugin' event
-        if ($this->hasEventHandlers(self::EVENT_AFTER_UNINSTALL_PLUGIN)) {
+        if ($plugin && $this->hasEventHandlers(self::EVENT_AFTER_UNINSTALL_PLUGIN)) {
             $this->trigger(self::EVENT_AFTER_UNINSTALL_PLUGIN, new PluginEvent([
                 'plugin' => $plugin,
             ]));

--- a/src/services/Plugins.php
+++ b/src/services/Plugins.php
@@ -597,7 +597,9 @@ class Plugins extends Component
             return true;
         }
 
-        if (!$force && !$this->isPluginEnabled($handle)) {
+        $enabled = $this->isPluginEnabled($handle);
+
+        if (!$enabled && !$force) {
             // Don't allow uninstalling disabled plugins, because that could be buggy
             // if the plugin was composer-updated while disabled, and its uninstall()
             // function is out of sync with what's actually in the database
@@ -623,7 +625,7 @@ class Plugins extends Component
         $transaction = Craft::$app->getDb()->beginTransaction();
         try {
             // Let the plugin uninstall itself first
-            if ($plugin && ($plugin->uninstall() === false) && !$force) {
+            if ($plugin && $enabled && ($plugin->uninstall() === false) && !$force) {
                 $transaction->rollBack();
                 return false;
             }


### PR DESCRIPTION
This PR adds a `$force` arg to `craft\services\Plugins::uninstallPlugin()`, which forces the plugin to be removed from the `plugins` table and project config, even if:

- it’s disabled
- it’s enabled but its `uninstall()` method returns `false`
- its files aren’t present (Composer-uninstalled already)

To avoid unexpected PHP errors, if plugin uninstallation is forced for a disabled plugin, its `uninstall()` method will **not** be called.