### PR TITLE
Using search query throws `Array to string conversion`

### DIFF
--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -576,7 +576,7 @@ SQL;
 
             if (!empty($fieldId)) {
                 $attr = 'fieldId';
-                $val = (string)$fieldId;
+                $val = $fieldId;
             } else {
                 $attr = 'attribute';
                 $val = strtolower($term->attribute);


### PR DESCRIPTION
### Description
E.g.
  ```
              {% set results = craft.entries()
                    .section('news')
                    .search('topic::"anime"')
                    .all() %}
```
    The recent added string type cast throws error when using wild card search
[](url)
![Screen Shot 2022-05-06 at 4 36 25 PM](https://user-images.githubusercontent.com/4172750/167098600-59b0e235-dcce-4ec4-a7a4-46f525dd2a60.png)

