### PR TITLE
Custom config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - It’s now possible to edit images’ focal points from their preview modals. ([#8489](https://github.com/craftcms/cms/discussions/8489))
 - Added the `assetUploaders` user query param.
 - Added the `authors` user query param.
+- Added support for setting custom config settings from `config/custom.php`, which are accessible via `Craft::$app->config->custom`. ([#10012](https://github.com/craftcms/cms/issues/10012))
 - Added `craft\base\Volume::CONFIG_MIMETYPE`.
 - Added `craft\base\Volume::CONFIG_VISIBILITY`.
 - Added `craft\base\Volume::VISIBILITY_DEFAULT`.
@@ -73,6 +74,8 @@
 - Added `craft\services\AssetIndexer::startIndexingSession()`.
 - Added `craft\services\AssetIndexer::stopIndexingSession()`.
 - Added `craft\services\AssetTransforms::deleteTransformIndexDataByAssetIds()`.
+- Added `craft\services\Config::CATEGORY_CUSTOM`.
+- Added `craft\services\Config::getCustom()`.
 - Added `craft\services\ProjectConfig::ASSOC_KEY`.
 - Added `craft\services\ProjectConfig::PATH_CATEGORY_GROUPS`.
 - Added `craft\services\ProjectConfig::PATH_DATE_MODIFIED`.
@@ -258,7 +261,7 @@
 ### Removed
 - Removed the `--type` option from `migrate/*` commands. `--track` or `--plugin` can be used instead.
 - Removed the “Header Column Heading” element source setting.
-- Removed support for custom config settings. ([#10012](https://github.com/craftcms/cms/issues/10012))
+- Removed support for setting custom config settings from `config/general.php`. `config/custom.php` should be used instead. ([#10012](https://github.com/craftcms/cms/issues/10012))
 - Removed the `customAsciiCharMappings` config setting.
 - Removed the `siteName` config setting. Environment-specific site names can be defined via environment variables.
 - Removed the `sitUrl` config setting. Environment-specific site URLs can be defined via environment variables.

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1693,7 +1693,11 @@ class GeneralConfig extends BaseObject
             return;
         }
 
-        parent::__set($name, $value);
+        try {
+            parent::__set($name, $value);
+        } catch (UnknownPropertyException $e) {
+            throw new UnknownPropertyException("Invalid general config setting: $name. You can set custom config settings from config/custom.php.");
+        }
     }
 
     /**

--- a/src/services/Config.php
+++ b/src/services/Config.php
@@ -144,6 +144,7 @@ class Config extends Component
      * ```
      *
      * @return object
+     * @since 4.0.0
      */
     public function getCustom(): object
     {

--- a/src/services/Config.php
+++ b/src/services/Config.php
@@ -26,11 +26,16 @@ use yii\base\InvalidConfigException;
  *
  * @property-read DbConfig $db the DB config settings
  * @property-read GeneralConfig $general the general config settings
+ * @property-read object $custom the custom config settings
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
 class Config extends Component
 {
+    /**
+     * @since 4.0.0
+     */
+    public const CATEGORY_CUSTOM = 'custom';
     public const CATEGORY_DB = 'db';
     public const CATEGORY_GENERAL = 'general';
 
@@ -97,6 +102,8 @@ class Config extends Component
         $config = $this->getConfigFromFile($category);
 
         switch ($category) {
+            case self::CATEGORY_CUSTOM:
+                return (object)$config;
             case self::CATEGORY_DB:
                 return new DbConfig($config);
             case self::CATEGORY_GENERAL:
@@ -122,6 +129,25 @@ class Config extends Component
             default:
                 throw new InvalidArgumentException("Invalid config category: $category");
         }
+    }
+
+    /**
+     * Returns the custom config settings.
+     *
+     * ---
+     *
+     * ```php
+     * $myCustomSetting = Craft::$app->config->custom->myCustomSetting;
+     * ```
+     * ```twig
+     * {% set myCustomSetting = craft.app.config.custom.myCustomSetting %}
+     * ```
+     *
+     * @return object
+     */
+    public function getCustom(): object
+    {
+        return $this->getConfigSettings(self::CATEGORY_CUSTOM);
     }
 
     /**


### PR DESCRIPTION
Adds support for a new `config/custom.php` file, where any custom config settings should be defined (rather than `config/general.php`.

The file can optionally be a multi-environment config, like other config files.

```php
return [
    '*' => [
        // global defaults
    ],
    'dev' => [
        // dev environment settings
    ],
    'production' => [
        // prod environment settings
    ],
];
```

Custom config settings are accessible via `Craft::$app->config->custom` (PHP) or `craft.app.config.custom` (Twig).

Resolves #10012