### PR TITLE
4.0 Fix sendmail command being incorrectly formatted

### DIFF
--- a/src/mail/transportadapters/Sendmail.php
+++ b/src/mail/transportadapters/Sendmail.php
@@ -118,7 +118,7 @@ class Sendmail extends BaseTransportAdapter
     public function defineTransport(): array|AbstractTransport
     {
         return [
-            'dsn' => 'sendmail://default?command=' . $this->command ? App::parseEnv($this->command) : self::DEFAULT_COMMAND,
+            'dsn' => 'sendmail://default?command=' . ($this->command ? App::parseEnv($this->command) : self::DEFAULT_COMMAND),
         ];
     }
 


### PR DESCRIPTION
Getting an error with the default Sendmail mailer, trying to send a test email on 4.0.

```
Symfony\Component\Mailer\Exception\InvalidArgumentException
The "/usr/sbin/sendmail" mailer DSN must contain a scheme.
```

I'm pretty sure it's because the DSN is being sent incorrectly, due to incorrect grouping with the ternary operator here 

https://github.com/craftcms/cms/blob/7594767f9f326e7c6810037311dfe1046c2e3323/src/mail/transportadapters/Sendmail.php#L121

This results in:

```
[
    'dsn' => '/usr/sbin/sendmail -bs'
]
```

Where is should be:

```
[
    'dsn' => 'sendmail://default?command=/usr/sbin/sendmail -bs'
]
```

This PR just fixes that so that the default command isn't used without the `sendmail://default?command=` part.

![screencapture-craft4-test-admin-settings-email-2022-03-09-14_43_12](https://user-images.githubusercontent.com/1221575/157368649-69d51ddb-0411-4ec4-b384-26f70e36e2cf.png)