### PR TITLE
Make properties private

### DIFF
--- a/src/services/Addresses.php
+++ b/src/services/Addresses.php
@@ -40,17 +40,17 @@ class Addresses extends Component
     /**
      * @var CountryRepository
      */
-    public CountryRepository $_countryRepository;
+    private CountryRepository $_countryRepository;
 
     /**
      * @var SubdivisionRepository
      */
-    public SubdivisionRepository $_subdivisionRepository;
+    private SubdivisionRepository $_subdivisionRepository;
 
     /**
      * @var AddressFormatRepository
      */
-    public AddressFormatRepository $_addressFormatRepository;
+    private AddressFormatRepository $_addressFormatRepository;
 
     /**
      * @inheritdoc


### PR DESCRIPTION
Changed the visibility of these properties to private, which the underscores and getter methods would seem to suggest they should be.