### PR TITLE
Add description property to Section and EntryTypes

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -5,6 +5,8 @@
 - Added a `one()` alias for `first()` to collections. ([#11134](https://github.com/craftcms/cms/discussions/11134))
 - Added `craft\console\controllers\UsersController::$activate`.
 - Added `craft\elements\conditions\ElementCondition::$sourceKey`.
+- Added `craft\models\Section::description`
+- Added `craft\models\EntryTypes::description`
 
 ### Changed
 - Improved pagination UI accessibility. ([#11126](https://github.com/craftcms/cms/pull/11126))

--- a/src/controllers/SectionsController.php
+++ b/src/controllers/SectionsController.php
@@ -132,6 +132,7 @@ class SectionsController extends Controller
         // Main section settings
         $section->name = $this->request->getBodyParam('name');
         $section->handle = $this->request->getBodyParam('handle');
+        $section->description = $this->request->getBodyParam('description');
         $section->type = $this->request->getBodyParam('type');
         $section->enableVersioning = $this->request->getBodyParam('enableVersioning', true);
         $section->propagationMethod = $this->request->getBodyParam('propagationMethod', Section::PROPAGATION_METHOD_ALL);
@@ -331,6 +332,7 @@ class SectionsController extends Controller
         $entryType->sectionId = $this->request->getRequiredBodyParam('sectionId');
         $entryType->name = $this->request->getBodyParam('name', $entryType->name);
         $entryType->handle = $this->request->getBodyParam('handle', $entryType->handle);
+        $entryType->description = $this->request->getBodyParam('description', $entryType->description);
         $entryType->hasTitleField = (bool)$this->request->getBodyParam('hasTitleField', $entryType->hasTitleField);
         $entryType->titleTranslationMethod = $this->request->getBodyParam('titleTranslationMethod', $entryType->titleTranslationMethod);
         $entryType->titleTranslationKeyFormat = $this->request->getBodyParam('titleTranslationKeyFormat', $entryType->titleTranslationKeyFormat);

--- a/src/migrations/m220516_124013_add_entry_type_description.php
+++ b/src/migrations/m220516_124013_add_entry_type_description.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m220516_124013_add_entry_type_description migration.
+ */
+class m220516_124013_add_entry_type_description extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn(Table::ENTRYTYPES, 'description', $this->string()->after('handle'));
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m220516_124013_add_section_description cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/migrations/m220516_124013_add_section_description.php
+++ b/src/migrations/m220516_124013_add_section_description.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m220516_124013_add_section_description migration.
+ */
+class m220516_124013_add_section_description extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn(Table::SECTIONS, 'description', $this->string()->after('handle'));
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m220516_124013_add_section_description cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/EntryType.php
+++ b/src/models/EntryType.php
@@ -53,6 +53,11 @@ class EntryType extends Model
     public ?string $handle = null;
 
     /**
+     * @var string|null Description
+     */
+    public ?string $description = null;
+
+    /**
      * @var int|null Sort order
      * @since 3.5.0
      */
@@ -107,6 +112,7 @@ class EntryType extends Model
         return [
             'handle' => Craft::t('app', 'Handle'),
             'name' => Craft::t('app', 'Name'),
+            'description' => Craft::t('app', 'Description'),
             'titleFormat' => Craft::t('app', 'Title Format'),
         ];
     }
@@ -217,6 +223,7 @@ class EntryType extends Model
         $config = [
             'name' => $this->name,
             'handle' => $this->handle,
+            'description' => $this->description,
             'hasTitleField' => $this->hasTitleField,
             'titleTranslationMethod' => $this->titleTranslationMethod,
             'titleTranslationKeyFormat' => $this->titleTranslationKeyFormat ?: null,

--- a/src/models/Section.php
+++ b/src/models/Section.php
@@ -68,6 +68,11 @@ class Section extends Model
     public ?string $handle = null;
 
     /**
+     * @var string|null Description
+      */
+    public ?string $description = null;
+
+    /**
      * @var string|null Type
      */
     public ?string $type = null;
@@ -152,6 +157,7 @@ class Section extends Model
             'handle' => Craft::t('app', 'Handle'),
             'name' => Craft::t('app', 'Name'),
             'type' => Craft::t('app', 'Section Type'),
+            'description' => Craft::t('app', 'Description'),
         ];
     }
 
@@ -365,6 +371,7 @@ class Section extends Model
         $config = [
             'name' => $this->name,
             'handle' => $this->handle,
+            'description' => $this->description,
             'type' => $this->type,
             'enableVersioning' => $this->enableVersioning,
             'propagationMethod' => $this->propagationMethod,

--- a/src/records/EntryType.php
+++ b/src/records/EntryType.php
@@ -21,6 +21,7 @@ use yii2tech\ar\softdelete\SoftDeleteBehavior;
  * @property int|null $fieldLayoutId Field layout ID
  * @property string $name Name
  * @property string $handle Handle
+ * @property string $description Description
  * @property bool $hasTitleField Has title field
  * @property string $titleTranslationMethod Title translation method
  * @property string|null $titleTranslationKeyFormat Title translation key format

--- a/src/records/Section.php
+++ b/src/records/Section.php
@@ -20,6 +20,7 @@ use yii2tech\ar\softdelete\SoftDeleteBehavior;
  * @property int|null $structureId Structure ID
  * @property string $name Name
  * @property string $handle Handle
+ * @property string $description Description
  * @property string $type Type
  * @property bool $enableVersioning Enable versioning
  * @property bool $propagationMethod Propagation method

--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -517,6 +517,7 @@ class Sections extends Component
                 if ($section->type === Section::TYPE_SINGLE) {
                     $entryType->name = $section->name;
                     $entryType->handle = $section->handle;
+                    $entryType->description = $section->description;
                     $entryType->hasTitleField = false;
                     $entryType->titleFormat = '{section.name|raw}';
                 } else {
@@ -545,6 +546,7 @@ class Sections extends Component
                             if ($entryType->name !== $section->name || $entryType->handle !== $section->handle) {
                                 $entryType->name = $section->name;
                                 $entryType->handle = $section->handle;
+                                $entryType->description = $section->description;
                                 $this->saveEntryType($entryType);
                             }
 
@@ -590,6 +592,7 @@ class Sections extends Component
             $sectionRecord->uid = $sectionUid;
             $sectionRecord->name = $data['name'];
             $sectionRecord->handle = $data['handle'];
+            $sectionRecord->description = $data['description'];
             $sectionRecord->type = $data['type'];
             $sectionRecord->enableVersioning = (bool)$data['enableVersioning'];
             $sectionRecord->propagationMethod = $data['propagationMethod'] ?? Section::PROPAGATION_METHOD_ALL;
@@ -1162,6 +1165,7 @@ class Sections extends Component
 
             $entryTypeRecord->name = $data['name'];
             $entryTypeRecord->handle = $data['handle'];
+            $entryTypeRecord->description = $data['description'];
             $entryTypeRecord->hasTitleField = $data['hasTitleField'];
             $entryTypeRecord->titleTranslationMethod = $data['titleTranslationMethod'] ?? '';
             $entryTypeRecord->titleTranslationKeyFormat = $data['titleTranslationKeyFormat'] ?? null;
@@ -1429,6 +1433,7 @@ class Sections extends Component
                 'sections.structureId',
                 'sections.name',
                 'sections.handle',
+                'sections.description',
                 'sections.type',
                 'sections.enableVersioning',
                 'sections.defaultPlacement',
@@ -1609,6 +1614,7 @@ class Sections extends Component
                 'fieldLayoutId',
                 'name',
                 'handle',
+                'description',
                 'sortOrder',
                 'hasTitleField',
                 'titleTranslationMethod',

--- a/src/templates/settings/sections/_edit.twig
+++ b/src/templates/settings/sections/_edit.twig
@@ -55,6 +55,15 @@
         required: true
     }) }}
 
