### PR TITLE
feat: Add logging of Twig `{% deprecated %}` notices

### DIFF
--- a/src/web/View.php
+++ b/src/web/View.php
@@ -340,7 +340,7 @@ class View extends \yii\web\View
         set_error_handler(static function ($type, $msg) {
             if (E_USER_DEPRECATED === $type) {
                 $file = null;
-                $line = $null;
+                $line = null;
                 if (preg_match('/\(.*(".*") at line (\d+)\)\.$/', $msg, $matches)) {
                     $file = $matches[1] ?? null;
                     $line = $matches[2] ?? null;

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -339,7 +339,13 @@ class View extends \yii\web\View
         // Log Twig {% deprecation %} notices
         set_error_handler(static function ($type, $msg) {
             if (E_USER_DEPRECATED === $type) {
-                Craft::$app->getDeprecator()->log('twig.templates', $msg);
+                $file = null;
+                $line = $null;
+                if (preg_match('/\(.*(".*") at line (\d+)\)\.$/', $msg, $matches)) {
+                    $file = $matches[1] ?? null;
+                    $line = $matches[2] ?? null;
+                }
+                Craft::$app->getDeprecator()->log('twig.templates', $msg, $file, $line);
             }
         });
 

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -336,6 +336,13 @@ class View extends \yii\web\View
         $core = $twig->getExtension(CoreExtension::class);
         $core->setTimezone(Craft::$app->getTimeZone());
 
+        // Log Twig {% deprecation %} notices
+        set_error_handler(static function ($type, $msg) {
+            if (E_USER_DEPRECATED === $type) {
+                Craft::$app->getDeprecator()->log('twig.templates', $msg);
+            }
+        });
+
         return $twig;
     }
 


### PR DESCRIPTION
### Description

Since Twig 2.6, Twig has supported the [`{% deprecated %}` tag](https://twig.symfony.com/doc/3.x/tags/deprecated.html). Currently, it does nothing in Craft (despite it being [documented as doing something](https://craftcms.com/docs/3.x/dev/tags.html))

This PR implements it in Craft as described here:

https://twig.symfony.com/doc/3.x/recipes.html#deprecation-notices

...by passing along Twig deprecaction errors to `Craft::$app->getDeprecator()->log()`

So Twig code like this:

```twig
        {% deprecated 'The "base.twig" template is deprecated, use "layout.twig" instead.' %}
```

Will generate this:

<img width="987" alt="Screen Shot 2021-11-29 at 11 33 20 PM" src="https://user-images.githubusercontent.com/7570798/143986139-b45fe6b4-80f0-4e4d-821e-49e8ee35df43.png">

### Related issues

Closes: https://github.com/craftcms/cms/discussions/10181