### PR TITLE
Support AVIF format

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -153,6 +153,7 @@ class GeneralConfig extends BaseObject
         'asc',
         'asf',
         'avi',
+        'avif',
         'bmp',
         'cap',
         'cin',

--- a/src/helpers/Assets.php
+++ b/src/helpers/Assets.php
@@ -488,6 +488,7 @@ class Assets
                 Asset::KIND_IMAGE => [
                     'label' => Craft::t('app', 'Image'),
                     'extensions' => [
+                        'avif',
                         'bmp',
                         'gif',
                         'jfif',

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -83,7 +83,7 @@ class Image
      */
     public static function webSafeFormats(): array
     {
-        return ['jpg', 'jpeg', 'gif', 'png', 'svg', 'webp'];
+        return ['jpg', 'jpeg', 'gif', 'png', 'svg', 'webp', 'avif'];
     }
 
     /**

--- a/src/services/AssetTransforms.php
+++ b/src/services/AssetTransforms.php
@@ -1535,6 +1535,10 @@ class AssetTransforms extends Component
             throw new AssetTransformException("The `webp` format is not supported on this server!");
         }
 
+        if ($index->format === 'avif' && !$images->getSupportsAvif()) {
+            throw new AssetTransformException("The `avif` format is not supported on this server!");
+        }
+
         $volume = $asset->getVolume();
         $transformPath = $asset->folderPath . $this->getTransformSubpath($asset, $index);
 

--- a/src/services/Images.php
+++ b/src/services/Images.php
@@ -120,6 +120,10 @@ class Images extends Component
             $supportedFormats[] = 'webp';
         }
 
+        if ($this->getSupportsAvif()) {
+            $supportedFormats[] = 'avif';
+        }
+
         return $supportedFormats;
     }
 
@@ -180,6 +184,17 @@ class Images extends Component
     public function getSupportsWebP(): bool
     {
         return $this->getIsImagick() ? !empty(Imagick::queryFormats('WEBP')) : function_exists('imagewebp');
+    }
+
+
+    /**
+     * Returns whether the Avif image format is supported.
+     *
+     * @return bool
+     */
+    public function getSupportsAvif(): bool
+    {
+        return $this->getIsImagick() ? !empty(Imagick::queryFormats('AVIF')) : function_exists('imageavif');
     }
 
     /**

--- a/src/templates/settings/assets/transforms/_settings.html
+++ b/src/templates/settings/assets/transforms/_settings.html
@@ -140,7 +140,9 @@
 
         {% if (transform is defined and transform.format == 'webp') or craft.app.images.supportsWebP %}
             {% set formatOptions = formatOptions|merge([{label: 'webp', value: 'webp'}]) %}
-        {% elseif (transform is defined and transform.format == 'avif') or craft.app.images.supportsAvif %}
+        {% endif %}
+        
+        {% if (transform is defined and transform.format == 'avif') or craft.app.images.supportsAvif %}
             {% set formatOptions = formatOptions|merge([{label: 'avif', value: 'avif'}]) %}
         {% endif %}
 

--- a/src/templates/settings/assets/transforms/_settings.html
+++ b/src/templates/settings/assets/transforms/_settings.html
@@ -140,6 +140,8 @@
 
         {% if (transform is defined and transform.format == 'webp') or craft.app.images.supportsWebP %}
             {% set formatOptions = formatOptions|merge([{label: 'webp', value: 'webp'}]) %}
+        {% elseif (transform is defined and transform.format == 'avif') or craft.app.images.supportsAvif %}
+            {% set formatOptions = formatOptions|merge([{label: 'avif', value: 'avif'}]) %}
         {% endif %}
 
         {{ forms.selectField({

--- a/tests/unit/helpers/ImageHelperTest.php
+++ b/tests/unit/helpers/ImageHelperTest.php
@@ -71,7 +71,7 @@ class ImageHelperTest extends Unit
      */
     public function testWebSafeFormats()
     {
-        self::assertSame(['jpg', 'jpeg', 'gif', 'png', 'svg', 'webp'], Image::webSafeFormats());
+        self::assertSame(['jpg', 'jpeg', 'gif', 'png', 'svg', 'webp', 'avif'], Image::webSafeFormats());
     }
 
     /**


### PR DESCRIPTION
### Description
Hi!

Since the Avif format is landing quickly (https://caniuse.com/?search=AVIF) and the gains are considerable compared to jpeg and even webp, it would be nice to have the support when necessary. I've landed a few progressive enhanced websites since its release and the compression is out of this world, especially on larger images and gradients (they almost keep their original quality, especially compared to jpegs 😳 ).

I made those edits pretty quickly and naively, basing my code changes on the somewhat recent (2017) rollout of webp. Plus, ImageMagick and GD both already support Avif, so I thought basing my changes on webp to add progressive support for the servers would be the best solution. 

Feel free to review and have a nice day 👍 

