### PR TITLE
Append `.UTF-8` to locale for currencies

### DIFF
--- a/src/i18n/Locale.php
+++ b/src/i18n/Locale.php
@@ -622,7 +622,7 @@ class Locale extends BaseObject
     public function getCurrencySymbol(string $currency): string
     {
         // hat tip: https://stackoverflow.com/a/30026774
-        $formatter = new NumberFormatter("$this->id@currency=$currency", NumberFormatter::CURRENCY);
+        $formatter = new NumberFormatter("$this->id.UTF-8@currency=$currency", NumberFormatter::CURRENCY);
         return $formatter->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
     }
 


### PR DESCRIPTION
By default php returns non UTF-8 currency symbols. Example:

* `JPY` (default) vs `¥` (UTF-8)
* `EUR` (default) vs `€` (UTF-8)

Before (Default):

<img width="326" alt="image" src="https://user-images.githubusercontent.com/25124/153417391-f5c27f92-71ed-4b65-b1c7-a7544b38e989.png">

After (UTF-8):

<img width="317" alt="image" src="https://user-images.githubusercontent.com/25124/153417329-ccffa430-057e-4af9-81fa-9289ef47dd37.png">

@lukeholder 