### PR TITLE
Wrong type for Config::$_dotEnvPath

### DIFF
--- a/src/services/Config.php
+++ b/src/services/Config.php
@@ -72,9 +72,9 @@ class Config extends Component
     private array $_configSettings = [];
 
     /**
-     * @var bool|null
+     * @var string|null
      */
-    private ?bool $_dotEnvPath = null;
+    private ?string $_dotEnvPath = null;
 
     /**
      * Returns all of the config settings for a given category.

--- a/tests/unit/services/ConfigTest.php
+++ b/tests/unit/services/ConfigTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace crafttests\unit\services;
+
+use Codeception\Test\Unit;
+use Craft;
+use craft\services\Tokens;
+use Exception;
+use UnitTester;
+
+/**
+ * Unit tests for the config service
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @author Oliver Stark <os@fortrabbit.com>
+ * @since 4.0
+ */
+class ConfigTest extends Unit
+{
+    /**
+     * @var UnitTester
+     */
+    protected $tester;
+
+    /**
+     * @var Tokens
+     */
+    protected $token;
+
+    public function testDotEnvPathIsNotABooleanString()
+    {
+        Craft::setAlias('@root', CRAFT_TESTS_PATH);
+
+        $config = Craft::$app->getConfig();
+        $path = $config->getDotEnvPath();
+        $this->assertEquals(CRAFT_TESTS_PATH . '/.env', $path);
+    }
+
+    
+}


### PR DESCRIPTION
`Craft::$app->getConfig()->getDotEnvPath()` returns `'1'` when using strict types.

The reason is a wrong type of `craft\services\Config::$_dotEnvPath`;


---

The [ConfigTest](https://github.com/craftcms/cms/pull/10761/commits/69fc7dbbf37e9b02c33da0a59f9b24d1bba7aa6d#diff-3026b0038b5ca9e43db9de4a59ca0ad37f1d57722c133f525bb31e2092a1561f) fails unless the type is changed from `boolean` to `string`

