### PR TITLE
Added preferSite argument to Element Arguments

### DIFF
--- a/src/gql/base/ElementArguments.php
+++ b/src/gql/base/ElementArguments.php
@@ -45,6 +45,11 @@ abstract class ElementArguments extends Arguments
                 'type' => Type::boolean(),
                 'description' => 'Determines whether only elements with unique IDs should be returned by the query.',
             ],
+            'preferSite' => [
+                'name' => 'preferSite',
+                'type' => Type::listOf(Type::string()),
+                'description' => 'Determines which site should be selected when querying multi-site elements.',
+            ],
             'enabledForSite' => [
                 'name' => 'enabledForSite',
                 'type' => Type::boolean(),


### PR DESCRIPTION
### Description

Adds preferSite to the ElementArguments.

For example, when querying siteA and siteB for the homepage, you could prefer siteB like this:
```
query Entry {
  entry(
    uri: "__home__", 
    site: ["siteA", "siteB"], 
    unique: true,
    preferSites: ["siteB"]
  ) {
   id
  }
}

```

Only the type definition is added since the rest is already part of craft's Models.

