### PR TITLE
Fixes typo in PHPDoc since tag

### DIFF
--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -845,7 +845,7 @@ class Html extends \yii\helpers\Html
      *
      * @param string $html
      * @return string
-     * @since 2.7.27
+     * @since 3.7.27
      */
     public static function encodeInvalidTags(string $html): string
     {


### PR DESCRIPTION
### Description

Fixes a typo in the PHPDoc `@since` tag for the [`craft\helpers\Html::encodeInvalidTags()`](https://github.com/craftcms/cms/blob/develop/src/helpers/Html.php#L850) method.

### Related issues

