### PR TITLE
Added memoization to `craft\services\Fields::getLayoutsByType()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-### Fixed
-- Fixed a bug that could cause duplicated queries on element indexes.
+### Changed
+- `craft\services\Fields::getLayoutsByType()` now memoizes its results. ([#11037](https://github.com/craftcms/cms/pull/11037))
 
 ## 3.7.39 - 2022-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft CMS 3.x
 
+## Unreleased
+
+### Fixed
+- Fixed a bug that could cause duplicated queries on element indexes.
+
 ## 3.7.39 - 2022-04-26
 
 ### Added

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -1656,7 +1656,7 @@ class Fields extends Component
             ]));
         }
 
-        if (!array_key_exists($layout->type, $this->_allLayoutsByType)) {
+        if ($this->_allLayoutsByType === null || !array_key_exists($layout->type, $this->_allLayoutsByType)) {
             $this->_allLayoutsByType[$layout->type] = [];
         }
 

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -1185,7 +1185,7 @@ class Fields extends Component
                 ->andWhere(['type' => $type])
                 ->all();
 
-            $this->_allLayoutsByType = [];
+            $this->_allLayoutsByType[$type] = [];
 
             foreach ($results as $result) {
                 $this->_allLayoutsByType[$type][] = new FieldLayout($result);


### PR DESCRIPTION
### Description
If you have an element type that lists its sources by type e.g Products by product type.

This could cause duplicated queries on the element index.

The PR adds memoization to the `getLayoutsByType` method in the fields service which improves performance and negates duplicated queries.


### Related issues
craftcms/commerce#2779
