### PR TITLE
Allow modules to register custom migration tracks to run on `migrate/all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added `craft\helpers\ArrayHelper::onlyContains()`.
 - Added `craft\test\Craft::assertNotPushedToQueue()`. ([#10510](https://github.com/craftcms/cms/pull/10510))
+- Added `craft\console\controllers\MigrateController::EVENT_REGISTER_MIGRATION_TRACKS`.
 
 ### Changed
 - Duplicated elements no longer have “copy” appended to the end of their titles. ([#10707](https://github.com/craftcms/cms/pull/10707))

--- a/src/events/MigrationTracksEvent.php
+++ b/src/events/MigrationTracksEvent.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+
+/**
+ * Event used to register or modify a list of migration tracks.
+ *
+ * @author Michael Rog <michael@michaelrog.com>
+ * @since 3.7.38
+ */
+class MigrationTracksEvent extends Event
+{
+	/**
+	 * @var string[] The list of migration tracks
+	 */
+	public array $tracks = [];
+}


### PR DESCRIPTION
Currently, [custom migration tracks](https://github.com/craftcms/cms/issues/6172) exposed via `MigrateController::EVENT_REGISTER_MIGRATOR` must be explicitly run via a `migrate/up --track=my-custom-track` command.

This PR adds `EVENT_REGISTER_MIGRATION_TRACKS` event to `MigrateController`, with an accompanying `MigrationTracksEvent` class for registering a list of custom migration tracks.

Now, modules can add their custom migration tracks to be run automatically on `migrate/all` (similar to how Craft automatically runs plugin migrations), which lets me keep my deploy scripts nice and tidy:

```php
use craft\console\controllers\MigrateController;
use craft\events\MigrationTracksEvent;
use yii\base\Event;

Event::on(
    MigrateController::class,
    MigrateController::EVENT_REGISTER_MIGRATION_TRACKS,
    function(MigrationTracksEvent $event) {
        $event->tracks[] = 'my-custom-track';
    }
);
```