### PR TITLE
Console command doc cleanup

### DIFF
--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -188,9 +188,9 @@ class DbController extends Controller
     /**
      * Converts tables’ character sets and collations. (MySQL only)
      *
-     * @param string|null $charset   The target character set, which honors [[DbConfig::$charset]]
+     * @param string|null $charset   The target character set, which honors `DbConfig::$charset`
      *                               or defaults to `utf8`.
-     * @param string|null $collation The target collation, which honors [[DbConfig::$collation]]
+     * @param string|null $collation The target collation, which honors `DbConfig::$collation`
      *                               or defaults to `utf8_unicode_ci`.
      * @return int
      */

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -50,13 +50,18 @@ class DbController extends Controller
     /**
      * Creates a new database backup.
      *
+     * Example:
+     * ```
+     * php craft db/backup ./my-backups/
+     * ```
+     *
      * @param string|null $path The path the database backup should be created at.
      * Can be any of the following:
      *
      * - A full file path
      * - A folder path (backup will be saved in there with a dynamically-generated name)
      * - A filename (backup will be saved in the working directory with the given name)
-     * - Blank (backup will be saved to the config/backups/ folder with a dynamically-generated name)
+     * - Blank (backup will be saved to the `config/backups/` folder with a dynamically-generated name)
      *
      * @return int
      */
@@ -125,7 +130,7 @@ class DbController extends Controller
     /**
      * Restores a database backup.
      *
-     * @param string|null The path to the database backup file.
+     * @param string|null $path The path to the database backup file.
      * @return int
      */
     public function actionRestore(string $path = null): int
@@ -183,8 +188,10 @@ class DbController extends Controller
     /**
      * Converts tables’ character sets and collations. (MySQL only)
      *
-     * @param string|null $charset The character set
-     * @param string|null $collation
+     * @param string|null $charset   The target character set, which honors [[DbConfig::$charset]]
+     *                               or defaults to `utf8`.
+     * @param string|null $collation The target collation, which honors [[DbConfig::$collation]]
+     *                               or defaults to `utf8_unicode_ci`.
      * @return int
      */
     public function actionConvertCharset(?string $charset = null, ?string $collation = null): int

--- a/src/console/controllers/GcController.php
+++ b/src/console/controllers/GcController.php
@@ -31,7 +31,7 @@ class GcController extends Controller
     /**
      * @var bool Whether all soft-deleted items should be deleted, rather than just
      * the ones that were deleted long enough ago to be ready for hard-deletion
-     * per the `softDeleteDuration` config setting.
+     * per the <config3:softDeleteDuration> config setting.
      */
     public $deleteAllTrashed = false;
 

--- a/src/console/controllers/GcController.php
+++ b/src/console/controllers/GcController.php
@@ -31,7 +31,7 @@ class GcController extends Controller
     /**
      * @var bool Whether all soft-deleted items should be deleted, rather than just
      * the ones that were deleted long enough ago to be ready for hard-deletion
-     * per the <config3:softDeleteDuration> config setting.
+     * per the `softDeleteDuration` config setting.
      */
     public $deleteAllTrashed = false;
 

--- a/src/console/controllers/GraphqlController.php
+++ b/src/console/controllers/GraphqlController.php
@@ -29,7 +29,7 @@ class GraphqlController extends Controller
     const GQL_SCHEMA_EXTENSION = ".graphql";
 
     /**
-     * @var string The token to look up to determine the appropriate GraphQL schema
+     * @var string The token to look up to determine the appropriate GraphQL schema.
      */
     public $token = null;
 
@@ -51,7 +51,7 @@ class GraphqlController extends Controller
     }
 
     /**
-     * Print out a given GraphQL schema.
+     * Prints a given GraphQL schema.
      *
      * @return int
      */
@@ -73,7 +73,7 @@ class GraphqlController extends Controller
     }
 
     /**
-     * Dump out a given GraphQL schema to a file.
+     * Dumps a given GraphQL schema to a file.
      *
      * @return int
      */

