### PR TITLE
Expand formatting locale options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,8 @@
 - The “What’ New” HUD now displays an icon and label above each announcement, identifying where it came from (Craft CMS or a plugin). ([#9747](https://github.com/craftcms/cms/discussions/9747))
 - The control panel now keeps track of the currently-edited site on a per-tab basis by adding a `site` query string param to all control panel URLs. ([#8920](https://github.com/craftcms/cms/discussions/8920))
 - Users are no longer required to have a username or email.
+- Users can now set their Formatting Locale to any known locale; not just the available Language options. ([#10519](https://github.com/craftcms/cms/pull/10519))
+- Users’ Language and Formatting Locale settings now display locale names in the current language and their native languages. ([#10519](https://github.com/craftcms/cms/pull/10519))
 - User queries now return all users by default, rather than only active users.
 - Filtering users by `active`, `pending`, and `locked` statuses no longer excludes suspended users.
 - `credentialed` and `inactive` are now reserved user group handles.

--- a/src/templates/_includes/forms/selectize.twig
+++ b/src/templates/_includes/forms/selectize.twig
@@ -114,6 +114,7 @@
     };
 
     $select.selectize($.extend({
+        searchField: ['text', 'hint'],
         render: {
             option: data => {
                 const classes = ['option'];

--- a/src/templates/users/_edit.twig
+++ b/src/templates/users/_edit.twig
@@ -212,21 +212,21 @@
 
         {% if user.getIsCurrent() %}
             <div id="prefs" class="flex-fields hidden">
-                {{ forms.selectField({
+                {{ forms.selectizeField({
                     id: 'preferredLanguage',
                     name: 'preferredLanguage',
                     label: "Language"|t('app'),
                     instructions: 'The language that the control panel should use.'|t('app'),
-                    options: localeOptions,
+                    options: languageOptions,
                     value: userLanguage,
                 }) }}
 
-                {{ forms.selectField({
+                {{ forms.selectizeField({
                     id: 'preferredLocale',
                     name: 'preferredLocale',
                     label: "Formatting Locale"|t('app'),
                     instructions: 'The locale that should be used for date and number formatting.'|t('app'),
-                    options: (localeOptions ?? [])|unshift({label: 'Same as language'|t('app'), value: ''}),
+                    options: localeOptions,
                     value: userLocale,
                 }) }}
 


### PR DESCRIPTION
## Description

- Implements Selectize components for users’ Language and Formatting Locale settings.
- Options now show locale names in the current app language as well as their native language.
- The Formatting Locale can now be set to any known locale; not just the ones the control panel is translated into.

<img width="470" alt="The Language and Formatting Locale settings. Formatting Locale is expanded with “aust” entered into the search input, and three results are showing: German (Austria), English (Austria), and English (Australia)." src="https://user-images.githubusercontent.com/47792/153417963-dc5e6a69-065b-485c-84af-242950fe6bca.png">

## Related issues

- #10514