### PR TITLE
Added option to add the attribute 'hidden' to the select options

### DIFF
--- a/src/templates/_includes/forms/select.html
+++ b/src/templates/_includes/forms/select.html
@@ -49,6 +49,7 @@
                     value: optionValue ?? '',
                     selected: (optionValue~'') is same as (value~''),
                     disabled: option.disabled ?? false,
+                    hidden: option.hidden ?? false,
                     text: option.label is defined ? option.label : option,
                     data: option.data ?? false,
                 }) }}


### PR DESCRIPTION
### Description

Allows for the option to have attribute 'hidden' (for example, lead/description of select), and not appear in the list of options. Works the same way as the existing ability to have the attribute 'disabled'.

### Related issues

