### PR TITLE
Full names for users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Field layout tabs, fields, and UI elements can now be conditionally shown based on properties of the current user and/or element being edited. ([#8099](https://github.com/craftcms/cms/discussions/8099), [#8154](https://github.com/craftcms/cms/discussions/8154))
 - Assets, Entries, and Users fields have new condition settings that can be used to further limit which elements should be relatable, beyond the existing field settings. ([#10393](https://github.com/craftcms/cms/pull/10393))
 - Assets, Entries, and Users fields have new “Min Relations” settings, and their former “Limit” settings have been renamed to “Max Relations”. ([#8621](https://github.com/craftcms/cms/discussions/8621))
+- Added a dedicated “Full Name” field to users. “First Name” and “Last Name” are now parsed out from the full name automatically when a user is saved. ([#10405](https://github.com/craftcms/cms/discussions/10405))
 - Added the “Inactive” user status, which can be used by users which can’t be signed into. ([#8963](https://github.com/craftcms/cms/discussions/8963))
 - Added “Credentialed” and “Inactive” user sources.
 - Added the “Deactivate…” user action for pending and active users.
@@ -24,9 +25,8 @@
 - It’s now possible to edit images’ focal points from their preview modals. ([#8489](https://github.com/craftcms/cms/discussions/8489))
 - Added the `|money` Twig filter.
 - Added the `collect()` Twig function.
-- Added the `assetUploaders` user query param.
+- Added the `assetUploaders`, `authors`, and `fullName` user query params.
 - Added the `primaryOwner` and `primaryOwnerId` Matrix block query params.
-- Added the `authors` user query param.
 - Added the `hasAlt` asset query param.
 - Added the `button`, `submitButton`, `fs`, and `fsField` macros to the `_includes/forms` control panel template.
 - Added support for setting custom config settings from `config/custom.php`, which are accessible via `Craft::$app->config->custom`. ([#10012](https://github.com/craftcms/cms/issues/10012))
@@ -141,6 +141,7 @@
 - Added `craft\elements\MatrixBlock::$primaryOwnerId`.
 - Added `craft\elements\MatrixBlock::$saveOwnership`.
 - Added `craft\elements\User::$active`.
+- Added `craft\elements\User::$fullName`.
 - Added `craft\elements\User::canAssignUserGroups()`.
 - Added `craft\elements\User::getIsCredentialed()`.
 - Added `craft\elements\User::STATUS_INACTIVE`.
@@ -352,6 +353,7 @@
 - Added the Money package.
 - Added the yii2-symfonymailer package.
 - Added the symfony/var-dumper package.
+- Added the theiconic/name-parser package.
 
 ### Changed
 - Craft now requires PHP 8.0.2 or later.
@@ -566,6 +568,7 @@
 - Deprecated the `anyStatus` element query param. `status(null)` should be used instead.
 - Deprecated the `immediately` argument for transforms created over GraphQL. It no longer has any effect.
 - Deprecated `craft\behaviors\FieldLayoutBehavior::getFields()`. `getCustomFields()` should be used instead.
+- Deprecated `craft\elements\User::getFullName()`. `$fullName` should be used instead.
 - Deprecated `craft\fieldlayoutelements\StandardField`. `craft\fieldlayoutelements\BaseNativeField` should be used instead.
 - Deprecated `craft\fieldlayoutelements\StandardTextField`. `craft\fieldlayoutelements\TextField` should be used instead.
 - Deprecated `craft\gql\TypeManager::flush()`. `craft\services\Gql::flushCaches()` should be used instead.

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "symfony/http-client": "^6.0.3",
     "symfony/var-dumper": "^5.0|^6.0",
     "symfony/yaml": "^5.2.3",
+    "theiconic/name-parser": "^1.2",
     "true/punycode": "^2.1.1",
     "twig/twig": "~3.3.0",
     "voku/stringy": "^6.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c97efec014e68b79ba1a281184e4790e",
+    "content-hash": "1457a03a17c4ee96610bda194ce6bc5d",
     "packages": [
         {
             "name": "cebe/markdown",
@@ -4834,6 +4834,54 @@
                 }
             ],
             "time": "2022-01-26T16:32:32+00:00"
+        },
+        {
+            "name": "theiconic/name-parser",
+            "version": "v1.2.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theiconic/name-parser.git",
+                "reference": "9a54a713bf5b2e7fd990828147d42de16bf8a253"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theiconic/name-parser/zipball/9a54a713bf5b2e7fd990828147d42de16bf8a253",
+                "reference": "9a54a713bf5b2e7fd990828147d42de16bf8a253",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "php-mock/php-mock-phpunit": "^2.1",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TheIconic\\NameParser\\": [
+                        "src/",
+                        "tests/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "The Iconic",
+                    "email": "engineering@theiconic.com.au"
+                }
+            ],
+            "description": "PHP library for parsing a string containing a full name into its parts",
+            "support": {
+                "issues": "https://github.com/theiconic/name-parser/issues",
+                "source": "https://github.com/theiconic/name-parser/tree/v1.2.11"
+            },
+            "time": "2019-11-14T14:08:48+00:00"
         },
         {
             "name": "true/punycode",

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '4.0.0-alpha',
-    'schemaVersion' => '4.0.0.1',
+    'schemaVersion' => '4.0.0.2',
     'minVersionRequired' => '3.7.11',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -926,8 +926,7 @@ class UsersController extends Controller
                 $errors = $user->getErrors();
                 $accountFields = [
                     'username',
-                    'firstName',
-                    'lastName',
+                    'fullName',
                     'email',
                     'password',
                     'newPassword',
@@ -1221,8 +1220,7 @@ JS,
             $user->username = $this->request->getBodyParam('username', ($user->username ?: $user->email));
         }
 
-        $user->firstName = $this->request->getBodyParam('firstName', $user->firstName);
-        $user->lastName = $this->request->getBodyParam('lastName', $user->lastName);
+        $user->fullName = $this->request->getBodyParam('fullName', $user->fullName);
 
         // New users should always be initially saved in a pending state,
         // even if an admin is doing this and opted to not send the verification email

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1220,7 +1220,21 @@ JS,
             $user->username = $this->request->getBodyParam('username', ($user->username ?: $user->email));
         }
 
-        $user->fullName = $this->request->getBodyParam('fullName', $user->fullName);
+        $fullName = $this->request->getBodyParam('fullName');
+
+        if ($fullName !== null) {
+            $user->fullName = $fullName;
+        } else {
+            // Still check for firstName/lastName in case a front-end form is still posting them
+            $firstName = $this->request->getBodyParam('firstName');
+            $lastName = $this->request->getBodyParam('lastName');
+
+            if ($firstName !== null || $lastName !== null) {
+                $user->fullName = null;
+                $user->firstName = $firstName ?? $user->firstName;
+                $user->lastName = $lastName ?? $user->lastName;
+            }
+        }
 
         // New users should always be initially saved in a pending state,
         // even if an admin is doing this and opted to not send the verification email

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -346,7 +346,7 @@ class User extends Element implements IdentityInterface
      */
     protected static function defineSearchableAttributes(): array
     {
-        return ['username', 'fullName', 'email'];
+        return ['username', 'fullName', 'firstName', 'lastName', 'email'];
     }
 
     /**

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -42,6 +42,7 @@ use craft\validators\UsernameValidator;
 use craft\validators\UserPasswordValidator;
 use DateInterval;
 use DateTime;
+use TheIconic\NameParser\Parser as NameParser;
 use Throwable;
 use yii\base\ErrorHandler;
 use yii\base\Exception;
@@ -59,7 +60,6 @@ use yii\web\IdentityInterface;
  * @property UserGroup[] $groups the user's groups
  * @property string $name the user's full name or username
  * @property string|null $friendlyName the user's first name or username
- * @property string|null $fullName the user's full name
  * @property-read DateInterval|null $remainingCooldownTime the remaining cooldown time for this user, if they've entered their password incorrectly too many times
  * @property-read DateTime|null $cooldownEndTime the time when the user will be over their cooldown period
  * @property-read array $preferences the user’s preferences
@@ -346,7 +346,7 @@ class User extends Element implements IdentityInterface
      */
     protected static function defineSearchableAttributes(): array
     {
-        return ['username', 'firstName', 'lastName', 'fullName', 'email'];
+        return ['username', 'fullName', 'email'];
     }
 
     /**
@@ -357,6 +357,7 @@ class User extends Element implements IdentityInterface
         if (Craft::$app->getConfig()->getGeneral()->useEmailAsUsername) {
             $attributes = [
                 'email' => Craft::t('app', 'Email'),
+                'fullName' => Craft::t('app', 'Full Name'),
                 'firstName' => Craft::t('app', 'First Name'),
                 'lastName' => Craft::t('app', 'Last Name'),
                 [
@@ -385,6 +386,7 @@ class User extends Element implements IdentityInterface
         } else {
             $attributes = [
                 'username' => Craft::t('app', 'Username'),
+                'fullName' => Craft::t('app', 'Full Name'),
                 'firstName' => Craft::t('app', 'First Name'),
                 'lastName' => Craft::t('app', 'Last Name'),
                 'email' => Craft::t('app', 'Email'),
@@ -581,6 +583,12 @@ class User extends Element implements IdentityInterface
     public ?string $username = null;
 
     /**
+     * @var string|null Full name
+     * @since 4.0.0
+     */
+    public ?string $fullName = null;
+
+    /**
      * @var string|null First name
      */
     public ?string $firstName = null;
@@ -723,6 +731,13 @@ class User extends Element implements IdentityInterface
         if ($this->email) {
             $this->email = StringHelper::idnToUtf8Email($this->email);
         }
+
+        $names = ['fullName', 'firstName', 'lastName'];
+        foreach ($names as $name) {
+            if (isset($this->$name) && trim($this->$name) === '') {
+                $this->$name = null;
+            }
+        }
     }
 
     /**
@@ -801,6 +816,7 @@ class User extends Element implements IdentityInterface
         $labels = parent::attributeLabels();
         $labels['currentPassword'] = Craft::t('app', 'Current Password');
         $labels['email'] = Craft::t('app', 'Email');
+        $labels['fullName'] = Craft::t('app', 'Full Name');
         $labels['firstName'] = Craft::t('app', 'First Name');
         $labels['lastName'] = Craft::t('app', 'Last Name');
         $labels['newPassword'] = Craft::t('app', 'New Password');
@@ -821,9 +837,9 @@ class User extends Element implements IdentityInterface
 
         $rules[] = [['lastLoginDate', 'lastInvalidLoginDate', 'lockoutDate', 'lastPasswordChangeDate', 'verificationCodeIssuedDate'], DateTimeValidator::class];
         $rules[] = [['invalidLoginCount', 'photoId'], 'number', 'integerOnly' => true];
-        $rules[] = [['username', 'email', 'unverifiedEmail', 'firstName', 'lastName'], 'trim', 'skipOnEmpty' => true];
+        $rules[] = [['username', 'email', 'unverifiedEmail', 'fullName', 'firstName', 'lastName'], 'trim', 'skipOnEmpty' => true];
         $rules[] = [['email', 'unverifiedEmail'], 'email', 'enableIDN' => App::supportsIdn(), 'enableLocalIDN' => false];
-        $rules[] = [['email', 'username', 'firstName', 'lastName', 'password', 'unverifiedEmail'], 'string', 'max' => 255];
+        $rules[] = [['email', 'username', 'fullName', 'firstName', 'lastName', 'password', 'unverifiedEmail'], 'string', 'max' => 255];
         $rules[] = [['verificationCode'], 'string', 'max' => 100];
         $rules[] = [['email'], 'required', 'when' => $treatAsActive];
         $rules[] = [['lastLoginAttemptIp'], 'string', 'max' => 45];
@@ -863,7 +879,7 @@ class User extends Element implements IdentityInterface
         ];
 
         $rules[] = [
-            ['firstName', 'lastName'], function($attribute, $params, Validator $validator) {
+            ['fullName', 'firstName', 'lastName'], function($attribute, $params, Validator $validator) {
                 if (str_contains($this->$attribute, '://')) {
                     $validator->addError($this, $attribute, Craft::t('app', 'Invalid value “{value}”.'));
                 }
@@ -1103,25 +1119,11 @@ class User extends Element implements IdentityInterface
      * Returns the user's full name.
      *
      * @return string|null
+     * @deprecated in 4.0.0. [[fullName]] should be used instead.
      */
     public function getFullName(): ?string
     {
-        $firstName = trim($this->firstName);
-        $lastName = trim($this->lastName);
-
-        if (!$firstName && !$lastName) {
-            return null;
-        }
-
-        $name = $firstName;
-
-        if ($firstName && $lastName) {
-            $name .= ' ';
-        }
-
-        $name .= $lastName;
-
-        return $name;
+        return $this->fullName;
     }
 
     /**
@@ -1150,11 +1152,7 @@ class User extends Element implements IdentityInterface
             }
         }
 
-        if (($fullName = $this->getFullName()) !== null) {
-            return $fullName;
-        }
-
-        return (string)$this->username;
+        return $this->fullName ?? (string)$this->username;
     }
 
     /**
@@ -1194,11 +1192,7 @@ class User extends Element implements IdentityInterface
             }
         }
 
-        if ($firstName = trim($this->firstName)) {
-            return $firstName;
-        }
-
-        return $this->username;
+        return $this->firstName ?? $this->username;
     }
 
     /**
@@ -1696,9 +1690,18 @@ class User extends Element implements IdentityInterface
             $record->suspended = $this->suspended;
         }
 
+        if ($this->fullName !== null) {
+            $name = (new NameParser())->parse($this->fullName);
+            $this->firstName = $name->getFirstname() ?: null;
+            $this->lastName = $name->getLastname() ?: null;
+        } else if ($this->firstName !== null || $this->lastName !== null) {
+            $this->fullName = trim("$this->firstName $this->lastName") ?: null;
+        }
+
         $record->photoId = (int)$this->photoId ?: null;
         $record->admin = $this->admin;
         $record->username = $this->username;
+        $record->fullName = $this->fullName;
         $record->firstName = $this->firstName;
         $record->lastName = $this->lastName;
         $record->email = $this->email;

--- a/src/helpers/MailerHelper.php
+++ b/src/helpers/MailerHelper.php
@@ -106,8 +106,8 @@ class MailerHelper
 
         foreach ($emails as $key => $value) {
             if ($value instanceof User) {
-                if (($name = $value->getFullName()) !== null) {
-                    $normalized[$value->email] = $name;
+                if ($value->fullName !== null) {
+                    $normalized[$value->email] = $value->fullName;
                 } else {
                     $normalized[] = $value->email;
                 }

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -708,6 +708,7 @@ class Install extends Migration
             'suspended' => $this->boolean()->defaultValue(false)->notNull(),
             'admin' => $this->boolean()->defaultValue(false)->notNull(),
             'username' => $this->string(),
+            'fullName' => $this->string(),
             'firstName' => $this->string(),
             'lastName' => $this->string(),
             'email' => $this->string(),

--- a/src/migrations/m220222_122159_full_names.php
+++ b/src/migrations/m220222_122159_full_names.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace craft\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Table;
+use yii\db\Expression;
+
+/**
+ * m220222_122159_full_names migration.
+ */
+class m220222_122159_full_names extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn(Table::USERS, 'fullName', $this->string()->after('username'));
+
+        $this->update(Table::USERS, [
+            'fullName' => new Expression("TRIM(CONCAT([[firstName]], ' ', [[lastName]]))"),
+        ], new Expression("TRIM(CONCAT([[firstName]], [[lastName]])) <> ''"), [], false);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m220222_122159_full_names cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/records/User.php
+++ b/src/records/User.php
@@ -24,8 +24,9 @@ use yii\db\ActiveQueryInterface;
  * @property bool $suspended Suspended
  * @property bool $admin Admin
  * @property string $username Username
- * @property string $firstName First name
- * @property string $lastName Last name
+ * @property string|null $fullName
+ * @property string|null $firstName First name
+ * @property string|null $lastName Last name
  * @property string $email Email
  * @property string $password Password
  * @property DateTime $lastLoginDate Last login date

--- a/src/templates/users/_accountfields.twig
+++ b/src/templates/users/_accountfields.twig
@@ -20,28 +20,13 @@
 {% endif %}
 
 {{ forms.textField({
-    fieldClass: 'width-50',
-    label: "First Name"|t('app'),
-    id: 'firstName',
-    name: 'firstName',
-    value: user.firstName,
+    label: "Full Name"|t('app'),
+    id: 'fullName',
+    name: 'fullName',
+    value: user.fullName,
     autocomplete: false,
-    errors: user.getErrors('firstName'),
+    errors: user.getErrors('fullName'),
     autofocus: craft.app.config.general.useEmailAsUsername,
-    inputAttributes: {
-        data: {lpignore: 'true'},
-    },
-    disabled: static,
-}) }}
-
-{{ forms.textField({
-    fieldClass: 'width-50',
-    label: "Last Name"|t('app'),
-    id: 'lastName',
-    name: 'lastName',
-    value: user.lastName,
-    autocomplete: false,
-    errors: user.getErrors('lastName'),
     inputAttributes: {
         data: {lpignore: 'true'},
     },

--- a/tests/functional/users/EditUserCest.php
+++ b/tests/functional/users/EditUserCest.php
@@ -56,7 +56,7 @@ class EditUserCest
         $I->see('My Account');
 
         $I->submitForm('#userform', [
-            'firstName' => 'IM A CHANGED FIRSTNAME',
+            'fullName' => 'IM A CHANGED FULLNAME',
         ]);
 
         $I->see('User saved');
@@ -64,10 +64,10 @@ class EditUserCest
 
         // Check that the Db was updated.
         $I->assertSame(
-            'IM A CHANGED FIRSTNAME',
+            'IM A CHANGED FULLNAME',
             User::find()
                 ->id($this->currentUser->id)
-                ->one()->firstName
+                ->one()->fullName
         );
     }
 

--- a/tests/unit/services/SearchTest.php
+++ b/tests/unit/services/SearchTest.php
@@ -87,8 +87,8 @@ class SearchTest extends Unit
         $user->active = true;
         $user->username = 'testIndexElementAttributes1';
         $user->email = 'testIndexElementAttributes1@test.com';
-        $user->firstName = 'john smith';
-        $user->lastName = 'WIL K ER SON!';
+        $user->firstName = 'john';
+        $user->lastName = 'wilkerson';
         $user->id = 1;
 
         // Index them.
@@ -98,9 +98,8 @@ class SearchTest extends Unit
         $searchIndex = (new Query())->from([Table::SEARCHINDEX])->where(['elementId' => $user->id])->all();
 
         self::assertSame(' testindexelementattributes1 test com ', $this->_getSearchIndexValueByAttribute('email', $searchIndex));
-        self::assertSame(' john smith ', $this->_getSearchIndexValueByAttribute('firstname', $searchIndex));
-        self::assertSame(' wil k er son ', $this->_getSearchIndexValueByAttribute('lastname', $searchIndex));
-        self::assertSame(' john smith wil k er son ', $this->_getSearchIndexValueByAttribute('fullname', $searchIndex));
+        self::assertSame(' john ', $this->_getSearchIndexValueByAttribute('firstname', $searchIndex));
+        self::assertSame(' wilkerson ', $this->_getSearchIndexValueByAttribute('lastname', $searchIndex));
     }
 
     /**


### PR DESCRIPTION
### Description

Replaces the ºFirst Name” and “Last Name” fields on Edit User pages with a new “Full Name” field.

When a user is saved, its First/Last Name values will be automatically parsed from its Full Name, if set, and those values are still stored so they can be shown/sorted from user indexes.

There’s also a new `fullName` user query param which maps to the new `fullName` values.

The `users/save-user` action still supports posting separate `firstName`/`lastName` values; they will be automatically merged into `fullName` on save.

### Related issues

- #10405