### PR TITLE
Two-space Twig+HTML docblock indent

### DIFF
--- a/src/base/ConfigurableComponentInterface.php
+++ b/src/base/ConfigurableComponentInterface.php
@@ -63,7 +63,7 @@ interface ConfigurableComponentInterface extends ComponentInterface
      * ```html
      * <textarea id="foo" name="foo"></textarea>
      * <script type="text/javascript">
-     *     var textarea = document.getElementById('foo');
+     *   var textarea = document.getElementById('foo');
      * </script>
      * ```
      *
@@ -72,7 +72,7 @@ interface ConfigurableComponentInterface extends ComponentInterface
      * ```html
      * <textarea id="namespace-foo" name="namespace[foo]"></textarea>
      * <script type="text/javascript">
-     *     var textarea = document.getElementById('foo');
+     *   var textarea = document.getElementById('foo');
      * </script>
      * ```
      *
@@ -109,7 +109,7 @@ interface ConfigurableComponentInterface extends ComponentInterface
      * ```twig
      * <textarea id="{{ id }}" name="foo">{{ widget.foo }}</textarea>
      * <script type="text/javascript">
-     *     var textarea = document.getElementById('{{ namespacedId }}');
+     *   var textarea = document.getElementById('{{ namespacedId }}');
      * </script>
      * ```
      *

--- a/src/base/FieldInterface.php
+++ b/src/base/FieldInterface.php
@@ -191,7 +191,7 @@ interface FieldInterface extends SavableComponentInterface
      * ```html
      * <textarea id="foo" name="foo"></textarea>
      * <script type="text/javascript">
-     *     var textarea = document.getElementById('foo');
+     *   var textarea = document.getElementById('foo');
      * </script>
      * ```
      *
@@ -200,7 +200,7 @@ interface FieldInterface extends SavableComponentInterface
      * ```html
      * <textarea id="namespace-foo" name="namespace[foo]"></textarea>
      * <script type="text/javascript">
-     *     var textarea = document.getElementById('foo');
+     *   var textarea = document.getElementById('foo');
      * </script>
      * ```
      *
@@ -240,7 +240,7 @@ interface FieldInterface extends SavableComponentInterface
      * ```twig
      * <textarea id="{{ id }}" name="{{ name }}">{{ value }}</textarea>
      * <script type="text/javascript">
-     *     var textarea = document.getElementById('{{ namespacedId }}');
+     *   var textarea = document.getElementById('{{ namespacedId }}');
      * </script>
      * ```
      *

--- a/src/db/Paginator.php
+++ b/src/db/Paginator.php
@@ -31,8 +31,8 @@ use yii\di\Instance;
  * ```
  * ```twig
  * {% set paginator = create('craft\\db\\Paginator', [query, {
- *     pageSize: 10,
- *     currentPage: craft.app.request.pageNum,
+ *   pageSize: 10,
+ *   currentPage: craft.app.request.pageNum,
  * }]) %}
  *
  * {% set pageResults = paginator.getPageResults() %}

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -909,7 +909,7 @@ class Asset extends Element
      * ```
      * ```twig{2}
      * {% if asset.isEditable %}
-     *     <a href="{{ asset.cpEditUrl }}">Edit</a>
+     *   <a href="{{ asset.cpEditUrl }}">Edit</a>
      * {% endif %}
      * ```
      * @since 3.4.0

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -732,7 +732,7 @@ class Entry extends Element
      * ```
      * ```twig
      * {% if entry.expiryDate %}
-     *     {{ entry.expiryDate|date('short') }}
+     *   {{ entry.expiryDate|date('short') }}
      * {% endif %}
      * ```
      */
@@ -1109,10 +1109,10 @@ class Entry extends Element
      * ```
      * ```twig{1}
      * {% switch entry.type.handle %}
-     *     {% case 'article' %}
-     *         {% include "news/_article" %}
-     *     {% case 'link' %}
-     *         {% include "news/_link" %}
+     *   {% case 'article' %}
+     *     {% include "news/_article" %}
+     *   {% case 'link' %}
+     *     {% include "news/_link" %}
      * {% endswitch %}
      * ```
      *
@@ -1213,7 +1213,7 @@ class Entry extends Element
      * ```
      * ```twig{1}
      * {% if entry.isEditable %}
-     *     <a href="{{ entry.cpEditUrl }}">Edit</a>
+     *   <a href="{{ entry.cpEditUrl }}">Edit</a>
      * {% endif %}
      * ```
      */
@@ -1284,7 +1284,7 @@ class Entry extends Element
      * ```
      * ```twig{2}
      * {% if entry.isEditable %}
