### PR TITLE
Lazy translations for queue jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Added `craft\helpers\Db::renameTable()`.
 - Added `craft\helpers\Number::isInt()`.
 - Added `craft\helpers\Number::toIntOrFloat()`.
+- Added `craft\i18n\Translation`.
 - Added `craft\models\AssetIndexingSession`.
 - Added `craft\models\VolumeListing`.
 - Added `craft\records\AssetIndexingSession`.
@@ -65,6 +66,7 @@
 - User queries now return all users by default, rather than only active users.
 - Filtering users by `active`, `pending`, and `locked` statuses no longer excludes suspended users.
 - Relational fields now load elements in the current site rather than the primary site, if the source element isn’t localizable. ([#7048](https://github.com/craftcms/cms/issues/7048))
+- Built-in queue jobs are now always translated for the current user’s language. ([#9745](https://github.com/craftcms/cms/pull/9745))
 - Template autosuggestions now include their filename. ([#9744](https://github.com/craftcms/cms/pull/9744))
 - All control panel templates end in `.twig` now. ([#9743](https://github.com/craftcms/cms/pull/9743))
 - The `users/save-user` action no longer includes a `unverifiedEmail` key in failure responses.

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -39,6 +39,7 @@ use craft\helpers\Json;
 use craft\helpers\Queue;
 use craft\helpers\StringHelper;
 use craft\i18n\Locale;
+use craft\i18n\Translation;
 use craft\models\FieldLayoutTab;
 use craft\models\MatrixBlockType;
 use craft\queue\jobs\ApplyNewPropagationMethod;
@@ -988,7 +989,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
             $oldPropagationKeyFormat = $this->oldSettings['propagationKeyFormat'] ?? null;
             if ($this->propagationMethod !== $oldPropagationMethod || $this->propagationKeyFormat !== $oldPropagationKeyFormat) {
                 Queue::push(new ApplyNewPropagationMethod([
-                    'description' => Craft::t('app', 'Applying new propagation method to Matrix blocks'),
+                    'description' => Translation::prep('app', 'Applying new propagation method to Matrix blocks'),
                     'elementType' => MatrixBlock::class,
                     'criteria' => [
                         'fieldId' => $this->id,

--- a/src/i18n/Translation.php
+++ b/src/i18n/Translation.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\i18n;
+
+use Craft;
+use craft\helpers\Json;
+use yii\base\InvalidArgumentException;
+
+/**
+ * Translation helper
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.0.0
+ */
+abstract class Translation
+{
+    /**
+     * Prepares a source translation to be lazy-translated with [[translate()]].
+     *
+     * @param string $category The message category.
+     * @param string $message The message to be translated.
+     * @param array $params The parameters that will be used to replace the corresponding placeholders in the message.
+     * @param string|null $language The language code (e.g. `en-US`, `en`). If this is `null`, the current
+     * [[\yii\base\Application::language|application language]] will be used by default.
+     * @return string The translated message.
+     */
+    public static function prep(string $category, string $message, array $params = [], ?string $language = null): string
+    {
+        return 't9n:' . Json::encode(func_get_args());
+    }
+
+    /**
+     * Lazy-translates a source translation that was prepared by [[prep()]].
+     *
+     * @param string The prepared source translation.
+     * @return string The translated message.
+     */
+    public static function translate(string $translation): string
+    {
+        if (strpos($translation, 't9n:') !== 0) {
+            return $translation;
+        }
+
+        try {
+            $args = Json::decode(substr($translation, 4));
+        } catch (InvalidArgumentException $e) {
+            return $translation;
+        }
+
+        return Craft::t(...$args);
+    }
+}

--- a/src/queue/BaseJob.php
+++ b/src/queue/BaseJob.php
@@ -18,7 +18,12 @@ use yii\base\BaseObject;
 abstract class BaseJob extends BaseObject implements JobInterface
 {
     /**
-     * @var string|null The configured job description
+     * @var string|null The configured job description.
+     *
+     * ::: tip
+     * Run the description through [[\craft\i18n\Translation::prep()]] rather than [[\yii\BaseYii::t()|Craft::t()]]
+     * so it can be lazy-translated for users’ preferred languages rather that the current app language.
+     * :::
      */
     public ?string $description = null;
 
@@ -54,6 +59,11 @@ abstract class BaseJob extends BaseObject implements JobInterface
     /**
      * Returns a default description for [[getDescription()]].
      *
+     * ::: tip
+     * Run the description through [[\craft\i18n\Translation::prep()]] rather than [[\yii\BaseYii::t()|Craft::t()]]
+     * so it can be lazy-translated for users’ preferred languages rather that the current app language.
+     * :::
+     *
      * @return string|null
      */
     protected function defaultDescription(): ?string
@@ -63,6 +73,11 @@ abstract class BaseJob extends BaseObject implements JobInterface
 
     /**
      * Sets the job progress on the queue.
+     *
+     * ::: tip
+     * Run the label through [[\craft\i18n\Translation::prep()]] rather than [[\yii\BaseYii::t()|Craft::t()]]
+     * so it can be lazy-translated for users’ preferred languages rather that the current app language.
+     * :::
      *
      * @param \yii\queue\Queue|QueueInterface $queue
      * @param float $progress A number between 0 and 1

--- a/src/queue/Queue.php
+++ b/src/queue/Queue.php
@@ -15,6 +15,7 @@ use craft\helpers\Db;
 use craft\helpers\Json;
 use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
+use craft\i18n\Translation;
 use yii\base\Exception;
 use yii\base\InvalidArgumentException;
 use yii\db\Expression;
@@ -406,8 +407,8 @@ class Queue extends \yii\queue\cli\Queue implements QueueInterface
             'status' => $this->_status($result),
             'error' => $result['error'] ?? '',
             'progress' => $result['progress'],
-            'progressLabel' => $result['progressLabel'],
-            'description' => $result['description'],
+            'progressLabel' => Translation::translate((string)$result['progressLabel']) ?: null,
+            'description' => Translation::translate((string)$result['description']) ?: null,
             'job' => $job,
             'ttr' => (int)$result['ttr'],
             'Priority' => $result['priority'],
@@ -463,8 +464,8 @@ class Queue extends \yii\queue\cli\Queue implements QueueInterface
                 'delay' => max(0, $result['timePushed'] + $result['delay'] - time()),
                 'status' => $this->_status($result),
                 'progress' => (int)$result['progress'],
-                'progressLabel' => $result['progressLabel'],
-                'description' => $result['description'],
+                'progressLabel' => Translation::translate((string)$result['progressLabel']) ?: null,
+                'description' => Translation::translate((string)$result['description']) ?: null,
                 'error' => $result['error'],
             ];
         }

--- a/src/queue/QueueInterface.php
+++ b/src/queue/QueueInterface.php
@@ -91,7 +91,8 @@ interface QueueInterface
      * - `delay` – the number of seconds remaining before the job will start
      * - `status` – the job status (1 = waiting, 2 = reserved, 3 = done, 4 = failed)
      * - `progress` – the job progress (0-100)
-     * - `description` – the job description
+     * - `progressLabel` – the progress label (lazy-translated with [[\craft\i18n\Translation::translate()]])
+     * - `description` – the job description (lazy-translated with [[\craft\i18n\Translation::translate()]])
      * - `error` – the error message (if the job failed)
      *
      * @param int|null $limit
@@ -107,7 +108,8 @@ interface QueueInterface
      * - `delay` – the number of seconds remaining before the job will start
      * - `status` – the job status (1 = waiting, 2 = reserved, 3 = done, 4 = failed)
      * - `progress` – the job progress (0-100)
-     * - `description` – the job description
+     * - `progressLabel` – the progress label (lazy-translated with [[\craft\i18n\Translation::translate()]])
+     * - `description` – the job description (lazy-translated with [[\craft\i18n\Translation::translate()]])
      * - `ttr` – the job’s time-to-reserve, in seconds
      * - `error` – the error message (if the job failed)
      * - `job` – the deserialized job

--- a/src/queue/jobs/Announcement.php
+++ b/src/queue/jobs/Announcement.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\db\Table;
 use craft\elements\User;
 use craft\helpers\Db;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 use DateTime;
 use yii\base\Exception;
@@ -108,6 +109,6 @@ class Announcement extends BaseJob
      */
     protected function defaultDescription(): ?string
     {
-        return Craft::t('app', 'Pushing announcement to control panel users');
+        return Translation::prep('app', 'Pushing announcement to control panel users');
     }
 }

--- a/src/queue/jobs/ApplyNewPropagationMethod.php
+++ b/src/queue/jobs/ApplyNewPropagationMethod.php
@@ -15,6 +15,7 @@ use craft\events\BatchElementActionEvent;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 use craft\services\Elements;
 
@@ -61,7 +62,7 @@ class ApplyNewPropagationMethod extends BaseJob
 
         $callback = function(BatchElementActionEvent $e) use ($elementType, $queue, $query, $total, $elementsService, $allSiteIds) {
             if ($e->query === $query) {
-                $this->setProgress($queue, ($e->position - 1) / $total, Craft::t('app', '{step, number} of {total, number}', [
+                $this->setProgress($queue, ($e->position - 1) / $total, Translation::prep('app', '{step, number} of {total, number}', [
                     'step' => $e->position,
                     'total' => $total,
                 ]));
@@ -127,6 +128,6 @@ class ApplyNewPropagationMethod extends BaseJob
      */
     protected function defaultDescription(): ?string
     {
-        return Craft::t('app', 'Applying new propagation method to elements');
+        return Translation::prep('app', 'Applying new propagation method to elements');
     }
 }

--- a/src/queue/jobs/FindAndReplace.php
+++ b/src/queue/jobs/FindAndReplace.php
@@ -13,6 +13,7 @@ use craft\db\Table;
 use craft\fields\Matrix;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 use yii\base\Exception;
 
@@ -72,7 +73,7 @@ class FindAndReplace extends BaseJob
      */
     protected function defaultDescription(): ?string
     {
-        return Craft::t('app', 'Replacing “{find}” with “{replace}”', [
+        return Translation::prep('app', 'Replacing “{find}” with “{replace}”', [
             'find' => $this->find,
             'replace' => $this->replace,
         ]);

--- a/src/queue/jobs/GeneratePendingTransforms.php
+++ b/src/queue/jobs/GeneratePendingTransforms.php
@@ -8,6 +8,7 @@
 namespace craft\queue\jobs;
 
 use Craft;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 
 /**
@@ -31,7 +32,7 @@ class GeneratePendingTransforms extends BaseJob
 
         foreach ($indexIds as $i => $id) {
             if ($index = $assetTransformsService->getTransformIndexModelById($id)) {
-                $this->setProgress($queue, $i / $totalIndexes, Craft::t('app', '{step, number} of {total, number}', [
+                $this->setProgress($queue, $i / $totalIndexes, Translation::prep('app', '{step, number} of {total, number}', [
                     'step' => $i + 1,
                     'total' => $totalIndexes,
                 ]));
@@ -50,6 +51,6 @@ class GeneratePendingTransforms extends BaseJob
      */
     protected function defaultDescription(): ?string
     {
-        return Craft::t('app', 'Generating pending image transforms');
+        return Translation::prep('app', 'Generating pending image transforms');
     }
 }

--- a/src/queue/jobs/LocalizeRelations.php
+++ b/src/queue/jobs/LocalizeRelations.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\db\Query;
 use craft\db\Table;
 use craft\helpers\Db;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 
 /**
@@ -72,6 +73,6 @@ class LocalizeRelations extends BaseJob
      */
     protected function defaultDescription(): ?string
     {
-        return Craft::t('app', 'Localizing relations');
+        return Translation::prep('app', 'Localizing relations');
     }
 }

--- a/src/queue/jobs/PropagateElements.php
+++ b/src/queue/jobs/PropagateElements.php
@@ -12,6 +12,7 @@ use craft\base\ElementInterface;
 use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
 use craft\events\BatchElementActionEvent;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 use craft\services\Elements;
 
@@ -52,7 +53,7 @@ class PropagateElements extends BaseJob
 
         $callback = function(BatchElementActionEvent $e) use ($queue, $query, $total) {
             if ($e->query === $query) {
-                $this->setProgress($queue, ($e->position - 1) / $total, Craft::t('app', '{step, number} of {total, number}', [
+                $this->setProgress($queue, ($e->position - 1) / $total, Translation::prep('app', '{step, number} of {total, number}', [
                     'step' => $e->position,
                     'total' => $total,
                 ]));
@@ -74,7 +75,7 @@ class PropagateElements extends BaseJob
         /** @var ElementInterface $elementType */
         $elementType = $query->elementType;
         $total = $query->count();
-        return Craft::t('app', 'Propagating {type}', [
+        return Translation::prep('app', 'Propagating {type}', [
             'type' => $total == 1 ? $elementType::lowerDisplayName() : $elementType::pluralLowerDisplayName(),
         ]);
     }

--- a/src/queue/jobs/PruneRevisions.php
+++ b/src/queue/jobs/PruneRevisions.php
@@ -9,6 +9,7 @@ namespace craft\queue\jobs;
 
 use Craft;
 use craft\base\ElementInterface;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 
 /**
@@ -81,6 +82,6 @@ class PruneRevisions extends BaseJob
      */
     protected function defaultDescription(): ?string
     {
-        return Craft::t('app', 'Pruning extra revisions');
+        return Translation::prep('app', 'Pruning extra revisions');
     }
 }

--- a/src/queue/jobs/ResaveElements.php
+++ b/src/queue/jobs/ResaveElements.php
@@ -12,6 +12,7 @@ use craft\base\ElementInterface;
 use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
 use craft\events\BatchElementActionEvent;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 use craft\services\Elements;
 
@@ -54,7 +55,7 @@ class ResaveElements extends BaseJob
 
         $callback = function(BatchElementActionEvent $e) use ($queue, $query, $total) {
             if ($e->query === $query) {
-                $this->setProgress($queue, ($e->position - 1) / $total, Craft::t('app', '{step, number} of {total, number}', [
+                $this->setProgress($queue, ($e->position - 1) / $total, Translation::prep('app', '{step, number} of {total, number}', [
                     'step' => $e->position,
                     'total' => $total,
                 ]));
@@ -75,7 +76,7 @@ class ResaveElements extends BaseJob
         $query = $this->_query();
         /** @var ElementInterface $elementType */
         $elementType = $query->elementType;
-        return Craft::t('app', 'Resaving {type}', [
+        return Translation::prep('app', 'Resaving {type}', [
             'type' => $elementType::pluralLowerDisplayName(),
         ]);
     }

--- a/src/queue/jobs/UpdateElementSlugsAndUris.php
+++ b/src/queue/jobs/UpdateElementSlugsAndUris.php
@@ -13,6 +13,7 @@ use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
 use craft\errors\OperationAbortedException;
 use craft\helpers\Db;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 use craft\queue\QueueInterface;
 use yii\queue\Queue;
@@ -79,7 +80,7 @@ class UpdateElementSlugsAndUris extends BaseJob
      */
     protected function defaultDescription(): ?string
     {
-        return Craft::t('app', 'Updating element slugs and URIs');
+        return Translation::prep('app', 'Updating element slugs and URIs');
     }
 
     /**

--- a/src/queue/jobs/UpdateSearchIndex.php
+++ b/src/queue/jobs/UpdateSearchIndex.php
@@ -9,6 +9,7 @@ namespace craft\queue\jobs;
 
 use Craft;
 use craft\base\ElementInterface;
+use craft\i18n\Translation;
 use craft\queue\BaseJob;
 
 /**
@@ -67,6 +68,6 @@ class UpdateSearchIndex extends BaseJob
      */
     protected function defaultDescription(): ?string
     {
-        return Craft::t('app', 'Updating search indexes');
+        return Translation::prep('app', 'Updating search indexes');
     }
 }

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -46,6 +46,7 @@ use craft\helpers\Db;
 use craft\helpers\ElementHelper;
 use craft\helpers\Queue;
 use craft\helpers\StringHelper;
+use craft\i18n\Translation;
 use craft\queue\jobs\FindAndReplace;
 use craft\queue\jobs\UpdateElementSlugsAndUris;
 use craft\queue\jobs\UpdateSearchIndex;
@@ -1535,13 +1536,13 @@ class Elements extends Component
                 $refTagPrefix = "{{$refHandle}:";
 
                 Queue::push(new FindAndReplace([
-                    'description' => Craft::t('app', 'Updating element references'),
+                    'description' => Translation::prep('app', 'Updating element references'),
                     'find' => $refTagPrefix . $mergedElement->id . ':',
                     'replace' => $refTagPrefix . $prevailingElement->id . ':',
                 ]));
 
                 Queue::push(new FindAndReplace([
-                    'description' => Craft::t('app', 'Updating element references'),
+                    'description' => Translation::prep('app', 'Updating element references'),
                     'find' => $refTagPrefix . $mergedElement->id . '}',
                     'replace' => $refTagPrefix . $prevailingElement->id . '}',
                 ]));

--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -26,6 +26,7 @@ use craft\helpers\Json;
 use craft\helpers\ProjectConfig as ProjectConfigHelper;
 use craft\helpers\Queue;
 use craft\helpers\StringHelper;
+use craft\i18n\Translation;
 use craft\models\EntryType;
 use craft\models\FieldLayout;
 use craft\models\Section;
@@ -704,7 +705,7 @@ class Sections extends Component
                 // If the propagation method just changed, we definitely need to update entries for that
                 if ($propagationMethodChanged) {
                     Queue::push(new ApplyNewPropagationMethod([
-                        'description' => Craft::t('app', 'Applying new propagation method to {section} entries', [
+                        'description' => Translation::prep('app', 'Applying new propagation method to {section} entries', [
                             'section' => $sectionRecord->name,
                         ]),
                         'elementType' => Entry::class,
@@ -715,7 +716,7 @@ class Sections extends Component
                     ]));
                 } else if ($this->autoResaveEntries) {
                     Queue::push(new ResaveElements([
-                        'description' => Craft::t('app', 'Resaving {section} entries', [
+                        'description' => Translation::prep('app', 'Resaving {section} entries', [
                             'section' => $sectionRecord->name,
                         ]),
                         'elementType' => Entry::class,
@@ -1206,7 +1207,7 @@ class Sections extends Component
         } else if (!$isNewEntryType && $resaveEntries && $this->autoResaveEntries) {
             // Re-save the entries of this type
             Queue::push(new ResaveElements([
-                'description' => Craft::t('app', 'Resaving {type} entries', [
+                'description' => Translation::prep('app', 'Resaving {type} entries', [
                     'type' => ($section->type !== Section::TYPE_SINGLE ? $section->name . ' - ' : '') . $entryType->name,
                 ]),
                 'elementType' => Entry::class,


### PR DESCRIPTION
### Description

Adds a new `craft\i18n\Translation` class with two static methods:

- `prep()` – Has same arguments as `Craft::t()`, but instead of translating the message immediately, it will package the arguments up into a JSON-encoded string prefixed with `t9n:`.
- `translate()` – Takes a prepared string from `prep()` and unpacks it, then translates it for the current application language (which could be different than whatever it was when `prep()` was called).

All built-in queue jobs are now calling `Translation::prep()` instead of `Craft::t()` when defining their descriptions and progress labels, and the built-in queue driver is calling `Translation::translate()` on job descriptions and progress labels from `getJobDetails()` and `getJobInfo()`.

The result is that queue messages are now always translated for the current user’s language, rather than whatever language was active at the time the job was queued up, or whatever language the queue runner is using.

### Examples

Queuing up a job with a custom description:

```php
use craft\elements\Entry;
use craft\helpers\Queue;
use craft\i18n\Translation;
use craft\queue\jobs\ResaveElements;

Queue::push(new ResaveElements([
    'elementType' => Entry::class,
    'criteria' => ['section' => 'news'],
    'description' => Translation::prep('site', 'Resaving News entries'),
]));
```

Defining a default description from a job type:

```php
use craft\i18n\Translation;

protected function defaultDescription(): ?string
{
    return Translation::prep('app', 'Resaving {type}', [
        'type' => $this->elementType::pluralLowerDisplayName(),
    ]);
}
```

Setting the progress:

```php
use craft\i18n\Translation;

$progress = ($step - 1) / $total;
$this->setProgress($queue, $progress, Translation::prep('app', '{step, number} of {total, number}', [
    'step' => $step,
    'total' => $total,
]));
```

### Related issues

- #9696