### PR TITLE
Fix a `$expectedType must not be accessed before initialisation` error with `MissingComponentTrait`

### DIFF
--- a/src/base/MissingComponentTrait.php
+++ b/src/base/MissingComponentTrait.php
@@ -24,7 +24,7 @@ trait MissingComponentTrait
      * @var string The expected component class name.
      * @phpstan-var class-string<ComponentInterface>
      */
-    public string $expectedType;
+    public string $expectedType = '';
 
     /**
      * @var string|null The exception message that explains why the component class was invalid


### PR DESCRIPTION
I'm getting the following issue with [Formie](https://github.com/verbb/formie/issues/820) which uses this trait. I'm not _quite_ sure if this shouldn't be an issue, but I've also found that anything strictly-typed should have a default value.