### PR TITLE
User status tweaks

### DIFF
--- a/src/controllers/LivePreviewController.php
+++ b/src/controllers/LivePreviewController.php
@@ -8,6 +8,7 @@
 namespace craft\controllers;
 
 use Craft;
+use craft\elements\db\UserQuery;
 use craft\elements\User;
 use craft\web\Controller;
 use yii\base\InvalidRouteException;
@@ -93,7 +94,7 @@ class LivePreviewController extends Controller
         /** @var User|null $user */
         $user = User::find()
             ->id($userId)
-            ->status([User::STATUS_ACTIVE, User::STATUS_PENDING])
+            ->status(UserQuery::STATUS_CREDENTIALED)
             ->one();
 
         if (!$user) {

--- a/src/elements/actions/SuspendUsers.php
+++ b/src/elements/actions/SuspendUsers.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\ElementAction;
 use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
+use craft\elements\db\UserQuery;
 use craft\elements\User;
 use Throwable;
 
@@ -73,10 +74,7 @@ JS;
     {
         /** @var ElementQuery $query */
         // Get the users that aren't already suspended
-        $query->status = [
-            User::STATUS_ACTIVE,
-            User::STATUS_PENDING,
-        ];
+        $query->status = UserQuery::STATUS_CREDENTIALED;
 
         /** @var User[] $users */
         $users = $query->all();

--- a/src/elements/db/UserQuery.php
+++ b/src/elements/db/UserQuery.php
@@ -37,6 +37,11 @@ use yii\db\Expression;
 class UserQuery extends ElementQuery
 {
     /**
+     * @since 4.0.4
+     */
+    public const STATUS_CREDENTIALED = 'credentialed';
+
+    /**
      * @inheritdoc
      */
     protected array $defaultOrderBy = ['users.username' => SORT_ASC];
@@ -714,6 +719,7 @@ class UserQuery extends ElementQuery
      * | `'inactive'` | with inactive accounts.
      * | `'active'` | with active accounts.
      * | `'pending'` | with accounts that are still pending activation.
+     * | `'credentialed'` | with either active or pending accounts.
      * | `'suspended'` | with suspended accounts.
      * | `'locked'` | with locked accounts (regardless of whether they’re active or suspended).
      * | `['active', 'suspended']` | with active or suspended accounts.
@@ -939,8 +945,14 @@ class UserQuery extends ElementQuery
             ],
             User::STATUS_ACTIVE => [
                 'users.active' => true,
+                'users.suspended' => false,
             ],
             User::STATUS_PENDING => [
+                'users.pending' => true,
+            ],
+            self::STATUS_CREDENTIALED => [
+                'or',
+                'users.active' => true,
                 'users.pending' => true,
             ],
             User::STATUS_SUSPENDED => [


### PR DESCRIPTION
### Description

- Fixes a bug where querying users by `active` status now includes suspended users, which is an undocumented change in behavior compared to Craft 3.
- Adds a new `credentialed` status param option, which returns users that are either active (regardless of suspended status) or pending, which should be used in place of `status(['active', 'pending'])`.


### Related issues

- #11322
