### PR TITLE
Removes duplicate Webpack externals config

### DIFF
--- a/packages/craftcms-webpack/index.js
+++ b/packages/craftcms-webpack/index.js
@@ -239,9 +239,6 @@ const getConfig = ({
       resolve: {
         extensions: [".wasm", ".ts", ".tsx", ".mjs", ".js", ".json", ".vue"],
       },
-      externals: {
-        jquery: 'jQuery',
-      },
       module: {
         rules: [
           {


### PR DESCRIPTION
### Description

Currently, there are two `externals` objects in the config. jQuery is in both, so this just removes the redundant one.