### PR TITLE
Default to `true` when creating new migrations

### DIFF
--- a/src/console/controllers/MigrateController.php
+++ b/src/console/controllers/MigrateController.php
@@ -278,7 +278,7 @@ class MigrateController extends BaseMigrateController
 
         $file = $this->migrationPath . DIRECTORY_SEPARATOR . $name . '.php';
 
-        if ($this->confirm("Create new migration '$file'?")) {
+        if ($this->confirm("Create new migration '$file'?", true)) {
             $templateFile = Craft::getAlias($this->templateFile);
 
             if ($templateFile === false) {


### PR DESCRIPTION
Another unsolicited PR from yours truly; this time to change the default behavior when creating a new migration via the CLI.

The existing `false` default doesn't make a lot of sense, insofar as I've already manually tapped out the command, a name, scope, etc. _and_ have a built-in opportunity via the confirmation itself to cancel the operation.