### PR TITLE
[3.x] Fix srcset eager loading when specific format is defined and allow srcset eager loading on multiple transforms

### DIFF
--- a/src/services/AssetTransforms.php
+++ b/src/services/AssetTransforms.php
@@ -483,6 +483,11 @@ class AssetTransforms extends Component
                         $transform['height'] = (int)ceil($refTransform->height * $sizeValue);
                     }
                 }
+                
+                // Only maintain format if the reference transform had a specific format set
+                if ($refTransform && $refTransform->format) {
+                    $transform['format'] = $refTransform->format;
+                }
             }
 
             $transform = $this->normalizeTransform($transform);
@@ -508,6 +513,8 @@ class AssetTransforms extends Component
                 // Use this as the reference transform in case any srcset-style transforms follow it
                 $refTransform = $transform;
             }
+            
+            unset($sizeValue, $sizeUnit);
         }
 
         unset($refTransform);

--- a/src/services/AssetTransforms.php
+++ b/src/services/AssetTransforms.php
@@ -474,19 +474,21 @@ class AssetTransforms extends Component
                 } else {
                     $transform['width'] = (int)ceil($refTransform->width * $sizeValue);
                 }
-
-                // Only set the height if the reference transform has a height set on it
-                if ($refTransform && $refTransform->height) {
-                    if ($sizeUnit === 'w') {
-                        $transform['height'] = (int)ceil($refTransform->height * $transform['width'] / $refTransform->width);
-                    } else {
-                        $transform['height'] = (int)ceil($refTransform->height * $sizeValue);
-                    }
-                }
                 
-                // Only maintain format if the reference transform had a specific format set
-                if ($refTransform && $refTransform->format) {
-                    $transform['format'] = $refTransform->format;
+                if ($refTransform) {
+                    // Only set the height if the reference transform has a height set on it
+                    if ($refTransform->height) {
+                        if ($sizeUnit === 'w') {
+                            $transform['height'] = (int)ceil($refTransform->height * $transform['width'] / $refTransform->width);
+                        } else {
+                            $transform['height'] = (int)ceil($refTransform->height * $sizeValue);
+                        }
+                    }
+
+                    // Only maintain format if the reference transform had a specific format set
+                    if ($refTransform->format) {
+                        $transform['format'] = $refTransform->format;
+                    }
                 }
             }
 


### PR DESCRIPTION
This pull request would fix srcset eager loading by maintaining the `format` provided by the the base transform. 

Also this pull request would add support for allowing srcset transforms on multiple transforms like this:
```twig
{% set query = craft.entries.section('blogArticles').orderBy('postDate').limit(8).with([
    ['primaryImage', {withTransforms: ['cardIndexLarge', '2x', 'cardIndexMedium', '2x', 'cardIndexSmall', '2x']}],
]) %}
```


### Related issues
https://github.com/craftcms/cms/issues/11209
