### PR TITLE
Regression after upgrading craft, fix incorrect tab field resolution

### DIFF
--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -1230,15 +1230,9 @@ class Fields extends Component
             return;
         }
 
-        $result = $this->_createLayoutTabQuery()
-            ->where(['layoutId' => array_keys($layouts)])
-            ->all();
-
         $tabsByLayoutId = [];
-        $isMysql = Craft::$app->getDb()->getIsMysql();
-
-        foreach ($result as $row) {
-            $tabsByLayoutId[$row['layoutId']][] = $this->_createLayoutTabFromRow($row, $isMysql);
+        foreach(array_keys($layouts) as $layoutId){
+            $tabsByLayoutId[$layoutId] = $this->getLayoutTabsById($layoutId);
         }
 
         foreach ($tabsByLayoutId as $layoutId => $tabs) {


### PR DESCRIPTION
### Description
I'm currently using `fab permission` plugin, it broke after upgrading craft from version 3.7.26 to 3.7.27, the problem seems to be that tab fields are not resolved correctly (see image below, don't mind the low mouse battery alert):

<img width="1792" alt="Captura de pantalla 2022-01-28 a las 1 34 42" src="https://user-images.githubusercontent.com/90317987/151467935-97acb152-8300-49d9-bc14-0ca4e15eb438.png">

In `Variables` bottom right panel, you will see that elements[4]->_fields is `PlainText` when it should be `StaticFieldDecorator` 

The problem seem to have arised in craft 3.7.27 `src/services/Sections.php` _entryTypes method tries to load the Tab data calling `getLayoutsByIds` (this methods calls _loadTabs) which tries to do the same thing than getLayoutTabsById() but differently (this is called later to load the tabs data, but with 3.7.27 is now loaded earlier).

In this pull request, i've updated the method `_loadTabs` to use `getLayoutTabsById()` instead of doing the same differently, fixing the issue (see image below)

<img width="1792" alt="Captura de pantalla 2022-01-28 a las 1 35 48" src="https://user-images.githubusercontent.com/90317987/151467929-05fa45be-5e72-4083-8719-13fd16ce38ae.png">

### Related issues
https://github.com/moa-crypto/craft-fab-permissions/issues/30
