### PR TITLE
Use FileHelper::normalizePath to normalize some asset/transform paths.

### DIFF
--- a/src/fs/Local.php
+++ b/src/fs/Local.php
@@ -72,8 +72,8 @@ class Local extends Fs implements LocalFsInterface
     {
         // Config normalization
         if (isset($config['path'])) {
-            $config['path'] = rtrim(str_replace('\\', '/', $config['path']), '/');
-            if ($config['path'] === '') {
+            $config['path'] = FileHelper::normalizePath($config['path']);
+            if ($config['path'] === '' || $config['path'] === '.')   {
                 unset($config['path']);
             }
         }

--- a/src/fs/Local.php
+++ b/src/fs/Local.php
@@ -73,7 +73,7 @@ class Local extends Fs implements LocalFsInterface
         // Config normalization
         if (isset($config['path'])) {
             $config['path'] = FileHelper::normalizePath($config['path']);
-            if ($config['path'] === '' || $config['path'] === '.')   {
+            if ($config['path'] === '' || $config['path'] === '.') {
                 unset($config['path']);
             }
         }

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -85,7 +85,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface, E
 
         if ($imageTransformIndex->fileExists) {
             $fs = $asset->getVolume()->getTransformFs();
-            $uri = FileHelper::normalizePath($this->getTransformBasePath($asset)) . $this->getTransformUri($asset, $imageTransformIndex);
+            $uri = str_replace('\\', '/', $this->getTransformBasePath($asset)) . $this->getTransformUri($asset, $imageTransformIndex);
 
             // Check if it really exists
             if ($fs instanceof LocalFsInterface && !$fs->fileExists($uri)) {

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -85,7 +85,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface, E
 
         if ($imageTransformIndex->fileExists) {
             $fs = $asset->getVolume()->getTransformFs();
-            $uri = str_replace('\\', '/', $this->getTransformBasePath($asset)) . $this->getTransformUri($asset, $imageTransformIndex);
+            $uri = FileHelper::normalizePath($this->getTransformBasePath($asset)) . $this->getTransformUri($asset, $imageTransformIndex);
 
             // Check if it really exists
             if ($fs instanceof LocalFsInterface && !$fs->fileExists($uri)) {


### PR DESCRIPTION
Cleaner than manually doing it.