### PR TITLE
Multi-Matrix block ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - It’s now possible to edit images’ focal points from their preview modals. ([#8489](https://github.com/craftcms/cms/discussions/8489))
 - Added the `|money` Twig filter.
 - Added the `assetUploaders` user query param.
+- Added the `primaryOwner` and `primaryOwnerId` Matrix block query params.
 - Added the `authors` user query param.
 - Added the `hasAlt` asset query param.
 - Added the `button`, `submitButton`, `fs`, and `fsField` macros to the `_includes/forms` control panel template.
@@ -91,6 +92,7 @@
 - Added `craft\db\Table::ASSETINDEXINGSESSIONS`.
 - Added `craft\db\Table::IMAGETRANSFORMINDEX`.
 - Added `craft\db\Table::IMAGETRANSFORMS`.
+- Added `craft\db\Table::MATRIXBLOCKS_OWNERS`.
 - Added `craft\elements\Asset::$alt`.
 - Added `craft\elements\Asset::getFs()`.
 - Added `craft\elements\Asset::setFilename()`.
@@ -135,6 +137,7 @@
 - Added `craft\elements\conditions\users\LastNameConditionRule`.
 - Added `craft\elements\conditions\users\UserCondition`.
 - Added `craft\elements\conditions\users\UsernameConditionRule`.
+- Added `craft\elements\MatrixBlock::$primaryOwnerId`.
 - Added `craft\elements\User::$active`.
 - Added `craft\elements\User::canAssignUserGroups()`.
 - Added `craft\elements\User::getIsCredentialed()`.
@@ -253,11 +256,13 @@
 - Added `craft\services\Conditions`.
 - Added `craft\services\Config::CATEGORY_CUSTOM`.
 - Added `craft\services\Config::getCustom()`.
+- Added `craft\services\Drafts::removeDraftData()`.
 - Added `craft\services\ElementSources`, which replaces `craft\services\ElementIndexes`.
 - Added `craft\services\Fields::createLayout()`.
 - Added `craft\services\Fs`.
 - Added `craft\services\Gql::prepareFieldDefinitions()`.
 - Added `craft\services\ImageTransforms`.
+- Added `craft\services\Matrix::duplicateOwnership()`.
 - Added `craft\services\ProjectConfig::applyExternalChanges()`.
 - Added `craft\services\ProjectConfig::ASSOC_KEY`.
 - Added `craft\services\ProjectConfig::getDoesExternalConfigExist()`.
@@ -342,6 +347,7 @@
 - Craft now requires PHP 8.0 or later.
 - Craft now requires MySQL 5.7.8 / MariaDB 10.2.7 / PostgreSQL 10.0 or later.
 - Craft now requires the [Intl](https://php.net/manual/en/book.intl.php) PHP extension.
+- Improved draft creation/application performance. ([#10577](https://github.com/craftcms/cms/pull/10577))
 - The “What’ New” HUD now displays an icon and label above each announcement, identifying where it came from (Craft CMS or a plugin). ([#9747](https://github.com/craftcms/cms/discussions/9747))
 - The control panel now keeps track of the currently-edited site on a per-tab basis by adding a `site` query string param to all control panel URLs. ([#8920](https://github.com/craftcms/cms/discussions/8920))
 - Users are no longer required to have a username or email.

--- a/src/db/Table.php
+++ b/src/db/Table.php
@@ -60,6 +60,8 @@ abstract class Table
     public const GQLTOKENS = '{{%gqltokens}}';
     public const INFO = '{{%info}}';
     public const MATRIXBLOCKS = '{{%matrixblocks}}';
+    /** @since 4.0.0 */
+    public const MATRIXBLOCKS_OWNERS = '{{%matrixblocks_owners}}';
     public const MATRIXBLOCKTYPES = '{{%matrixblocktypes}}';
     public const MIGRATIONS = '{{%migrations}}';
     /** @since 3.4.0 */

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1318,15 +1318,15 @@ class ElementQuery extends Query implements ElementQueryInterface
         $this->query->withQueries = $this->withQueries;
         $this->subQuery = new Query();
 
-        // Give other classes a chance to make changes up front
-        if (!$this->beforePrepare()) {
-            throw new QueryAbortedException();
-        }
-
         $this->query
             ->from(['subquery' => $this->subQuery])
             ->innerJoin(['elements' => Table::ELEMENTS], '[[elements.id]] = [[subquery.elementsId]]')
             ->innerJoin(['elements_sites' => Table::ELEMENTS_SITES], '[[elements_sites.id]] = [[subquery.elementsSitesId]]');
+
+        // Give other classes a chance to make changes up front
+        if (!$this->beforePrepare()) {
+            throw new QueryAbortedException();
+        }
 
         $this->subQuery
             ->addSelect([

--- a/src/elements/db/ElementRelationParamParser.php
+++ b/src/elements/db/ElementRelationParamParser.php
@@ -370,7 +370,7 @@ class ElementRelationParamParser extends BaseObject
                             ->innerJoin([$targetMatrixBlocksAlias => Table::MATRIXBLOCKS], "[[$targetMatrixBlocksAlias.id]] = [[$sourcesAlias.sourceId]]")
                             ->innerJoin([$targetMatrixElementsAlias => Table::ELEMENTS], "[[$targetMatrixElementsAlias.id]] = [[$targetMatrixBlocksAlias.id]]")
                             ->where([
-                                "$targetMatrixBlocksAlias.ownerId" => $relElementIds,
+                                "$targetMatrixBlocksAlias.primaryOwnerId" => $relElementIds,
                                 "$targetMatrixBlocksAlias.fieldId" => $fieldModel->id,
                                 "$targetMatrixElementsAlias.enabled" => true,
                                 "$targetMatrixElementsAlias.dateDeleted" => null,
@@ -394,7 +394,7 @@ class ElementRelationParamParser extends BaseObject
                         $matrixBlockTargetsAlias = 'matrixblock_targets' . self::$_relateSourceMatrixBlocksCount;
 
                         $subQuery = (new Query())
-                            ->select(["$sourceMatrixBlocksAlias.ownerId"])
+                            ->select(["$sourceMatrixBlocksAlias.primaryOwnerId"])
                             ->from([$sourceMatrixBlocksAlias => Table::MATRIXBLOCKS])
                             ->innerJoin([$sourceMatrixElementsAlias => Table::ELEMENTS], "[[$sourceMatrixElementsAlias.id]] = [[$sourceMatrixBlocksAlias.id]]")
                             ->innerJoin([$matrixBlockTargetsAlias => Table::RELATIONS], "[[$matrixBlockTargetsAlias.sourceId]] = [[$sourceMatrixBlocksAlias.id]]")

--- a/src/elements/db/MatrixBlockQuery.php
+++ b/src/elements/db/MatrixBlockQuery.php
@@ -18,6 +18,7 @@ use craft\fields\Matrix as MatrixField;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Db;
 use craft\models\MatrixBlockType;
+use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 use yii\db\Connection;
 
@@ -25,6 +26,7 @@ use yii\db\Connection;
  * MatrixBlockQuery represents a SELECT SQL statement for global sets in a way that is independent of DBMS.
  *
  * @property-write ElementInterface $owner The owner element the Matrix blocks must belong to
+ * @property-write ElementInterface $primaryOwner The primary owner element the Matrix blocks must belong to
  * @property-write string|string[]|MatrixBlockType|null $type The block type(s) that resulting Matrix blocks must have
  * @property-write string|string[]|MatrixField|null $field The field the Matrix blocks must belong to
  * @method MatrixBlock[]|array all($db = null)
@@ -46,7 +48,7 @@ class MatrixBlockQuery extends ElementQuery
     /**
      * @inheritdoc
      */
-    protected array $defaultOrderBy = ['matrixblocks.sortOrder' => SORT_ASC];
+    protected array $defaultOrderBy = ['matrixblocks_owners.sortOrder' => SORT_ASC];
 
     // General parameters
     // -------------------------------------------------------------------------
@@ -56,6 +58,14 @@ class MatrixBlockQuery extends ElementQuery
      * @used-by fieldId()
      */
     public $fieldId;
+
+    /**
+     * @var int|int[]|null The primary owner element ID(s) that the resulting Matrix blocks must belong to.
+     * @used-by primaryOwner()
+     * @used-by primaryOwnerId()
+     * @since 4.0.0
+     */
+    public $primaryOwnerId;
 
     /**
      * @var int|int[]|null The owner element ID(s) that the resulting Matrix blocks must belong to.
@@ -109,6 +119,9 @@ class MatrixBlockQuery extends ElementQuery
                 break;
             case 'owner':
                 $this->owner($value);
+                break;
+            case 'primaryOwner':
+                $this->primaryOwner($value);
                 break;
             case 'type':
                 $this->type($value);
@@ -221,6 +234,76 @@ class MatrixBlockQuery extends ElementQuery
     public function fieldId($value): self
     {
         $this->fieldId = $value;
+        return $this;
+    }
+
+    /**
+     * Narrows the query results based on the primary owner element of the Matrix blocks, per the owners’ IDs.
+     *
+     * Possible values include:
+     *
+     * | Value | Fetches Matrix blocks…
+     * | - | -
+     * | `1` | created for an element with an ID of 1.
+     * | `'not 1'` | not created for an element with an ID of 1.
+     * | `[1, 2]` | created for an element with an ID of 1 or 2.
+     * | `['not', 1, 2]` | not created for an element with an ID of 1 or 2.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch Matrix blocks created for an element with an ID of 1 #}
+     * {% set {elements-var} = {twig-method}
+     *   .primaryOwnerId(1)
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch Matrix blocks created for an element with an ID of 1
+     * ${elements-var} = {php-method}
+     *     ->primaryOwnerId(1)
+     *     ->all();
+     * ```
+     *
+     * @param int|int[]|null $value The property value
+     * @return self self reference
+     * @uses $primaryOwnerId
+     * @since 4.0.0
+     */
+    public function primaryOwnerId($value): self
+    {
+        $this->primaryOwnerId = $value;
+        return $this;
+    }
+
+    /**
+     * Sets the [[primaryOwnerId()]] and [[siteId()]] parameters based on a given element.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch Matrix blocks created for this entry #}
+     * {% set {elements-var} = {twig-method}
+     *   .primaryOwner(myEntry)
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch Matrix blocks created for this entry
+     * ${elements-var} = {php-method}
+     *     ->primaryOwner($myEntry)
+     *     ->all();
+     * ```
+     *
+     * @param ElementInterface $primaryOwner The primary owner element
+     * @return self self reference
+     * @uses $primaryOwnerId
+     * @since 4.0.0
+     */
+    public function primaryOwner(ElementInterface $primaryOwner): self
+    {
+        $this->primaryOwnerId = [$primaryOwner->id];
+        $this->siteId = $primaryOwner->siteId;
         return $this;
     }
 
@@ -424,13 +507,35 @@ class MatrixBlockQuery extends ElementQuery
 
     /**
      * @inheritdoc
+     * @throws InvalidConfigException
      */
     protected function beforePrepare(): bool
     {
         $this->_normalizeFieldId();
-        $this->_normalizeOwnerId();
+
+        try {
+            $this->primaryOwnerId = $this->_normalizeOwnerId($this->primaryOwnerId);
+        } catch (InvalidArgumentException) {
+            throw new InvalidConfigException('Invalid ownerId param value');
+        }
+
+        try {
+            $this->ownerId = $this->_normalizeOwnerId($this->ownerId);
+        } catch (InvalidArgumentException) {
+            throw new InvalidConfigException('Invalid ownerId param value');
+        }
 
         $this->joinElementTable('matrixblocks');
+
+        // Join in the matrixblocks_owners table
+        $ownersCondition = [
+            'and',
+            '[[matrixblocks_owners.blockId]] = [[elements.id]]',
+            $this->ownerId ? ['matrixblocks_owners.ownerId' => $this->ownerId] : '[[matrixblocks_owners.ownerId]] = [[matrixblocks.primaryOwnerId]]',
+        ];
+
+        $this->query->innerJoin(['matrixblocks_owners' => Table::MATRIXBLOCKS_OWNERS], $ownersCondition);
+        $this->subQuery->innerJoin(['matrixblocks_owners' => Table::MATRIXBLOCKS_OWNERS], $ownersCondition);
 
         // Figure out which content table to use
         $this->contentTable = null;
@@ -442,19 +547,20 @@ class MatrixBlockQuery extends ElementQuery
             }
         }
 
-        $this->query->select([
+        $this->query->addSelect([
             'matrixblocks.fieldId',
-            'matrixblocks.ownerId',
+            'matrixblocks.primaryOwnerId',
             'matrixblocks.typeId',
-            'matrixblocks.sortOrder',
+            'matrixblocks_owners.ownerId',
+            'matrixblocks_owners.sortOrder',
         ]);
 
         if ($this->fieldId) {
             $this->subQuery->andWhere(['matrixblocks.fieldId' => $this->fieldId]);
         }
 
-        if ($this->ownerId) {
-            $this->subQuery->andWhere(['matrixblocks.ownerId' => $this->ownerId]);
+        if ($this->primaryOwnerId) {
+            $this->subQuery->andWhere(['matrixblocks.primaryOwnerId' => $this->primaryOwnerId]);
         }
 
         if (isset($this->typeId)) {
@@ -467,12 +573,15 @@ class MatrixBlockQuery extends ElementQuery
         }
 
         // Ignore revision/draft blocks by default
-        $allowOwnerDrafts = $this->allowOwnerDrafts ?? ($this->id || $this->ownerId);
-        $allowOwnerRevisions = $this->allowOwnerRevisions ?? ($this->id || $this->ownerId);
+        $allowOwnerDrafts = $this->allowOwnerDrafts ?? ($this->id || $this->primaryOwnerId || $this->ownerId);
+        $allowOwnerRevisions = $this->allowOwnerRevisions ?? ($this->id || $this->primaryOwnerId || $this->ownerId);
 
         if (!$allowOwnerDrafts || !$allowOwnerRevisions) {
             // todo: we will need to expand on this when Matrix blocks can be nested.
-            $this->subQuery->innerJoin(['owners' => Table::ELEMENTS], '[[owners.id]] = [[matrixblocks.ownerId]]');
+            $this->subQuery->innerJoin(
+                ['owners' => Table::ELEMENTS],
+                $this->ownerId ? '[[owners.id]] = [[matrixblocks_owners.ownerId]]' : '[[owners.id]] = [[matrixblocks.primaryOwnerId]]'
+            );
 
             if (!$allowOwnerDrafts) {
                 $this->subQuery->andWhere(['owners.draftId' => null]);
@@ -521,19 +630,24 @@ class MatrixBlockQuery extends ElementQuery
     }
 
     /**
-     * Normalizes the ownerId param to an array of IDs or null
+     * Normalizes the primaryOwnerId param to an array of IDs or null
      *
-     * @throws InvalidConfigException
+     * @param mixed $value
+     * @return int[]|null
+     * @throws InvalidArgumentException
      */
-    private function _normalizeOwnerId(): void
+    private function _normalizeOwnerId(mixed $value): ?array
     {
-        if (empty($this->ownerId)) {
-            $this->ownerId = null;
-        } else if (is_numeric($this->ownerId)) {
-            $this->ownerId = [$this->ownerId];
-        } else if (!is_array($this->ownerId) || !ArrayHelper::isNumeric($this->ownerId)) {
-            throw new InvalidConfigException('Invalid ownerId param value');
+        if (empty($value)) {
+            return null;
         }
+        if (is_numeric($value)) {
+            return [$value];
+        }
+        if (!is_array($value) || !ArrayHelper::isNumeric($value)) {
+            throw new InvalidArgumentException();
+        }
+        return $value;
     }
 
     /**
@@ -563,11 +677,11 @@ class MatrixBlockQuery extends ElementQuery
     protected function cacheTags(): array
     {
         $tags = [];
-        // If both the field and owner are set, then only tag the combos
-        if ($this->fieldId && $this->ownerId) {
+        // If both the field and primary owner are set, then only tag the combos
+        if ($this->fieldId && $this->primaryOwnerId) {
             foreach ($this->fieldId as $fieldId) {
-                foreach ($this->ownerId as $ownerId) {
-                    $tags[] = "field-owner:$fieldId-$ownerId";
+                foreach ($this->primaryOwnerId as $primaryOwnerId) {
+                    $tags[] = "field-owner:$fieldId-$primaryOwnerId";
                 }
             }
         } else {
@@ -576,9 +690,9 @@ class MatrixBlockQuery extends ElementQuery
                     $tags[] = "field:$fieldId";
                 }
             }
-            if ($this->ownerId) {
-                foreach ($this->ownerId as $ownerId) {
-                    $tags[] = "owner:$ownerId";
+            if ($this->primaryOwnerId) {
+                foreach ($this->primaryOwnerId as $primaryOwnerId) {
+                    $tags[] = "owner:$primaryOwnerId";
                 }
             }
         }

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -578,7 +578,11 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
         $existsQuery = (new Query())
             ->from(["matrixblocks_$ns" => DbTable::MATRIXBLOCKS])
             ->innerJoin(["elements_$ns" => DbTable::ELEMENTS], "[[elements_$ns.id]] = [[matrixblocks_$ns.id]]")
-            ->where("[[matrixblocks_$ns.ownerId]] = [[elements.id]]")
+            ->innerJoin(["matrixblocks_owners_$ns" => DbTable::MATRIXBLOCKS_OWNERS], [
+                'and',
+                "[[matrixblocks_owners_$ns.blockId]] = [[elements_$ns.id]]",
+                "[[matrixblocks_owners_$ns.ownerId]] = [[elements.id]]"
+            ])
             ->andWhere([
                 "matrixblocks_$ns.fieldId" => $this->id,
                 "elements_$ns.enabled" => true,
@@ -852,13 +856,18 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
 
         // Return any relation data on these elements, defined with this field
         $map = (new Query())
-            ->select(['ownerId as source', 'id as target'])
-            ->from([DbTable::MATRIXBLOCKS])
-            ->where([
-                'fieldId' => $this->id,
-                'ownerId' => $sourceElementIds,
+            ->select([
+                'source' => 'matrixblocks_owners.ownerId',
+                'target' => 'matrixblocks.id',
             ])
-            ->orderBy(['sortOrder' => SORT_ASC])
+            ->from(['matrixblocks' => DbTable::MATRIXBLOCKS])
+            ->innerJoin(['matrixblocks_owners' => DbTable::MATRIXBLOCKS_OWNERS], [
+                'and',
+                '[[matrixblocks_owners.blockId]] = [[matrixblocks.id]]',
+                ['matrixblocks_owners.ownerId' => $sourceElementIds],
+            ])
+            ->where(['matrixblocks.fieldId' => $this->id])
+            ->orderBy(['matrixblocks_owners.sortOrder' => SORT_ASC])
             ->all();
 
         return [
@@ -1011,7 +1020,12 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
         $resetValue = false;
 
         if ($element->duplicateOf !== null) {
-            $matrixService->duplicateBlocks($this, $element->duplicateOf, $element, true);
+            // If this is a draft, just duplicate the relations
+            if ($element->getIsDraft()) {
+                $matrixService->duplicateOwnership($this, $element->duplicateOf, $element);
+            } else {
+                $matrixService->duplicateBlocks($this, $element->duplicateOf, $element, true);
+            }
             $resetValue = true;
         } else if ($element->isFieldDirty($this->handle) || !empty($element->newSiteIds)) {
             $matrixService->saveField($this, $element);
@@ -1040,13 +1054,13 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
             return false;
         }
 
-        // Delete any Matrix blocks that belong to this element(s)
+        // Delete any Matrix blocks that primarily belong to this element
         foreach (Craft::$app->getSites()->getAllSiteIds() as $siteId) {
             $elementsService = Craft::$app->getElements();
             $matrixBlocks = MatrixBlock::find()
                 ->status(null)
                 ->siteId($siteId)
-                ->ownerId($element->id)
+                ->primaryOwnerId($element->id)
                 ->all();
 
             foreach ($matrixBlocks as $matrixBlock) {
@@ -1069,7 +1083,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
             $blocks = MatrixBlock::find()
                 ->status(null)
                 ->siteId($siteInfo['siteId'])
-                ->ownerId($element->id)
+                ->primaryOwnerId($element->id)
                 ->trashed()
                 ->andWhere(['matrixblocks.deletedWithOwner' => true])
                 ->all();
@@ -1250,7 +1264,22 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
             // Existing block?
             if (isset($oldBlocksById[$blockId])) {
                 $block = $oldBlocksById[$blockId];
-                $block->dirty = !empty($blockData);
+                $dirty = !empty($blockData);
+
+                // Is this a derivative element, and does the block primarily belong to the canonical?
+                if ($dirty && $element->getIsDerivative() && $block->primaryOwnerId === $element->getCanonicalId()) {
+                    // Duplicate it as a draft. (We'll drop its draft status from `Matrix::saveField()`.)
+                    $block = Craft::$app->getDrafts()->createDraft($block, Craft::$app->getUser()->getId(), null, null, [
+                        'canonicalId' => $block->id,
+                        'primaryOwnerId' => $element->id,
+                        'owner' => $element,
+                        'siteId' => $element->siteId,
+                        'propagating' => false,
+                        'markAsSaved' => false,
+                    ]);
+                }
+
+                $block->dirty = $dirty;
             } else {
                 // Make sure it's a valid block type
                 if (!isset($blockData['type']) || !isset($blockTypes[$blockData['type']])) {
@@ -1259,7 +1288,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
                 $block = new MatrixBlock();
                 $block->fieldId = $this->id;
                 $block->typeId = $blockTypes[$blockData['type']]->id;
-                $block->ownerId = $element->id;
+                $block->primaryOwnerId = $element->id;
                 $block->siteId = $element->siteId;
 
                 // Preserve the collapsed state, which the browser can't remember on its own for new blocks

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1288,7 +1288,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
                 $block = new MatrixBlock();
                 $block->fieldId = $this->id;
                 $block->typeId = $blockTypes[$blockData['type']]->id;
-                $block->primaryOwnerId = $element->id;
+                $block->primaryOwnerId = $block->ownerId = $element->id;
                 $block->siteId = $element->siteId;
 
                 // Preserve the collapsed state, which the browser can't remember on its own for new blocks

--- a/src/gql/arguments/elements/MatrixBlock.php
+++ b/src/gql/arguments/elements/MatrixBlock.php
@@ -30,10 +30,10 @@ class MatrixBlock extends ElementArguments
                 'type' => Type::listOf(QueryArgument::getType()),
                 'description' => 'Narrows the query results based on the field the Matrix blocks belong to, per the fields’ IDs.',
             ],
-            'ownerId' => [
-                'name' => 'ownerId',
+            'primaryOwnerId' => [
+                'name' => 'primaryOwnerId',
                 'type' => Type::listOf(QueryArgument::getType()),
-                'description' => ' Narrows the query results based on the owner element of the Matrix blocks, per the owners’ IDs.',
+                'description' => ' Narrows the query results based on the primary owner element of the Matrix blocks, per the owners’ IDs.',
             ],
             'typeId' => Type::listOf(QueryArgument::getType()),
             'type' => [

--- a/src/gql/interfaces/elements/MatrixBlock.php
+++ b/src/gql/interfaces/elements/MatrixBlock.php
@@ -71,10 +71,10 @@ class MatrixBlock extends Element
                 'type' => Type::nonNull(Type::int()),
                 'description' => 'The ID of the field that owns the matrix block.',
             ],
-            'ownerId' => [
-                'name' => 'ownerId',
+            'primaryOwnerId' => [
+                'name' => 'primaryOwnerId',
                 'type' => Type::nonNull(Type::int()),
-                'description' => 'The ID of the element that owns the matrix block.',
+                'description' => 'The ID of the primary owner of the Matrix block.',
             ],
             'typeId' => [
                 'name' => 'typeId',

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -463,7 +463,7 @@ class Install extends Migration
             'blockId' => $this->integer()->notNull(),
             'ownerId' => $this->integer()->notNull(),
             'sortOrder' => $this->smallInteger()->unsigned()->notNull(),
-            'PRIMARY KEY([[blockId]], [[elementId]])',
+            'PRIMARY KEY([[blockId]], [[ownerId]])',
         ]);
         $this->createTable(Table::MATRIXBLOCKTYPES, [
             'id' => $this->primaryKey(),

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -451,14 +451,19 @@ class Install extends Migration
         ]);
         $this->createTable(Table::MATRIXBLOCKS, [
             'id' => $this->integer()->notNull(),
-            'ownerId' => $this->integer()->notNull(),
+            'primaryOwnerId' => $this->integer()->notNull(),
             'fieldId' => $this->integer()->notNull(),
             'typeId' => $this->integer()->notNull(),
-            'sortOrder' => $this->smallInteger()->unsigned(),
             'deletedWithOwner' => $this->boolean()->null(),
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
             'PRIMARY KEY([[id]])',
+        ]);
+        $this->createTable(Table::MATRIXBLOCKS_OWNERS, [
+            'blockId' => $this->integer()->notNull(),
+            'ownerId' => $this->integer()->notNull(),
+            'sortOrder' => $this->smallInteger()->unsigned()->notNull(),
+            'PRIMARY KEY([[blockId]], [[elementId]])',
         ]);
         $this->createTable(Table::MATRIXBLOCKTYPES, [
             'id' => $this->primaryKey(),
@@ -834,10 +839,9 @@ class Install extends Migration
         $this->createIndex(null, Table::IMAGETRANSFORMINDEX, ['assetId', 'transformString'], false);
         $this->createIndex(null, Table::IMAGETRANSFORMS, ['name']);
         $this->createIndex(null, Table::IMAGETRANSFORMS, ['handle']);
-        $this->createIndex(null, Table::MATRIXBLOCKS, ['ownerId'], false);
+        $this->createIndex(null, Table::MATRIXBLOCKS, ['primaryOwnerId'], false);
         $this->createIndex(null, Table::MATRIXBLOCKS, ['fieldId'], false);
         $this->createIndex(null, Table::MATRIXBLOCKS, ['typeId'], false);
-        $this->createIndex(null, Table::MATRIXBLOCKS, ['sortOrder'], false);
         $this->createIndex(null, Table::MATRIXBLOCKTYPES, ['name', 'fieldId']);
         $this->createIndex(null, Table::MATRIXBLOCKTYPES, ['handle', 'fieldId']);
         $this->createIndex(null, Table::MATRIXBLOCKTYPES, ['fieldId'], false);
@@ -1004,8 +1008,10 @@ class Install extends Migration
         $this->addForeignKey(null, Table::GQLTOKENS, 'schemaId', Table::GQLSCHEMAS, 'id', 'SET NULL', null);
         $this->addForeignKey(null, Table::MATRIXBLOCKS, ['fieldId'], Table::FIELDS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::MATRIXBLOCKS, ['id'], Table::ELEMENTS, ['id'], 'CASCADE', null);
-        $this->addForeignKey(null, Table::MATRIXBLOCKS, ['ownerId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, Table::MATRIXBLOCKS, ['primaryOwnerId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::MATRIXBLOCKS, ['typeId'], Table::MATRIXBLOCKTYPES, ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, Table::MATRIXBLOCKS_OWNERS, ['blockId'], Table::MATRIXBLOCKS, ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, Table::MATRIXBLOCKS_OWNERS, ['ownerId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::MATRIXBLOCKTYPES, ['fieldId'], Table::FIELDS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::MATRIXBLOCKTYPES, ['fieldLayoutId'], Table::FIELDLAYOUTS, ['id'], 'SET NULL', null);
         $this->addForeignKey(null, Table::RELATIONS, ['fieldId'], Table::FIELDS, ['id'], 'CASCADE', null);

--- a/src/migrations/m220213_015220_matrixblocks_owners_table.php
+++ b/src/migrations/m220213_015220_matrixblocks_owners_table.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace craft\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m220213_015220_matrixblocks_elements_table migration.
+ */
+class m220213_015220_matrixblocks_owners_table extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->dropTableIfExists(Table::MATRIXBLOCKS_OWNERS);
+
+        $this->createTable(Table::MATRIXBLOCKS_OWNERS, [
+            'blockId' => $this->integer()->notNull(),
+            'ownerId' => $this->integer()->notNull(),
+            'sortOrder' => $this->smallInteger()->unsigned()->notNull(),
+            'PRIMARY KEY([[blockId]], [[ownerId]])',
+        ]);
+
+        $this->addForeignKey(null, Table::MATRIXBLOCKS_OWNERS, ['blockId'], Table::MATRIXBLOCKS, ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, Table::MATRIXBLOCKS_OWNERS, ['ownerId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
+
+        $blocksTable = Table::MATRIXBLOCKS;
+        $ownersTable = Table::MATRIXBLOCKS_OWNERS;
+
+        $this->execute(<<<SQL
+INSERT INTO $ownersTable ([[blockId]], [[ownerId]], [[sortOrder]]) 
+SELECT [[id]], [[ownerId]], [[sortOrder]] 
+FROM $blocksTable
+SQL);
+
+        // drop sortOrder
+        $this->dropIndexIfExists(Table::MATRIXBLOCKS, ['sortOrder'], false);
+        $this->dropColumn(Table::MATRIXBLOCKS, 'sortOrder');
+
+        // ownerId => primaryOwnerId
+        $this->renameColumn(Table::MATRIXBLOCKS, 'ownerId', 'primaryOwnerId');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m220213_015220_matrixblocks_owners_table cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/records/MatrixBlock.php
+++ b/src/records/MatrixBlock.php
@@ -15,10 +15,9 @@ use yii\db\ActiveQueryInterface;
  * Class MatrixBlock record.
  *
  * @property int $id ID
- * @property int $ownerId Owner ID
+ * @property int $primaryOwnerId Primary owner ID
  * @property int $fieldId Field ID
  * @property int $typeId Type ID
- * @property int $sortOrder Sort order
  * @property Element $element Element
  * @property Element $owner Owner
  * @property Field $field Field
@@ -49,13 +48,13 @@ class MatrixBlock extends ActiveRecord
     }
 
     /**
-     * Returns the matrix block’s owner.
+     * Returns the matrix block’s primary owner.
      *
      * @return ActiveQueryInterface The relational query object.
      */
-    public function getOwner(): ActiveQueryInterface
+    public function getPrimaryOwner(): ActiveQueryInterface
     {
-        return $this->hasOne(Element::class, ['id' => 'ownerId']);
+        return $this->hasOne(Element::class, ['id' => 'primaryOwnerId']);
     }
 
     /**

--- a/src/services/Matrix.php
+++ b/src/services/Matrix.php
@@ -682,7 +682,7 @@ class Matrix extends Component
             foreach ($blocks as $block) {
                 $sortOrder++;
                 if ($saveAll || !$block->id || $block->dirty) {
-                    $block->primaryOwnerId = $owner->id;
+                    $block->primaryOwnerId = $block->ownerId = $owner->id;
                     $block->sortOrder = $sortOrder;
                     $elementsService->saveElement($block, false);
 

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -982,7 +982,7 @@ class Sites extends Component
                     $blockIds = (new Query())
                         ->select(['id'])
                         ->from([Table::MATRIXBLOCKS])
-                        ->where(['ownerId' => $entryIds])
+                        ->where(['primaryOwnerId' => $entryIds])
                         ->column();
 
                     if (!empty($blockIds)) {


### PR DESCRIPTION
### Description

This PR introduces the ability for a Matrix block to have multiple owners, via a new `matrixblocks_owners` join table. This enables a massive performance improvement when creating new drafts: we no longer need to duplicate Matrix blocks for drafts, unless something has actually changed within the block. Instead we can just duplicate the block/owner relation rows.

Here’s a look at the performance gains when saving an entry with 100 blocks and 10 sites:

<img width="851" alt="Three bar charts showing the performance gains that this PR introduces. See the table below for the raw data" src="https://user-images.githubusercontent.com/47792/154180110-d02eedb7-5ed9-4cee-a4cd-56d31e76e070.png">

|  | Before | After |
| -- | -- | -- |
| **Time** | 31.27s | 2.08s |
| **Queries** | 13,193 | 263 |
| **Memory** | 114MB | 49MB |

Similarly, when applying a draft, we no longer need to re-save any blocks that were never touched for the draft. However the improvement isn’t quite as stark there if versioning is enabled for the section, as we still need to duplicate all the blocks when creating the revision.


### Related issues

- #9802