### PR TITLE
Improve `backup` phrasing

### DIFF
--- a/src/console/controllers/BackupTrait.php
+++ b/src/console/controllers/BackupTrait.php
@@ -75,7 +75,7 @@ trait BackupTrait
             return $backupOnUpdate;
         }
 
-        return $this->confirm('Back up the database?', $backupOnUpdate);
+        return $this->confirm('Create database backup?', $backupOnUpdate);
     }
 
     /**

--- a/src/console/controllers/BackupTrait.php
+++ b/src/console/controllers/BackupTrait.php
@@ -75,7 +75,7 @@ trait BackupTrait
             return $backupOnUpdate;
         }
 
-        return $this->confirm('Backup the database?', $backupOnUpdate);
+        return $this->confirm('Back up the database?', $backupOnUpdate);
     }
 
     /**


### PR DESCRIPTION
### Description

Another excruciating one-character PR because [_backup_ is a noun, but _back up_ is a verb](https://www.merriam-webster.com/dictionary/backup).

Revised in favor of [@Mosnar’s suggestion](https://github.com/craftcms/cms/pull/9060#issuecomment-866176476).