### PR TITLE
Correction of Asset.php

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2340,7 +2340,7 @@ class Asset extends Element
         // Make sure it's not within a system directory
         $systemDirs = $pathService->getSystemPaths();
 
-        $systemDirs = array_map("_normalizeTempPath", $systemDirs);
+        $systemDirs = array_map(array($this, "_normalizeTempPath"), $systemDirs);
         $systemDirs = array_filter($systemDirs, function($value) {
             return ($value !== false);
         });


### PR DESCRIPTION
array_map parameter 1 need to be a function!

But the way it is it's only a string, please update your code. 

By passing an array with ($this, "_normalizeTempPath") to send the context of the string that represent the class method.

### Description



### Related issues

