### PR TITLE
Configure all constants via env var, stream log tweaks

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -7,6 +7,7 @@
  * @license https://craftcms.github.io/license/
  */
 
+use craft\helpers\App;
 use craft\helpers\ArrayHelper;
 use craft\services\Config;
 use yii\base\ErrorException;
@@ -24,8 +25,10 @@ if (!isset($appType) || ($appType !== 'web' && $appType !== 'console')) {
 }
 
 $findConfig = function($constName, $argName) {
-    if (defined($constName)) {
-        return constant($constName);
+    $constant = App::constant($constName);
+
+    if ($constant) {
+        return $constant;
     }
 
     if (!empty($_SERVER['argv'])) {
@@ -104,11 +107,13 @@ $environment = $findConfig('CRAFT_ENVIRONMENT', 'env') ?: ($_SERVER['SERVER_NAME
 // Validate the paths
 // -----------------------------------------------------------------------------
 
-if (!defined('CRAFT_LICENSE_KEY')) {
+if (!App::constant('CRAFT_LICENSE_KEY')) {
+    $licenseKeyPath = App::constant('CRAFT_LICENSE_KEY_PATH');
+
     // Validate permissions on the license key file path (default config/) and storage/
-    if (defined('CRAFT_LICENSE_KEY_PATH')) {
-        $licensePath = dirname(CRAFT_LICENSE_KEY_PATH);
-        $licenseKeyName = basename(CRAFT_LICENSE_KEY_PATH);
+    if ($licenseKeyPath) {
+        $licensePath = dirname($licenseKeyPath);
+        $licenseKeyName = basename($licenseKeyPath);
     } else {
         $licensePath = $configPath;
         $licenseKeyName = 'license.key';

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -157,7 +157,7 @@ if (!defined('CRAFT_EPHEMERAL') || CRAFT_EPHEMERAL === false) {
 }
 
 // Log errors to storage/logs/phperrors.log or php://stderr
-if (!defined('CRAFT_LOG_PHP_ERRORS') || CRAFT_LOG_PHP_ERRORS) {
+if (!App::constant('CRAFT_LOG_PHP_ERRORS', $bool = true)) {
     ini_set('log_errors', 1);
     ini_set('error_log', $storagePath . DIRECTORY_SEPARATOR . 'logs' . DIRECTORY_SEPARATOR . 'phperrors.log');
 

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -177,7 +177,7 @@ return [
         ],
         'sites' => [
             'class' => craft\services\Sites::class,
-            'currentSite' => defined('CRAFT_SITE') ? CRAFT_SITE : null,
+            'currentSite' => craft\helpers\App::constant('CRAFT_SITE'),
         ],
         'i18n' => [
             'class' => craft\i18n\I18N::class,

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -1469,7 +1469,7 @@ class User extends Element implements IdentityInterface
      */
     public function getPreferredLanguage(): ?string
     {
-        return $this->_validateLocale($this->getPreference('language'));
+        return $this->_validateLocale($this->getPreference('language'), false);
     }
 
     /**
@@ -1482,18 +1482,20 @@ class User extends Element implements IdentityInterface
      */
     public function getPreferredLocale(): ?string
     {
-        return $this->_validateLocale($this->getPreference('locale'));
+        return $this->_validateLocale($this->getPreference('locale'), true);
     }
 
     /**
      * Validates and returns a locale ID.
      *
      * @param string|null $locale
+     * @param bool $checkAllLocales Whether to check all known locale IDs, rather than just the app locales
      * @return string|null
      */
-    private function _validateLocale(?string $locale = null): ?string
+    private function _validateLocale(?string $locale, bool $checkAllLocales): ?string
     {
-        if ($locale !== null && in_array($locale, Craft::$app->getI18n()->getAppLocaleIds(), true)) {
+        $locales = $checkAllLocales ? Craft::$app->getI18n()->getAllLocaleIds() : Craft::$app->getI18n()->getAppLocaleIds();
+        if ($locale && in_array($locale, $locales, true)) {
             return $locale;
         }
 

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -503,7 +503,7 @@ class App
      */
     public static function isEphemeral(): bool
     {
-        return static::constant('CRAFT_EPHEMERAL', $bool = true);
+        return static::constant('CRAFT_EPHEMERAL', $bool = true) === true;
     }
 
     /**
@@ -514,7 +514,7 @@ class App
      */
     public static function isStreamLog(): bool
     {
-        return defined('CRAFT_STREAM_LOG') && CRAFT_STREAM_LOG === true;
+        return static::constant('CRAFT_STREAM_LOG', $bool = true) === true;
     }
 
     // App component configs

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -65,9 +65,22 @@ class App
      * @return string|array|false The environment variable value
      * @since 3.4.18
      */
-    public static function env(string $name)
+    public static function env(string $name): array|string|false
     {
         return $_SERVER[$name] ?? getenv($name);
+    }
+
+    /**
+     * Returns the value of a constant, falling back to an environment variable.
+     *
+     * @param string $name The name of the constant
+     * @param string|null $envName The name of the environment variable, if different from $name
+     * @return mixed The value of the constant or environment variable
+     * @since 4.0.0
+     */
+    public static function constant(string $name, ?string $envName = null): mixed
+    {
+        return defined($name) ? constant($name) : self::env($envName ?? $name);
     }
 
     /**

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -79,7 +79,7 @@ class App
      * @return mixed The value of the constant or environment variable, or null if neither are found
      * @since 4.0.0
      */
-    public static function constant(string $constName, ?string $envName = null, $bool = false): mixed
+    public static function constant(string $constName, ?string $envName = null, bool $bool = false): mixed
     {
         if (defined($constName)) {
             return constant($constName);

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -73,14 +73,14 @@ class App
     /**
      * Returns the value of a constant, falling back to an environment variable.
      *
-     * @param string $name The name of the constant
-     * @param string|null $envName The name of the environment variable, if different from $name
-     * @return mixed The value of the constant or environment variable
+     * @param string $constName The name of the constant
+     * @param string|null $envName The name of the environment variable, if different from $constName
+     * @return mixed The value of the constant or environment variable, or false if neither are found
      * @since 4.0.0
      */
-    public static function constant(string $name, ?string $envName = null): mixed
+    public static function constant(string $constName, ?string $envName = null): mixed
     {
-        return defined($name) ? constant($name) : self::env($envName ?? $name);
+        return defined($constName) ? constant($constName) : self::env($envName ?? $constName);
     }
 
     /**


### PR DESCRIPTION
- Adds `App::constant` to get the value of a constant, falling back to an environment var
- [All constants](https://craftcms.com/docs/3.x/config/#php-constants) now support retrieval from env var.
 
Stream log Changes:

- Adds and uses an `App::isStreamLog` helper
- When `isStreamLog`, we only log to stderr/stdout, not in addition to file like we were
- Previously, we didn't log to stderr/stdout at all for console requests, as to not pollute the console output. We still don't log - info, but we will log errors (otherwise they'd have nowhere to go)
