### PR TITLE
Consistently use “deprecation warnings”

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -16,6 +16,7 @@
 - Selectize options can now specify searchable `keywords` that won’t be visible in the UI.
 - Selectize inputs will now include their options’ values as search keywords.
 - The `users/create` command now asks whether the user should be activated when saved.
+- Deprecation messages are now consistently referred to as “deprecation warnings” in the control panel.
 
 ### Removed
 - Removed `craft\elements\conditions\entries\EntryTypeCondition::$sectionUid`.

--- a/src/controllers/UtilitiesController.php
+++ b/src/controllers/UtilitiesController.php
@@ -33,7 +33,7 @@ class UtilitiesController extends Controller
      * Index
      *
      * @return Response
-     * @throws ForbiddenHttpException if the user doesn't have access to any utilities
+     * @throws ForbiddenHttpException if the user doesn’t have access to any utilities
      */
     public function actionIndex(): Response
     {
@@ -43,7 +43,7 @@ class UtilitiesController extends Controller
             throw new ForbiddenHttpException('User not permitted to view Utilities');
         }
 
-        // Don't go to the Updates or Upgrade utilities by default if there are any others
+        // Don’t go to the Updates or Upgrade utilities by default if there are any others
         $firstUtility = null;
         foreach ($utilities as $utility) {
             if (!in_array($utility, [Updates::class, Upgrade::class])) {
@@ -65,7 +65,7 @@ class UtilitiesController extends Controller
      * @param string $id
      * @return Response
      * @throws NotFoundHttpException if $id is invalid
-     * @throws ForbiddenHttpException if the user doesn't have access to the requested utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the requested utility
      * @throws Exception in case of failure
      */
     public function actionShowUtility(string $id): Response
@@ -98,7 +98,7 @@ class UtilitiesController extends Controller
      * View stack trace for a deprecator log entry.
      *
      * @return Response
-     * @throws ForbiddenHttpException if the user doesn't have access to the Deprecation Warnings utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the Deprecation Warnings utility
      */
     public function actionGetDeprecationErrorTracesModal(): Response
     {
@@ -117,10 +117,10 @@ class UtilitiesController extends Controller
     }
 
     /**
-     * Deletes all deprecation errors.
+     * Deletes all deprecation warnings.
      *
      * @return Response
-     * @throws ForbiddenHttpException if the user doesn't have access to the Deprecation Warnings utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the Deprecation Warnings utility
      */
     public function actionDeleteAllDeprecationErrors(): Response
     {
@@ -137,7 +137,7 @@ class UtilitiesController extends Controller
      * Deletes a deprecation error.
      *
      * @return Response
-     * @throws ForbiddenHttpException if the user doesn't have access to the Deprecation Warnings utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the Deprecation Warnings utility
      */
     public function actionDeleteDeprecationError(): Response
     {
@@ -155,7 +155,7 @@ class UtilitiesController extends Controller
      * Performs a Clear Caches action
      *
      * @return Response
-     * @throws ForbiddenHttpException if the user doesn't have access to the Clear Caches utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the Clear Caches utility
      * @throws BadRequestHttpException
      */
     public function actionClearCachesPerformAction(): Response
@@ -193,7 +193,7 @@ class UtilitiesController extends Controller
      * Performs an Invalidate Data Caches action.
      *
      * @return Response
-     * @throws ForbiddenHttpException if the user doesn't have access to the Clear Caches utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the Clear Caches utility
      * @throws BadRequestHttpException
      * @since 3.5.0
      */
@@ -215,7 +215,7 @@ class UtilitiesController extends Controller
      * Performs a DB Backup action
      *
      * @return Response|null
-     * @throws ForbiddenHttpException if the user doesn't have access to the DB Backup utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the DB Backup utility
      * @throws Exception if the backup could not be created
      */
     public function actionDbBackupPerformAction(): ?Response
@@ -249,7 +249,7 @@ class UtilitiesController extends Controller
      * Performs a Find And Replace action
      *
      * @return Response
-     * @throws ForbiddenHttpException if the user doesn't have access to the Find an Replace utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the Find and Replace utility
      */
     public function actionFindAndReplacePerformAction(): Response
     {
@@ -271,7 +271,7 @@ class UtilitiesController extends Controller
      * Applies new migrations
      *
      * @return Response
-     * @throws ForbiddenHttpException if the user doesn't have access to the Migrations utility
+     * @throws ForbiddenHttpException if the user doesn’t have access to the Migrations utility
      */
     public function actionApplyNewMigrations(): Response
     {

--- a/src/services/Deprecator.php
+++ b/src/services/Deprecator.php
@@ -40,10 +40,10 @@ class Deprecator extends Component
     public bool $throwExceptions = false;
 
     /**
-     * @var string|false Whether deprecation errors should be logged in the database ('db'),
+     * @var string|false Whether deprecation warnings should be logged in the database ('db'),
      * error logs ('logs'), or not at all (false).
      *
-     * Changing this will prevent deprecation errors from showing up in the "Deprecation Warnings" utility
+     * Changing this will prevent deprecation warnings from showing up in the "Deprecation Warnings" utility
      * or in the "Deprecated" panel in the Debug Toolbar.
      *
      * @since 3.0.7
@@ -51,17 +51,17 @@ class Deprecator extends Component
     public string|false $logTarget = 'db';
 
     /**
-     * @var DeprecationError[] The deprecation errors that were logged in the current request
+     * @var DeprecationError[] The deprecation warnings that were logged in the current request
      */
     private array $_requestLogs = [];
 
     /**
-     * @var DeprecationError[] The deprecation errors that still need to be stored in the DB
+     * @var DeprecationError[] The deprecation warnings that still need to be stored in the DB
      */
     private array $_pendingRequestLogs = [];
 
     /**
-     * @var DeprecationError[]|null All the unique deprecation errors that have been logged
+     * @var DeprecationError[]|null All the unique deprecation warnings that have been logged
      */
     private ?array $_allLogs = null;
 
@@ -163,7 +163,7 @@ class Deprecator extends Component
     }
 
     /**
-     * Returns the deprecation errors that were logged in the current request.
+     * Returns the deprecation warnings that were logged in the current request.
      *
      * @return DeprecationError[]
      */
@@ -173,7 +173,7 @@ class Deprecator extends Component
     }
 
     /**
-     * Returns the total number of deprecation errors that have been logged.
+     * Returns the total number of deprecation warnings that have been logged.
      *
      * @return int
      */

--- a/src/templates/_components/utilities/DeprecationErrors/index.twig
+++ b/src/templates/_components/utilities/DeprecationErrors/index.twig
@@ -7,7 +7,7 @@
 
 <div class="readable">
     <p id="nologs" class="zilch{% if logs %} hidden{% endif %}">
-        {{ "No deprecation errors to report!"|t('app') }}
+        {{ "No deprecation warnings to report!"|t('app') }}
     </p>
 
     {% if logs %}

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -947,7 +947,7 @@ return [
     'No blocks.' => 'No blocks.',
     'No category groups exist yet.' => 'No category groups exist yet.',
     'No content migrations.' => 'No content migrations.',
-    'No deprecation errors to report!' => 'No deprecation errors to report!',
+    'No deprecation warnings to report!' => 'No deprecation warnings to report!',
     'No entries exist yet.' => 'No entries exist yet.',
     'No entry types exist for this section.' => 'No entry types exist for this section.',
     'No fields exist yet.' => 'No fields exist yet.',

--- a/src/views/debug/deprecated/detail.php
+++ b/src/views/debug/deprecated/detail.php
@@ -18,7 +18,7 @@ $logs = $panel->data;
 ?>
 
 <?php if (empty($logs)): ?>
-    <p>No deprecation errors were logged on this request.</p>
+    <p>No deprecation warnings were logged on this request.</p>
 <?php else: ?>
     <div class="table-responsive">
         <table class="table table-condensed table-bordered table-striped table-hover"
@@ -47,4 +47,4 @@ $logs = $panel->data;
 <?php endif; ?>
 
 <p><a href="<?= UrlHelper::cpUrl('utilities/deprecation-errors') ?>"
-      target="_parent">View all deprecation errors</a></p>
+      target="_parent">View all deprecation warnings</a></p>

--- a/tests/functional/PageRenderChecksCest.php
+++ b/tests/functional/PageRenderChecksCest.php
@@ -13,8 +13,7 @@ use craft\elements\User;
 use FunctionalTester;
 
 /**
- * Test that most pages within Craft are rendered successfully and that we can - some a minor degree -
- * establish that the correct content is loaded on those pages.
+ * Test that most pages within Craft are rendered successfully and the correct content is loaded on those pages.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @author Global Network Group | Giel Tettelaar <giel@yellowflash.net>
@@ -203,7 +202,7 @@ class PageRenderChecksCest
             ],
             [
                 'url' => '/utilities/deprecation-errors', 'title' => 'Deprecation Warnings', 'extraContent' => [
-                ['rendered' => 'No deprecation errors to report!'],
+                ['rendered' => 'No deprecation warnings to report!'],
             ],
             ],
             [


### PR DESCRIPTION
### Description

This PR updates a few “deprecation error” references to “deprecation warning” for consistency, with a few bonus updates in docblocks.

It _only_ touches labels and comments, and not any method names, property names, or functional bits.