### PR TITLE
`AuthorGroupConditionRule::isSelectable()` implementation and Fixed `isConditionRuleSelectable` logic

### DIFF
--- a/src/base/conditions/BaseCondition.php
+++ b/src/base/conditions/BaseCondition.php
@@ -150,10 +150,15 @@ abstract class BaseCondition extends Component implements ConditionInterface
      */
     protected function isConditionRuleSelectable(ConditionRuleInterface $rule): bool
     {
-        return (
-            $rule->isSelectable() &&
-            !$this->forProjectConfig || $rule::supportsProjectConfig()
-        );
+        if (!$rule->isSelectable()) {
+            return false;
+        }
+
+        if ($this->forProjectConfig && !$rule::supportsProjectConfig()) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/elements/conditions/entries/AuthorGroupConditionRule.php
+++ b/src/elements/conditions/entries/AuthorGroupConditionRule.php
@@ -39,6 +39,14 @@ class AuthorGroupConditionRule extends BaseMultiSelectConditionRule implements E
     /**
      * @inheritdoc
      */
+    public static function isSelectable(): bool
+    {
+        return (bool)count(Craft::$app->getUserGroups()->getAllGroups());
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function options(): array
     {
         $sections = Craft::$app->getUserGroups()->getAllGroups();

--- a/src/elements/conditions/entries/AuthorGroupConditionRule.php
+++ b/src/elements/conditions/entries/AuthorGroupConditionRule.php
@@ -41,7 +41,7 @@ class AuthorGroupConditionRule extends BaseMultiSelectConditionRule implements E
      */
     public static function isSelectable(): bool
     {
-        return (bool)count(Craft::$app->getUserGroups()->getAllGroups());
+        return !empty(Craft::$app->getUserGroups()->getAllGroups());
     }
 
     /**

--- a/tests/unit/conditions/EntryConditionTest.php
+++ b/tests/unit/conditions/EntryConditionTest.php
@@ -10,8 +10,8 @@ namespace crafttests\unit\conditions;
 
 use Codeception\Test\Unit;
 use Craft;
-use craft\elements\conditions\entries\AuthorGroupConditionRule;
 use craft\elements\conditions\entries\EntryCondition;
+use craft\elements\conditions\entries\ExpiryDateConditionRule;
 use craft\elements\conditions\SlugConditionRule;
 use craft\test\TestCase;
 
@@ -40,7 +40,7 @@ class EntryConditionTest extends TestCase
         self::assertCount(1, $condition->getConditionRules());
 
         $ruleConfig2 = [
-            'class' => AuthorGroupConditionRule::class,
+            'class' => ExpiryDateConditionRule::class,
         ];
         $rule1 = Craft::$app->getConditions()->createConditionRule($ruleConfig2);
         $condition->addConditionRule($rule1);


### PR DESCRIPTION
### Description

Before this PR rules that weren’t selectable would still show in the rule type dropdown but then would disappear upon selection.

This PR also implements the `isSelectable()` method on the `AuthorGroupConditionRule` to add logic to only allow its selection if there are any user groups in the system.
