### PR TITLE
Add `EVENT_PREP_QUERY_FOR_TABLE_ATTRIBUTE` Event for customizing Element Index Queries

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -226,7 +226,7 @@ abstract class Element extends Component implements ElementInterface
      * 
      * Event::on(
      *     Entry::class,
-     *     Entry::EVENT_PREP_QUERY_FOR_TABLE_ATTRIBUTE,
+     *     Entry::EVENT_SET_TABLE_ATTRIBUTE_HTML,
      *     function (SetElementTableAttributeHtmlEvent $e) {
      *         $attribute = $e->attribute;
      * 

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -199,10 +199,10 @@ abstract class Element extends Component implements ElementInterface
      * 
      * ```php
      * use craft\elements\Entry;
-     * use craft\helpers\Cp;
      * use craft\events\PrepareElementQueryForTableAttributeEvent;
      * use craft\events\RegisterElementTableAttributesEvent;
      * use craft\events\SetElementTableAttributeHtmlEvent;
+     * use craft\helpers\Cp;
      * use yii\base\Event;
      * 
      * Event::on(

--- a/src/events/PrepareElementQueryForTableAttributeEvent.php
+++ b/src/events/PrepareElementQueryForTableAttributeEvent.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use craft\elements\db\ElementQueryInterface;
+use yii\base\Event;
+
+/**
+ * Table attribute Element Query preparation event
+ * 
+ * Triggered while preparing an Element query for an Element index, for each attribute present in the table.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.7.13
+ */
+class PrepareElementQueryForTableAttributeEvent extends Event
+{
+    /**
+     * @var ElementQueryInterface The Element query being built
+     */
+    public $query;
+
+    /**
+     * @var string The table attribute name, as registered by the Element, and not implicitly a native field or attribute name.
+     */
+    public $attribute;
+}


### PR DESCRIPTION
### Description

This came up [in Discord](https://discord.com/channels/456442477667418113/456442884258922529/889907290784804934), and although it's not a direct solution for the developer's more radical reverse-relations problem, it seems like a worthwhile + lightweight addition, for those of us who are interesting in making Element Index views as useful and performant as possible.

The goal is to let each of the defined "table attributes" on a built-in (or Plugin-owned) Element have control over the query, _in addition to_ the HTML output. I've added the `EVENT_PREP_QUERY_FOR_TABLE_ATTRIBUTE` event, just after the Element has a chance to set its own (native) query arguments, but while still in the context of a specific table attribute.

It didn't seem worthwhile to have a before _and_ after event (like many others in the class) as applying values _before_ could get squashed by native behavior, anyway—despite many using the `->andWidth()` method.

From the new Event constant's doc-block, it basically allows this:

```php
use craft\elements\Entry;
use craft\events\PrepareElementQueryForTableAttributeEvent;
use craft\events\RegisterElementTableAttributesEvent;
use craft\events\SetElementTableAttributeHtmlEvent;
use craft\helpers\Cp;
use yii\base\Event;

Event::on(
    Entry::class,
    Entry::EVENT_REGISTER_TABLE_ATTRIBUTES,
    function (RegisterElementTableAttributesEvent $e) {
        $e->attributes[] = 'authorExpertise';
    });

Event::on(
    Entry::class,
    Entry::EVENT_PREP_QUERY_FOR_TABLE_ATTRIBUTE,
    function (PrepareElementQueryForTableAttributeEvent $e) {
        $query = $e->query;
        $attr = $e->attribute;

        if ($attr === 'authorExpertise') {
            $query->andWith(['author.areasOfExpertiseCategoryField']);
        }
    });

Event::on(
    Entry::class,
    Entry::EVENT_SET_TABLE_ATTRIBUTE_HTML,
    function (SetElementTableAttributeHtmlEvent $e) {
        $attribute = $e->attribute;

        if ($attribute !== 'authorExpertise') {
            return;
        }

        // The field data is eager-loaded!
        $author = $e->sender->getAuthor();
        $categories = $author->areasOfExpertiseCategoryField;

        $e->html = Cp::elementPreviewHtml($categories);
    });
```