### PR TITLE
fix: running in console has no session for temp folder

### DIFF
--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -1020,6 +1020,9 @@ class Assets extends Component
 
         if ($user) {
             $folderName = 'user_' . $user->id;
+        }elseif(Craft::$app->getRequest()->getIsConsoleRequest() ){
+            $folderName = 'temp_' . sha1(time());
+
         } else {
             // A little obfuscation never hurt anyone
             $folderName = 'user_' . sha1(Craft::$app->getSession()->id);


### PR DESCRIPTION
### Description
When running in console mode and uploading an image, the `getUserTemporaryUploadFolder` method is causing an exception to be thrown, this breaks the feed-me plugin.

by checking if in console mode we now use a temp folder instead of a user folder.


### Related issues

* [ ] https://github.com/craftcms/feed-me/issues/863
* [ ] https://github.com/craftcms/feed-me/issues/642