### PR TITLE
Make global sets custom-sortable

### DIFF
--- a/CHANGELOG-v3.7.md
+++ b/CHANGELOG-v3.7.md
@@ -7,6 +7,7 @@
 - Edit Entry pages no longer appear to create a draft when the Current revision is edited within Live Preview. Unsaved changes are now stored within a “provisional draft”, which is mostly hidden from the author. ([#7899](https://github.com/craftcms/cms/pull/7899))
 - Category groups now have a “Default Category Placement” setting, which determines where new categories should be placed within the structure by default. ([#7759](https://github.com/craftcms/cms/issues/7759))
 - Structure sections now have a “Default Entry Placement” setting, which determines where new entries should be placed within the structure by default. ([#7759](https://github.com/craftcms/cms/issues/7759))
+- It’s now possible to reorder global sets. ([#4972](https://github.com/craftcms/cms/issues/4972))
 - Date fields now have a “Show Time Zone” setting, allowing authors to choose which time zone the date is set to, rather than using the system time zone.
 - Matrix fields can now be set to custom propagation methods, based on a propagation key template. ([#7610](https://github.com/craftcms/cms/issues/7610))
 - Added a “Refresh” button to Live Preview, for preview targets whose “Auto-refresh” (formerly “Refresh”) setting is disabled.

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '3.7.0-alpha',
-    'schemaVersion' => '3.7.5',
+    'schemaVersion' => '3.7.6',
     'minVersionRequired' => '2.6.2788',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/controllers/GlobalsController.php
+++ b/src/controllers/GlobalsController.php
@@ -10,6 +10,7 @@ namespace craft\controllers;
 use Craft;
 use craft\base\Element;
 use craft\elements\GlobalSet;
+use craft\helpers\Json;
 use craft\helpers\UrlHelper;
 use craft\web\Controller;
 use yii\web\BadRequestHttpException;
@@ -91,6 +92,23 @@ class GlobalsController extends Controller
 
         $this->setSuccessFlash(Craft::t('app', 'Global set saved.'));
         return $this->redirectToPostedUrl($globalSet);
+    }
+
+    /**
+     * Reorders global sets.
+     *
+     * @return Response
+     * @since 3.7.0
+     */
+    public function actionReorderSets(): Response
+    {
+        $this->requirePostRequest();
+        $this->requireAcceptsJson();
+
+        $setIds = Json::decode($this->request->getRequiredBodyParam('ids'));
+        Craft::$app->getGlobals()->reorderSets($setIds);
+
+        return $this->asJson(['success' => true]);
     }
 
     /**

--- a/src/elements/GlobalSet.php
+++ b/src/elements/GlobalSet.php
@@ -151,6 +151,12 @@ class GlobalSet extends Element
     public $handle;
 
     /**
+     * @var int Sort order
+     * @since 3.7.0
+     */
+    public $sortOrder;
+
+    /**
      * Use the global set's name as its string representation.
      *
      * @return string
@@ -275,6 +281,7 @@ class GlobalSet extends Element
         $config = [
             'name' => $this->name,
             'handle' => $this->handle,
+            'sortOrder' => (int)$this->sortOrder,
         ];
 
         $fieldLayout = $this->getFieldLayout();

--- a/src/elements/db/GlobalSetQuery.php
+++ b/src/elements/db/GlobalSetQuery.php
@@ -52,6 +52,19 @@ class GlobalSetQuery extends ElementQuery
     public $handle;
 
     /**
+     * @inheritdoc
+     */
+    public function __construct(string $elementType, array $config = [])
+    {
+        // todo: set this from the property def in v4
+        if (version_compare(Craft::$app->getInstalledSchemaVersion(), '3.7.6', '>=')) {
+            $this->defaultOrderBy = ['globalsets.sortOrder' => SORT_ASC];
+        }
+
+        parent::__construct($elementType, $config);
+    }
+
+    /**
      * Sets the [[$editable]] property.
      *
      * @param bool $value The property value (defaults to true)
@@ -112,6 +125,7 @@ class GlobalSetQuery extends ElementQuery
         $this->query->select([
             'globalsets.name',
             'globalsets.handle',
+            'globalsets.sortOrder',
             'globalsets.uid',
         ]);
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -395,6 +395,7 @@ class Install extends Migration
             'name' => $this->string()->notNull(),
             'handle' => $this->string()->notNull(),
             'fieldLayoutId' => $this->integer(),
+            'sortOrder' => $this->smallInteger()->unsigned(),
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
             'uid' => $this->uid(),
@@ -835,6 +836,7 @@ class Install extends Migration
         $this->createIndex(null, Table::GLOBALSETS, ['name'], false);
         $this->createIndex(null, Table::GLOBALSETS, ['handle'], false);
         $this->createIndex(null, Table::GLOBALSETS, ['fieldLayoutId'], false);
+        $this->createIndex(null, Table::GLOBALSETS, ['sortOrder'], false);
         $this->createIndex(null, Table::GQLTOKENS, ['accessToken'], true);
         $this->createIndex(null, Table::GQLTOKENS, ['name'], true);
         $this->createIndex(null, Table::MATRIXBLOCKS, ['ownerId'], false);

--- a/src/migrations/m210613_145522_sortable_global_sets.php
+++ b/src/migrations/m210613_145522_sortable_global_sets.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace craft\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\db\Table;
+use craft\helpers\MigrationHelper;
+use craft\services\Globals;
+use craft\services\ProjectConfig;
+use yii\base\BaseObject;
+
+/**
+ * m210613_145522_sortable_global_sets migration.
+ */
+class m210613_145522_sortable_global_sets extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->addColumn(Table::GLOBALSETS, 'sortOrder', $this->smallInteger()->unsigned()->after('fieldLayoutId'));
+        $this->createIndex(null, Table::GLOBALSETS, ['sortOrder'], false);
+
+        $projectConfig = Craft::$app->getProjectConfig();
+        $schemaVersion = $projectConfig->get('system.schemaVersion', true);
+
+        if (version_compare($schemaVersion, '3.7.6', '>=')) {
+            return;
+        }
+
+        $uids = (new Query())
+            ->select(['uid'])
+            ->from([Table::GLOBALSETS])
+            ->orderBy(['name' => SORT_ASC])
+            ->column();
+
+        foreach ($uids as $i => $uid) {
+            $projectConfig->set(Globals::CONFIG_GLOBALSETS_KEY . ".$uid.sortOrder", $i + 1);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        MigrationHelper::dropIndexIfExists(Table::GLOBALSETS, ['sortOrder'], false, $this);
+        $this->dropColumn(Table::GLOBALSETS, 'sortOrder');
+    }
+}

--- a/src/records/GlobalSet.php
+++ b/src/records/GlobalSet.php
@@ -21,6 +21,7 @@ use yii\db\ActiveQueryInterface;
  * @property int $fieldLayoutId Field layout ID
  * @property string $name Name
  * @property string $handle Handle
+ * @property int $sortOrder Sort order
  * @property Element $element Element
  * @property FieldLayout $fieldLayout Field layout
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>

--- a/src/services/Globals.php
+++ b/src/services/Globals.php
@@ -23,6 +23,7 @@ use craft\helpers\ProjectConfig as ProjectConfigHelper;
 use craft\helpers\StringHelper;
 use craft\models\FieldLayout;
 use craft\records\GlobalSet as GlobalSetRecord;
+use yii\base\BaseObject;
 use yii\base\Component;
 
 /**
@@ -295,6 +296,9 @@ class Globals extends Component
 
         if ($isNewSet) {
             $globalSet->uid = $globalSet->uid ?: StringHelper::UUID();
+            $globalSet->sortOrder = (new Query())
+                    ->from([Table::GLOBALSETS])
+                    ->max('[[sortOrder]]') + 1;
         } else if (!$globalSet->uid) {
             $globalSet->uid = Db::uidById(Table::GLOBALSETS, $globalSet->id);
         }
@@ -331,6 +335,7 @@ class Globals extends Component
 
             $globalSetRecord->name = $data['name'];
             $globalSetRecord->handle = $data['handle'];
+            $globalSetRecord->sortOrder = $data['sortOrder'] ?? 0;
             $globalSetRecord->uid = $globalSetUid;
 
             if (!empty($data['fieldLayouts'])) {
@@ -404,6 +409,30 @@ class Globals extends Component
 
         // Invalidate all element caches
         Craft::$app->getElements()->invalidateAllCaches();
+    }
+
+    /**
+     * Reorders global sets.
+     *
+     * @param array $setIds
+     * @return bool
+     * @throws \Throwable
+     * @since 3.7.0
+     */
+    public function reorderSets(array $setIds): bool
+    {
+        $projectConfig = Craft::$app->getProjectConfig();
+
+        $uidsByIds = Db::uidsByIds(Table::GLOBALSETS, $setIds);
+
+        foreach ($setIds as $i => $setId) {
+            if (!empty($uidsByIds[$setId])) {
+                $setUid = $uidsByIds[$setId];
+                $projectConfig->set(self::CONFIG_GLOBALSETS_KEY . ".$setUid.sortOrder", $i + 1, 'Reorder global sets');
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/templates/settings/globals/index.html
+++ b/src/templates/settings/globals/index.html
@@ -52,6 +52,7 @@ new Craft.VueAdminTable({
     container: '#sets-vue-admin-table',
     deleteAction: 'globals/delete-set',
     emptyMessage: Craft.t('app', 'No global sets exist yet.'),
+    reorderAction: '{{ globalSets|length > 1 ? 'globals/reorder-sets' : ''}}',
     tableData: {{ tableData|json_encode|raw }}
-    });
+});
 {% endjs %}


### PR DESCRIPTION
Adds the ability to reorder global sets from **Settings** → **Globals**, which sets the default order that global sets are returned by global set queries, as well as the order they’re listed in the **Globals** section.

By default, global sets will be ordered alphabetically by name, as before.

Resolves #4972