### PR TITLE
PluginInterface::config()

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -119,6 +119,7 @@
 - Added `craft\base\Model::defineBehaviors()`. ([#10691](https://github.com/craftcms/cms/pull/10691))
 - Added `craft\base\ModelInterface`.
 - Added `craft\base\NameTrait`.
+- Added `craft\base\PluginInterface::config()`. ([#11039](https://github.com/craftcms/cms/pull/11039))
 - Added `craft\behaviors\SessionBehavior::broadcastToJs()`.
 - Added `craft\behaviors\SessionBehavior::getError()`.
 - Added `craft\behaviors\SessionBehavior::getNotice()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Added `craft\base\PluginInterface::config()`. ([#11039](https://github.com/craftcms/cms/pull/11039))
 - Added `craft\helpers\Html::unwrapCondition()`.
 - Added `craft\helpers\Html::unwrapNoscript()`.
 - Added `craft\web\View::clearCssFileBuffer()`.

--- a/src/base/Plugin.php
+++ b/src/base/Plugin.php
@@ -50,6 +50,14 @@ class Plugin extends Module implements PluginInterface
     /**
      * @inheritdoc
      */
+    public static function config(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
     public static function editions(): array
     {
         return [

--- a/src/base/PluginInterface.php
+++ b/src/base/PluginInterface.php
@@ -24,6 +24,52 @@ use yii\base\Module;
 interface PluginInterface
 {
     /**
+     * Returns the base config that the plugin should be instantiated with.
+     *
+     * It is recommended that plugins define their internal components from here:
+     *
+     * ```php
+     * public static function config(): array
+     * {
+     *     return [
+     *         'components' => [
+     *             'myComponent' => ['class' => MyComponent::class],
+     *             // ...
+     *         ],
+     *     ];
+     * }
+     * ```
+     *
+     * Doing that enables projects to customize the components as needed, by
+     * overriding `\craft\services\Plugins::$pluginConfigs` in `config/app.php`:
+     *
+     * ```php
+     * return [
+     *     'components' => [
+     *         'plugins' => [
+     *             'pluginConfigs' => [
+     *                 'my-plugin' => [
+     *                     'components' => [
+     *                         'myComponent' => [
+     *                             'myProperty' => 'foo',
+     *                             // ...
+     *                         ],
+     *                     ],
+     *                 ],
+     *             ],
+     *         ],
+     *     ],
+     * ];
+     * ```
+     *
+     * The resulting config will be passed to `\Craft::createObject()` to instantiate the plugin.
+     *
+     * @return array
+     * @since 4.0.0
+     */
+    public static function config(): array;
+
+    /**
      * Returns supported plugin editions (lowest to highest).
      *
      * @return string[]

--- a/src/services/Plugins.php
+++ b/src/services/Plugins.php
@@ -915,6 +915,9 @@ class Plugins extends Component
             return null;
         }
 
+        // Merge in the plugin’s dynamic config
+        $config = ArrayHelper::merge($config, $class::config());
+
         // Is it installed?
         if ($info !== null) {
             $config['isInstalled'] = true;


### PR DESCRIPTION
This adds a new static `config()` method to `craft\base\PluginInterface`, giving plugins a way to define their configuration.

Plugins that have their own additional components (e.g. services) should start using this to define them:

```php
public static function config(): array
{
    return [
        'components' => [
            'myComponent' => ['class' => MyComponent::class],
            // ...
        ],
    ];
}
```

Doing that enables projects to customize the components as needed, by overriding `craft\services\Plugins::$pluginConfigs` in `config/app.php`:

```php
return [
    'components' => [
        'plugins' => [
            'pluginConfigs' => [
                'my-plugin' => [
                    'components' => [
                        'myComponent' => [
                            'myProperty' => 'foo',
                            // ...
                        ],
                    ],
                ],
            ],
        ],
    ],
];
```