### PR TITLE
Fix `$_parentId` for elements

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -1751,7 +1751,7 @@ abstract class Element extends Component implements ElementInterface
      * @see getParentId()
      * @see setParentId()
      */
-    private self|false|null $_parentId = null;
+    private int|false|null $_parentId = null;
 
     /**
      * @var static|false|null


### PR DESCRIPTION
Looks like the typehints are correct, just not the code:

```
/**
 * @var int|false|null Parent ID
 * @see getParentId()
 * @see setParentId()
 */
private self|false|null $_parentId = null;
```

This will error when calling `setParent()` which will try and set the `$_parentId` to an int, but also of course when calling `setParentId()`.