-     *     <a href="{{ entry.cpEditUrl }}">Edit</a>
+     *   <a href="{{ entry.cpEditUrl }}">Edit</a>
      * {% endif %}
      * ```
      */

--- a/src/elements/db/AssetQuery.php
+++ b/src/elements/db/AssetQuery.php
@@ -77,8 +77,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# fetch assets in the Logos volume #}
      * {% set logos = craft.assets()
-     *     .volume('logos')
-     *     .all() %}
+     *   .volume('logos')
+     *   .all() %}
      * ```
      * @used-by volume()
      * @used-by volumeId()
@@ -139,8 +139,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# fetch only images #}
      * {% set logos = craft.assets()
-     *     .kind('image')
-     *     .all() %}
+     *   .kind('image')
+     *   .all() %}
      * ```
      * @used-by kind()
      */
@@ -159,9 +159,9 @@ class AssetQuery extends ElementQuery
      * ```twig{4}
      * {# fetch images that are at least 500 pixes wide #}
      * {% set logos = craft.assets()
-     *     .kind('image')
-     *     .width('>= 500')
-     *     .all() %}
+     *   .kind('image')
+     *   .width('>= 500')
+     *   .all() %}
      * ```
      * @used-by width()
      */
@@ -180,9 +180,9 @@ class AssetQuery extends ElementQuery
      * ```twig{4}
      * {# fetch images that are at least 500 pixes high #}
      * {% set logos = craft.assets()
-     *     .kind('image')
-     *     .height('>= 500')
-     *     .all() %}
+     *   .kind('image')
+     *   .height('>= 500')
+     *   .all() %}
      * ```
      * @used-by height()
      */
@@ -219,9 +219,9 @@ class AssetQuery extends ElementQuery
      * ```twig{4}
      * {# fetch images with their 'thumb' transforms preloaded #}
      * {% set logos = craft.assets()
-     *     .kind('image')
-     *     .withTransforms(['thumb'])
-     *     .all() %}
+     *   .kind('image')
+     *   .withTransforms(['thumb'])
+     *   .all() %}
      * ```
      * @used-by withTransforms()
      */
@@ -257,8 +257,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch assets in the Foo volume #}
      * {% set {elements-var} = {twig-method}
-     *     .volume('foo')
-     *     .all() %}
+     *   .volume('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -322,8 +322,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch assets in the volume with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .volumeId(1)
-     *     .all() %}
+     *   .volumeId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -374,8 +374,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch assets in the folder with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .folderId(1)
-     *     .all() %}
+     *   .folderId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -416,8 +416,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch assets uploaded by the user with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .uploader(1)
-     *     .all() %}
+     *   .uploader(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -464,8 +464,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch all the hi-res images #}
      * {% set {elements-var} = {twig-method}
-     *     .filename('*@2x*')
-     *     .all() %}
+     *   .filename('*@2x*')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -523,8 +523,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch all the images #}
      * {% set {elements-var} = {twig-method}
-     *     .kind('image')
-     *     .all() %}
+     *   .kind('image')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -560,9 +560,9 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch XL images #}
      * {% set {elements-var} = {twig-method}
-     *     .kind('image')
-     *     .width('>= 1000')
-     *     .all() %}
+     *   .kind('image')
+     *   .width('>= 1000')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -599,9 +599,9 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch XL images #}
      * {% set {elements-var} = {twig-method}
-     *     .kind('image')
-     *     .height('>= 1000')
-     *     .all() %}
+     *   .kind('image')
+     *   .height('>= 1000')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -638,8 +638,8 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch assets that are smaller than 1KB #}
      * {% set {elements-var} = {twig-method}
-     *     .size('< 1000')
-     *     .all() %}
+     *   .size('< 1000')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -677,8 +677,8 @@ class AssetQuery extends ElementQuery
      * {% set start = date('30 days ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .dateModified(">= #{start}")
-     *     .all() %}
+     *   .dateModified(">= #{start}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -708,9 +708,9 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch assets in the folder with an ID of 1 (including its subfolders) #}
      * {% set {elements-var} = {twig-method}
-     *     .folderId(1)
-     *     .includeSubfolders()
-     *     .all() %}
+     *   .folderId(1)
+     *   .includeSubfolders()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -767,9 +767,9 @@ class AssetQuery extends ElementQuery
      * ```twig
      * {# Fetch assets with the 'thumbnail' and 'hiResThumbnail' transform data preloaded #}
      * {% set {elements-var} = {twig-method}
-     *     .kind('image')
-     *     .withTransforms(['thumbnail', 'hiResThumbnail'])
-     *     .all() %}
+     *   .kind('image')
+     *   .withTransforms(['thumbnail', 'hiResThumbnail'])
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/CategoryQuery.php
+++ b/src/elements/db/CategoryQuery.php
@@ -113,8 +113,8 @@ class CategoryQuery extends ElementQuery
      * ```twig
      * {# Fetch categories in the Foo group #}
      * {% set {elements-var} = {twig-method}
-     *     .group('foo')
-     *     .all() %}
+     *   .group('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -163,8 +163,8 @@ class CategoryQuery extends ElementQuery
      * ```twig
      * {# Fetch categories in the group with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .groupId(1)
-     *     .all() %}
+     *   .groupId(1)
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/ElementQueryInterface.php
+++ b/src/elements/db/ElementQueryInterface.php
@@ -36,8 +36,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} in reverse #}
      * {% set {elements-var} = {twig-method}
-     *     .inReverse()
-     *     .all() %}
+     *   .inReverse()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -60,8 +60,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} as arrays #}
      * {% set {elements-var} = {twig-method}
-     *     .asArray()
-     *     .all() %}
+     *   .asArray()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -94,9 +94,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch a draft {element} #}
      * {% set {elements-var} = {twig-function}
-     *     .drafts()
-     *     .id(123)
-     *     .one() %}
+     *   .drafts()
+     *   .id(123)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -127,8 +127,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch a draft #}
      * {% set {elements-var} = {twig-method}
-     *     .draftId(10)
-     *     .all() %}
+     *   .draftId(10)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -161,8 +161,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch drafts of the {element} #}
      * {% set {elements-var} = {twig-method}
-     *     .draftOf({myElement})
-     *     .all() %}
+     *   .draftOf({myElement})
+     *   .all() %}
      * ```
      *
      * ```php
