### PR TITLE
Prevent hidden folders in volumes from being indexed

### DIFF
--- a/src/services/AssetIndexer.php
+++ b/src/services/AssetIndexer.php
@@ -50,7 +50,6 @@ use yii\base\InvalidConfigException;
  */
 class AssetIndexer extends Component
 {
-
     /**
      * Returns a sorted list of files on a volume.
      *

--- a/src/services/AssetIndexer.php
+++ b/src/services/AssetIndexer.php
@@ -164,9 +164,8 @@ class AssetIndexer extends Component
 
         /** @var Volume $volume */
         foreach ($volumeList as $volume) {
-            if ($fileList = $this->getIndexListOnVolume($volume)) {
-                $total += $this->storeIndexList($fileList, $session->id, (int)$volume->id);
-            }
+            $fileList = $this->getIndexListOnVolume($volume);
+            $total += $this->storeIndexList($fileList, $session->id, (int)$volume->id);
         }
 
         $session->totalEntries = $total;


### PR DESCRIPTION
### Description

I don't know if this is the way you want to go with it, but if merged this PR should resolve #11362.

This PR changes the way the Asset Indexes utility compiles the list of files to index, by making the `AssetIndexer::startIndexingSession()` method pull the indexing file list via the `AssetIndexer::getIndexListOnVolume()` method, instead of getting it directly from the volume's filesystem instance. 

This makes sure that any files in folders beginning with an underscore are completely ignored during the indexing process, which is consistent with [how asset indexing currently works in 4.x via CLI](https://github.com/craftcms/cms/blob/develop/src/console/controllers/IndexAssetsController.php#L151), as well as how indexing via the Asset Indexes utility worked in 3.x.

This PR also fixes a wrongly typed exception handler in the AssetIndexer service.

### Related issues

#11362 