+    {{ forms.textareaField({
+        label: 'Description'|t('app'),
+        id: 'description',
+        class: 'nicetext',
+        name: 'description',
+        value: section.description ?? null,
+        errors: (section is defined ? section.getErrors('description') : null),
+    }) }}
+
     {{ forms.checkboxField({
         label: 'Enable versioning for entries in this section'|t('app'),
         id: 'enableVersioning',

--- a/src/templates/settings/sections/_entrytypes/edit.twig
+++ b/src/templates/settings/sections/_entrytypes/edit.twig
@@ -49,6 +49,15 @@
             required: true
         }) }}
 
+        {{ forms.textareaField({
+            label: 'Description'|t('app'),
+            id: 'description',
+            class: 'nicetext',
+            name: 'description',
+            value: entryType.description ?? null,
+            errors: (entryType is defined ? entryType.getErrors('description') : null),
+        }) }}
+
         <hr>
 
     {% endif %}


### PR DESCRIPTION
### Description

At [Newism](https://github.com/newism/) we've been discussing ways to better self document the CraftCMS control panel.

I noticed that `UserGroups` have descriptions but `Sections` and `EntryTypes` do not so I added them.

There's no front end display of these values yet – open to discussion. The values could be used in custom UI elements at the discretion of the developer.

One thing that could throw a spanner in the works… what happens when a new property is added to a model and there's an existing custom field with the same handle?

- Added `craft\models\Section::description`
- Added `craft\models\EntryTypes::description`

<img width="584" alt="Screen Shot 2022-05-16 at 11 58 34 pm" src="https://user-images.githubusercontent.com/25124/168609773-f5bbe683-49a2-4c51-9c29-4bf53f399610.png">

<img width="518" alt="image" src="https://user-images.githubusercontent.com/25124/168609891-3ee3957c-6fe9-404b-8d6f-cfafdd4d0734.png">