@@ -193,8 +193,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch drafts by the current user #}
      * {% set {elements-var} = {twig-method}
-     *     .draftCreator(currentUser)
-     *     .all() %}
+     *   .draftCreator(currentUser)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -218,9 +218,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch provisional drafts created by the current user #}
      * {% set {elements-var} = {twig-method}
-     *     .provisionalDrafts()
-     *     .draftCreator(currentUser)
-     *     .all() %}
+     *   .provisionalDrafts()
+     *   .draftCreator(currentUser)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -245,9 +245,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch saved, unpublished draft {elements} #}
      * {% set {elements-var} = {twig-function}
-     *     .draftOf(false)
-     *     .savedDraftsOnly()
-     *     .all() %}
+     *   .draftOf(false)
+     *   .savedDraftsOnly()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -272,9 +272,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch a revision {element} #}
      * {% set {elements-var} = {twig-function}
-     *     .revisions()
-     *     .id(123)
-     *     .one() %}
+     *   .revisions()
+     *   .id(123)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -305,8 +305,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch a revision #}
      * {% set {elements-var} = {twig-method}
-     *     .revisionId(10)
-     *     .all() %}
+     *   .revisionId(10)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -337,8 +337,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch revisions of the {element} #}
      * {% set {elements-var} = {twig-method}
-     *     .revisionOf({myElement})
-     *     .all() %}
+     *   .revisionOf({myElement})
+     *   .all() %}
      * ```
      *
      * ```php
@@ -369,8 +369,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch revisions by the current user #}
      * {% set {elements-var} = {twig-method}
-     *     .revisionCreator(currentUser)
-     *     .all() %}
+     *   .revisionCreator(currentUser)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -403,8 +403,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch the {element} by its ID #}
      * {% set {element-var} = {twig-method}
-     *     .id(1)
-     *     .one() %}
+     *   .id(1)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -433,8 +433,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch the {element} by its UID #}
      * {% set {element-var} = {twig-method}
-     *     .uid('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
-     *     .one() %}
+     *   .uid('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx')
+     *   .one() %}
      * ```
      *
      * ```php
@@ -466,8 +466,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch the {element} by its ID in the elements_sites table #}
      * {% set {element-var} = {twig-method}
-     *     .siteSettingsId(1)
-     *     .one() %}
+     *   .siteSettingsId(1)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -491,9 +491,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} in a specific order #}
      * {% set {elements-var} = {twig-method}
-     *     .id([1, 2, 3, 4, 5])
-     *     .fixedOrder()
-     *     .all() %}
+     *   .id([1, 2, 3, 4, 5])
+     *   .fixedOrder()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -524,8 +524,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch disabled {elements} #}
      * {% set {elements-var} = {twig-method}
-     *     .status('disabled')
-     *     .all() %}
+     *   .status('disabled')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -556,8 +556,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch trashed {elements} #}
      * {% set {elements-var} = {twig-method}
-     *     .trashed()
-     *     .all() %}
+     *   .trashed()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -592,8 +592,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * {% set end = date('first day of this month')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .dateCreated(['and', ">= #{start}", "< #{end}"])
-     *     .all() %}
+     *   .dateCreated(['and', ">= #{start}", "< #{end}"])
+     *   .all() %}
      * ```
      *
      * ```php
