### PR TITLE
Add getter method to WidgetTrait.

### DIFF
--- a/src/base/WidgetTrait.php
+++ b/src/base/WidgetTrait.php
@@ -19,4 +19,12 @@ trait WidgetTrait
      * @var int|null The user’s chosen cospan for the widget
      */
     public $colspan;
+    
+    /**
+     * @return int|null
+     */
+    public function getColspan(): ?int
+    {
+        return $this->colspan;
+    }
 }

--- a/src/base/WidgetTrait.php
+++ b/src/base/WidgetTrait.php
@@ -18,7 +18,7 @@ trait WidgetTrait
     /**
      * @var int|null The user’s chosen cospan for the widget
      */
-    public $colspan;
+    protected $colspan;
     
     /**
      * @return int|null

--- a/src/controllers/DashboardController.php
+++ b/src/controllers/DashboardController.php
@@ -201,7 +201,7 @@ class DashboardController extends Controller
             'id' => $widget->id,
             'dateCreated' => $widget->dateCreated,
             'dateUpdated' => $widget->dateUpdated,
-            'colspan' => $widget->colspan,
+            'colspan' => $widget->getColspan(),
             'type' => get_class($widget),
             'settings' => $settings,
         ]);
@@ -518,7 +518,7 @@ class DashboardController extends Controller
         $settingsJs = $view->clearJsBuffer(false);
 
         // Get the colspan (limited to the widget type's max allowed colspan)
-        $colspan = ($widget->colspan ?: 1);
+        $colspan = ($widget->getColspan() ?: 1);
 
         if (($maxColspan = $widget::maxColspan()) && $colspan > $maxColspan) {
             $colspan = $maxColspan;


### PR DESCRIPTION
Add a getter method for the widget's colspan. This way it is possible to define a min colspan for example.