### PR TITLE
Re-enable text scaling and zoom on mobile by removing maximum-scale =…

### DIFF
--- a/src/templates/_layouts/base.html
+++ b/src/templates/_layouts/base.html
@@ -29,7 +29,7 @@
     <title>{{ docTitle ~ (docTitle|length and systemName|length ? ' - ') ~ systemName }}</title>
     {{ head() }}
     <meta name="referrer" content="origin-when-cross-origin">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% set hasCustomIcon = false %}
     {% for tag in craft.app.config.general.cpHeadTags %}


### PR DESCRIPTION
… 1 from meta viewport

### Description
Removed maximum scale from viewport settings to allow text scaling and zoom.

@brandonkelly hopefully this doesn't re-introduce the issue you were trying to solve. 🤞🏼 


### Related issues
N/A
