### PR TITLE
Add data-name to the .matrixblock

### DIFF
--- a/src/templates/_components/fieldtypes/Matrix/input.twig
+++ b/src/templates/_components/fieldtypes/Matrix/input.twig
@@ -20,6 +20,7 @@
                 ]|filter,
                 data: {
                     id: blockId,
+                    name: block.getType().name,
                     type: block.getType().handle,
                     collapsed: block.collapsed,
                 },


### PR DESCRIPTION
### Description
We use CPSS very much to extend/style our Matrix Builders.
The data-attr would be very helpful to do things like: content: attr(data-name); for custom labels on the blocks. It's a bit sugar and has no side effects I think.

Here is an image what we do:
![image](https://user-images.githubusercontent.com/764292/169486574-4080dbe2-ef3a-453d-a5b2-0996dd4fd80d.png)
it's a bit easier to scan on huge content pages.

Created the same PR on the NEO Field.
