### PR TITLE
FindAndReplace is now compatible with columnSuffixes

### DIFF
--- a/src/queue/jobs/FindAndReplace.php
+++ b/src/queue/jobs/FindAndReplace.php
@@ -90,6 +90,11 @@ class FindAndReplace extends BaseJob
             return;
         }
 
+        $columnName = $fieldColumnPrefix . $field->handle;
+        if ($field->columnSuffix !== null) {
+            $columnName .= '_' . $field->columnSuffix;
+        }
+
         $columnType = $field->getContentColumnType();
         if (is_array($columnType)) {
             $columnType = reset($columnType);
@@ -110,7 +115,7 @@ class FindAndReplace extends BaseJob
             'string',
             'char',
         ], true)) {
-            $this->_textColumns[] = [$table, $fieldColumnPrefix . $field->handle];
+            $this->_textColumns[] = [$table, $columnName];
         }
     }
 


### PR DESCRIPTION
It seems that FindAndReplace ignores the columnSuffixes (that were introduced in 3.7.x ?)

Personally, I think that the logic for generating the column name should be in the Field model but that's probably a different issue and not something for my first PR.

