### PR TITLE
Don't log errors to STDOUT/STDERR for console requests

### DIFF
--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -634,7 +634,7 @@ class App
 
             $targets[Dispatcher::TARGET_FILE] = $fileTargetConfig;
 
-            if (defined('CRAFT_STREAM_LOG') && CRAFT_STREAM_LOG === true) {
+            if (!Craft::$app->getRequest()->isConsoleRequest && defined('CRAFT_STREAM_LOG') && CRAFT_STREAM_LOG === true) {
                 $streamErrLogTarget = [
                     'class' => StreamLogTarget::class,
                     'url' => 'php://stderr',


### PR DESCRIPTION
When running a cli command with `CRAFT_STREAM_LOG` set, the output can get very noisy, as the output is shared by the expected output from the console controller, as well as any logged warning/error + stack trace + req vars.

The easiest way to demonstrate this is to set `CRAFT_STREAM_LOG = true` and run something like:

```zsh
❯ craft foo
Unknown command: foo

Did you mean one of these?
    - on
    - off
Error: exit status 1
2021-07-27 12:11:25 [-][-][-][error][yii\console\UnknownCommandException] yii\base\InvalidRouteException: Unable to resolve the request "not-a-command". in /app/vendor/yiisoft/yii2/base/Module.php:543
Stack trace:
#0 /app/vendor/yiisoft/yii2/console/Application.php(181): yii\base\Module->runAction('not-a-command', Array)
…
…
…
```

The debug output here is obnoxious and unnecessary, so long as it is going somewhere (in this case, it will still go to the `console.log` `FileTarget`).

This follows the same pattern CLI tools like `npm` use, where they display CLI-friendly error message, but log the details to `npm-debug.log`.