### PR TITLE
Add option to disable SVG transforms

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -941,7 +941,7 @@ class GeneralConfig extends BaseObject
      * Set to `0` to disable this feature.
      *
      * See [[ConfigHelper::durationInSeconds()]] for a list of supported value types.
-     * 
+     *
      * ::: tip
      * Users will only be purged when [garbage collection](https://craftcms.com/docs/3.x/gc.html) is run.
      * :::
@@ -1245,6 +1245,13 @@ class GeneralConfig extends BaseObject
      * @group Image Handling
      */
     public $transformGifs = true;
+
+    /**
+     * @var bool Whether SVG files should be transformed.
+     * @since 3.7.0
+     * @group Image Handling
+     */
+    public $transformSvgs = true;
 
     /**
      * @var bool Whether translated messages should be wrapped in special characters to help find any strings that are not being run through

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1248,7 +1248,7 @@ class GeneralConfig extends BaseObject
 
     /**
      * @var bool Whether SVG files should be transformed.
-     * @since 3.7.0
+     * @since 3.7.1
      * @group Image Handling
      */
     public $transformSvgs = true;

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1125,7 +1125,11 @@ class Asset extends Element
             return null;
         }
 
-        if ($this->getMimeType() === 'image/gif' && !Craft::$app->getConfig()->getGeneral()->transformGifs) {
+        if (($this->getMimeType() === 'image/gif'
+                && !Craft::$app->getConfig()->getGeneral()->transformGifs
+            ) || ($this->getMimeType() === 'image/svg+xml'
+                && !Craft::$app->getConfig()->getGeneral()->transformSvgs)
+            ) {
             return AssetsHelper::generateUrl($volume, $this);
         }
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1125,11 +1125,13 @@ class Asset extends Element
             return null;
         }
 
-        if (($this->getMimeType() === 'image/gif'
-                && !Craft::$app->getConfig()->getGeneral()->transformGifs
-            ) || ($this->getMimeType() === 'image/svg+xml'
-                && !Craft::$app->getConfig()->getGeneral()->transformSvgs)
-            ) {
+        $mimeType = $this->getMimeType();
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+
+        if (
+            ($mimeType === 'image/gif' && !$generalConfig->transformGifs) ||
+            ($mimeType === 'image/svg+xml' && !$generalConfig->transformSvgs)
+        ) {
             return AssetsHelper::generateUrl($volume, $this);
         }
 


### PR DESCRIPTION
This adds an option similar to `transformGifs` to prevent transforming SVGs.  My use case is with GQL.  To produce a number of crops for used with `<picture>` and `srcset`, I have this fragment:

```gql
fragment srcSet on AssetInterface {
	id
	width
	height
	focalPoint
	title
	mimeType
	w1920:      url @transform(width: 1920, immediately: true)
	w1920_webp: url @transform(width: 1920, immediately: true, format:"webp")
	w1440:      url @transform(width: 1440, immediately: true)
	w1440_webp: url @transform(width: 1440, immediately: true, format:"webp")
	w1024:      url @transform(width: 1024, immediately: true)
	w1024_webp: url @transform(width: 1024, immediately: true, format:"webp")
	w768:       url @transform(width: 768, immediately: true)
	w768_webp:  url @transform(width: 768, immediately: true, format:"webp")
	w425:       url @transform(width: 425, immediately: true)
	w425_webp:  url @transform(width: 425, immediately: true, format:"webp")
	w210:       url @transform(width: 160, immediately: true)
	w210_webp:  url @transform(width: 160, immediately: true, format:"webp")
}
```
I was seeing issues like in `web.log`:

```
2021-07-13 12:31:18 [-][-][-][error][craft\errors\AssetTransformException] craft\errors\AssetTransformException: Failed to generate transform with id of 3203. in /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/services/AssetTransforms.php:657
Stack trace:
#0 /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/services/Assets.php(620): craft\services\AssetTransforms->ensureTransformUrlByIndexModel()
#1 /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/elements/Asset.php(1154): craft\services\Assets->getAssetUrl()
#2 /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/gql/directives/Transform.php(107): craft\elements\Asset->getUrl()
...
2021-07-13 12:31:56 [-][-][-][error][craft\errors\ImageException] Imagine\Exception\RuntimeException: An image could not be created from the given input in /home/forge/cms.kivaconfections.com/cms/vendor/pixelandtonic/imagine/src/Gd/Imagine.php:214
Stack trace:
#0 /home/forge/cms.kivaconfections.com/cms/vendor/pixelandtonic/imagine/src/Gd/Imagine.php(108): Imagine\Gd\Imagine->doLoad()
#1 /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/image/Raster.php(509): Imagine\Gd\Imagine->load()
#2 /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/services/Images.php(197): craft\image\Raster->loadFromSVG()
...
Next craft\errors\ImageException: Failed to load the SVG string. in /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/image/Raster.php:511
Stack trace:
#0 /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/services/Images.php(197): craft\image\Raster->loadFromSVG()
#1 /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/services/AssetTransforms.php(1538): craft\services\Images->loadImage()
#2 /home/forge/cms.kivaconfections.com/cms/vendor/craftcms/cms/src/services/AssetTransforms.php(803): craft\services\AssetTransforms->_createTransformForAsset()
```

This was with:

- Craft Pro 3.5.12.1
- GD 7.4.16
- PHP 7.4.16 

When I looked into the `asssettransformindex` table, it was the `format:"webp"` transforms that were erroring.  

I don't really know whether the user is going to upload SVGs, PNGs, or JPGs into my asset field.  In the case of SVGs, I don't really want Craft to transform them but there isn't a way in the GraphQL API to say "only transform if raster" so this is the solution I came up with.