### PR TITLE
Some fixes related to GraphiQL page in RTL

### DIFF
--- a/src/templates/graphql/graphiql.html
+++ b/src/templates/graphql/graphiql.html
@@ -4,7 +4,7 @@
 {% set showHeader = false %}
 
 {% block body %}
-    <div endpoint="{{ url }}" id="graphiql" schemas="{{ schemas|json_encode}}" selectedSchema="{{ {name: selectedSchema.name, schema: selectedSchema.uid, }|json_encode }}">
+    <div dir="ltr" endpoint="{{ url }}" id="graphiql" schemas="{{ schemas|json_encode}}" selectedSchema="{{ {name: selectedSchema.name, schema: selectedSchema.uid, }|json_encode }}">
         <div class="spinner big"></div>
     </div>
 {% endblock %}

--- a/src/web/assets/cp/src/css/_cp.scss
+++ b/src/web/assets/cp/src/css/_cp.scss
@@ -286,7 +286,12 @@ $systemInfoHoverBgColor: darken($grey800, 10%);
       }
 
       &.external:after {
-        margin-left: 5px;
+        body.ltr & {
+          margin-left: 5px;
+        }
+        body.rtl & {
+          margin-right: 5px;
+        }
         @include icon;
         content: 'external';
       }

--- a/src/web/assets/cp/src/css/_cp.scss
+++ b/src/web/assets/cp/src/css/_cp.scss
@@ -286,12 +286,7 @@ $systemInfoHoverBgColor: darken($grey800, 10%);
       }
 
       &.external:after {
-        body.ltr & {
-          margin-left: 5px;
-        }
-        body.rtl & {
-          margin-right: 5px;
-        }
+        @include margin-left(5px);
         @include icon;
         content: 'external';
       }

--- a/src/web/assets/graphiql/src/graphiql.scss
+++ b/src/web/assets/graphiql/src/graphiql.scss
@@ -59,6 +59,9 @@ body,
 
   .topBarWrap {
     .topBar {
+      body.rtl & {
+        direction: rtl;
+      }
       padding: 14px 24px;
 
       .title {
@@ -143,7 +146,12 @@ body,
       }
 
       svg {
-        margin-left: 5px;
+        body.ltr & {
+          margin-left: 5px;
+        }
+        body.rtl & {
+          margin-right: 5px;
+        }
       }
     }
 

--- a/src/web/assets/graphiql/src/graphiql.scss
+++ b/src/web/assets/graphiql/src/graphiql.scss
@@ -146,12 +146,7 @@ body,
       }
 
       svg {
-        body.ltr & {
-          margin-left: 5px;
-        }
-        body.rtl & {
-          margin-right: 5px;
-        }
+        @include margin-left(5px);
       }
     }
 


### PR DESCRIPTION
GraphiQL on RTL interface causes lots of problems like wrong direction for explorer and code mirror, missing side number when explorer is open and ...

![graphql - Copy](https://user-images.githubusercontent.com/55586085/152238322-a1adf137-54a3-4028-b84d-1dbcbceadb35.jpg)

Most parts of GraphiQL page is written code in English (explorer, code mirror, history, although code result could be mixed) so this PR suggests to always use LTR orientation for this page.

in this PR only top bar for RTL uses RTL direction.

![Untitle1d - Copy](https://user-images.githubusercontent.com/55586085/152242970-53c1896a-a014-402f-a67e-9e54415fb557.jpg)


the change to _cp.scss is related to fixing external link icon position

![graphqli - Copy](https://user-images.githubusercontent.com/55586085/152238263-8e751688-0d26-43ba-b4a1-c590d1d28ae8.jpg)

