### PR TITLE
Parse config/db.php url for querystring parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Improved dropdown menu styling for Firefox.
 - Improved GraphQL performance.
 - `{% nav %}` tags now skips elements whose immediate parent weren’t included in the output. ([#10925](https://github.com/craftcms/cms/issues/10925))
+- Craft will now parse the [url](https://craftcms.com/docs/3.x/config/db-settings.html#url) database config setting for querystring parameters and pass them into PDO.
 
 ### Fixed
 - Fixed a bug where Matrix blocks could lose their Date field values, if multiple Date fields had with the same handle across different block types. ([#10884](https://github.com/craftcms/cms/issues/10884))

--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -1115,6 +1115,11 @@ class Db
 
         $config['dsn'] = "{$driver}:" . implode(';', $dsnParams);
 
+        if (isset($parsed['query'])) {
+            parse_str($parsed['query'], $queryParams);
+            $config['attributes'] = $queryParams;
+        }
+
         return $config;
     }
 


### PR DESCRIPTION
Craft will now parse the url database config setting for querystring parameters and pass them into PDO into the [4th $options parameter](https://www.php.net/manual/en/pdo.construct.php) which allows for driver-specific connection options.