### PR TITLE
Fix widget method comments

### DIFF
--- a/src/services/Dashboard.php
+++ b/src/services/Dashboard.php
@@ -253,7 +253,7 @@ class Dashboard extends Component
     }
 
     /**
-     * Soft-deletes a widget by its ID.
+     * Deletes a widget by its ID.
      *
      * @param int $widgetId The widget’s ID
      * @return bool Whether the widget was deleted successfully
@@ -270,7 +270,7 @@ class Dashboard extends Component
     }
 
     /**
-     * Soft-deletes a widget.
+     * Deletes a widget.
      *
      * @param WidgetInterface $widget The widget to be deleted
      * @return bool Whether the widget was deleted successfully


### PR DESCRIPTION
### Description

Widgets are hard deleted, not soft deleted.

Also, the `enabled` column on the `widgets` table does not seem to do anything.
Not sure if anything needs to be fixed there.

### Related issues

