### PR TITLE
Redirect site requests to CP when baseCpUrl is configured

### DIFF
--- a/src/web/Application.php
+++ b/src/web/Application.php
@@ -257,7 +257,18 @@ class Application extends \yii\web\Application
             return $response;
         }
 
-        // If we're still here, finally let Yii do it's thing.
+        // If this is a request to a configured baseCpUrl,
+        // redirect any would-be site requests to the CP.
+        $currentBaseUrl = rtrim(Craft::$app->getRequest()->hostInfo, '/') . '/';
+        if (Craft::$app->getRequest()->isSiteRequest &&
+            $currentBaseUrl === UrlHelper::baseCpUrl() &&
+            $this->getConfig()->getGeneral()->baseCpUrl
+        ) {
+            Craft::$app->getResponse()->redirect(UrlHelper::cpUrl());
+            $this->end();
+        }
+
+        // If we're still here, finally let Yii do its thing.
         try {
             return parent::handleRequest($request);
         } catch (\Throwable $e) {


### PR DESCRIPTION
Currently, if https://craftcms.com/docs/3.x/config/config-settings.html#basecpurl is configured, Craft will still serve site URLs from that domain.

This feels weird, seems bad in terms of duplicate content, and still requires the user to know the `cpTrigger` slug, which shouldn't really be necessary when using `baseCpUrl`.

This will redirect to the CP in the event that the request is from the same origin as the configured `baseCpUrl`.

### Examples:

**Given:**

```
[
  'siteUrl' => 'https://site.test',
  'baseCpUrl' => 'https://cp.test',
]
```

**Redirects:**
- https://cp.test/ → https://cp.test/admin/
- https://cp.test/foo/bar → https://cp.test/admin/ (could arguably redirect to https://cp.test/admin/foo/bar?)
- https://cp.test/admin/* → (no redirect)
- https://site.test/admin/ → (404, no redirect)

### Docs

Somewhat related…

@mattstein In its current state, https://craftcms.com/knowledge-base/access-the-cp-from-a-subdomain is misleading:

> If someone accesses the control panel from https://your-domain.com/admin, you can have Craft automatically redirect them over to your subdomain with the baseCpUrl config setting.

That isn't currently true, nor do I think it should be…I think it makes sense for it to 404 as it does now.