--- a/src/console/controllers/MigrateController.php
+++ b/src/console/controllers/MigrateController.php
@@ -83,7 +83,7 @@ class MigrateController extends BaseMigrateController
     /**
      * @var string The migration track to work with (e.g. `craft`, `content`, `plugin:commerce`, etc.)
      *
-     * If --plugin is passed, this will automatically be set to the plugin’s track. Otherwise defaults to 'content'.
+     * Defaults to `content`, or automatically set to the plugin’s track when `--plugin` is passed.
      * @since 3.5.0
      */
     public $track = MigrationManager::TRACK_CONTENT;
@@ -95,7 +95,7 @@ class MigrateController extends BaseMigrateController
     public $type;
 
     /**
-     * @var string|PluginInterface|null The handle of the plugin to use during migration operations, or the plugin itself
+     * @var string|PluginInterface|null The handle of the plugin to use during migration operations, or the plugin itself.
      */
     public $plugin;
 
@@ -255,9 +255,9 @@ class MigrateController extends BaseMigrateController
      * craft migrate/create create_news_section
      * ```
      *
-     * By default the migration will be created within the project's migrations/
-     * folder (as a "content migration").
-     * Use `--plugin=<plugin-handle>` to create a new plugin migration.
+     * By default, the migration is created in the project’s `migrations/`
+     * folder (as a “content migration”).\
+     * Use `--plugin=<plugin-handle>` to create a new plugin migration.\
      * Use `--type=app` to create a new Craft CMS app migration.
      *
      * @param string $name the name of the new migration. This should only contain

--- a/src/console/controllers/OffController.php
+++ b/src/console/controllers/OffController.php
@@ -23,15 +23,16 @@ class OffController extends Controller
     /**
      * @var int|null Number of seconds the `Retry-After` HTTP header should be set to for 503 responses.
      *
-     * The [Retry Duration](config3:retryDuration) setting can be used to configure a *system-wide* `Retry-After` header.
+     * The `retryDuration` config setting can be used to configure a *system-wide* `Retry-After` header.
      *
      * ::: warning
-     * The <config3:isSystemLive> setting takes precedence over the `system.live` project config value, so if `config/general.php` sets `isSystemLive` to `true` or `false` these `on`/`off` commands to error out.
+     * The `isSystemLive` config setting takes precedence over the `system.live` project config value,
+     * so if `config/general.php` sets `isSystemLive` to `true` or `false` these `on`/`off` commands error out.
      * :::
      *
      * **Example**
      *
-     * Running the following takes the system offline and returns 503 responses until it’s switched [on](#on) again:
+     * Running the following takes the system offline and returns 503 responses until it’s switched on again:
      *
      * ```
      * $ php craft off --retry=60
@@ -52,20 +53,20 @@ class OffController extends Controller
     }
 
     /**
-     * Disables `system.live` project config value—bypassing any <config3:allowAdminChanges> restrictions—
+     * Disables `system.live` project config value—bypassing any `allowAdminChanges` config setting restrictions—
      * meant for temporary use during the deployment process.
      *
      * @return int
      */
     public function actionIndex(): int
     {
-        // If the isSystemLive config setting is set, then we can't control it from here
+        // If the isSystemLive config setting is set, then we can’t control it from here
         if (is_bool($live = Craft::$app->getConfig()->getGeneral()->isSystemLive)) {
             $this->stderr('It\'s not possible to toggle the system status when the `isSystemLive` config setting is set.' . PHP_EOL, Console::FG_RED);
             return ExitCode::UNSPECIFIED_ERROR;
         }
 
-        // Allow changes to the project config even if it's supposed to be read only,
+        // Allow changes to the project config even if it’s supposed to be read only,
         // and prevent changes from getting written to YAML
         $projectConfig = Craft::$app->getProjectConfig();
         $projectConfig->readOnly = false;

--- a/src/console/controllers/OffController.php
+++ b/src/console/controllers/OffController.php
@@ -13,7 +13,7 @@ use craft\helpers\Console;
 use yii\console\ExitCode;
 
 /**
- * Takes the system offline
+ * Takes the system offline.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.5.7
@@ -21,7 +21,23 @@ use yii\console\ExitCode;
 class OffController extends Controller
 {
     /**
-     * @var int|null Number of seconds that the `Retry-After` HTTP header should be set to for 503 responses
+     * @var int|null Number of seconds the `Retry-After` HTTP header should be set to for 503 responses.
+     *
+     * The [Retry Duration](config3:retryDuration) setting can be used to configure a *system-wide* `Retry-After` header.
+     *
+     * ::: warning
+     * The <config3:isSystemLive> setting takes precedence over the `system.live` project config value, so if `config/general.php` sets `isSystemLive` to `true` or `false` these `on`/`off` commands to error out.
+     * :::
+     *
+     * **Example**
+     *
+     * Running the following takes the system offline and returns 503 responses until it’s switched [on](#on) again:
+     *
+     * ```
+     * $ php craft off --retry=60
+     * The system is now offline.
+     * The retry duration is now set to 60.
+     * ```
      */
     public $retry;
 
@@ -36,7 +52,8 @@ class OffController extends Controller
     }
 
     /**
-     * Turns the system off.
+     * Disables `system.live` project config value—bypassing any <config3:allowAdminChanges> restrictions—
+     * meant for temporary use during the deployment process.
      *
      * @return int
      */

