### PR TITLE
Time travel

### DIFF
--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -227,6 +227,12 @@ trait ApplicationTrait
      * @see saveInfoAfterRequest()
      */
     private $_waitingToSaveInfo = false;
+    
+    /**
+     * @var string The current time that Craft's time helpers will respond with. Usefull for time traveling
+     *             during unit tests
+     */
+    private $_now = 'now';
 
     /**
      * Sets the target application language.
@@ -841,6 +847,20 @@ trait ApplicationTrait
         }
 
         return true;
+    }
+    
+    public function timetravel($now = 'now'): self
+    {
+        $this->_now = $now;
+        
+        return $this;
+    }
+    
+    public function timetravelBack(): self
+    {
+        $this->_now = 'now';
+        
+        return $this;
     }
 
     // Service Getters

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -854,7 +854,7 @@ trait ApplicationTrait
      *
      * @return self
      */
-    public function timetravel($now = 'now'): self
+    public function timetravel($now = null): self
     {
         $this->_now = $now;
         

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -232,7 +232,7 @@ trait ApplicationTrait
      * @var string The current time that Craft's time helpers will respond with. Usefull for time traveling
      *             during unit tests
      */
-    private $_now = 'now';
+    private $_now = null;
 
     /**
      * Sets the target application language.
@@ -849,6 +849,11 @@ trait ApplicationTrait
         return true;
     }
     
+    /**
+     * Time travel forward or backwards by passing in `+1 month` or `-1 month`
+     *
+     * @return self
+     */
     public function timetravel($now = 'now'): self
     {
         $this->_now = $now;
@@ -856,11 +861,26 @@ trait ApplicationTrait
         return $this;
     }
     
+    /**
+     * Time travel back to the current time (null, by default)
+     *
+     * @return self
+     */
     public function timetravelBack(): self
     {
-        $this->_now = 'now';
+        $this->_now = null;
         
         return $this;
+    }
+    
+    /**
+     * Get the current time
+     *
+     * @return ?string
+     */
+    public function getNow(): ?string
+    {
+        return $this->_now;
     }
 
     // Service Getters

--- a/src/helpers/DateTimeHelper.php
+++ b/src/helpers/DateTimeHelper.php
@@ -256,7 +256,8 @@ class DateTimeHelper
      */
     public static function currentUTCDateTime(): DateTime
     {
-        return new DateTime(null, new DateTimeZone('UTC'));
+        $now = \Craft::$app->getNow();
+        return new DateTime($now, new DateTimeZone('UTC'));
     }
 
     /**


### PR DESCRIPTION
Adds a "timetravel" feature to the `DateTimeHelper`. I'm using something like this in some unit tests where I set a post date to `now` and then run tests at points in time like `-1 month` and `+1 month` to make sure things appear/disappear as they should.

Notably, this affects and `$entry->getStatus()` return and flips around the `PENDING` or `EXPIRED` status of that return.

Not sure if this is something you're looking to implement. It's ripe for abuse from developers and I'd be cautious to use it anywhere other than a unit test. But for unit testing it's _really_ helpful.