### PR TITLE
Fixed issue where testing queue jobs was broken

### DIFF
--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -545,9 +545,9 @@ class Craft extends Yii2
             throw new InvalidArgumentException('Not a job');
         }
 
-        Craft::$app->getQueue()->push($job);
+        \Craft::$app->getQueue()->push($job);
 
-        Craft::$app->getQueue()->run();
+        \Craft::$app->getQueue()->run();
     }
 
     /**


### PR DESCRIPTION
### Description
I was trying to test my queue jobs and ran into the issue that it results in an exception:
```
[Error] Access to undeclared static property: craft\test\Craft::$app
```

Concluded it used the wrong Craft class.

