### PR TITLE
Add defineBehaviors() to base Model

### DIFF
--- a/src/base/Model.php
+++ b/src/base/Model.php
@@ -87,9 +87,14 @@ abstract class Model extends \yii\base\Model
      */
     public function behaviors(): array
     {
-        // Fire a 'defineBehaviors' event
-        $event = new DefineBehaviorsEvent();
+        $behaviors = $this->defineBehaviors();
+        
+        // Give plugins a chance to modify them
+        $event = new DefineBehaviorsEvent([
+            'behaviors' => $behaviors,
+        ]);
         $this->trigger(self::EVENT_DEFINE_BEHAVIORS, $event);
+
         return $event->behaviors;
     }
 
@@ -129,6 +134,22 @@ abstract class Model extends \yii\base\Model
         }
     }
 
+    /**
+     * Returns the behaviors to attach to this class.
+     *
+     * See [[behaviors()]] for details about what should be returned.
+     *
+     * Models should override this method instead of [[behaviors()]] so [[EVENT_DEFINE_BEHAVIORS]] handlers can modify the
+     * class-defined behaviors.
+     *
+     * @return array
+     * @since 4.0.0
+     */
+    protected function defineBehaviors(): array
+    {
+        return [];
+    }
+    
     /**
      * Returns the validation rules for attributes.
      *


### PR DESCRIPTION
This PR adds a `defineBehaviors()` to the base `Model` class, making it easier for models to attach behaviors without having to call the `parent` method, similar to `defineRules()`. It also uses the `behaviors` attribute of the `DefineBehaviorsEvent` event so that plugins can modify behaviors already defined.

Usage before:
```php
    public function behaviors(): array
    {
        $behaviors = parent::behaviors();
        $behaviors['parser'] = [
            'class' => EnvAttributeParserBehavior::class,
            'attributes' => ['apiKey'],
        ];

        return $behaviors;
    }
```

Usage after:
```php
    public function defineBehaviors(): array
    {
        return [
            'parser' => [
                'class' => EnvAttributeParserBehavior::class,
                'attributes' => ['apiKey'],
            ],
        ];
    }
```