### PR TITLE
Fix incorrect `baseUrl` for `install/craft` using the parsed URL, instead of the raw URL

### DIFF
--- a/src/console/controllers/InstallController.php
+++ b/src/console/controllers/InstallController.php
@@ -156,7 +156,7 @@ class InstallController extends Controller
 
         // Try to save the site URL to a PRIMARY_SITE_URL environment variable
         // if it's not already set to an alias or environment variable
-        if ($site->baseUrl[0] !== '@' && $site->baseUrl[0] !== '$') {
+        if ($site->getBaseUrl(false)[0] !== '@' && $site->getBaseUrl(false)[0] !== '$') {
             try {
                 $configService->setDotEnvVar('PRIMARY_SITE_URL', $site->baseUrl);
                 $site->baseUrl = '$PRIMARY_SITE_URL';


### PR DESCRIPTION
Fix for https://github.com/craftcms/cms/issues/9724