@@ -629,8 +629,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * {% set lastWeek = date('1 week ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .dateUpdated(">= #{lastWeek}")
-     *     .all() %}
+     *   .dateUpdated(">= #{lastWeek}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -672,8 +672,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} from the Foo site #}
      * {% set {elements-var} = {twig-method}
-     *     .site('foo')
-     *     .all() %}
+     *   .site('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -707,8 +707,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} from the site with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .siteId(1)
-     *     .all() %}
+     *   .siteId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -734,9 +734,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch unique {elements} across all sites #}
      * {% set {elements-var} = {twig-method}
-     *     .site('*')
-     *     .unique()
-     *     .all() %}
+     *   .site('*')
+     *   .unique()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -767,10 +767,10 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch unique {elements} from Site A, or Site B if they don’t exist in Site A #}
      * {% set {elements-var} = {twig-method}
-     *     .site('*')
-     *     .unique()
-     *     .preferSites(['a', 'b'])
-     *     .all() %}
+     *   .site('*')
+     *   .unique()
+     *   .preferSites(['a', 'b'])
+     *   .all() %}
      * ```
      *
      * ```php
@@ -803,8 +803,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch all {elements}, including ones disabled for this site #}
      * {% set {elements-var} = {twig-method}
-     *     .enabledForSite(false)
-     *     .all() %}
+     *   .enabledForSite(false)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -830,8 +830,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch all {elements} that are related to myCategory #}
      * {% set {elements-var} = {twig-method}
-     *     .relatedTo(myCategory)
-     *     .all() %}
+     *   .relatedTo(myCategory)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -856,9 +856,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch all {elements} that are related to myCategoryA and myCategoryB #}
      * {% set {elements-var} = {twig-method}
-     *     .relatedTo(myCategoryA)
-     *     .andRelatedTo(myCategoryBy)
-     *     .all() %}
+     *   .relatedTo(myCategoryA)
+     *   .andRelatedTo(myCategoryBy)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -895,8 +895,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} with a title that contains "Foo" #}
      * {% set {elements-var} = {twig-method}
-     *     .title('*Foo*')
-     *     .all() %}
+     *   .title('*Foo*')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -934,8 +934,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      *
      * {# Fetch the {element} with that slug #}
      * {% set {element-var} = {twig-method}
-     *     .slug(requestedSlug|literal)
-     *     .one() %}
+     *   .slug(requestedSlug|literal)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -976,8 +976,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      *
      * {# Fetch the {element} with that URI #}
      * {% set {element-var} = {twig-method}
-     *     .uri(requestedUri|literal)
-     *     .one() %}
+     *   .uri(requestedUri|literal)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -1008,8 +1008,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      *
      * {# Fetch all {elements} that match the search query #}
      * {% set {elements-var} = {twig-method}
-     *     .search(searchQuery)
-     *     .all() %}
+     *   .search(searchQuery)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1045,8 +1045,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} eager-loaded with the "Related" field’s relations #}
      * {% set {elements-var} = {twig-method}
-     *     .with(['related'])
-     *     .all() %}
+     *   .with(['related'])
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1104,8 +1104,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} positioned at level 3 or above #}
      * {% set {elements-var} = {twig-method}
-     *     .level('>= 3')
-     *     .all() %}
+     *   .level('>= 3')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1130,8 +1130,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} that have descendants #}
      * {% set {elements-var} = {twig-method}
-     *     .hasDescendants()
-     *     .all() %}
+     *   .hasDescendants()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1157,8 +1157,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} that have no descendants #}
      * {% set {elements-var} = {twig-method}
-     *     .leaves()
-     *     .all() %}
+     *   .leaves()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1188,8 +1188,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} above this one #}
      * {% set {elements-var} = {twig-method}
-     *     .ancestorOf({myElement})
-     *     .all() %}
+     *   .ancestorOf({myElement})
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1218,9 +1218,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} above this one #}
      * {% set {elements-var} = {twig-method}
-     *     .ancestorOf({myElement})
-     *     .ancestorDist(3)
-     *     .all() %}
+     *   .ancestorOf({myElement})
+     *   .ancestorDist(3)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1251,8 +1251,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} below this one #}
      * {% set {elements-var} = {twig-method}
-     *     .descendantOf({myElement})
-     *     .all() %}
+     *   .descendantOf({myElement})
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1281,9 +1281,9 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} below this one #}
      * {% set {elements-var} = {twig-method}
-     *     .descendantOf({myElement})
-     *     .descendantDist(3)
-     *     .all() %}
+     *   .descendantOf({myElement})
+     *   .descendantDist(3)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1314,8 +1314,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} beside this one #}
      * {% set {elements-var} = {twig-method}
-     *     .siblingOf({myElement})
-     *     .all() %}
+     *   .siblingOf({myElement})
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1345,8 +1345,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch the previous {element} #}
      * {% set {element-var} = {twig-method}
-     *     .prevSiblingOf({myElement})
-     *     .one() %}
+     *   .prevSiblingOf({myElement})
+     *   .one() %}
      * ```
      *
      * ```php
