### PR TITLE
Fall back to @web alias for baseCPUrl

### DIFF
--- a/src/helpers/UrlHelper.php
+++ b/src/helpers/UrlHelper.php
@@ -474,9 +474,9 @@ class UrlHelper
         if ($generalConfig->baseCpUrl) {
             return rtrim($generalConfig->baseCpUrl, '/') . '/';
         }
-
-        // Use the request's base URL as a fallback
-        return static::baseRequestUrl();
+        
+        // Use @web as a fallback
+        return Craft::getAlias('@web');        
     }
 
     /**


### PR DESCRIPTION
In `baseCpUrl`, we were falling back to the deprecated `baseRequestUrl` instead of using the `@web` alias (like we do in `baseSiteUrl`).

This means someone setting `@web` (including a path segment) would have to explicitly set `@web` AND `baseCpUrl`:

```
    'baseCpUrl' => 'http://mysite/backend',
    'aliases' => [
        '@web' => 'http://mysite/backend',
    ]
```

With this PR, they would only have to set `@web`, as `baseCpUrl` would appropriately fall back to that.

## Related issues:
- https://github.com/craftcms/cms/issues/9909