### PR TITLE
Language mistake corrected

### DIFF
--- a/src/translations/de-CH/app.php
+++ b/src/translations/de-CH/app.php
@@ -636,7 +636,7 @@ return [
     'Formatting Locale' => 'Formatierungsgebietschema',
     'Free' => 'Kostenlos',
     'From {date}' => 'Vom {date}',
-    'From' => 'Vom',
+    'From' => 'Von',
     'Full Name' => 'Vollständiger Name',
     'Full Schema' => 'Ganzes Schema',
     'General Settings' => 'Allgemeine Einstellungen',

--- a/src/translations/de/app.php
+++ b/src/translations/de/app.php
@@ -636,7 +636,7 @@ return [
     'Formatting Locale' => 'Formatierungsgebietschema',
     'Free' => 'Kostenlos',
     'From {date}' => 'Vom {date}',
-    'From' => 'Vom',
+    'From' => 'Von',
     'Full Name' => 'Vollständiger Name',
     'Full Schema' => 'Ganzes Schema',
     'General Settings' => 'Allgemeine Einstellungen',


### PR DESCRIPTION
### Description
Wrong kasus in test email translation.

Just a language kasus error in the test email translation. 

"Vom Person" is wrong in German instead you use "von Person".