@@ -1376,8 +1376,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch the next {element} #}
      * {% set {element-var} = {twig-method}
-     *     .nextSiblingOf({myElement})
-     *     .one() %}
+     *   .nextSiblingOf({myElement})
+     *   .one() %}
      * ```
      *
      * ```php
@@ -1407,8 +1407,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} before this one #}
      * {% set {elements-var} = {twig-method}
-     *     .positionedBefore({myElement})
-     *     .all() %}
+     *   .positionedBefore({myElement})
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1438,8 +1438,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch {elements} after this one #}
      * {% set {elements-var} = {twig-method}
-     *     .positionedAfter({myElement})
-     *     .all() %}
+     *   .positionedAfter({myElement})
+     *   .all() %}
      * ```
      *
      * ```php
@@ -1462,8 +1462,8 @@ interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, 
      * ```twig
      * {# Fetch all {elements}, regardless of status #}
      * {% set {elements-var} = {twig-method}
-     *     .anyStatus()
-     *     .all() %}
+     *   .anyStatus()
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -70,8 +70,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# fetch entries in the News section #}
      * {% set entries = craft.entries()
-     *     .section('news')
-     *     .all() %}
+     *   .section('news')
+     *   .all() %}
      * ```
      * @used-by section()
      * @used-by sectionId()
@@ -91,9 +91,9 @@ class EntryQuery extends ElementQuery
      * ```twig{4}
      * {# fetch entries in the News section #}
      * {% set entries = craft.entries()
-     *     .section('news')
-     *     .type('article')
-     *     .all() %}
+     *   .section('news')
+     *   .type('article')
+     *   .all() %}
      * ```
      * @used-by EntryQuery::type()
      * @used-by typeId()
@@ -118,8 +118,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# fetch entries authored by people in the Authors group #}
      * {% set entries = craft.entries()
-     *     .authorGroup('authors')
-     *     .all() %}
+     *   .authorGroup('authors')
+     *   .all() %}
      * ```
      * @used-by authorGroup()
      * @used-by authorGroupId()
@@ -138,8 +138,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# fetch entries written in 2018 #}
      * {% set entries = craft.entries()
-     *     .postDate(['and', '>= 2018-01-01', '< 2019-01-01'])
-     *     .all() %}
+     *   .postDate(['and', '>= 2018-01-01', '< 2019-01-01'])
+     *   .all() %}
      * ```
      * @used-by postDate()
      */
@@ -157,8 +157,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# fetch entries written before 4/4/2018 #}
      * {% set entries = craft.entries()
-     *     .before('2018-04-04')
-     *     .all() %}
+     *   .before('2018-04-04')
+     *   .all() %}
      * ```
      * @used-by before()
      */
@@ -176,8 +176,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# fetch entries written in the last 7 days #}
      * {% set entries = craft.entries()
-     *     .after(now|date_modify('-7 days'))
-     *     .all() %}
+     *   .after(now|date_modify('-7 days'))
+     *   .all() %}
      * ```
      * @used-by after()
      */
@@ -272,8 +272,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# Fetch entries in the Foo section #}
      * {% set {elements-var} = {twig-method}
-     *     .section('foo')
-     *     .all() %}
+     *   .section('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -331,8 +331,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# Fetch entries in the section with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .sectionId(1)
-     *     .all() %}
+     *   .sectionId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -370,9 +370,9 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# Fetch entries in the Foo section with a Bar entry type #}
      * {% set {elements-var} = {twig-method}
-     *     .section('foo')
-     *     .type('bar')
-     *     .all() %}
+     *   .section('foo')
+     *   .type('bar')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -421,8 +421,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# Fetch entries of the entry type with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .typeId(1)
-     *     .all() %}
+     *   .typeId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -459,8 +459,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# Fetch entries with an author with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .authorId(1)
-     *     .all() %}
+     *   .authorId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -498,8 +498,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# Fetch entries with an author in the Foo user group #}
      * {% set {elements-var} = {twig-method}
-     *     .authorGroup('foo')
-     *     .all() %}
+     *   .authorGroup('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -547,8 +547,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# Fetch entries with an author in a group with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .authorGroupId(1)
-     *     .all() %}
+     *   .authorGroupId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -587,8 +587,8 @@ class EntryQuery extends ElementQuery
      * {% set end = date('first day of this month')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .postDate(['and', ">= #{start}", "< #{end}"])
-     *     .all() %}
+     *   .postDate(['and', ">= #{start}", "< #{end}"])
+     *   .all() %}
      * ```
      *
      * ```php
