### PR TITLE
Allow `random()` in GraphQL for PostgreSQL #11063

### DIFF
--- a/src/gql/ArgumentManager.php
+++ b/src/gql/ArgumentManager.php
@@ -124,8 +124,9 @@ class ArgumentManager extends Component
         $orderBy = $arguments['orderBy'] ?? null;
         if ($orderBy) {
             foreach (StringHelper::split($orderBy) as $chunk) {
-                // Special case for `RAND()`
-                if (strtolower($chunk) === 'rand()') {
+                // Special case for `RAND()`, and `random()` in PostgreSQL
+                $chunkLower = strtolower($chunk);
+                if ($chunkLower === 'rand()' || $chunkLower === 'random()') {
                     continue;
                 }
                 if (


### PR DESCRIPTION
### Description

To my knowledge, if you are using PostgreSQL, you need to use `random()` for `orderBy` [rather than `RAND()`](https://www.postgresql.org/message-id/Pine.LNX.4.21.0007182150230.1545-100000@localhost.localdomain).

This PR allows `random()` in GraphQL, in the same way #11063 was fixed.

### Related issues

#11063
https://github.com/craftcms/cms/commit/aca7413d3bca5aabc265f3aea981d778f5075299