### PR TITLE
Bug fix create new entry: "Entry is missing its section ID"

### DIFF
--- a/src/gql/resolvers/mutations/Entry.php
+++ b/src/gql/resolvers/mutations/Entry.php
@@ -224,12 +224,13 @@ class Entry extends ElementMutationResolver
             throw new Error('Impossible to change the section of an existing entry');
         }
 
+        $entry->sectionId = $section->id;
+
         // Null the field layout id in case the entry type changes.
         if ($entry->getTypeId() !== $entryType->id) {
             $entry->fieldLayoutId = null;
         }
 
-        $entry->sectionId = $section->id;
         $entry->setTypeId($entryType->id);
 
         return $entry;


### PR DESCRIPTION
I created a section (posts) which has only a basic field `title`. The type of the section was channel. When I wanted to create a new entry through the GraphQL api I got the exception `Entry is missing its section ID`. 

I found out that a new entry is created without a `sectionId`. So before the `sectionId` is set the method `entry->getTypeId()` is called. Deeper in the in code it calls the function `getSection()` inside the namespace `craft\elements\Entry` which throws that error. 


