### PR TITLE
Add `|address` twig filter

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -26,6 +26,7 @@
 - Added support for `JSON` columns. ([#9089](https://github.com/craftcms/cms/pull/9089))
 - It’s now possible to edit images’ focal points from their preview modals. ([#8489](https://github.com/craftcms/cms/discussions/8489))
 - Added support for Monolog and the PSR-3 logging interface. ([#10659](https://github.com/craftcms/cms/pull/10659))
+- Added the `|address` Twig filter.
 - Added the `|money` Twig filter.
 - Added the `collect()` Twig function.
 - Added the `assetUploaders`, `authors`, and `fullName` user query params.
@@ -345,6 +346,7 @@
 - Added `craft\web\Controller::getPostedRedirectUrl()`.
 - Added `craft\web\Controller::TemplateResponseBehavior()`.
 - Added `craft\web\Controller::TemplateResponseFormatter()`.
+- Added `craft\web\twig\Extension::addressFilter()`.
 - Added `craft\web\twig\Extension::moneyFilter()`.
 - Added `craft\web\twig\variables\Cp::fieldLayoutDesigner()`.
 - Added `craft\web\twig\variables\Cp::getFsOptions()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > {warning} Due to a data corruption bug, projects that were updated to Craft 4 from Craft 3 are advised to re-update from a Craft 3 database backup.
 
 ### Added
+- Added the `|address` Twig filter.
 - Added `craft\base\Element::notesFieldHtml()`.
 - Added `craft\base\Element::statusFieldHtml()`.
 - Added `craft\events\DefineAssetThumbUrlEvent`, which replaces `GetAssetThumbUrlEvent` (previously removed).
@@ -13,6 +14,7 @@
 - Added `craft\imagetransforms\ImageTransformer::EVENT_DELETE_TRANSFORMED_IMAGE`.
 - Added `craft\imagetransforms\ImageTransformer::EVENT_TRANSFORM_IMAGE`.
 - Added `craft\services\Assets::EVENT_DEFINE_THUMB_URL`, which replaces `craft\services\Assets::EVENT_GET_ASSET_THUMB_URL` (previously removed).
+- Added `craft\web\twig\Extension::addressFilter()`.
 
 ### Changed
 - Field grids within slideouts can now only have up to two columns. ([#10726](https://github.com/craftcms/cms/issues/10726))

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -7,10 +7,12 @@
 
 namespace craft\web\twig;
 
+use CommerceGuys\Addressing\Formatter\FormatterInterface;
 use Countable;
 use Craft;
 use craft\base\MissingComponentInterface;
 use craft\base\PluginInterface;
+use craft\elements\Address;
 use craft\elements\Asset;
 use craft\errors\AssetException;
 use craft\helpers\App;
@@ -173,6 +175,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
         $security = Craft::$app->getSecurity();
 
         return [
+            new TwigFilter('address', [$this, 'addressFilter'], ['is_safe' => ['html']]),
             new TwigFilter('append', [$this, 'appendFilter'], ['is_safe' => ['html']]),
             new TwigFilter('ascii', [StringHelper::class, 'toAscii']),
             new TwigFilter('atom', [$this, 'atomFilter'], ['needs_environment' => true]),
@@ -291,6 +294,21 @@ class Extension extends AbstractExtension implements GlobalsInterface
                 return is_string($obj);
             }),
         ];
+    }
+
+    /**
+     * @param Address|null $address
+     * @param array $options
+     * @param FormatterInterface|null $formatter
+     * @return string
+     */
+    public function addressFilter(?Address $address, array $options = [], FormatterInterface $formatter = null): string
+    {
+        if ($address === null) {
+            return '';
+        }
+
+        return Craft::$app->getAddresses()->formatAddress($address, $options, $formatter);
     }
 
     /**

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -301,6 +301,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * @param array $options
      * @param FormatterInterface|null $formatter
      * @return string
+     * @since 4.0.0
      */
     public function addressFilter(?Address $address, array $options = [], FormatterInterface $formatter = null): string
     {

--- a/tests/unit/web/twig/ExtensionTest.php
+++ b/tests/unit/web/twig/ExtensionTest.php
@@ -10,6 +10,7 @@ namespace crafttests\unit\web\twig;
 use ArrayObject;
 use Codeception\Test\Unit;
 use Craft;
+use craft\elements\Address;
 use craft\elements\Entry;
 use craft\elements\User;
 use craft\fields\MissingField;
@@ -747,6 +748,32 @@ class ExtensionTest extends Unit
             '<strong>Hello</strong>',
             '{{ "**Hello**"|md(inlineOnly=true) }}'
         );
+    }
+
+    /**
+     * @param string $renderString
+     * @param array $variables
+     * @param string $expected
+     * @return void
+     * @throws LoaderError
+     * @throws SyntaxError
+     * @dataProvider addressFilterDataProvider
+     */
+    public function testAddressFilter(string $renderString, array $variables, string $expected)
+    {
+        $this->testRenderResult($expected, $renderString, $variables);
+    }
+
+    public function addressFilterDataProvider(): array
+    {
+        return [
+            ['{{ myAddress|address }}', ['myAddress' => Craft::createObject(Address::class, ['config' => ['attributes' => ['addressLine1' => '1 Main Stree', 'postalCode' => '12345', 'countryCode' => 'US', 'administrativeArea' => 'OR']]])], '<p translate="no">
+<span class="address-line1">1 Main Stree</span><br>
+<span class="administrative-area">OR</span> <span class="postal-code">12345</span><br>
+<span class="country">United States</span>
+</p>'],
+            ['{{ myAddress|address }}', ['myAddress' => null], ''],
+        ];
     }
 
     /**


### PR DESCRIPTION
With the addition of addresses in Craft 4 it seems like a logical thing to have an address filter in twig for easy output of addresses on the front end.

For example in Commerce outputting an address related to an order looks like the following **without** the filter:

```twig
{{ craft.app.addresses.formatAddress(cart.shippingAddress)|raw }}
```

**With** the filter that becomes:

```twig
{{ cart.shippingAddress|address }}
```

The address filter just wraps the `formatAddress` method so you are still able to pass `options` and a custom formatter if required.