### PR TITLE
Add en-AU translation file

### DIFF
--- a/src/translations/en-AU/app.php
+++ b/src/translations/en-AU/app.php
@@ -1,0 +1,3 @@
+<?php
+
+return require __DIR__ . '/../en-GB/app.php';


### PR DESCRIPTION
### Description

Added an `en-AU` translation file. This `en-AU` translation file imports the `en-GB` translation file.

The purpose of this PR is to add `English (Australia)` to both Language and Formatting user preferences.

<img width="490" alt="image" src="https://user-images.githubusercontent.com/25124/153394472-f1ea375f-dc81-4b75-ba3b-bf4e3a3a9a2f.png">

This is important becuase the `src/i18n/Locale.php` class uses the users locale when formatting numbers and **currency** (new Money Field).

Ideally the `Formatting Locale` drop down options would be independent of the language and include a more exhaustive list of locales.

Example OSX settings:

<img width="780" alt="Screen Shot 2022-02-10 at 10 12 37 pm" src="https://user-images.githubusercontent.com/25124/153395693-532613f8-9430-4e4a-886a-9c3d9c77df59.png">


