### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+* @craftcms/dev
+.codecov.yml @bradbell
+.travis.yml @bradbell
+CHANGELOG.md @brandonkelly
+codeception.yml @bradbell
+crowdin.yml @bradbell
+/src/gql/ @andris-sevcenko
+/src/web/assets/admintable/ @nfourtythree
+/src/web/assets/pluginstore/ @benjamindavid


### PR DESCRIPTION
### Description

Adds a GitHub [code owners file](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) that determines who will automatically get selected to review pull requests.

You’ll probably want to edit further, but I took a stab at high-level areas and made the @craftcms/dev team the catch-all default.

That GitHub “dev” team is currently empty, so it may make sense to add people to it or change the default (`*`).