### PR TITLE
Makes ElementQuery::count compatible with both ElementQueryInterface and Countable

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1622,6 +1622,7 @@ class ElementQuery extends Query implements ElementQueryInterface
     /**
      * @inheritdoc
      */
+    #[ReturnTypeWillChange]
     public function count($q = '*', $db = null)
     {
         // Cached?


### PR DESCRIPTION
### Description

Fixes the following exception on PHP 8.1:

```
yii\base\ErrorException: During inheritance of Countable: Uncaught yii\base\ErrorException: Return type of yii\db\QueryInterface::count($q = '*', $db = null) should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/user/vendor/yiisoft/yii2/db/QueryInterface.php:49
```


### Related issues

Fixes https://github.com/solspace/craft-calendar/issues/103
