### PR TITLE
Ties non-customizable Tab to related Field Layout

### DIFF
--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -1372,7 +1372,7 @@ JS, [
         $tabs = array_filter($fieldLayout->getTabs(), fn(FieldLayoutTab $tab) => !empty($tab->getElements()));
 
         if (!$config['customizableTabs']) {
-            $tab = array_shift($tabs) ?? new FieldLayoutTab();
+            $tab = array_shift($tabs) ?? new FieldLayoutTab(['layout' => $fieldLayout]);
             $tab->name = $config['pretendTabName'] ?? Craft::t('app', 'Content');
 
             // Any extra tabs?


### PR DESCRIPTION
### Description

This one is hard to explain... It was throwing an error in Ad Wizard, which has a non-customizable Tab in the Field Layout.

I traced it back to the fact that the `_layout` value hadn't been properly set when the Tab was created. Since the Tab had no existing `_layout` (and no `layoutId`, since it's a brand new Layout), it ended up triggering [this error](https://github.com/craftcms/cms/blob/3cdc4128654e67761b50d2ad4aa3cde43c3d71ac/src/models/FieldLayoutTab.php#L245)...

```
yii\base\InvalidConfigException: Field layout tab is missing its field layout. in /.../craftcms/cms/src/models/FieldLayoutTab.php:245
Stack trace:
#0 /.../craftcms/cms/src/base/FieldLayoutComponent.php(209): craft\models\FieldLayoutTab->getLayout()
#1 /.../craftcms/cms/src/helpers/Cp.php(1565): craft\base\FieldLayoutComponent->getSettingsHtml()
#2 /.../craftcms/cms/src/web/View.php(1439): craft\helpers\Cp::craft\helpers\{closure}()
#3 /.../craftcms/cms/src/helpers/Cp.php(1565): craft\web\View->namespaceInputs(Object(Closure), 'tab-0a3ba9d0-e6...')
#4 /.../craftcms/cms/src/helpers/Cp.php(1529): craft\helpers\Cp::_fldTabSettingsData(Object(craft\models\FieldLayoutTab))
#5 /.../craftcms/cms/src/helpers/Cp.php(1446): craft\helpers\Cp::_fldTabHtml(Object(craft\models\FieldLayoutTab), false)
#6 [internal function]: craft\helpers\Cp::craft\helpers\{closure}(Object(craft\models\FieldLayoutTab))
#7 /.../craftcms/cms/src/helpers/Cp.php(1446): array_map(Object(Closure), Array)
#8 /.../craftcms/cms/src/web/twig/variables/Cp.php(871): craft\helpers\Cp::fieldLayoutDesignerHtml(Object(craft\models\FieldLayout), Array)
#9 /.../twig/twig/src/Extension/CoreExtension.php(1607): craft\web\twig\variables\Cp->fieldLayoutDesigner(Object(craft\models\FieldLayout), Array)
```

Fortunately, setting the `'layout'` when the Tab gets created seems to resolve the issue nicely. 👍 