### PR TITLE
fix: doc-block typo

### DIFF
--- a/src/web/Session.php
+++ b/src/web/Session.php
@@ -49,7 +49,7 @@ class Session extends \yii\web\Session
      * $messages = Craft::$app->session->getAllFlashes(true);
      * ```
      * ```twig{1}
-     * {% set messages = craft.app.session.getAllFLashes(true) %}
+     * {% set messages = craft.app.session.getAllFlashes(true) %}
      * {% for key, message in messages %}
      *   <p class="{{ key }}">
      *     {{ message }}


### PR DESCRIPTION
### Description

`getAllFlashes` was written as `getAllFLashes` in twig doc block.

### Related issues

