### PR TITLE
refactor(static-analysis): add array shape to return type

### DIFF
--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -513,7 +513,7 @@ class App
      * Returns the `mailer` component config.
      *
      * @param MailSettings|null $settings The system mail settings
-     * @return array
+     * @return array{class: class-string<Mailer>}
      * @since 3.0.18
      */
     public static function mailerConfig(?MailSettings $settings = null): array


### PR DESCRIPTION
### Description
When running PHPStan level 8 on a local project, doing in `app.php` to customize mail settings...:

```php
// snip!

// Create a Mailer component config with these settings
$config = craft\helpers\App::mailerConfig($settings);

// Instantiate and return it
return Craft::createObject($config);

// snip!
```

...the follow error message is given by PHPStan:

>Parameter #1 $type of static method Craft::createObject() expects array{class: class-string<mixed>}|(callable(): mixed)|class-string<mixed>, array given.

Adding the array shape to the PHPDoc's annotations solves this issue (https://phpstan.org/writing-php-code/phpdoc-types#array-shapes).

### PHPStan playground example:

Simplified example showing the error:
https://phpstan.org/r/d5c07ee3-23ef-47f4-b462-a9079489ff6e