### PR TITLE
Adding Ability for GQL to parse dates as System Timezone Defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Craft CMS 3.x
 
+## 3.7.0 - Unreleased
+- Added the `$enableGraphQlSystemTimezone` setting, when set to true GQL DateTime types will by default return dates in the set System Timezone, when set to false it will return dates as UTC
+
 ## 3.6.16 - 2021-06-01
 
 ### Added

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -657,6 +657,17 @@ class GeneralConfig extends BaseObject
     public $enableGraphQlCaching = true;
 
     /**
+     * @var bool Whether Craft should use the system date for default GraphQL dates.
+     *
+     * If set to `true`, Craft will use the system timezone when returning DateTime Objects in favor of UTC. 
+     *
+     *
+     * @since 3.7.0
+     * @group GraphQL
+     */
+    public $enableGraphQlSystemTimezone = false;
+
+    /**
      * @var bool Whether to enable Craft’s template `{% cache %}` tag on a global basis.
      * @see http://craftcms.com/docs/templating/cache
      * @group System

--- a/src/gql/directives/FormatDateTime.php
+++ b/src/gql/directives/FormatDateTime.php
@@ -54,7 +54,7 @@ class FormatDateTime extends Directive
                     'name' => 'timezone',
                     'type' => Type::string(),
                     'description' => 'The full name of the timezone, defaults to UTC. (E.g., America/New_York)',
-                    'defaultValue' => self::DEFAULT_TIMEZONE,
+                    'defaultValue' => self::defaultTimezone(),
                 ]),
                 new FieldArgument([
                     'name' => 'locale',
@@ -84,7 +84,7 @@ class FormatDateTime extends Directive
         if ($value instanceof \DateTime) {
             /* @var \DateTime $value */
             $format = $arguments['format'] ?? self::DEFAULT_FORMAT;
-            $timezone = $arguments['timezone'] ?? self::DEFAULT_TIMEZONE;
+            $timezone = $arguments['timezone'] ?? self::defaultTimezone();
 
             // Is this a custom PHP date format?
             if ($format !== null && !in_array($format, [Locale::LENGTH_SHORT, Locale::LENGTH_MEDIUM, Locale::LENGTH_LONG, Locale::LENGTH_FULL], true)) {
@@ -107,5 +107,13 @@ class FormatDateTime extends Directive
         }
 
         return $value;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function defaultTimezone(): string
+    {
+        return Craft::$app->getConfig()->getGeneral()->enableGraphQlSystemTimezone ? Craft::$app->getTimezone() : self::DEFAULT_TIMEZONE;
     }
 }

--- a/src/gql/types/DateTime.php
+++ b/src/gql/types/DateTime.php
@@ -62,7 +62,7 @@ class DateTime extends ScalarType
     {
         // The value not being a datetime would indicate an already formatted date.
         if ($value instanceof \DateTime) {
-            $value->setTimezone(new \DateTimeZone(FormatDateTime::DEFAULT_TIMEZONE));
+            $value->setTimezone(new \DateTimeZone(FormatDateTime::defaultTimezone();));
             $value = $value->format(FormatDateTime::DEFAULT_FORMAT);
         }
 

--- a/tests/unit/gql/ScalarTypesTest.php
+++ b/tests/unit/gql/ScalarTypesTest.php
@@ -109,7 +109,7 @@ class ScalarTypesTest extends Unit
         return [
             [DateTime::getType(), 'testString', 'testString'],
             [DateTime::getType(), null, null],
-            [DateTime::getType(), clone $now, $now->setTimezone(new \DateTimeZone(FormatDateTime::DEFAULT_TIMEZONE))->format(FormatDateTime::DEFAULT_FORMAT)],
+            [DateTime::getType(), clone $now, $now->setTimezone(new \DateTimeZone(FormatDateTime::defaultTimezone();))->format(FormatDateTime::DEFAULT_FORMAT)],
 
             [Number::getType(), 'testString', 'testString'],
             [Number::getType(), '', null],


### PR DESCRIPTION
### Description

This PR adds a simple small addition:

Currently when parsing a date through a GQL query, the timezone will ALWAYS be UTC unless you specifically set the directive `@formatDateTime(timezone: "Europe/London")` which would then apply the `Europe/London` timezone.

This can get quite cumbersome when working with a lot of dates in a project and queries relying on these dates. 
Not all projects need timezone support, not all headless projects need timezone support.

So it would be nice, that the default parsing of the DateTime could be set to the system time zone when returning data.

--> in my general settings of the site I have set `"Europe/London"` , I want all my dates returned by GQL to follow that specific timezone. 

In this PR I have added a general config setting ( because it's global for GQL in this case ) `$enableGraphQlSystemTimezone`, this has by default been set to false, to not break any installs relying on UTC.

In the `FormatDateTime` directive a new method has been created that will determine if this setting is set and will return the system timezone or the default timezone set:

```
    /**
     * @inheritdoc
     */
    public static function defaultTimezone(): string
    {
        return Craft::$app->getConfig()->getGeneral()->enableGraphQlSystemTimezone ? Craft::$app->getTimezone() : self::DEFAULT_TIMEZONE;
    }
```
    
The instances using `self::DEFAULT_TIMEZONE` have been replace by `self::defaultTimezone()`
    
 Always open for any other ideas or suggestions! 

