### PR TITLE
Auto-property typecasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@
 - Added `craft\helpers\Number::toIntOrFloat()`.
 - Added `craft\helpers\ProjectConfig::encodeValueAsString()`.
 - Added `craft\helpers\ProjectConfig::ensureAllSectionsProcessed()`.
+- Added `craft\helpers\Typecast`. ([#10706](https://github.com/craftcms/cms/pull/10706))
 - Added `craft\i18n\Translation`.
 - Added `craft\imagetransforms\ImageTransformer`.
 - Added `craft\models\AssetIndexingSession`.
@@ -418,6 +419,7 @@
 - `craft\base\ElementInterface::getEagerLoadedElements()` now returns an `Illuminate\Support\Collection` object instead of an array. ([#8513](https://github.com/craftcms/cms/discussions/8513))
 - `craft\base\ElementInterface::getSidebarHtml()` now has a `static` argument.
 - `craft\base\MemoizableArray` no longer extends `ArrayObject`, and now implements `IteratorAggregate` and `Countable` directly.
+- `craft\base\Model::__construct()` and `setAttributes()` now automatically typecast values that map to properties with `int`, `float`, `string`, `bool`, `array`, or `DateTime` type declarations. ([#10706](https://github.com/craftcms/cms/pull/10706))
 - `craft\base\Model::datetimeAttributes()` is now called from the constructor, instead of the `init()` method.
 - `craft\base\Model::setAttributes()` now normalizes date attributes into `DateTime` objects.
 - `craft\behaviors\FieldLayoutBehavior::getFields()` has been renamed to `getCustomFields()`.
@@ -447,6 +449,7 @@
 - `craft\helpers\App::env()` now returns an integer or float if the original value was numeric.
 - `craft\helpers\Assets::generateUrl()` no longer accepts a transform index for date modified comparisons. A `DateTime` object is expected instead.
 - `craft\helpers\Assets::urlAppendix()` no longer accepts a transform index for date modified comparisons. A `DateTime` object is expected instead.
+- `craft\helpers\Component::createComponent()` now automatically typecasts values that map to properties with `int`, `float`, `string`, `bool`, `array`, or `DateTime` type declarations. ([#10706](https://github.com/craftcms/cms/pull/10706))
 - `craft\helpers\Db::batchInsert()`, `craft\helpers\Db::insert()`, `craft\db\Command::batchInsert()`, `craft\db\Command::insert()`, `craft\db\Migration::batchInsert()`, and `craft\db\Migration::insert()` no longer have `$includeAuditColumns` arguments, and now check if the table has `dateCreated`, `dateUpdated`, and/or `uid` columns before setting their values.
 - `craft\helpers\Db::parseParam()` now validates that numeric values are passed if the `$columnType` is set to a numeric column type. ([#9142](https://github.com/craftcms/cms/issues/9142))
 - `craft\helpers\Db::prepareDateForDb()` no longer has a `$stripSeconds` argument.
@@ -515,6 +518,7 @@
 ### Deprecated
 - Deprecated the `anyStatus` element query param. `status(null)` should be used instead.
 - Deprecated the `immediately` argument for transforms created over GraphQL. It no longer has any effect.
+- Deprecated `craft\base\Model::datetimeAttributes()`. ([#10706](https://github.com/craftcms/cms/pull/10706))
 - Deprecated `craft\elements\User::getFullName()`. `$fullName` should be used instead.
 - Deprecated `craft\gql\TypeManager::flush()`. `craft\services\Gql::flushCaches()` should be used instead.
 - Deprecated `craft\gql\TypeManager::prepareFieldDefinitions()`. `craft\services\Gql::prepareFieldDefinitions()` should be used instead.

--- a/src/base/ConfigurableComponent.php
+++ b/src/base/ConfigurableComponent.php
@@ -9,6 +9,7 @@ namespace craft\base;
 
 use craft\events\DefineValueEvent;
 use craft\helpers\DateTimeHelper;
+use DateTime;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -61,11 +62,11 @@ abstract class ConfigurableComponent extends Component implements ConfigurableCo
         $datetimeAttributes = array_flip($this->datetimeAttributes());
 
         foreach ($this->settingsAttributes() as $attribute) {
-            if (isset($datetimeAttributes[$attribute])) {
-                $settings[$attribute] = DateTimeHelper::toIso8601($this->$attribute) ?: null;
-            } else {
-                $settings[$attribute] = $this->$attribute;
+            $value = $this->$attribute;
+            if ($value instanceof DateTime || isset($datetimeAttributes[$attribute])) {
+                $value = DateTimeHelper::toIso8601($value) ?: null;
             }
+            $settings[$attribute] = $value;
         }
 
         return $settings;

--- a/src/base/ConfigurableComponentInterface.php
+++ b/src/base/ConfigurableComponentInterface.php
@@ -24,7 +24,7 @@ interface ConfigurableComponentInterface extends ComponentInterface
      * By default, this method returns all public non-static properties that were defined on the called class.
      * You may override this method to change the default behavior.
      *
-     * @return array The list of settings attribute names
+     * @return string[] The list of settings attribute names
      * @see getSettings()
      */
     public function settingsAttributes(): array;

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2208,16 +2208,6 @@ abstract class Element extends Component implements ElementInterface
     }
 
     /**
-     * @inheritdoc
-     */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'dateLastMerged';
-        return $attributes;
-    }
-
-    /**
      * Normalizes a field’s validation rule.
      *
      * @param string $attribute

--- a/src/base/Model.php
+++ b/src/base/Model.php
@@ -189,6 +189,13 @@ abstract class Model extends \yii\base\Model
         // Typecast them
         Typecast::properties(static::class, $values);
 
+        // Normalize the date/time attributes
+        foreach ($this->datetimeAttributes() as $name) {
+            if (isset($values[$name])) {
+                $values[$name] = DateTimeHelper::toDateTime($values[$name]) ?: null;
+            }
+        }
+
         parent::setAttributes($values, $safeOnly);
     }
 

--- a/src/base/Model.php
+++ b/src/base/Model.php
@@ -13,6 +13,11 @@ use craft\events\DefineFieldsEvent;
 use craft\events\DefineRulesEvent;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\StringHelper;
+use craft\helpers\Typecast;
+use DateTime;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionProperty;
 use yii\validators\Validator;
 
 /**
@@ -60,6 +65,9 @@ abstract class Model extends \yii\base\Model
 
     public function __construct($config = [])
     {
+        // Typecast the properties
+        Typecast::properties(static::class, $config);
+
         // Normalize the DateTime attributes
         foreach ($this->datetimeAttributes() as $attribute) {
             if (array_key_exists($attribute, $config) && $config[$attribute] !== null) {
@@ -151,6 +159,7 @@ abstract class Model extends \yii\base\Model
      * @return string[]
      * @see init()
      * @see fields()
+     * @deprecated in 4.0.0. Use [[\DateTime]] type declarations instead.
      */
     public function datetimeAttributes(): array
     {
@@ -177,12 +186,8 @@ abstract class Model extends \yii\base\Model
      */
     public function setAttributes($values, $safeOnly = true): void
     {
-        // Normalize the date/time attributes
-        foreach ($this->datetimeAttributes() as $name) {
-            if (isset($values[$name])) {
-                $values[$name] = DateTimeHelper::toDateTime($values[$name]) ?: null;
-            }
-        }
+        // Typecast them
+        Typecast::properties(static::class, $values);
 
         parent::setAttributes($values, $safeOnly);
     }
@@ -194,8 +199,21 @@ abstract class Model extends \yii\base\Model
     {
         $fields = parent::fields();
 
+        $datetimeAttributes = [];
+        foreach ((new ReflectionClass($this))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if (!$property->isStatic()) {
+                $type = $property->getType();
+                if ($type instanceof ReflectionNamedType && $type->getName() === DateTime::class) {
+                    $datetimeAttributes[] = $property->getName();
+                }
+            }
+        }
+
+        // Include datetimeAttributes() for now
+        $datetimeAttributes = array_unique(array_merge($datetimeAttributes, $this->datetimeAttributes()));
+
         // Have all DateTime attributes converted to ISO-8601 strings
-        foreach ($this->datetimeAttributes() as $attribute) {
+        foreach ($datetimeAttributes as $attribute) {
             $fields[$attribute] = function($model, $attribute) {
                 if (!empty($model->$attribute)) {
                     return DateTimeHelper::toIso8601($model->$attribute);

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -838,16 +838,6 @@ class Asset extends Element
     /**
      * @inheritdoc
      */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'dateModified';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function afterValidate(): void
     {
         $scenario = $this->getScenario();

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -800,17 +800,6 @@ class Entry extends Element
     /**
      * @inheritdoc
      */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'postDate';
-        $attributes[] = 'expiryDate';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function attributeLabels(): array
     {
         return array_merge(parent::attributeLabels(), [

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -802,20 +802,6 @@ class User extends Element implements IdentityInterface
     /**
      * @inheritdoc
      */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'lastLoginDate';
-        $attributes[] = 'lastInvalidLoginDate';
-        $attributes[] = 'lockoutDate';
-        $attributes[] = 'lastPasswordChangeDate';
-        $attributes[] = 'verificationCodeIssuedDate';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function attributeLabels(): array
     {
         $labels = parent::attributeLabels();

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -214,20 +214,6 @@ class Assets extends BaseRelationField
             }
         }
 
-        // Config normalization
-        $nullables = [
-            'allowedKinds',
-            'defaultUploadLocationSource',
-            'defaultUploadLocationSubpath',
-            'restrictedLocationSource',
-            'restrictedLocationSubpath',
-        ];
-        foreach ($nullables as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
-        }
-
         // Default showUnpermittedVolumes to true for existing Assets fields
         if (isset($config['id']) && !isset($config['showUnpermittedVolumes'])) {
             $config['showUnpermittedVolumes'] = true;

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -225,19 +225,8 @@ abstract class BaseRelationField extends Field implements PreviewableFieldInterf
         }
 
         // Config normalization
-        $nullables = [
-            'maxRelations',
-            'minRelations',
-            'selectionLabel',
-            'selectionLabel',
-            'source',
-            'targetSiteId',
-            'viewMode',
-        ];
-        foreach ($nullables as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
+        if (($config['source'] ?? null) === '') {
+            unset($config['source']);
         }
 
         if (array_key_exists('sources', $config) && empty($config['sources'])) {

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -104,19 +104,6 @@ class Categories extends BaseRelationField
     /**
      * @inheritdoc
      */
-    public function __construct(array $config = [])
-    {
-        // Config normalization
-        if (($config['branchLimit'] ?? null) === '') {
-            unset($config['branchLimit']);
-        }
-
-        parent::__construct($config);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function normalizeValue(mixed $value, ?ElementInterface $element = null): mixed
     {
         if (is_array($value)) {

--- a/src/fields/Color.php
+++ b/src/fields/Color.php
@@ -49,19 +49,6 @@ class Color extends Field implements PreviewableFieldInterface
     /**
      * @inheritdoc
      */
-    public function __construct($config = [])
-    {
-        // Config normalization
-        if (($config['defaultColor'] ?? null) === '') {
-            unset($config['defaultColor']);
-        }
-
-        parent::__construct($config);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getContentColumnType(): string
     {
         return Schema::TYPE_STRING . '(7)';

--- a/src/fields/Date.php
+++ b/src/fields/Date.php
@@ -127,17 +127,6 @@ class Date extends Field implements PreviewableFieldInterface, SortableFieldInte
     /**
      * @inheritdoc
      */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'min';
-        $attributes[] = 'max';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function init(): void
     {
         parent::init();

--- a/src/fields/Lightswitch.php
+++ b/src/fields/Lightswitch.php
@@ -72,14 +72,6 @@ class Lightswitch extends Field implements PreviewableFieldInterface, SortableFi
         if (($onLabel = ArrayHelper::remove($config, 'label')) !== null) {
             $config['onLabel'] = $onLabel;
         }
-        foreach (['onLabel', 'offLabel'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
-        }
-        if (array_key_exists('default', $config) && !is_bool($config['default'])) {
-            $config['default'] = (bool)$config['default'];
-        }
 
         parent::__construct($config);
     }

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -149,10 +149,8 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
     public function __construct($config = [])
     {
         // Config normalization
-        foreach (['minBlocks', 'maxBlocks', 'propagationKeyFormat', 'contentTable'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
+        if (($config['contentTable'] ?? null) === '') {
+            unset($config['contentTable']);
         }
         if (array_key_exists('localizeBlocks', $config)) {
             $config['propagationMethod'] = $config['localizeBlocks'] ? 'none' : 'all';

--- a/src/fields/Number.php
+++ b/src/fields/Number.php
@@ -118,7 +118,7 @@ class Number extends Field implements PreviewableFieldInterface, SortableFieldIn
                 $config[$name] = $this->_normalizeNumber($config[$name]);
             }
         }
-        foreach (['defaultValue', 'max', 'decimals', 'size', 'prefix', 'suffix', 'previewCurrency'] as $name) {
+        foreach (['defaultValue', 'max', 'decimals'] as $name) {
             if (($config[$name] ?? null) === '') {
                 unset($config[$name]);
             }

--- a/src/fields/PlainText.php
+++ b/src/fields/PlainText.php
@@ -98,12 +98,6 @@ class PlainText extends Field implements PreviewableFieldInterface, SortableFiel
             unset($config['limitUnit'], $config['fieldLimit']);
         }
 
-        foreach (['charLimit', 'byteLimit', 'placeholder', 'columnType'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
-        }
-
         if (($config['columnType'] ?? null) === 'auto') {
             unset($config['columnType']);
         }

--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -94,17 +94,7 @@ class Table extends Field
      */
     public function __construct($config = [])
     {
-        // Config normalization
-        foreach (['minRows', 'maxRows', 'addRowLabel'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
-        }
-
-        if (!isset($config['addRowLabel'])) {
-            $config['addRowLabel'] = Craft::t('app', 'Add a row');
-        }
-
+        // Config normalization}
         if (array_key_exists('columns', $config)) {
             if (!is_array($config['columns'])) {
                 unset($config['columns']);
@@ -153,6 +143,18 @@ class Table extends Field
         }
 
         parent::__construct($config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function init(): void
+    {
+        parent::init();
+
+        if (!isset($this->addRowLabel)) {
+            $this->addRowLabel = Craft::t('app', 'Add a row');
+        }
     }
 
     /**

--- a/src/helpers/Component.php
+++ b/src/helpers/Component.php
@@ -106,6 +106,9 @@ class Component
         // Merge the settings sub-key into the main config
         $config = self::mergeSettings($config);
 
+        // Typecast the properties
+        Typecast::properties($class, $config);
+
         // Instantiate and return
         $config['class'] = $class;
         return Craft::createObject($config);

--- a/src/helpers/Typecast.php
+++ b/src/helpers/Typecast.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+declare(strict_types=1);
+
+namespace craft\helpers;
+
+use DateTime;
+use ReflectionException;
+use ReflectionNamedType;
+use ReflectionProperty;
+use yii\base\InvalidArgumentException;
+use yii\base\InvalidValueException;
+
+/**
+ * Typecast Helper
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.0.0
+ */
+final class Typecast
+{
+    private static array $types = [];
+
+    /**
+     * Typecasts the given property values based on their type declarations.
+     *
+     * @param string $class The class name
+     * @param array $properties The property values
+     */
+    public static function properties(string $class, array &$properties): void
+    {
+        foreach ($properties as $name => &$value) {
+            self::property($class, $name, $value);
+        }
+    }
+
+    /**
+     * Typecasts the given property value based on its type declaration.
+     *
+     * @param string $class The class name
+     * @param string $property The property name
+     * @param mixed $value The property value
+     */
+    private static function property(string $class, string $property, mixed &$value): void
+    {
+        $type = self::propertyType($class, $property);
+        if (!$type) {
+            return;
+        }
+
+        if ($value === '') {
+            $value = null;
+        }
+
+        if ($value === null && $type->allowsNull()) {
+            return;
+        }
+
+        switch ($type->getName()) {
+            case 'int':
+                if ($value !== null && !is_scalar($value)) {
+                    throw new InvalidValueException("Unable to typecast $property value to an int.");
+                }
+                $value = (int)$value;
+                return;
+            case 'float':
+                if ($value !== null && !is_scalar($value)) {
+                    throw new InvalidValueException("Unable to typecast $property value to a float.");
+                }
+                $value = (float)$value;
+                return;
+            case 'string':
+                if ($value !== null && !is_scalar($value)) {
+                    // We could technically call __toString() here, but that seems hacky.
+                    // If an object is getting set to a string property, that's probably a bug that shouldn't go unnoticed.
+                    throw new InvalidValueException("Unable to typecast $property value to a string.");
+                }
+                $value = (string)$value;
+                return;
+            case 'bool':
+                if ($value !== null && !is_scalar($value)) {
+                    throw new InvalidValueException("Unable to typecast $property value to a bool.");
+                }
+                $value = (bool)$value;
+                return;
+            case 'array':
+                if ($value === null) {
+                    $value = [];
+                }
+                if (is_array($value)) {
+                    return;
+                }
+                if (is_string($value)) {
+                    try {
+                        $decoded = Json::decode($value) ?? [];
+                        if (!is_array($decoded)) {
+                            throw new InvalidValueException();
+                        }
+                        $value = $decoded;
+                    } catch (InvalidArgumentException | InvalidValueException) {
+                        $value = StringHelper::split($value);
+                    }
+                    return;
+                }
+                if (is_iterable($value)) {
+                    $value = iterator_to_array($value);
+                    return;
+                }
+                throw new InvalidValueException("Unable to typecast $property value to an array.");
+            case DateTime::class:
+                if ($value instanceof DateTime) {
+                    return;
+                }
+                $date = DateTimeHelper::toDateTime($value);
+                if (!$date && !$type->allowsNull()) {
+                    throw new InvalidValueException("Unable to typecast $property value to a DateTime object.");
+                }
+                $value = $date ?: null;
+                return;
+        }
+    }
+
+    private static function propertyType(string $class, string $property): ?ReflectionNamedType
+    {
+        if (!isset(self::$types[$class][$property])) {
+            try {
+                $ref = new ReflectionProperty($class, $property);
+                if (!$ref->isPublic() || $ref->isStatic()) {
+                    self::$types[$class][$property] = false;
+                } else {
+                    $type = $ref->getType();
+                    if ($type instanceof ReflectionNamedType) {
+                        self::$types[$class][$property] = $type;
+                    } else {
+                        // We don't support typecasting properties with union types
+                        self::$types[$class][$property] = false;
+                    }
+                }
+            } catch (ReflectionException) {
+                // The property doesn’t exist
+                self::$types[$class][$property] = false;
+            }
+        }
+
+        return self::$types[$class][$property] ?: null;
+    }
+}

--- a/src/mail/transportadapters/Gmail.php
+++ b/src/mail/transportadapters/Gmail.php
@@ -46,21 +46,6 @@ class Gmail extends BaseTransportAdapter
     /**
      * @inheritdoc
      */
-    public function __construct($config = [])
-    {
-        // Config normalization
-        foreach (['username', 'password'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
-        }
-
-        parent::__construct($config);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function behaviors(): array
     {
         $behaviors = parent::behaviors();

--- a/src/mail/transportadapters/Sendmail.php
+++ b/src/mail/transportadapters/Sendmail.php
@@ -34,19 +34,6 @@ class Sendmail extends BaseTransportAdapter
 
     /**
      * @inheritdoc
-     */
-    public function __construct($config = [])
-    {
-        // Config normalization
-        if (($config['command'] ?? null) === '') {
-            unset($config['command']);
-        }
-
-        parent::__construct($config);
-    }
-
-    /**
-     * @inheritdoc
      * @since 3.4.0
      */
     public function behaviors(): array

--- a/src/mail/transportadapters/Smtp.php
+++ b/src/mail/transportadapters/Smtp.php
@@ -69,10 +69,8 @@ class Smtp extends BaseTransportAdapter
     public function __construct($config = [])
     {
         // Config normalization
-        foreach (['host', 'port', 'useAuthentication', 'username', 'password', 'encryptionMethod'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
+        if (($config['useAuthentication'] ?? null) === '') {
+            unset($config['useAuthentication']);
         }
 
         parent::__construct($config);

--- a/src/models/AssetIndexData.php
+++ b/src/models/AssetIndexData.php
@@ -94,15 +94,4 @@ class AssetIndexData extends Model
     {
         return (string)$this->uri;
     }
-
-    /**
-     * @inheritdoc
-     */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'timestamp';
-
-        return $attributes;
-    }
 }

--- a/src/models/CraftIdToken.php
+++ b/src/models/CraftIdToken.php
@@ -78,16 +78,4 @@ class CraftIdToken extends Model
 
         return $expiryDate->getTimestamp() - $now->getTimestamp();
     }
-
-    /**
-     * @inheritdoc
-     */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-
-        $attributes[] = 'expiryDate';
-
-        return $attributes;
-    }
 }

--- a/src/models/DeprecationError.php
+++ b/src/models/DeprecationError.php
@@ -8,7 +8,6 @@
 namespace craft\models;
 
 use craft\base\Model;
-use craft\helpers\Json;
 use craft\validators\DateTimeValidator;
 use DateTime;
 
@@ -59,25 +58,6 @@ class DeprecationError extends Model
      * @var array|null Traces
      */
     public ?array $traces = null;
-
-    /**
-     * Constructor
-     */
-    public function __construct($config = [])
-    {
-        // Config normalization
-        foreach (['file', 'line', 'message', 'traces'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
-        }
-
-        if (isset($config['traces']) && is_string($config['traces'])) {
-            $config['traces'] = Json::decode($config['traces']);
-        }
-
-        parent::__construct($config);
-    }
 
     /**
      * @inheritdoc

--- a/src/models/DeprecationError.php
+++ b/src/models/DeprecationError.php
@@ -82,16 +82,6 @@ class DeprecationError extends Model
     /**
      * @inheritdoc
      */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'lastOccurrence';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
     protected function defineRules(): array
     {
         $rules = parent::defineRules();

--- a/src/models/GqlToken.php
+++ b/src/models/GqlToken.php
@@ -106,17 +106,6 @@ class GqlToken extends Model
     /**
      * @inheritdoc
      */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'expiryDate';
-        $attributes[] = 'lastUsed';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
     protected function defineRules(): array
     {
         $rules = parent::defineRules();

--- a/src/models/ImageTransform.php
+++ b/src/models/ImageTransform.php
@@ -216,16 +216,6 @@ class ImageTransform extends Model
     }
 
     /**
-     * @inheritdoc
-     */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'parameterChangeTime';
-        return $attributes;
-    }
-
-    /**
      * Return the image transformer for this transform.
      *
      * @return ImageTransformerInterface

--- a/src/models/ImageTransformIndex.php
+++ b/src/models/ImageTransformIndex.php
@@ -97,16 +97,6 @@ class ImageTransformIndex extends Model
     /**
      * @inheritdoc
      */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'dateIndexed';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
     protected function defineRules(): array
     {
         $rules = parent::defineRules();

--- a/src/models/UpdateRelease.php
+++ b/src/models/UpdateRelease.php
@@ -43,16 +43,6 @@ class UpdateRelease extends Model
     /**
      * @inheritdoc
      */
-    public function datetimeAttributes(): array
-    {
-        $attributes = parent::datetimeAttributes();
-        $attributes[] = 'date';
-        return $attributes;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function fields(): array
     {
         $fields = parent::fields();

--- a/src/widgets/Feed.php
+++ b/src/widgets/Feed.php
@@ -57,10 +57,8 @@ class Feed extends Widget
     public function __construct($config = [])
     {
         // Config normalization
-        foreach (['url', 'title', 'limit'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
+        if (($config['limit'] ?? null) === '') {
+            unset($config['limit']);
         }
 
         parent::__construct($config);

--- a/src/widgets/NewUsers.php
+++ b/src/widgets/NewUsers.php
@@ -58,21 +58,6 @@ class NewUsers extends Widget
     /**
      * @inheritdoc
      */
-    public function __construct($config = [])
-    {
-        // Config normalization
-        foreach (['userGroupId', 'dateRange'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
-        }
-
-        parent::__construct($config);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getTitle(): ?string
     {
         if ($groupId = $this->userGroupId) {

--- a/src/widgets/QuickPost.php
+++ b/src/widgets/QuickPost.php
@@ -80,13 +80,6 @@ class QuickPost extends Widget
             unset($config['sections']);
         }
 
-        // Config normalization
-        foreach (['section', 'entryType', 'fields'] as $name) {
-            if (($config[$name] ?? null) === '') {
-                unset($config[$name]);
-            }
-        }
-
         parent::__construct($config);
     }
 


### PR DESCRIPTION
### Description

Adds a new `craft\helpers\Typecast::properties()` method, which can be used to typecast a given array of property names/values, based on the type declarations of the given class.

Used in the following places:

- `craft\base\Model::__construct()`
- `craft\base\Model::setAttributes()`
- `craft\helpers\Component::createComponent()`

`craft\base\Model::datetimeAttributes()` is deprecated now, and date/time attributes are recommended to use a `DateTime` type declaration instead. We can remove `datetimeAttributes()` entirely in Craft 5.

### Related issues

- #10689