### PR TITLE
Set visibility to protected

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -312,7 +312,7 @@ class Asset extends Element
      * @inheritdoc
      * @since 3.5.0
      */
-    public static function defineFieldLayouts(string $source): array
+    protected static function defineFieldLayouts(string $source): array
     {
         $fieldLayouts = [];
         if (

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -189,7 +189,7 @@ class Category extends Element
      * @inheritdoc
      * @since 3.5.0
      */
-    public static function defineFieldLayouts(string $source): array
+    protected static function defineFieldLayouts(string $source): array
     {
         $fieldLayouts = [];
         if (


### PR DESCRIPTION
Sets the visibility of `defineFieldLayouts()` to `protected`, to match the visibility of the parent method: 
https://github.com/craftcms/cms/blob/6f5d4df5eebe733ecb8b7bb4eb7147d0198cc31c/src/base/Element.php#L703

This PR should ideally be merged into the 4.0 branch as well.