### PR TITLE
Revert `new self()`

### DIFF
--- a/src/errors/ShellCommandException.php
+++ b/src/errors/ShellCommandException.php
@@ -44,7 +44,7 @@ class ShellCommandException extends Exception
         $execCommand = $command->getExecCommand();
 
         if ($execCommand !== false) {
-            return new self($execCommand, $command->getExitCode(), $command->getStdErr());
+            return new static($execCommand, $command->getExitCode(), $command->getStdErr());
         }
 
         return false;

--- a/src/web/twig/variables/Paginate.php
+++ b/src/web/twig/variables/Paginate.php
@@ -33,7 +33,7 @@ class Paginate extends BaseObject
         $pageResults = $paginator->getPageResults();
         $pageOffset = $paginator->getPageOffset();
 
-        return new self([
+        return new static([
             'first' => $pageOffset + 1,
             'last' => $pageOffset + count($pageResults),
             'total' => $paginator->getTotalResults(),


### PR DESCRIPTION
This PR reverts incorrect changes made in https://github.com/craftcms/cms/commit/f61a082277f5c4b88c332232deeaff635c9b54c6, in which `new static()` was changed to `new self()`, breaking calls from extending classes that use these methods, such as Sprig's `PaginateVariable` class:
https://github.com/putyourlightson/craft-sprig-core/blob/0f181fee2012c9a629c509ee5341f4037ca96a19/src/variables/PaginateVariable.php#L17-L23