### PR TITLE
Remove structureId query fallback, allow elements to lazy-set structureId

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -942,10 +942,12 @@ abstract class Element extends Component implements ElementInterface
             // Special case for sorting by structure
             if (isset($viewState['order']) && $viewState['order'] === 'structure') {
                 $source = ElementHelper::findSource(static::class, $sourceKey, $context);
-
-                if (isset($source['structureId'])) {
-                    $elementQuery->orderBy(['lft' => SORT_ASC]);
-                    $variables['structure'] = Craft::$app->getStructures()->getStructureById($source['structureId']);
+                $structureId = $source['structureId'] ?? null;
+                if ($structureId) {
+                    $elementQuery
+                        ->structureId($structureId)
+                        ->orderBy(['lft' => SORT_ASC]);
+                    $variables['structure'] = Craft::$app->getStructures()->getStructureById($structureId);
 
                     // Are they allowed to make changes to this structure?
                     if ($context === 'index' && $variables['structure'] && !empty($source['structureEditable'])) {
@@ -1820,6 +1822,13 @@ abstract class Element extends Component implements ElementInterface
     private ?bool $_isFresh = null;
 
     /**
+     * @var int|null
+     * @see getStructureId()
+     * @see setStructureId()
+     */
+    private ?int $_structureId = null;
+
+    /**
      * @inheritdoc
      */
     public function __construct($config = [])
@@ -2517,6 +2526,22 @@ abstract class Element extends Component implements ElementInterface
     public function getIsUnpublishedDraft(): bool
     {
         return $this->getIsDraft() && $this->getIsCanonical();
+    }
+
+    /**
+     * @param int|null $structureId The element’s structure ID
+     */
+    public function setStructureId(?int $structureId): void
+    {
+        $this->_structureId = $structureId;
+    }
+
+    /**
+     * @return int|null The element’s structure ID
+     */
+    public function getStructureId(): ?int
+    {
+        return $this->_structureId;
     }
 
     /**

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2529,6 +2529,9 @@ abstract class Element extends Component implements ElementInterface
     }
 
     /**
+     * Sets the element’s structure ID.
+     *
+     * @since 4.0.0
      * @param int|null $structureId The element’s structure ID
      */
     public function setStructureId(?int $structureId): void
@@ -2537,6 +2540,9 @@ abstract class Element extends Component implements ElementInterface
     }
 
     /**
+     * Returns the element’s structure ID
+     *
+     * @since 4.0.0
      * @return int|null The element’s structure ID
      */
     public function getStructureId(): ?int

--- a/src/base/ElementTrait.php
+++ b/src/base/ElementTrait.php
@@ -62,11 +62,6 @@ trait ElementTrait
     public ?int $fieldLayoutId = null;
 
     /**
-     * @var int|null The element’s structure ID
-     */
-    public ?int $structureId = null;
-
-    /**
      * @var int|null The element’s content row ID
      */
     public ?int $contentId = null;

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -422,6 +422,29 @@ class Category extends Element
     }
 
     /**
+     * @inheritDoc
+     */
+    public function getStructureId(): ?int
+    {
+        if (($structureId = parent::getStructureId()) !== null) {
+            return $structureId;
+        }
+
+        if ($this->groupId) {
+            return (new Query())
+                ->select('structureId')
+                ->from([Table::CATEGORYGROUPS])
+                ->where([
+                    'id' => $this->groupId,
+                    'dateDeleted' => null
+                ])
+                ->scalar();
+        }
+
+        return null;
+    }
+
+    /**
      * @inheritdoc
      */
     protected function previewTargets(): array

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -14,6 +14,7 @@ use craft\base\Field;
 use craft\behaviors\DraftBehavior;
 use craft\behaviors\RevisionBehavior;
 use craft\controllers\ElementIndexesController;
+use craft\db\Query;
 use craft\db\Table;
 use craft\elements\actions\Delete;
 use craft\elements\actions\DeleteForSite;
@@ -925,6 +926,29 @@ class Entry extends Element
         }
 
         return $sites;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStructureId(): ?int
+    {
+        if (($structureId = parent::getStructureId()) !== null) {
+            return $structureId;
+        }
+
+        if ($this->sectionId) {
+            return (new Query())
+                ->select('structureId')
+                ->from([Table::SECTIONS])
+                ->where([
+                    'id' => $this->sectionId,
+                    'dateDeleted' => null
+                ])
+                ->scalar();
+        }
+
+        return null;
     }
 
     /**

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -2144,7 +2144,8 @@ class ElementQuery extends Query implements ElementQueryInterface
         return (
             !$this->trashed &&
             !$this->revisions &&
-            ($this->withStructure ?? (bool)$this->structureId)
+            (bool)$this->structureId &&
+            $this->withStructure
         );
     }
 
@@ -2186,37 +2187,16 @@ class ElementQuery extends Query implements ElementQueryInterface
                 'structureelements.level',
             ]);
 
-        if ($this->structureId) {
-            $this->query->leftJoin(['structureelements' => Table::STRUCTUREELEMENTS], [
-                'and',
-                '[[structureelements.elementId]] = [[subquery.elementsId]]',
-                ['structureelements.structureId' => $this->structureId],
-            ]);
-            $this->subQuery->leftJoin(['structureelements' => Table::STRUCTUREELEMENTS], [
-                'and',
-                '[[structureelements.elementId]] = [[elements.id]]',
-                ['structureelements.structureId' => $this->structureId],
-            ]);
-        } else {
-            $this->query
-                ->addSelect(['structureelements.structureId'])
-                ->leftJoin(['structureelements' => Table::STRUCTUREELEMENTS], [
-                    'and',
-                    '[[structureelements.elementId]] = [[subquery.elementsId]]',
-                    '[[structureelements.structureId]] = [[subquery.structureId]]',
-                ]);
-            $existsQuery = (new Query())
-                ->from([Table::STRUCTURES])
-                ->where('[[id]] = [[structureelements.structureId]]')
-                ->andWhere(['dateDeleted' => null]);
-            $this->subQuery
-                ->addSelect(['structureelements.structureId'])
-                ->leftJoin(['structureelements' => Table::STRUCTUREELEMENTS], [
-                    'and',
-                    '[[structureelements.elementId]] = [[elements.id]]',
-                    ['exists', $existsQuery],
-                ]);
-        }
+        $this->query->leftJoin(['structureelements' => Table::STRUCTUREELEMENTS], [
+            'and',
+            '[[structureelements.elementId]] = [[subquery.elementsId]]',
+            ['structureelements.structureId' => $this->structureId],
+        ]);
+        $this->subQuery->leftJoin(['structureelements' => Table::STRUCTUREELEMENTS], [
+            'and',
+            '[[structureelements.elementId]] = [[elements.id]]',
+            ['structureelements.structureId' => $this->structureId],
+        ]);
 
         if (isset($this->hasDescendants)) {
             if ($this->hasDescendants) {


### PR DESCRIPTION
Description
When an entry query does not contain a section or structureId, it will include a fallback to determine the structureId: https://github.com/craftcms/cms/blob/develop/src/elements/db/ElementQuery.php#L2503-L2526

This fallback is problematic if there are plugins that are leveraging structures, because it just joins on the matching element id, but there may be more rows with the same elementId.

This wouldn't happen with Craft's native use of structures, but theres nothing stopping others (Neo, etc).

I know there was an issue/discussion reporting this…but I can't find it.