### PR TITLE
fix m200620_230205_field_layout_changes migration

### DIFF
--- a/src/migrations/m200620_230205_field_layout_changes.php
+++ b/src/migrations/m200620_230205_field_layout_changes.php
@@ -19,9 +19,15 @@ class m200620_230205_field_layout_changes extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn(Table::FIELDLAYOUTTABS, 'elements', $this->text()->after('name'));
+        if (!$this->db->columnExists(Table::FIELDLAYOUTTABS, 'elements')) {
+            $this->addColumn(Table::FIELDLAYOUTTABS, 'elements', $this->text()->after('name'));
+        }
 
-        $this->dropColumn(Table::ENTRYTYPES, 'titleLabel');
+        if ($this->db->columnExists(Table::ENTRYTYPES, 'titleLabel')) {
+            $this->dropColumn(Table::ENTRYTYPES, 'titleLabel');
+        }
+        
+        
         if ($this->db->columnExists(Table::ENTRYTYPES, 'titleInstructions')) {
             $this->dropColumn(Table::ENTRYTYPES, 'titleInstructions');
         }


### PR DESCRIPTION
Safely check if the column to drop / add already exists

### Description

The m200620_230205_field_layout_changes migration checks if the titleInstructions exists, but not in titleLabel, and also doesn't check for the 'elements' column before trying to add it.

This fixes the `Column already exists: 1060 Duplicate column name 'elements'` error when trying to upgrade directly from 3.4.x to 3.6.17.