--- a/src/console/controllers/OnController.php
+++ b/src/console/controllers/OnController.php
@@ -13,7 +13,7 @@ use craft\helpers\Console;
 use yii\console\ExitCode;
 
 /**
- * Takes the system online
+ * Takes the system online.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.5.7
@@ -23,11 +23,17 @@ class OnController extends Controller
     /**
      * Turns the system on.
      *
+     * **Example**
+     *
+     * ```
+     * $ php craft on
+     * The system is now online.
+     * ```
      * @return int
      */
     public function actionIndex(): int
     {
-        // If the isSystemLive config setting is set, then we can't control it from here
+        // If the isSystemLive config setting is set, then we can’t control it from here
         if (is_bool($live = Craft::$app->getConfig()->getGeneral()->isSystemLive)) {
             $this->stderr('It\'s not possible to toggle the system status when the `isSystemLive` config setting is set.' . PHP_EOL, Console::FG_RED);
             return ExitCode::UNSPECIFIED_ERROR;
@@ -38,7 +44,7 @@ class OnController extends Controller
             return ExitCode::OK;
         }
 
-        // Allow changes to the project config even if it's supposed to be read only,
+        // Allow changes to the project config even if it’s supposed to be read only,
         // and prevent changes from getting written to YAML
         $projectConfig = Craft::$app->getProjectConfig();
         $projectConfig->readOnly = false;

--- a/src/console/controllers/PluginController.php
+++ b/src/console/controllers/PluginController.php
@@ -13,7 +13,7 @@ use craft\helpers\Console;
 use yii\console\ExitCode;
 
 /**
- * Manage plugins
+ * Manage plugins.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.5.0
@@ -54,7 +54,7 @@ class PluginController extends Controller
     /**
      * Installs a plugin.
      *
-     * @param string $handle The plugin handle
+     * @param string $handle The plugin handle.
      * @return int
      */
     public function actionInstall(string $handle): int
@@ -77,7 +77,7 @@ class PluginController extends Controller
     /**
      * Uninstalls a plugin.
      *
-     * @param string $handle The plugin handle
+     * @param string $handle The plugin handle.
      * @return int
      */
     public function actionUninstall(string $handle): int
@@ -104,7 +104,7 @@ class PluginController extends Controller
     /**
      * Enables a plugin.
      *
-     * @param string $handle The plugin handle
+     * @param string $handle The plugin handle.
      * @return int
      */
     public function actionEnable(string $handle): int
@@ -127,7 +127,7 @@ class PluginController extends Controller
     /**
      * Disables a plugin.
      *
-     * @param string $handle The plugin handle
+     * @param string $handle The plugin handle.
      * @return int
      */
     public function actionDisable(string $handle): int

--- a/src/console/controllers/ProjectConfigController.php
+++ b/src/console/controllers/ProjectConfigController.php
@@ -63,7 +63,7 @@ class ProjectConfigController extends Controller
                 $options[] = 'force';
                 break;
             case 'diff':
-                $options[] = 'reverse';
+                $options[] = 'invert';
         }
 
         return $options;

