### PR TITLE
Improve `Query::one()` dockblock

### DIFF
--- a/src/db/Query.php
+++ b/src/db/Query.php
@@ -157,8 +157,7 @@ class Query extends \yii\db\Query
 
     /**
      * @inheritdoc
-     * @return array|null the first row (in terms of an array) of the query result. Null is returned if the query
-     * results in nothing.
+     * @return mixed|null first row of the query result array, or `null` if there are no query results.
      */
     public function one($db = null)
     {


### PR DESCRIPTION
Fix return type since it’s the array *item* or `null` (and not an array), improve brevity+clarity.