### PR TITLE
4.0.0-alpha.1 — Quick Post Widget patch

### DIFF
--- a/src/templates/_components/widgets/QuickPost/body.twig
+++ b/src/templates/_components/widgets/QuickPost/body.twig
@@ -20,7 +20,7 @@
     {% endif %}
 
     {% namespace fieldNamespace %}
-        {% for field in fieldLayout.getFields() %}
+        {% for field in fieldLayout.getCustomFields() %}
             {% if field.required or field.id in widget.fields %}
                 {% include "_includes/field" with {
                     field: field,


### PR DESCRIPTION
### Description
Replaces a call to `FieldLayout::getFields()` with the renamed `FieldLayout::getCustomFields()`.

### Related issues
None, sorry! Figured I'd just patch and not clutter up the issues tab. 😉