--- a/src/console/controllers/ServeController.php
+++ b/src/console/controllers/ServeController.php
@@ -11,9 +11,9 @@ use craft\console\ControllerTrait;
 use yii\console\controllers\ServeController as BaseServeController;
 
 /**
- * Runs the PHP built-in web server.
+ * Runs the built-in PHP web server.
  *
- * In order to access server from remote machines use 0.0.0.0:8000. That is especially useful when running server in
+ * Use 0.0.0.0:8000 to access the server from remote machines, which is especially useful when running the server in
  * a virtual machine.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
@@ -24,7 +24,7 @@ class ServeController extends BaseServeController
     use ControllerTrait;
 
     /**
-     * @var string path or [path alias](guide:concept-aliases) to directory to serve
+     * @var string path or [path alias](https://craftcms.com/docs/3.x/config/#aliases) of the directory to serve.
      */
     public $docroot = '@webroot';
 
@@ -42,7 +42,7 @@ class ServeController extends BaseServeController
      */
     public function beforeAction($action)
     {
-        // Make sure this isn't a root user
+        // Make sure this isn’t a root user
         if (!$this->checkRootUser()) {
             return false;
         }

--- a/src/console/controllers/SetupController.php
+++ b/src/console/controllers/SetupController.php
@@ -128,7 +128,7 @@ class SetupController extends Controller
     }
 
     /**
-     * Called from the post-create-project-cmd Composer hook.
+     * Called from the `post-create-project-cmd` Composer hook.
      *
      * @return int
      */
@@ -171,7 +171,7 @@ EOD;
     }
 
     /**
-     * Generates a new application ID and saves it in the .env file.
+     * Generates a new application ID and saves it in the `.env` file.
      *
      * @return int
      * @since 3.4.25
@@ -188,7 +188,7 @@ EOD;
     }
 
     /**
-     * Generates a new security key and saves it in the .env file.
+     * Generates a new security key and saves it in the `.env` file.
      *
      * @return int
      */
@@ -206,7 +206,7 @@ EOD;
     }
 
     /**
-     * Stores new DB connection settings to the .env file.
+     * Stores new DB connection settings to the `.env` file.
      *
      * @return int
      */
@@ -488,7 +488,7 @@ EOD;
     }
 
     /**
-     * Sets an environment variable value in the project's .env file.
+     * Sets an environment variable value in the project’s `.env` file.
      *
      * @param $name
      * @param $value

--- a/src/console/controllers/UsersController.php
+++ b/src/console/controllers/UsersController.php
@@ -23,54 +23,54 @@ use yii\console\ExitCode;
 class UsersController extends Controller
 {
     /**
-     * @var string|null The user’s email
+     * @var string|null The user’s email address.
      * @since 3.7.0
      */
     public $email;
 
     /**
-     * @var string|null The user’s username
+     * @var string|null The user’s username.
      * @since 3.7.0
      */
     public $username;
 
     /**
-     * @var string|null The user’s new password
+     * @var string|null The user’s new password.
      */
     public $password;
 
     /**
-     * @var bool|null Whether the user should be an admin
+     * @var bool|null Whether the user should be an admin.
      * @since 3.7.0
      */
     public $admin;
 
     /**
-     * @var string[] The group handles to assign the created user to
+     * @var string[] The group handles to assign the created user to.
      * @since 3.7.0
      */
     public $groups = [];
 
     /**
-     * @var int[] The group IDs to assign the user to the created user to
+     * @var int[] The group IDs to assign the user to the created user to.
      * @since 3.7.0
      */
     public $groupIds = [];
 
     /**
-     * @var string|null The email or username of the user to inherit content when deleting a user
+     * @var string|null The email or username of the user to inherit content when deleting a user.
      * @since 3.7.0
      */
     public $inheritor;
 
     /**
-     * @var bool Whether to delete the user’s content if no inheritor is specified
+     * @var bool Whether to delete the user’s content if no inheritor is specified.
      * @since 3.7.0
      */
     public $deleteContent = false;
 
     /**
-     * @var bool Whether the user should be hard-deleted immediately, instead of soft-deleted
+     * @var bool Whether the user should be hard-deleted immediately, instead of soft-deleted.
      * @since 3.7.0
      */
     public $hard = false;
