### PR TITLE
Feature/4.x only volume column fs

### DIFF
--- a/src/services/Volumes.php
+++ b/src/services/Volumes.php
@@ -632,12 +632,11 @@ class Volumes extends Component
      */
     private function _createVolumeQuery(): Query
     {
-        return (new Query())
+        $query = (new Query())
             ->select([
                 'id',
                 'name',
                 'handle',
-                'fs',
                 'titleTranslationMethod',
                 'titleTranslationKeyFormat',
                 'sortOrder',
@@ -647,6 +646,13 @@ class Volumes extends Component
             ->from([Table::VOLUMES])
             ->where(['dateDeleted' => null])
             ->orderBy(['sortOrder' => SORT_ASC]);
+
+        $schemaVersion =  Craft::$app->getProjectConfig()->get('system.schemaVersion', true);
+        if (version_compare($schemaVersion, '4.0.0', '>=')) {
+            $query->addSelect(['fs']);
+        }
+
+        return $query;
     }
 
     /**


### PR DESCRIPTION
Since the `m210904_132612_store_element_source_settings_in_project_config.php` migration accesses the Asset element, this query is run before the fs migration is run.

