### PR TITLE
issue #9857, fixes redirection with array parameters

### DIFF
--- a/src/web/Controller.php
+++ b/src/web/Controller.php
@@ -533,9 +533,6 @@ abstract class Controller extends \yii\web\Controller
      */
     public function redirect($url, $statusCode = 302): YiiResponse
     {
-        if (is_string($url)) {
-            $url = UrlHelper::url($url);
-        }
 
         if ($url !== null) {
             return $this->response->redirect($url, $statusCode);

--- a/src/web/Response.php
+++ b/src/web/Response.php
@@ -173,7 +173,9 @@ class Response extends \yii\web\Response
      */
     public function redirect($url, $statusCode = 302, $checkAjax = true)
     {
-        $url = UrlHelper::url($url);
+        if (is_string($url)) {
+            $url = UrlHelper::url($url);
+        }
         return parent::redirect($url, $statusCode, $checkAjax);
     }
 


### PR DESCRIPTION
### Description

`craft\web\Controller::redirect()` with array parameters documented in https://docs.craftcms.com/api/v3/craft-web-controller.html#public-methods should work again. 

Moved the `is_string()` check from `Controller::redirect()` to `Response::redirect()`

### Related issues

#9857 