@@ -628,8 +628,8 @@ class EntryQuery extends ElementQuery
      * {% set firstDayOfMonth = date('first day of this month') %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .before(firstDayOfMonth)
-     *     .all() %}
+     *   .before(firstDayOfMonth)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -668,8 +668,8 @@ class EntryQuery extends ElementQuery
      * {% set firstDayOfMonth = date('first day of this month') %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .after(firstDayOfMonth)
-     *     .all() %}
+     *   .after(firstDayOfMonth)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -711,8 +711,8 @@ class EntryQuery extends ElementQuery
      * {% set nextMonth = date('first day of next month')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .expiryDate("< #{nextMonth}")
-     *     .all() %}
+     *   .expiryDate("< #{nextMonth}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -752,8 +752,8 @@ class EntryQuery extends ElementQuery
      * ```twig
      * {# Fetch disabled entries #}
      * {% set {elements-var} = {twig-method}
-     *     .status('disabled')
-     *     .all() %}
+     *   .status('disabled')
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/GlobalSetQuery.php
+++ b/src/elements/db/GlobalSetQuery.php
@@ -94,8 +94,8 @@ class GlobalSetQuery extends ElementQuery
      * ```twig
      * {# Fetch the global set with a handle of 'foo' #}
      * {% set {element-var} = {twig-method}
-     *     .handle('foo')
-     *     .one() %}
+     *   .handle('foo')
+     *   .one() %}
      * ```
      *
      * ```php

--- a/src/elements/db/MatrixBlockQuery.php
+++ b/src/elements/db/MatrixBlockQuery.php
@@ -94,8 +94,8 @@ class MatrixBlockQuery extends ElementQuery
      * ```twig
      * {# fetch the entry's text blocks #}
      * {% set blocks = entry.myMatrixField
-     *     .type('text')
-     *     .all() %}
+     *   .type('text')
+     *   .all() %}
      * ```
      * @used-by MatrixBlockQuery::type()
      * @used-by typeId()
@@ -140,8 +140,8 @@ class MatrixBlockQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} in the Foo field #}
      * {% set {elements-var} = {twig-method}
-     *     .field('foo')
-     *     .all() %}
+     *   .field('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -201,8 +201,8 @@ class MatrixBlockQuery extends ElementQuery
      * ```twig
      * {# Fetch Matrix blocks in the field with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .fieldId(1)
-     *     .all() %}
+     *   .fieldId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -239,8 +239,8 @@ class MatrixBlockQuery extends ElementQuery
      * ```twig
      * {# Fetch Matrix blocks created for an element with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .ownerId(1)
-     *     .all() %}
+     *   .ownerId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -298,8 +298,8 @@ class MatrixBlockQuery extends ElementQuery
      * ```twig
      * {# Fetch Matrix blocks created for this entry #}
      * {% set {elements-var} = {twig-method}
-     *     .owner(myEntry)
-     *     .all() %}
+     *   .owner(myEntry)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -380,8 +380,8 @@ class MatrixBlockQuery extends ElementQuery
      * ```twig
      * {# Fetch Matrix blocks with a Foo block type #}
      * {% set {elements-var} = myEntry.myMatrixField
-     *     .type('foo')
-     *     .all() %}
+     *   .type('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -429,8 +429,8 @@ class MatrixBlockQuery extends ElementQuery
      * ```twig
      * {# Fetch Matrix blocks of the block type with an ID of 1 #}
      * {% set {elements-var} = myEntry.myMatrixField
-     *     .typeId(1)
-     *     .all() %}
+     *   .typeId(1)
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/TagQuery.php
+++ b/src/elements/db/TagQuery.php
@@ -57,8 +57,8 @@ class TagQuery extends ElementQuery
      * ```twig
      * {# fetch tags in the Topics group #}
      * {% set tags = craft.tags()
-     *     .group('topics')
-     *     .all() %}
+     *   .group('topics')
+     *   .all() %}
      * ```
      * @used-by group()
      * @used-by groupId()
@@ -95,8 +95,8 @@ class TagQuery extends ElementQuery
      * ```twig
      * {# Fetch tags in the Foo group #}
      * {% set {elements-var} = {twig-method}
-     *     .group('foo')
-     *     .all() %}
+     *   .group('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -144,8 +144,8 @@ class TagQuery extends ElementQuery
      * ```twig
      * {# Fetch tags in the group with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .groupId(1)
-     *     .all() %}
+     *   .groupId(1)
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/UserQuery.php
+++ b/src/elements/db/UserQuery.php
@@ -60,8 +60,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# fetch all the admins #}
      * {% set admins = craft.users()
-     *     .admin()
-     *     .all()%}
+     *   .admin()
+     *   .all()%}
      *
      * {# fetch all the non-admins #}
      * {% set nonAdmins = craft.users()
@@ -90,8 +90,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# fetch users with control panel access #}
      * {% set admins = craft.users()
-     *     .can('accessCp')
-     *     .all() %}
+     *   .can('accessCp')
+     *   .all() %}
      * ```
      * @used-by can()
      */
@@ -109,8 +109,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# fetch the authors #}
      * {% set admins = craft.users()
-     *     .group('authors')
-     *     .all() %}
+     *   .group('authors')
+     *   .all() %}
      * ```
      * @used-by group()
      * @used-by groupId()
@@ -159,8 +159,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# fetch users with their user groups #}
      * {% set users = craft.users()
-     *     .withGroups()
-     *     .all() %}
+     *   .withGroups()
+     *   .all() %}
      * ```
      * @used-by withGroups()
      * @since 3.6.0
@@ -200,8 +200,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch admins #}
      * {% set {elements-var} = {twig-method}
-     *     .admin()
-     *     .all() %}
+     *   .admin()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -229,8 +229,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch users with photos #}
      * {% set {elements-var} = {twig-method}
-     *     .hasPhoto()
-     *     .all() %}
+     *   .hasPhoto()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -260,8 +260,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch users that can access the control panel #}
      * {% set {elements-var} = {twig-method}
-     *     .can('accessCp')
-     *     .all() %}
+     *   .can('accessCp')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -299,8 +299,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch users in the Foo user group #}
      * {% set {elements-var} = {twig-method}
-     *     .group('foo')
-     *     .all() %}
+     *   .group('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -348,8 +348,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch users in a group with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .groupId(1)
-     *     .all() %}
+     *   .groupId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -385,8 +385,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch users with a .co.uk domain on their email address #}
      * {% set {elements-var} = {twig-method}
-     *     .email('*.co.uk')
-     *     .all() %}
+     *   .email('*.co.uk')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -424,8 +424,8 @@ class UserQuery extends ElementQuery
      *
      * {# Fetch that user #}
      * {% set {element-var} = {twig-method}
-     *     .username(requestedUsername|literal)
-     *     .one() %}
+     *   .username(requestedUsername|literal)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -463,8 +463,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch all the Jane's #}
      * {% set {elements-var} = {twig-method}
-     *     .firstName('Jane')
-     *     .all() %}
+     *   .firstName('Jane')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -499,8 +499,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch all the Doe's #}
      * {% set {elements-var} = {twig-method}
-     *     .lastName('Doe')
-     *     .all() %}
+     *   .lastName('Doe')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -538,8 +538,8 @@ class UserQuery extends ElementQuery
      * {% set aWeekAgo = date('7 days ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .lastLoginDate(">= #{aWeekAgo}")
-     *     .all() %}
+     *   .lastLoginDate(">= #{aWeekAgo}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -579,8 +579,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# Fetch active and locked users #}
      * {% set {elements-var} = {twig-method}
-     *     .status(['active', 'locked'])
-     *     .all() %}
+     *   .status(['active', 'locked'])
+     *   .all() %}
      * ```
      *
      * ```php
@@ -618,8 +618,8 @@ class UserQuery extends ElementQuery
      * ```twig
      * {# fetch users with their user groups #}
      * {% set users = craft.users()
-     *     .withGroups()
-     *     .all() %}
+     *   .withGroups()
+     *   .all() %}
      * ```
      *
      * @param bool $value The property value (defaults to true)

--- a/src/feeds/Feeds.php
+++ b/src/feeds/Feeds.php
@@ -66,12 +66,12 @@ class Feeds extends Component
      * <h3>{{ feed.title }}</h3>
      *
      * {% for item in feed.items[0:10] %}
-     *     <article>
-     *         <h3><a href="{{ item.permalink }}">{{ item.title }}</a></h3>
-     *         <p class="author">{{ item.authors[0].name }}</p>
-     *         <p class="date">{{ item.date|date('short') }}</p>
-     *         {{ item.summary }}
-     *     </article>
+     *   <article>
+     *     <h3><a href="{{ item.permalink }}">{{ item.title }}</a></h3>
+     *     <p class="author">{{ item.authors[0].name }}</p>
+     *     <p class="date">{{ item.date|date('short') }}</p>
+     *     {{ item.summary }}
+     *   </article>
      * {% endfor %}
      * ```
      *
@@ -169,12 +169,12 @@ class Feeds extends Component
      * {% set items = craft.app.feeds.getFeedItems(feedUrl, 10) %}
      *
      * {% for item in items %}
-     *     <article>
-     *         <h3><a href="{{ item.permalink }}">{{ item.title }}</a></h3>
-     *         <p class="author">{{ item.authors[0].name }}</p>
-     *         <p class="date">{{ item.date|date('short') }}</p>
-     *         {{ item.summary }}
-     *     </article>
+     *   <article>
+     *     <h3><a href="{{ item.permalink }}">{{ item.title }}</a></h3>
+     *     <p class="author">{{ item.authors[0].name }}</p>
+     *     <p class="date">{{ item.date|date('short') }}</p>
+     *     {{ item.summary }}
+     *   </article>
      * {% endfor %}
      * ```
      *

--- a/src/services/Config.php
+++ b/src/services/Config.php
@@ -44,7 +44,7 @@ class Config extends Component
      * ```
      * ```twig
      * {% if craft.app.config.env == 'production' %}
-     *     {% include "_includes/ga" %}
+     *   {% include "_includes/ga" %}
      * {% endif %}
      * ```
      */
@@ -157,7 +157,7 @@ class Config extends Component
      * ```
      * ```twig
      * <a href="{{ url(craft.app.config.general.logoutPath) }}">
-     *     Logout
+     *   Logout
      * </a>
      * ```
      *

--- a/src/web/Session.php
+++ b/src/web/Session.php
@@ -29,9 +29,9 @@ class Session extends \yii\web\Session
      * ```twig{1}
      * {% set message = craft.app.session.getFlash('notice', null, true) %}
      * {% if message %}
-     *     <p class="notice">
-     *         {{ message }}
-     *     </p>
+     *   <p class="notice">
+     *     {{ message }}
+     *   </p>
      * {% endif %}
      * ```
      */
@@ -51,9 +51,9 @@ class Session extends \yii\web\Session
      * ```twig{1}
      * {% set messages = craft.app.session.getAllFLashes(true) %}
      * {% for key, message in messages %}
-     *     <p class="{{ key }}">
-     *         {{ message }}
-     *     </p>
+     *   <p class="{{ key }}">
+     *     {{ message }}
+     *   </p>
      * {% endfor %}
      * ```
      */
@@ -72,9 +72,9 @@ class Session extends \yii\web\Session
      * ```
      * ```twig{1}
      * {% if craft.app.session.hasFlash('notice') %}
-     *     <p class="notice">
-     *         {{ craft.app.session.getFlash('notice', null, true) }}
-     *     </p>
+     *   <p class="notice">
+     *     {{ craft.app.session.getFlash('notice', null, true) }}
+     *   </p>
      * {% endif %}
      * ```
      */

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -162,15 +162,15 @@ class User extends \yii\web\User
      * ```
      * ```twig{5}
      * <form method="post" action="" accept-charset="UTF-8">
-     *     {{ csrfInput() }}
-     *     {{ actionInput('users/login') }}
+     *   {{ csrfInput() }}
+     *   {{ actionInput('users/login') }}
      *
-     *     {% set username = craft.app.user.rememberedUsername %}
-     *     <input type="text" name="loginName" value="{{ username }}">
+     *   {% set username = craft.app.user.rememberedUsername %}
+     *   <input type="text" name="loginName" value="{{ username }}">
      *
-     *     <input type="password" name="password">
+     *   <input type="password" name="password">
      *
-     *     <input type="submit" value="Login">
+     *   <input type="submit" value="Login">
      * </form>
      * ```
      *
@@ -191,13 +191,13 @@ class User extends \yii\web\User
      * ```
      * ```twig
      * {% if craft.app.user.isGuest %}
-     *     <a href="{{ url(craft.app.config.general.getLoginPath()) }}">
-     *         Login
-     *     </a>
+     *   <a href="{{ url(craft.app.config.general.getLoginPath()) }}">
+     *     Login
+     *   </a>
      * {% else %}
-     *     <a href="{{ url(craft.app.config.general.getLogoutPath()) }}">
-     *         Logout
-     *     </a>
+     *   <a href="{{ url(craft.app.config.general.getLogoutPath()) }}">
+     *     Logout
+     *   </a>
      * {% endif %}
      * ```
      */

--- a/src/web/assets/admintable/README.md
+++ b/src/web/assets/admintable/README.md
@@ -26,7 +26,7 @@ The only markup that is required is an element to mount the table on.
 
 ## Javascript
 
-The table is initialised via javascript.
+The table is initialised via JavaScript.
 
 ```js
 new Craft.VueAdminTable({...options...});


### PR DESCRIPTION
### Description

Updates docblock fenced Twig and HTML chunks to use two-space indents instead of four. Coincides with a similar effort [in the docs](https://github.com/craftcms/docs/commit/6d824aa27e8710df16cc88ba3d50c2563e876901).