### PR TITLE
Delete annotated $site property

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -42,7 +42,6 @@ use yii\db\ExpressionInterface;
 /**
  * ElementQuery represents a SELECT SQL statement for elements in a way that is independent of DBMS.
  *
- * @property string|Site $site The site or site handle that the elements should be returned in
  * @mixin CustomFieldBehavior
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0


### PR DESCRIPTION
### Description

The annotated `$site` property is not available via the code. The following code results in an `UnknownPropertyException` being thrown.

```php
$query = Entry::find()->siteId(1);
Craft::dd($query->site);
```

<img width="792" alt="Screenshot 2021-11-04 at 09 59 09" src="https://user-images.githubusercontent.com/57572400/140302555-0fc23e05-86ed-4a3a-975f-3a5a339132d6.png">