### PR TITLE
Escape spaces in Sendmail commands for emails

### DIFF
--- a/src/mail/transportadapters/Sendmail.php
+++ b/src/mail/transportadapters/Sendmail.php
@@ -117,8 +117,12 @@ class Sendmail extends BaseTransportAdapter
      */
     public function defineTransport(): array|AbstractTransport
     {
+        // Replace any spaces with `%20` according to https://symfony.com/doc/current/mailer.html#other-options
+        $command = (App::parseEnv($this->command) ?: self::DEFAULT_COMMAND);
+        $command = str_replace(' ', '%20', $command);
+
         return [
-            'dsn' => 'sendmail://default?command=' . (App::parseEnv($this->command) ?: self::DEFAULT_COMMAND),
+            'dsn' => 'sendmail://default?command=' . $command,
         ];
     }
 


### PR DESCRIPTION
A fix for https://github.com/craftcms/cms/pull/10717 - I was going to use `urlencode()` but feel wrong because it's not really a URL. The command won't work without this, and looks correct according to the docs https://symfony.com/doc/current/mailer.html#other-options