### PR TITLE
set/to/if-empty options for resave/* commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- `resave/*` commands now support bulk-setting an attribute/custom field value via new `--set`, `--to`, and `--if-empty` options.
 - Added `craft\helpers\App::parseEnv()` and `parseBooleanEnv()`, replacing their `Craft` class counterparts. ([#10319](https://github.com/craftcms/cms/discussions/10319))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- `resave/*` commands now support bulk-setting an attribute/custom field value via new `--set`, `--to`, and `--if-empty` options.
+- `resave/*` commands now support bulk-setting an attribute/custom field value via new `--set`, `--to`, and `--if-empty` options. ([#10356](https://github.com/craftcms/cms/pull/10356))
 - Added `craft\helpers\App::parseEnv()` and `parseBooleanEnv()`, replacing their `Craft` class counterparts. ([#10319](https://github.com/craftcms/cms/discussions/10319))
 
 ### Changed

--- a/src/console/controllers/ResaveController.php
+++ b/src/console/controllers/ResaveController.php
@@ -19,7 +19,9 @@ use craft\elements\MatrixBlock;
 use craft\elements\Tag;
 use craft\elements\User;
 use craft\events\BatchElementActionEvent;
+use craft\fieldlayoutelements\CustomField;
 use craft\helpers\Queue;
+use craft\helpers\StringHelper;
 use craft\queue\jobs\ResaveElements;
 use craft\services\Elements;
 use yii\console\ExitCode;
@@ -118,6 +120,32 @@ class ResaveController extends Controller
     public $field;
 
     /**
+     * @var string|null An attribute name that should be set for each of the elements. The value will be determined by --to.
+     * @since 3.7.29
+     */
+    public $set;
+
+    /**
+     * @var string|null The value that should be set on the --set attribute.
+     *
+     * The following value types are supported:
+     * - An attribute name: --to myCustomField
+     * - An object template: --to "={myCustomField|lower}"
+     * - A raw value: --to "=foo bar"
+     * - A PHP arrow function: --to "fn(\$element) => \$element->callSomething()"
+     * - An empty value: --to :empty:
+     *
+     * @since 3.7.29
+     */
+    public $to;
+
+    /**
+     * @var bool Whether the --set attribute should only be set if it doesn’t have a value.
+     * @since 3.7.29
+     */
+    public $ifEmpty = false;
+
+    /**
      * @inheritdoc
      */
     public function options($actionID)
@@ -154,7 +182,28 @@ class ResaveController extends Controller
                 break;
         }
 
+        $options[] = 'set';
+        $options[] = 'to';
+        $options[] = 'ifEmpty';
+
         return $options;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beforeAction($action)
+    {
+        if (!parent::beforeAction($action)) {
+            return false;
+        }
+
+        if ($this->set && !isset($this->to)) {
+            $this->stderr('--to is required when using --set.' . PHP_EOL, Console::FG_RED);
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -356,16 +405,22 @@ class ResaveController extends Controller
             $count = min($count, (int)$query->limit);
         }
 
+        $to = $this->set ? $this->_normalizeTo() : null;
+
         $elementsText = $count === 1 ? $elementType::lowerDisplayName() : $elementType::pluralLowerDisplayName();
         $this->stdout("Resaving {$count} {$elementsText} ..." . PHP_EOL, Console::FG_YELLOW);
 
         $elementsService = Craft::$app->getElements();
         $fail = false;
 
-        $beforeCallback = function(BatchElementActionEvent $e) use ($query, $count) {
+        $beforeCallback = function(BatchElementActionEvent $e) use ($query, $count, $to) {
             if ($e->query === $query) {
                 $element = $e->element;
                 $this->stdout("    - [{$e->position}/{$count}] Resaving {$element} ({$element->id}) ... ");
+
+                if ($this->set && (!$this->ifEmpty || $this->_isSetAttributeEmpty($element))) {
+                    $element->{$this->set} = $to($element);
+                }
             }
         };
 
@@ -394,5 +449,66 @@ class ResaveController extends Controller
 
         $this->stdout("Done resaving {$elementsText}." . PHP_EOL . PHP_EOL, Console::FG_YELLOW);
         return $fail ? ExitCode::UNSPECIFIED_ERROR : ExitCode::OK;
+    }
+
+    /**
+     * Returns [[to]] normalized to a callable.
+     *
+     * @return callable
+     */
+    private function _normalizeTo(): callable
+    {
+        // empty
+        if ($this->to === ':empty:') {
+            return function() {
+                return null;
+            };
+        }
+
+        // object template
+        if (StringHelper::startsWith($this->to, '=')) {
+            $template = substr($this->to, 1);
+            $view = Craft::$app->getView();
+            return function(ElementInterface $element) use ($template, $view) {
+                return $view->renderObjectTemplate($template, $element);
+            };
+        }
+
+        // PHP arrow function
+        if (preg_match('/^fn\s*\(\s*\$(\w+)\s*\)\s*=>\s*(.+)/', $this->to, $match)) {
+            $var = $match[1];
+            $php = sprintf('return %s;', StringHelper::removeLeft(rtrim($match[2], ';'), 'return '));
+            return function(ElementInterface $element) use ($var, $php) {
+                $$var = $element;
+                return eval($php);
+            };
+        }
+
+        // attribute name
+        return function(ElementInterface $element) {
+            return $element->{$this->to};
+        };
+    }
+
+    /**
+     * Returns whether the [[set]] attribute on the given element is empty.
+     *
+     * @param ElementInterface $element
+     * @return bool
+     */
+    private function _isSetAttributeEmpty(ElementInterface $element): bool
+    {
+        // See if we're setting a custom field
+        if ($fieldLayout = $element->getFieldLayout()) {
+            foreach ($fieldLayout->getTabs() as $tab) {
+                foreach ($tab->elements as $layoutElement) {
+                    if ($layoutElement instanceof CustomField && $layoutElement->attribute() === $this->set) {
+                        return $layoutElement->getField()->isValueEmpty($element->getFieldValue($this->set), $element);
+                    }
+                }
+            }
+        }
+
+        return empty($element->{$this->set});
     }
 }


### PR DESCRIPTION
### Description

This adds new `--set`, `--to`, and `--if-empty` options to all `resave/*` commands, which can be used to bulk-set a new value on resaved elements’ attributes and custom fields.

Examples:

```sh
# set `foo` to "bar" if it’s empty:
php craft resave/entries --set foo --to "=bar" --if-empty

# copy the value of `baz` to `foo`:
php craft resave/entries --set foo --to baz

# clear out the `foo` field/attribute:
php craft resave/entries --set foo --to :empty:

# set `foo` to the result of an object template (Twig allowed):
php craft resave/entries --set foo --to "={author.name}"

# set `foo` to the result of an arrow function:
php craft resave/entries --set foo --to "fn(\$entry) => \$entry->author->name"
```

### Related issues

- #8132
- #8461