### PR TITLE
Use getGeneral() method

### DIFF
--- a/src/gql/directives/Transform.php
+++ b/src/gql/directives/Transform.php
@@ -79,7 +79,7 @@ class Transform extends Directive
             return $value;
         }
 
-        $generateNow = $arguments['immediately'] ?? Craft::$app->getConfig()->general->generateTransformsBeforePageLoad;
+        $generateNow = $arguments['immediately'] ?? Craft::$app->getConfig()->getGeneral()->generateTransformsBeforePageLoad;
         $transform = Gql::prepareTransformArguments($arguments);
 
         // If this directive is applied to an entire Asset

--- a/src/gql/types/elements/Asset.php
+++ b/src/gql/types/elements/Asset.php
@@ -42,7 +42,7 @@ class Asset extends Element
         $fieldName = $resolveInfo->fieldName;
 
         if (!empty($arguments) && in_array($fieldName, ['url', 'width', 'height'], true)) {
-            $generateNow = $arguments['immediately'] ?? Craft::$app->getConfig()->general->generateTransformsBeforePageLoad;
+            $generateNow = $arguments['immediately'] ?? Craft::$app->getConfig()->getGeneral()->generateTransformsBeforePageLoad;
             $transform = Gql::prepareTransformArguments($arguments);
 
             switch ($fieldName) {


### PR DESCRIPTION
### Description

Updates usage of getConfig() to also use the getGeneral() method. Mostly for consistency/guidelines, shouldn't have any functional difference.

