### PR TITLE
Allow unlocking users no matter their status (active, pending, suspended).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - The content in the `resourcepaths` table is now excluded from database backups by default.
+- Allow unlocking users no matter their status
 
 ## 3.7.28 - 2022-01-05
 

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -783,25 +783,7 @@ class UsersController extends Controller
                     }
                     break;
                 case User::STATUS_ACTIVE:
-                    if ($user->locked) {
-                        $statusLabel = Craft::t('app', 'Locked');
-                        if (
-                            !$isCurrentUser &&
-                            ($currentUser->admin || !$user->admin) &&
-                            $userSession->checkPermission('moderateUsers') &&
-                            (
-                                ($previousUserId = Session::get(User::IMPERSONATE_KEY)) === null ||
-                                $user->id != $previousUserId
-                            )
-                        ) {
-                            $statusActions[] = [
-                                'action' => 'users/unlock-user',
-                                'label' => Craft::t('app', 'Unlock'),
-                            ];
-                        }
-                    } else {
-                        $statusLabel = Craft::t('app', 'Active');
-                    }
+                    $statusLabel = Craft::t('app', 'Active');
 
                     if (!$isCurrentUser) {
                         $statusActions[] = [
@@ -816,6 +798,24 @@ class UsersController extends Controller
                         }
                     }
                     break;
+            }
+
+            if ($user->locked) {
+                $statusLabel = Craft::t('app', 'Locked');
+                if (
+                    !$isCurrentUser &&
+                    ($currentUser->admin || !$user->admin) &&
+                    $userSession->checkPermission('moderateUsers') &&
+                    (
+                        ($previousUserId = Session::get(User::IMPERSONATE_KEY)) === null ||
+                        $user->id != $previousUserId
+                    )
+                ) {
+                    $statusActions[] = [
+                        'action' => 'users/unlock-user',
+                        'label' => Craft::t('app', 'Unlock'),
+                    ];
+                }
             }
 
             if (!$isCurrentUser) {


### PR DESCRIPTION
Also fixes the status label on user edit page: "Locked" is always shown, when there is an ongoing cool-down period, no matter their status