### PR TITLE
Fix Guzzle config params not merged

### DIFF
--- a/src/Craft.php
+++ b/src/Craft.php
@@ -346,7 +346,8 @@ EOD;
         $guzzleConfig = static::$app->getConfig()->getConfigFromFile('guzzle');
 
         // Merge everything together
-        $guzzleConfig = ArrayHelper::merge($defaultConfig, $guzzleConfig, $config);
+        $guzzleConfig = ArrayHelper::merge($defaultConfig, $guzzleConfig);
+        $guzzleConfig = ArrayHelper::merge($guzzleConfig, $config);
 
         return new Client($guzzleConfig);
     }

--- a/src/Craft.php
+++ b/src/Craft.php
@@ -347,9 +347,9 @@ EOD;
 
         // Merge everything together
         $guzzleConfig = ArrayHelper::merge($defaultConfig, $guzzleConfig);
-        $guzzleConfig = ArrayHelper::merge($guzzleConfig, $config);
+        $config = ArrayHelper::merge($guzzleConfig, $config);
 
-        return new Client($guzzleConfig);
+        return new Client($config);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/craftcms/cms/commit/a81de4d50da933e5eeaa50e105f0e64d9a24d3a0, which incorrectly ignores config params when merging config settings.
