### PR TITLE
Adds aliased `$router` to `./craft serve`

### DIFF
--- a/src/console/controllers/ServeController.php
+++ b/src/console/controllers/ServeController.php
@@ -27,6 +27,12 @@ class ServeController extends BaseServeController
      * @var string path or [path alias](https://craftcms.com/docs/3.x/config/#aliases) of the directory to serve.
      */
     public $docroot = '@webroot';
+    
+    /**
+      * @var string path or [path alias](guide:concept-aliases) to router script.
+      * See https://secure.php.net/manual/en/features.commandline.webserver.php
+      */
+    public $router = '@webroot/index.php';
 
     /**
      * @inheritdoc


### PR DESCRIPTION
### Description

PHP's built-in CLI server is a bit finicky and tries to be sort of like Apache/Nginx without actually _being_ a web server. One of the quirks is that PHP's server will always try to serve something that _looks_ like a static file from the filesystem, even if the file doesn't exist. So a request to `/page/foo.json` will not go through Craft's routing. It'll never hit Craft because PHP will think it's a static file request and serve a 404 when the file doesn't actually exist.

I got aliased routing merged in to Yii so I think it'd make sense to update Craft's router to use the `@webroot` alias.

This bites me most commonly when using the Element API because any `.json` routes that Craft creates are completely inaccessible through `./craft serve` today.

### Related issues

- https://github.com/yiisoft/yii2/pull/18788/files
