### PR TITLE
previewTokenDuration config setting

### DIFF
--- a/CHANGELOG-v3.7.md
+++ b/CHANGELOG-v3.7.md
@@ -135,7 +135,7 @@
 - The `defaultCpLanguage` config setting no longer affects console requests. ([#7747](https://github.com/craftcms/cms/issues/7747))
 - The `{% cache %}` tag now stores any JavaScript or CSS code registered with `{% js %}`, `{% script %}`, and `{% css %}` tags. ([#7758](https://github.com/craftcms/cms/issues/7758))
 - The `date()` Twig function now supports arrays with `date` and/or `time` keys. ([#7681](https://github.com/craftcms/cms/issues/7681))
-- JavaScript code registered with `{% js %}` tags or `craft\web\View::registerJs()` is now automatically wrapped in self-executing functions. ([#8055](https://github.com/craftcms/cms/issues/8055))
+- JavaScript code registered with `{% js %}` tags or `craft\web\View::registerJs()` is now automatically wrapped in a self-executing function. ([#8055](https://github.com/craftcms/cms/issues/8055))
 - Custom field column names now include a random string, preventing column name conflicts when deploying multiple project config changes at once. ([#6922](https://github.com/craftcms/cms/issues/6922))
 - Custom fields can now store data across multiple columns in the `content` table.
 - Channel and Structure sections’ initial entry types are now named “Default” by default. ([#7078](https://github.com/craftcms/cms/issues/7078))

--- a/CHANGELOG-v3.7.md
+++ b/CHANGELOG-v3.7.md
@@ -15,6 +15,7 @@
 - Added the `siteSettingsId` element query and GraphQL API query parameter for all elements.
 - Added the `preferSites` GraphQL API query argument for all elements. ([#8006](https://github.com/craftcms/cms/pull/8006))
 - Added the `ancestors`, `descendants`, `drafts`, `draftCreator`, `revisions`, `currentRevision`, and `revisionCreator` fields to entry GraphQL queries. ([#7950]((https://github.com/craftcms/cms/issues/7950)))
+- Added the `previewTokenDuration` config setting. ([#2394](https://github.com/craftcms/cms/issues/2394))
 - Added the `revAssetUrls` config setting. ([#7847](https://github.com/craftcms/cms/issues/7847))
 - Added the `setGraphqlDatesToSystemTimeZone` config setting. ([#8016](https://github.com/craftcms/cms/pull/8016))
 - Added the “Validate custom fields on public registration” user setting. ([#4229](https://github.com/craftcms/cms/issues/4229))
@@ -96,6 +97,7 @@
 - Added `craft\services\Elements::mergeCanonicalChanges()`.
 - Added `craft\services\Elements::updateCanonicalElement()`.
 - Added `craft\services\Matrix::mergeCanonicalChanges()`.
+- Added `craft\services\Tokens::createPreviewToken()`.
 - Added `craft\web\Request::checkIfActionRequest()`.
 - Added `craft\web\View::clearCssBuffer()`.
 - Added `craft\web\View::clearScriptBuffer()`.

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1169,6 +1169,17 @@ class GeneralConfig extends BaseObject
     public $previewIframeResizerOptions = [];
 
     /**
+     * @var mixed The amount of time content preview tokens can be used before expiring.
+     *
+     * See [[ConfigHelper::durationInSeconds()]] for a list of supported value types.
+     *
+     * @group Security
+     * @defaultAlt 1 day
+     * @since 3.7.0
+     */
+    public $previewTokenDuration = 86400;
+
+    /**
      * @var mixed The amount of time to wait before Craft purges pending users from the system that have not activated.
      *
      * Any content assigned to a pending user will be deleted as well when the given time interval passes.
@@ -1778,6 +1789,7 @@ class GeneralConfig extends BaseObject
         $this->defaultTokenDuration = ConfigHelper::durationInSeconds($this->defaultTokenDuration);
         $this->elevatedSessionDuration = ConfigHelper::durationInSeconds($this->elevatedSessionDuration);
         $this->invalidLoginWindowDuration = ConfigHelper::durationInSeconds($this->invalidLoginWindowDuration);
+        $this->previewTokenDuration = ConfigHelper::durationInSeconds($this->previewTokenDuration);
         $this->purgePendingUsersDuration = ConfigHelper::durationInSeconds($this->purgePendingUsersDuration);
         $this->purgeUnsavedDraftsDuration = ConfigHelper::durationInSeconds($this->purgeUnsavedDraftsDuration);
         $this->rememberUsernameDuration = ConfigHelper::durationInSeconds($this->rememberUsernameDuration);

--- a/src/controllers/CategoriesController.php
+++ b/src/controllers/CategoriesController.php
@@ -593,7 +593,7 @@ class CategoriesController extends Controller
         }
 
         // Create the token and redirect to the category URL with the token in place
-        $token = Craft::$app->getTokens()->createToken([
+        $token = Craft::$app->getTokens()->createPreviewToken([
             'categories/view-shared-category',
             [
                 'categoryId' => $categoryId,

--- a/src/controllers/LivePreviewController.php
+++ b/src/controllers/LivePreviewController.php
@@ -57,16 +57,13 @@ class LivePreviewController extends Controller
             throw new BadRequestHttpException('Request missing required body param');
         }
 
-        // Create a 24 hour token
-        $route = [
+        // Create the token
+        $token = Craft::$app->getTokens()->createPreviewToken([
             'live-preview/preview', [
                 'previewAction' => $action,
                 'userId' => Craft::$app->getUser()->getId(),
             ],
-        ];
-
-        $expiryDate = (new \DateTime())->add(new \DateInterval('P1D'));
-        $token = Craft::$app->getTokens()->createToken($route, null, $expiryDate);
+        ]);
 
         if (!$token) {
             throw new ServerErrorHttpException('Could not create a Live Preview token.');

--- a/src/controllers/PreviewController.php
+++ b/src/controllers/PreviewController.php
@@ -67,8 +67,8 @@ class PreviewController extends Controller
             $this->requireAuthorization('previewElement:' . $sourceId);
         }
 
-        // Create a 24 hour token
-        $route = [
+        // Create the token
+        $token = Craft::$app->getTokens()->createPreviewToken([
             'preview/preview', [
                 'elementType' => $elementType,
                 'sourceId' => (int)$sourceId,
@@ -77,9 +77,7 @@ class PreviewController extends Controller
                 'revisionId' => (int)$revisionId ?: null,
                 'provisional' => $provisional,
             ],
-        ];
-
-        $token = Craft::$app->getTokens()->createToken($route);
+        ]);
 
         if (!$token) {
             throw new ServerErrorHttpException(Craft::t('app', 'Could not create a preview token.'));

--- a/src/services/Tokens.php
+++ b/src/services/Tokens.php
@@ -55,7 +55,7 @@ class Tokens extends Component
      * Defaults to the 'defaultTokenDuration' config setting.
      * @return string|false The generated token, or `false` if there was an error.
      */
-    public function createToken($route, int $usageLimit = null, DateTime $expiryDate = null)
+    public function createToken($route, ?int $usageLimit = null, ?DateTime $expiryDate = null)
     {
         if (!$expiryDate) {
             $generalConfig = Craft::$app->getConfig()->getGeneral();
@@ -81,6 +81,22 @@ class Tokens extends Component
         }
 
         return false;
+    }
+
+    /**
+     * Creates a new token for previewing content, using the <config3:previewTokenDuration> to determine the duration, if set.
+     *
+     * @param mixed $route Where matching requests should be routed to.
+     * @param int|null $usageLimit The maximum number of times this token can be
+     * used. Defaults to no limit.
+     * @return string|false The generated token, or `false` if there was an error.
+     * @since 3.7.0
+     */
+    public function createPreviewToken($route, ?int $usageLimit = null)
+    {
+        $interval = DateTimeHelper::secondsToInterval(Craft::$app->getConfig()->getGeneral()->previewTokenDuration);
+        $expiryDate = DateTimeHelper::currentUTCDateTime()->add($interval);
+        return $this->createToken($route, $usageLimit, $expiryDate);
     }
 
     /**


### PR DESCRIPTION
Adds a new `previewTokenDuration` config setting, which determines how long content preview tokens (e.g. entry Preview / Share buttons) should last, independently of the `defaultTokenDuration` config setting.

Resolves #2394

**This PR Addresses:**  
[DEV-41 previewTokenDuration config setting](https://linear.app/craftcms/issue/DEV-41/previewtokenduration-config-setting)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>