### PR TITLE
Setup `{% d %}` Twig tag to dump using symfony/var-dumper

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -36,6 +36,7 @@ use craft\web\twig\nodevisitors\Profiler;
 use craft\web\twig\tokenparsers\CacheTokenParser;
 use craft\web\twig\tokenparsers\DdTokenParser;
 use craft\web\twig\tokenparsers\DeprecatedTokenParser;
+use craft\web\twig\tokenparsers\DTokenParser;
 use craft\web\twig\tokenparsers\ExitTokenParser;
 use craft\web\twig\tokenparsers\HeaderTokenParser;
 use craft\web\twig\tokenparsers\HookTokenParser;
@@ -128,6 +129,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
         return [
             new CacheTokenParser(),
             new DeprecatedTokenParser(),
+            new DTokenParser(),
             new DdTokenParser(),
             new ExitTokenParser(),
             new HeaderTokenParser(),

--- a/src/web/twig/nodes/DNode.php
+++ b/src/web/twig/nodes/DNode.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\web\twig\nodes;
+
+use Craft;
+use Twig\Compiler;
+use Twig\Node\Node;
+
+/**
+ * Class DNode
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.2.0
+ */
+class DNode extends Node
+{
+    /**
+     * @inheritdoc
+     */
+    public function compile(Compiler $compiler): void
+    {
+        $compiler->addDebugInfo($this);
+
+        $compiler
+            ->write('dump(')
+            ->subcompile($this->getNode('var'))
+            ->raw(");\n");
+    }
+}

--- a/src/web/twig/tokenparsers/DTokenParser.php
+++ b/src/web/twig/tokenparsers/DTokenParser.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\web\twig\tokenparsers;
+
+use craft\web\twig\nodes\DNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+/**
+ * Class DTokenParser
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.2.0
+ */
+class DTokenParser extends AbstractTokenParser
+{
+    /**
+     * @inheritdoc
+     */
+    public function parse(Token $token): DNode
+    {
+        $lineno = $token->getLine();
+        $parser = $this->parser;
+        $stream = $parser->getStream();
+
+        $nodes = [
+            'var' => $parser->getExpressionParser()->parseExpression(),
+        ];
+
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        return new DNode($nodes, [], $lineno, $this->getTag());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTag(): string
+    {
+        return 'd';
+    }
+}


### PR DESCRIPTION
Now that `symfony/var-dumper` is installed in the Craft 4 core it might be useful to expose a Twig tag for dumping a variable, but not die out. 

```twig
{# Dump the request out and die #}
{% dd craft.app.request %}

{# Dump the request out using Symfony's VarDumper #}
{% d craft.app.request %}
```

Just a thought!