@@ -231,7 +231,7 @@ class UsersController extends Controller
     /**
      * Deletes a user.
      *
-     * @param string $usernameOrEmail The user’s username or email address
+     * @param string $usernameOrEmail The user’s username or email address.
      * @return int
      */
     public function actionDelete(string $usernameOrEmail): int

--- a/src/console/controllers/utils/RepairController.php
+++ b/src/console/controllers/utils/RepairController.php
@@ -22,7 +22,7 @@ use yii\console\ExitCode;
 use yii\db\Expression;
 
 /**
- * Repairs data
+ * Repairs data.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.4.24
@@ -30,7 +30,7 @@ use yii\db\Expression;
 class RepairController extends Controller
 {
     /**
-     * @var bool Whether to only do a dry run of the repair process
+     * @var bool Whether to only do a dry run of the repair process.
      */
     public $dryRun = false;
 
@@ -45,9 +45,9 @@ class RepairController extends Controller
     }
 
     /**
-     * Repairs structure data for a section
+     * Repairs structure data for a section.
      *
-     * @param string $handle The section handle
+     * @param string $handle The section handle.
      * @return int
      */
     public function actionSectionStructure(string $handle): int
@@ -68,9 +68,9 @@ class RepairController extends Controller
     }
 
     /**
-     * Repairs structure data for a category group
+     * Repairs structure data for a category group.
      *
-     * @param string $handle The category group handle
+     * @param string $handle The category group handle.
      * @return int
      */
     public function actionCategoryGroupStructure(string $handle): int

--- a/src/console/controllers/utils/UpdateUsernamesController.php
+++ b/src/console/controllers/utils/UpdateUsernamesController.php
@@ -15,7 +15,7 @@ use yii\console\ExitCode;
 use yii\db\Expression;
 
 /**
- * Updates all users’ usernames to ensure they match their email address
+ * Updates all users’ usernames to ensure they match their email address.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.5.8
@@ -23,7 +23,7 @@ use yii\db\Expression;
 class UpdateUsernamesController extends Controller
 {
     /**
-     * Updates all users’ usernames to ensure they match their email address
+     * Updates all users’ usernames to ensure they match their email address.
      *
      * @return int
      */

--- a/src/queue/Command.php
+++ b/src/queue/Command.php
@@ -12,7 +12,7 @@ use yii\console\ExitCode;
 use yii\db\Exception as YiiDbException;
 
 /**
- * Manages the queue
+ * Manages the queue.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @author Roman Zhuravlev <zhuravljov@gmail.com>
@@ -78,9 +78,9 @@ class Command extends \yii\queue\cli\Command
     }
 
     /**
-     * Listens for new jobs added to the queue and runs them
+     * Listens for new jobs added to the queue and runs them.
      *
-     * @param int $timeout The number of seconds to wait between cycles
+     * @param int $timeout The number of seconds to wait between cycles.
      * @return int
      */
     public function actionListen(int $timeout = 3): int
@@ -91,7 +91,7 @@ class Command extends \yii\queue\cli\Command
     /**
      * Re-adds a failed job(s) to the queue.
      *
-     * @param int|string $job The job ID that should be retried, or pass `all` to retry all failed jobs
+     * @param int|string $job The job ID that should be retried, or `all` to retry all failed jobs.
      * @return int
      * @since 3.1.21
      */
@@ -116,6 +116,12 @@ class Command extends \yii\queue\cli\Command
 
     /**
      * Releases job(s) from the queue.
+     *
+     * Example:
+     *
+     * ```
+     * php craft queue/release all
+     * ```
      *
      * @param string $job The job ID to release. Pass `all` to release all jobs.
      * @return int


### PR DESCRIPTION
### Description

Minor update to pull in some notes in from the hand-maintained [Console Commands](https://craftcms.com/docs/3.x/console-commands.html) page and improve consistency throughout.

Also fixes an options bug in the project config controller where `reverse` [should be `invert`](https://github.com/craftcms/cms/pull/9655/files#diff-8ec7ff0286928126818362751a055f71751cae46785745197b86f07f8883b9b7R66).

Relates to [DOC-141](https://linear.app/craftcms/issue/DOC-141/improve-console-command-docblocks) and moves us closer to auto-generating this page.