### PR TITLE
Fix devmode logging condition

### DIFF
--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -622,13 +622,13 @@ class App
 
             // Only log errors and warnings, unless Craft is running in Dev Mode or it's being installed/updated
             // (Explicitly check GeneralConfig::$devMode here, because YII_DEBUG is always `1` for console requests.)
-            $devModeLogging = (
+            $onlyLogErrors = (
                 !Craft::$app->getConfig()->getGeneral()->devMode &&
                 Craft::$app->getIsInstalled() &&
                 !Craft::$app->getUpdates()->getIsCraftDbMigrationNeeded()
             );
 
-            if ($devModeLogging) {
+            if ($onlyLogErrors) {
                 $fileTargetConfig['levels'] = Logger::LEVEL_ERROR | Logger::LEVEL_WARNING;
             }
 
@@ -644,7 +644,7 @@ class App
 
                 $targets[Dispatcher::TARGET_STDERR] = $streamErrLogTarget;
 
-                if ($devModeLogging) {
+                if (!$onlyLogErrors) {
                     $streamOutLogTarget = [
                         'class' => StreamLogTarget::class,
                         'url' => 'php://stdout',


### PR DESCRIPTION
When setting `CRAFT_STREAM_LOG`, logs included `devMode` output when **not** in `devMode`.

Looks like the condition got turned around here: https://github.com/craftcms/cms/commit/4aaecf4ef1cd20f1c9814f56567ddfde7fad77eb#diff-8ddcc488c3dc025ab9e7d97a17dedba912ac12119f5f5f7a010e07b4bf981688