### PR TITLE
`SCENARIO_MOVE` for move-only asset ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where progress bar labels weren’t always removed correctly.
 - Fixed a bug where it wasn’t possible to filter by status on the Categories index page. ([#9555](https://github.com/craftcms/cms/issues/9555))
 - Fixed a bug where Edit Category pages didn’t have a “Save and add another” action.
+- Fixed a bug where moving an asset with an invalid file extension would be treated as if there was a conflicting asset in the destination directory. ([#9147](https://github.com/craftcms/cms/issues/9147))
 
 ## 3.7.0 - 2021-07-13
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -94,6 +94,11 @@ class Asset extends Element
     // Validation scenarios
     // -------------------------------------------------------------------------
 
+    /**
+     * Validation scenario that should be used when the asset is only getting *moved*; not renamed.
+     * @since 3.7.1
+     */
+    const SCENARIO_MOVE = 'move';
     const SCENARIO_FILEOPS = 'fileOperations';
     const SCENARIO_INDEX = 'index';
     const SCENARIO_CREATE = 'create';
@@ -813,9 +818,23 @@ class Asset extends Element
         $rules[] = [['dateModified'], DateTimeValidator::class];
         $rules[] = [['filename', 'kind'], 'required'];
         $rules[] = [['kind'], 'string', 'max' => 50];
-        $rules[] = [['newLocation'], AssetLocationValidator::class, 'avoidFilenameConflicts' => $this->avoidFilenameConflicts];
-        $rules[] = [['newLocation'], 'required', 'on' => [self::SCENARIO_CREATE, self::SCENARIO_FILEOPS]];
-        $rules[] = [['tempFilePath'], 'required', 'on' => [self::SCENARIO_CREATE, self::SCENARIO_REPLACE]];
+        $rules[] = [['newLocation'], 'required', 'on' => [self::SCENARIO_CREATE, self::SCENARIO_MOVE, self::SCENARIO_FILEOPS]];
+        $rules[] = [['tempFilePath'], 'required', 'on' => [self::SCENARIO_CREATE, self::SCENARIO_MOVE, self::SCENARIO_REPLACE]];
+
+        // Validate the extension unless all we're doing is moving the file
+        $rules[] = [
+            ['newLocation'],
+            AssetLocationValidator::class,
+            'avoidFilenameConflicts' => $this->avoidFilenameConflicts,
+            'except' => [self::SCENARIO_MOVE],
+        ];
+        $rules[] = [
+            ['newLocation'],
+            AssetLocationValidator::class,
+            'avoidFilenameConflicts' => $this->avoidFilenameConflicts,
+            'allowedExtensions' => '*',
+            'on' => [self::SCENARIO_MOVE],
+        ];
 
         return $rules;
     }

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1855,9 +1855,12 @@ class Asset extends Element
     public function beforeSave(bool $isNew): bool
     {
         // newFolderId/newFilename => newLocation.
+        if ($this->newFilename === '') {
+            $this->newFilename = null;
+        }
         if ($this->newFolderId !== null || $this->newFilename !== null) {
             $folderId = $this->newFolderId ?: $this->folderId;
-            $filename = $this->newFilename ?: $this->filename;
+            $filename = $this->newFilename ?? $this->filename;
             $this->newLocation = "{folder:$folderId}$filename";
             $this->newFolderId = $this->newFilename = null;
         }

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -198,10 +198,15 @@ class Assets extends Component
      */
     public function moveAsset(Asset $asset, VolumeFolder $folder, string $filename = ''): bool
     {
-        // Set the new combined target location, and save it
-        $asset->newFilename = $filename;
         $asset->newFolderId = $folder->id;
-        $asset->setScenario(Asset::SCENARIO_FILEOPS);
+
+        // If the filename hasn’t changed, then we can use the `move` scenario
+        if ($filename === '' || $filename === $asset->filename) {
+            $asset->setScenario(Asset::SCENARIO_MOVE);
+        } else {
+            $asset->newFilename = $filename;
+            $asset->setScenario(Asset::SCENARIO_FILEOPS);
+        }
 
         return Craft::$app->getElements()->saveElement($asset);
     }

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -473,7 +473,7 @@ class Users extends Component
             return;
         }
 
-        $photo->setScenario(Asset::SCENARIO_FILEOPS);
+        $photo->setScenario(Asset::SCENARIO_MOVE);
         $photo->avoidFilenameConflicts = true;
         $photo->newFolderId = $folderId;
         Craft::$app->getElements()->saveElement($photo);

--- a/src/validators/AssetLocationValidator.php
+++ b/src/validators/AssetLocationValidator.php
@@ -49,7 +49,7 @@ class AssetLocationValidator extends Validator
     public $errorCodeAttribute = 'locationError';
 
     /**
-     * @var string[]|null Allowed file extensions
+     * @var string[]|string|null Allowed file extensions. Set to `'*'` to allow all extensions.
      */
     public $allowedExtensions;
 
@@ -115,9 +115,8 @@ class AssetLocationValidator extends Validator
         // Make sure the new filename has a valid extension
         $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
 
-        if (!in_array($extension, $this->allowedExtensions, true)) {
+        if (is_array($this->allowedExtensions) && !in_array($extension, $this->allowedExtensions, true)) {
             $this->addLocationError($model, $attribute, Asset::ERROR_DISALLOWED_EXTENSION, $this->disallowedExtension, ['extension' => $extension]);
-
             return;
         }
 


### PR DESCRIPTION
Adds a new `SCENARIO_MOVE` for assets, which is now used when assets are being moved and the filename isn’t changing in the process. It behaves identically to `SCENARIO_FILEOPS`, except that file extensions aren’t validated, fixing #9147.