### PR TITLE
De-structure drafts and revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,22 @@
 
 ## Unreleased
 
+> {tip} After updating, run the `utils/repair/section-structure` command for each Structure section, to prune unneeded structure data for drafts and revisions.
+
+### Added
+- Added `craft\services\Structures::remove()`.
+
 ### Changed
+- Entry drafts and revisions are no longer placed within the section’s structure (with the exception of unpublished drafts, and provisional drafts which have been assigned a new parent entry). ([#9977](https://github.com/craftcms/cms/issues/9977), [#9999](https://github.com/craftcms/cms/issues/9999))
+- The `utils/repair/section-structure` command now prunes unneeded structure data for drafts and revisions.
 - The `utils/repair/section-structure` command now appends entries to the structure root if they don’t have any supported sites in common with their parent.
+- `craft\services\Elements::duplicateElement()` no longer places derivative elements in the structure.
 
 ### Fixed
 - Fixed an error that occurred when updating to Craft 3.7.17+ from the control panel. ([#9990](https://github.com/craftcms/cms/issues/9990))
 - Fixed a bug where Structure section entries would forget who their parent entry was, if it was an unpublished draft.
 - Fixed a bug where Structure sections’ structure data wasn’t getting soft-deleted when the section type was changed.
+- Fixed a bug where provisional drafts weren’t given a position within the structure when converting a Channel section to a Structure.
 - Fixed a bug where `isset()` checks on renamed config settings were always returning `false`.
 
 ## 3.7.18.2 - 2021-10-27

--- a/src/console/controllers/utils/RepairController.php
+++ b/src/console/controllers/utils/RepairController.php
@@ -125,6 +125,13 @@ class RepairController extends Controller
                 '[[structureelements.elementId]] = [[elements.id]]',
                 ['structureelements.structureId' => $structureId],
             ])
+            // Only include unpublished and provisional drafts
+            ->andWhere([
+                'or',
+                ['elements.draftId' => null],
+                ['elements.canonicalId' => null],
+                ['and', ['drafts.provisional' => 1], ['not', ['structureelements.lft' => null]]],
+            ])
             ->orderBy([
                 new Expression('CASE WHEN [[structureelements.lft]] IS NOT NULL THEN 0 ELSE 1 END ASC'),
                 'structureelements.lft' => SORT_ASC,
@@ -143,6 +150,7 @@ class RepairController extends Controller
 
         $this->stdout('Processing ' . count($elements) . " $displayName" . ($this->dryRun ? ' (dry run)' : '') . ' ...' . PHP_EOL);
 
+        /** @var ElementInterface[] $ancestors */
         $ancestors = [];
         $level = 0;
 
@@ -162,65 +170,87 @@ class RepairController extends Controller
                 /** @var ElementInterface $element */
                 if (!$element->level) {
                     $issue = 'was missing from structure';
-                    if (!$this->dryRun) {
-                        $structuresService->appendToRoot($structureId, $element, Structures::MODE_INSERT);
-                    }
+                    $newLevel = 1;
                 } else if ($element->level < 1) {
                     $issue = "had unexpected level ($element->level)";
-                    if (!$this->dryRun) {
-                        $structuresService->appendToRoot($structureId, $element, Structures::MODE_INSERT);
-                    }
+                    $newLevel = 1;
                 } else if ($element->level > $level + 1 && (!$structure->maxLevels || $level < $structure->maxLevels)) {
                     $issue = "had unexpected level ($element->level)";
-                    if (!empty($ancestors)) {
-                        if (!$this->dryRun) {
-                            $this->_append($structureId, $element, end($ancestors), $structuresService, $issue);
-                        }
-                    } else {
-                        if (!$this->dryRun) {
-                            $structuresService->appendToRoot($structureId, $element, Structures::MODE_INSERT);
-                        }
-                    }
+                    $newLevel = !empty($ancestors) ? $level + 1 : 1;
                 } else if ($structure->maxLevels && $element->level > $structure->maxLevels) {
                     $issue = "exceeded the max level ($structure->maxLevels)";
-                    if (isset($ancestors[$level - 2])) {
-                        if (!$this->dryRun) {
-                            $this->_append($structureId, $element, $ancestors[$level - 2], $structuresService, $issue);
-                        }
-                    } else {
-                        if (!$this->dryRun) {
-                            $structuresService->appendToRoot($structureId, $element, Structures::MODE_INSERT);
-                        }
-                    }
+                    $newLevel = isset($ancestors[$level - 2]) ? $level : 1;
                 } else {
                     $issue = null;
-                    if ($element->level == 1) {
+                    $newLevel = $element->level;
+                }
+
+                // Skip provisional drafts if they exist directly after their canonical element
+                if (
+                    $element->isProvisionalDraft &&
+                    isset($ancestors[$newLevel - 1]) &&
+                    $element->getCanonicalId() == $ancestors[$newLevel - 1]->id
+                ) {
+                    $removed = true;
+                } else {
+                    if ($newLevel == 1) {
                         if (!$this->dryRun) {
                             $structuresService->appendToRoot($structureId, $element, Structures::MODE_INSERT);
                         }
                     } else {
-                        if (!$this->dryRun) {
-                            $this->_append($structureId, $element, $ancestors[$element->level - 2], $structuresService, $issue);
+                        // Make sure that the element has at least one site in common with the parent
+                        $parentElement = $ancestors[$newLevel - 2];
+                        $elementSites = ArrayHelper::getColumn(ElementHelper::supportedSitesForElement($element), 'siteId');
+                        $parentSites = ArrayHelper::getColumn(ElementHelper::supportedSitesForElement($parentElement), 'siteId');
+
+                        if (!array_intersect($elementSites, $parentSites)) {
+                            $issue = 'no supported sites in common with parent';
+                            if (!$this->dryRun) {
+                                $structuresService->appendToRoot($structureId, $element, Structures::MODE_INSERT);
+                            }
+                        } else if (!$this->dryRun) {
+                            $structuresService->append($structureId, $element, $parentElement, Structures::MODE_INSERT);
                         }
                     }
+
+                    $removed = false;
                 }
 
+                $this->stdout(' ');
+
                 $space = $element->level > 1 ? str_repeat(' ', ($element->level - 1) * 4 - 2) : '';
-                $this->stdout(' ' . ($issue ? '✖' : '✔') . ' ' . $space, $issue ? Console::FG_RED : Console::FG_GREEN);
-                $this->stdout(($element->level > 1 ? '∟ ' : '') . $element->title);
+
+                if ($removed) {
+                    $this->stdout('*', Console::FG_YELLOW);
+                } else if ($issue) {
+                    $this->stdout('✖', Console::FG_RED);
+                } else {
+                    $this->stdout('✔', Console::FG_GREEN);
+                }
+
+                $this->stdout(" $space" . ($element->level > 1 ? '∟ ' : '') . $element->title);
+
                 if ($element->getIsDraft() || $element->getIsRevision()) {
-                    if ($element->getIsDraft()) {
+                    if ($element->isProvisionalDraft) {
+                        $revLabel = 'provisional draft';
+                    } else if ($element->getIsUnpublishedDraft()) {
+                        $revLabel = 'unpublished draft';
+                    } else if ($element->getIsDraft()) {
                         /** @var DraftBehavior|ElementInterface $element */
-                        $revLabel = $element->draftName ?: 'Draft';
+                        $revLabel = 'draft' . ($element->draftName ? ": $element->draftName" : '');
                     } else {
                         /** @var RevisionBehavior|ElementInterface $element */
-                        $revLabel = $element->revisionNum ? "Revision $element->revisionNum" : 'Revision';
+                        $revLabel = 'revision' . ($element->revisionNum ? " $element->revisionNum" : '');
                     }
                     $this->stdout(" ($revLabel)", Console::FG_GREY);
                 }
-                if ($issue) {
+
+                if ($removed) {
+                    $this->stdout(' - removed', Console::FG_YELLOW);
+                } else if ($issue) {
                     $this->stdout(" - $issue", Console::FG_RED);
                 }
+
                 $this->stdout(PHP_EOL);
 
                 // Prepare for the next element
@@ -242,20 +272,6 @@ class RepairController extends Controller
         $this->stdout("Finished processing $displayName" . ($this->dryRun ? ' (dry run)' : '') . PHP_EOL);
 
         return ExitCode::OK;
-    }
-
-    private function _append(int $structureId, ElementInterface $element, $parentElement, Structures $structuresService, ?string &$issue): void
-    {
-        // Make sure that the element has at least one site in common with the parent
-        $elementSites = ArrayHelper::getColumn(ElementHelper::supportedSitesForElement($element), 'siteId');
-        $parentSites = ArrayHelper::getColumn(ElementHelper::supportedSitesForElement($parentElement), 'siteId');
-
-        if (!array_intersect($elementSites, $parentSites)) {
-            $issue = 'no supported sites in common with parent';
-            $structuresService->appendToRoot($structureId, $element, Structures::MODE_INSERT);
-        } else {
-            $structuresService->append($structureId, $element, $parentElement, Structures::MODE_INSERT);
-        }
     }
 
     /**

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -22,7 +22,6 @@ use craft\helpers\ElementHelper;
 use craft\helpers\UrlHelper;
 use craft\models\Section;
 use craft\models\Site;
-use craft\services\Structures;
 use craft\web\assets\editentry\EditEntryAsset;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
@@ -172,30 +171,24 @@ class EntriesController extends BaseEntriesController
             }
 
             // Get the initially selected parent
-            $parentId = $this->request->getParam('parentId');
-
-            if ($parentId === null) {
-                // Is it already set on the model (e.g. if we're loading a draft)?
-                if ($entry->newParentId !== null) {
-                    $parentId = $entry->newParentId;
-                } else {
-                    $parentId = $entry->getAncestors(1)
-                        ->drafts(null)
-                        ->draftOf(false)
-                        ->anyStatus()
-                        ->ids();
-                }
-            }
-
-            if (is_array($parentId)) {
-                $parentId = reset($parentId) ?: null;
-            }
+            $parentId = $this->request->getParam('parentId') ?? $entry->newParentId;
 
             if ($parentId) {
-                $variables['parent'] = Craft::$app->getEntries()->getEntryById($parentId, $site->id, [
-                    'drafts' => null,
-                    'draftOf' => false,
-                ]);
+                $variables['parent'] = Craft::$app->getEntries()->getEntryById(
+                    is_array($parentId) ? reset($parentId) : $parentId,
+                    $site->id,
+                    ['drafts' => null, 'draftOf' => false]
+                );
+            } else {
+                // If the entry already has structure data, use it.
+                // Otherwise, use its canonical entry
+                $variables['parent'] = Entry::find()
+                    ->ancestorOf($entry->lft ? $entry : ($entry->getIsCanonical() ? $entry->id : $entry->getCanonical(true)))
+                    ->ancestorDist(1)
+                    ->drafts(null)
+                    ->draftOf(false)
+                    ->anyStatus()
+                    ->one();
             }
         }
 
@@ -768,6 +761,7 @@ class EntriesController extends BaseEntriesController
                 ->provisionalDrafts()
                 ->draftOf($entryId)
                 ->draftCreator(Craft::$app->getUser()->getIdentity())
+                ->structureId($section->structureId)
                 ->siteId($site->id)
                 ->anyStatus()
                 ->one();
@@ -783,42 +777,7 @@ class EntriesController extends BaseEntriesController
             }
         }
 
-        if ($entry) {
-            return $entry;
-        }
-
-        // If a draft or revision was requested in a Structure section, see if it's just missing a `structureelements` record
-        if ($section->structureId) {
-            if ($draftId) {
-                $entry = Entry::find()
-                    ->draftId($draftId)
-                    ->siteId($site->id)
-                    ->anyStatus()
-                    ->one();
-            } else if ($revisionId) {
-                $entry = Entry::find()
-                    ->revisionId($revisionId)
-                    ->siteId($site->id)
-                    ->anyStatus()
-                    ->one();
-            }
-
-            if ($entry) {
-                // Get the source entry
-                $sourceEntry = Entry::find()
-                    ->id($entryId)
-                    ->siteId($site->id)
-                    ->anyStatus()
-                    ->one();
-                if ($sourceEntry) {
-                    // Insert the draft/revision alongside the source entry
-                    Craft::$app->getStructures()->moveAfter($section->structureId, $entry, $sourceEntry, Structures::MODE_INSERT);
-                    return $entry;
-                }
-            }
-        }
-
-        return null;
+        return $entry;
     }
 
     /**

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1638,20 +1638,7 @@ EOD;
             if (!$this->duplicateOf && $section->type == Section::TYPE_STRUCTURE) {
                 // Has the parent changed?
                 if ($this->_hasNewParent()) {
-                    $mode = $isNew ? Structures::MODE_INSERT : Structures::MODE_AUTO;
-                    if (!$this->newParentId) {
-                        if ($section->defaultPlacement === Section::DEFAULT_PLACEMENT_BEGINNING) {
-                            Craft::$app->getStructures()->prependToRoot($this->structureId, $this, $mode);
-                        } else {
-                            Craft::$app->getStructures()->appendToRoot($this->structureId, $this, $mode);
-                        }
-                    } else {
-                        if ($section->defaultPlacement === Section::DEFAULT_PLACEMENT_BEGINNING) {
-                            Craft::$app->getStructures()->prepend($this->structureId, $this, $this->getParent(), $mode);
-                        } else {
-                            Craft::$app->getStructures()->append($this->structureId, $this, $this->getParent(), $mode);
-                        }
-                    }
+                    $this->_placeInStructure($isNew, $section);
                 }
 
                 // Update the entry's descendants, who may be using this entry's URI in their own URIs
@@ -1664,6 +1651,40 @@ EOD;
         }
 
         parent::afterSave($isNew);
+    }
+
+    private function _placeInStructure(bool $isNew, Section $section): void
+    {
+        // If this is a provisional draft and its new parent matches the canonical entry’s, just drop it from the structure
+        if ($this->isProvisionalDraft) {
+            $canonicalParentId = Entry::find()
+                ->select(['elements.id'])
+                ->ancestorOf($this->getCanonicalId())
+                ->ancestorDist(1)
+                ->anyStatus()
+                ->scalar();
+
+            if ($this->newParentId == $canonicalParentId) {
+                Craft::$app->getStructures()->remove($this->structureId, $this);
+                return;
+            }
+        }
+
+        $mode = $isNew ? Structures::MODE_INSERT : Structures::MODE_AUTO;
+
+        if (!$this->newParentId) {
+            if ($section->defaultPlacement === Section::DEFAULT_PLACEMENT_BEGINNING) {
+                Craft::$app->getStructures()->prependToRoot($this->structureId, $this, $mode);
+            } else {
+                Craft::$app->getStructures()->appendToRoot($this->structureId, $this, $mode);
+            }
+        } else {
+            if ($section->defaultPlacement === Section::DEFAULT_PLACEMENT_BEGINNING) {
+                Craft::$app->getStructures()->prepend($this->structureId, $this, $this->getParent(), $mode);
+            } else {
+                Craft::$app->getStructures()->append($this->structureId, $this, $this->getParent(), $mode);
+            }
+        }
     }
 
     /**
@@ -1791,13 +1812,16 @@ EOD;
      */
     private function _checkForNewParent(): bool
     {
-        // Make sure this is a Structure section
-        if ($this->getSection()->type != Section::TYPE_STRUCTURE) {
+        // Make sure this is a Structure section, and that it’s either a canonical entry or provisional drafT
+        if (!(
+            $this->getSection()->type === Section::TYPE_STRUCTURE &&
+            ($this->getIsCanonical() || $this->isProvisionalDraft)
+        )) {
             return false;
         }
 
-        // Is it a brand new entry?
-        if ($this->id === null) {
+        // Is it a brand new (non-provisional) entry?
+        if ($this->id === null && !$this->isProvisionalDraft) {
             return true;
         }
 
@@ -1806,21 +1830,28 @@ EOD;
             return false;
         }
 
+        // If this is a provisional draft, but doesn't actually exist in the structure yet, check based on the canonical entry
+        if ($this->isProvisionalDraft && !$this->lft) {
+            $entry = $this->getCanonical(true);
+        } else {
+            $entry = $this;
+        }
+
         // Is it set to the top level now, but it hadn't been before?
-        if (!$this->newParentId && $this->level != 1) {
+        if (!$this->newParentId && $entry->level != 1) {
             return true;
         }
 
         // Is it set to be under a parent now, but didn't have one before?
-        if ($this->newParentId && $this->level == 1) {
+        if ($this->newParentId && $entry->level == 1) {
             return true;
         }
 
         // Is the parentId set to a different entry ID than its previous parent?
         $oldParentId = self::find()
-            ->ancestorOf($this)
+            ->ancestorOf($entry)
             ->ancestorDist(1)
-            ->siteId($this->siteId)
+            ->siteId($entry->siteId)
             ->anyStatus()
             ->select('elements.id')
             ->scalar();

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1112,7 +1112,8 @@ class Elements extends Component
      *
      * @param ElementInterface $element the element to duplicate
      * @param array $newAttributes any attributes to apply to the duplicate
-     * @param bool $placeInStructure whether to position the cloned element after the original one in its structure
+     * @param bool $placeInStructure whether to position the cloned element after the original one in its structure.
+     * (This will only happen if the duplicated element is canonical.)
      * @return ElementInterface the duplicated element
      * @throws UnsupportedSiteException if the element is being duplicated into a site it doesn’t support
      * @throws InvalidElementException if saveElement() returns false for any of the sites
@@ -1222,6 +1223,7 @@ class Elements extends Component
                 $placeInStructure &&
                 $element->structureId &&
                 $element->root &&
+                $mainClone->getIsCanonical() &&
                 !$mainClone->root &&
                 $mainClone->structureId == $element->structureId
             ) {

--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -1557,6 +1557,8 @@ class Sections extends Component
     {
         // Add all of the entries to the structure
         $query = Entry::find()
+            ->drafts(null)
+            ->draftOf(false)
             ->sectionId($sectionRecord->id)
             ->siteId('*')
             ->unique()

--- a/src/services/Structures.php
+++ b/src/services/Structures.php
@@ -399,6 +399,31 @@ class Structures extends Component
     }
 
     /**
+     * Removes an element from a given structure.
+     *
+     * @param int $structureId
+     * @param ElementInterface $element
+     * @return bool
+     * @throws Exception
+     * @since 3.7.19
+     */
+    public function remove(int $structureId, ElementInterface $element): bool
+    {
+        $elementRecord = $this->_getElementRecord($structureId, $element);
+
+        if ($elementRecord && !$elementRecord->delete()) {
+            return false;
+        }
+
+        $element->root = null;
+        $element->lft = null;
+        $element->rgt = null;
+        $element->level = null;
+
+        return true;
+    }
+
+    /**
      * Returns a structure element record from given structure and element IDs.
      *
      * @param int $structureId


### PR DESCRIPTION
### Description

With this change, drafts and revisions no longer store structure data, with the exception of:

- Unpublished drafts (since they are canonical)
- Provisional drafts which have been assigned a new parent

Removing existing draft/revision structure data is expensive since we need to patch up the other structure elements’ nested set values, so that is left up to the `utils/repair/section-structure` command.

### Related issues

- #9977
- #9999