### PR TITLE
Fix sidebar header styles

### DIFF
--- a/src/web/assets/cp/src/css/_cp.scss
+++ b/src/web/assets/cp/src/css/_cp.scss
@@ -156,6 +156,7 @@ $systemInfoHoverBgColor: darken($grey800, 10%);
   display: grid;
   grid-template-columns: 30px auto;
   grid-gap: 10px;
+  height: 100%;
   padding: 0 10px;
   position: relative;
   flex: 0 0 50px;


### PR DESCRIPTION
This fixes alignment issues with the sidebar header in Safari 15.4