### PR TITLE
Return new `static`

### DIFF
--- a/src/errors/ShellCommandException.php
+++ b/src/errors/ShellCommandException.php
@@ -44,7 +44,7 @@ class ShellCommandException extends Exception
         $execCommand = $command->getExecCommand();
 
         if ($execCommand !== false) {
-            return new self($execCommand, $command->getExitCode(), $command->getStdErr());
+            return new static($execCommand, $command->getExitCode(), $command->getStdErr());
         }
 
         return false;

--- a/src/web/twig/variables/Paginate.php
+++ b/src/web/twig/variables/Paginate.php
@@ -33,7 +33,7 @@ class Paginate extends BaseObject
         $pageResults = $paginator->getPageResults();
         $pageOffset = $paginator->getPageOffset();
 
-        return new self([
+        return new static([
             'first' => $pageOffset + 1,
             'last' => $pageOffset + count($pageResults),
             'total' => $paginator->getTotalResults(),


### PR DESCRIPTION
By replacing `self` with `static`, it makes it possible for extending classes to use this method. 

An example is in Sprig's `PaginateVariable` class:
https://github.com/putyourlightson/craft-sprig-core/blob/0f181fee2012c9a629c509ee5341f4037ca96a19/src/variables/PaginateVariable.php#L17-L23

With `return new self`, a `Paginate` class is returned. With `return new static`, a `PaginateVariable` class is returned, which is the desired beaviour.