### PR TITLE
Makes ElementQueryInterface::count compatible with Countable

### DIFF
--- a/src/elements/db/ElementQueryInterface.php
+++ b/src/elements/db/ElementQueryInterface.php
@@ -14,6 +14,7 @@ use craft\db\Query;
 use craft\models\Site;
 use craft\search\SearchQuery;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 use yii\base\Arrayable;
 use yii\db\Connection;
 use yii\db\QueryInterface;
@@ -28,6 +29,12 @@ use yii\db\QueryInterface;
  */
 interface ElementQueryInterface extends QueryInterface, ArrayAccess, Arrayable, Countable, IteratorAggregate
 {
+    /**
+     * @inheritdoc
+     */
+    #[ReturnTypeWillChange]
+    public function count($q = '*', $db = null);
+    
     /**
      * Causes the query results to be returned in reverse order.
      *


### PR DESCRIPTION
### Description

Fixes the following exception on PHP 8.1:

```
yii\base\ErrorException: During inheritance of Countable: Uncaught yii\base\ErrorException: Return type of yii\db\QueryInterface::count($q = '*', $db = null) should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/user/vendor/yiisoft/yii2/db/QueryInterface.php:49
```


### Related issues

Fixes https://github.com/solspace/craft-calendar/issues/103
