### PR TITLE
added option to customize GraphQL's authorization header

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -676,6 +676,15 @@ class GeneralConfig extends BaseObject
     public $enableGraphqlCaching = true;
 
     /**
+     * @var string Name of GraphQL's authorization header
+     *
+     * If the default `authorization` header cant't be used, a custom header name can be set.
+     *
+     * @group GraphQL
+     */
+    public $graphqlAuthorizationHeaderName = 'authorization';    
+
+    /**
      * @var bool Whether dates returned by the GraphQL API should be set to the system time zone by default, rather than UTC.
      * @since 3.7.0
      * @group GraphQL

--- a/src/controllers/GraphqlController.php
+++ b/src/controllers/GraphqlController.php
@@ -217,7 +217,7 @@ class GraphqlController extends Controller
         }
 
         // Was a specific token passed?
-        foreach ($requestHeaders->get('authorization', [], false) as $authHeader) {
+        foreach ($requestHeaders->get(Craft::$app->getConfig()->getGeneral()->graphqlAuthorizationHeaderName, [], false) as $authHeader) {
             $authValues = array_map('trim', explode(',', $authHeader));
             foreach ($authValues as $authValue) {
                 if (preg_match('/^Bearer\s+(.+)$/i', $authValue, $matches)) {


### PR DESCRIPTION
### Description

This PR makes it possible to customize the name of the header which GraphQL is using to get the token for private schemas. This can be useful in all non-prod environments, especially if Craft CMS is used as a headless CMS, where authentication like `Basic Auth` is in place.

### Related issues

Didn't found an issue about this, [just my own discussion thread](https://github.com/craftcms/cms/discussions/10539).