### PR TITLE
Adds support for WOFF2 files in Webpack config

### DIFF
--- a/packages/craftcms-webpack/index.js
+++ b/packages/craftcms-webpack/index.js
@@ -307,7 +307,7 @@ const getConfig = ({
             ],
           },
           {
-            test: /fonts\/[a-zA-Z0-9\-\_]*\.(ttf|woff|svg)$/,
+            test: /fonts\/[a-zA-Z0-9\-\_]*\.(ttf|woff|woff2|svg)$/,
             type: "asset/resource",
             generator: {
               filename: "fonts/[name][ext][query]",


### PR DESCRIPTION
### Description

This changes the default Webpack config so `.woff2` files are handled the same way as `.woff` files. Currently, they end up in a different directory, without the filename preserved.
