### PR TITLE
Don't assume every field layout type is an element

### DIFF
--- a/src/base/FieldLayoutComponent.php
+++ b/src/base/FieldLayoutComponent.php
@@ -204,7 +204,7 @@ abstract class FieldLayoutComponent extends Model
             /** @var ElementInterface|string|null $elementType */
             $elementType = $this->getLayout()->type;
 
-            if ($elementType) {
+            if ($elementType instanceof ElementInterface) {
                 $elementCondition = $this->_elementCondition ?? $elementType::createCondition();
                 $elementCondition->mainTag = 'div';
                 $elementCondition->id = 'element-condition';


### PR DESCRIPTION
For Vizy, we use a model for the owner of field layouts. This is because when configuring the field settings, you can have multiple blocktypes, each with their own field layout. Currently, this will assume the `type` of a field layout is an element, and try to run conditionals based on that. Being a model, it's not an element.

I'm not sure if I'm abusing field layouts (probably?), but this would be great.