### PR TITLE
Replace getSourceId() with getCanonicalId()

### DIFF
--- a/src/templates/_layouts/element.html
+++ b/src/templates/_layouts/element.html
@@ -60,7 +60,7 @@
     {% set isNewlySupportedSite = true %}
 {% elseif isDraft %}
     {% set isNewlySupportedSite = not element.find()
-        .id(element.getSourceId())
+        .id(element.getCanonicalId())
         .siteId(element.siteId)
         .anyStatus()
         .exists() %}
@@ -360,7 +360,7 @@
 
 {% block content %}
     {% if not isRevision %}
-        {{ hiddenInput('sourceId', element.getSourceId()) }}
+        {{ hiddenInput('sourceId', element.getCanonicalId()) }}
     {% else %}
         {{ hiddenInput('revisionId', entry.revisionId) }}
     {% endif %}
@@ -518,7 +518,7 @@
 
 {% set settings = {
     elementType: className(element),
-    sourceId: element.getSourceId(),
+    sourceId: element.getCanonicalId(),
     siteId: element.siteId,
     isUnpublishedDraft: isUnpublishedDraft,
     enabled: element.enabled ? true : false,


### PR DESCRIPTION
Replaced deprecated `getSourceId()` method with `getCanonicalId()`. I've left the `sourceId` property names as they are because I assume they also need be changed in other places.