### PR TITLE
Fix input of localized value in number field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed an error that could occur when saving an element to a disabled site. ([#10499](https://github.com/craftcms/cms/issues/10499))
 - Fixed a bug where newly-added condition rules’ types were still selectable for preexisting condition rules, when they shouldn’t have been.
 - Fixed a bug where field layout designers were checking the wrong setting when determining whether to include UI elements (`customizableTabs` instead of `customizableUi`).
+- Fixed a bug where localized numbers weren’t being saved correctly.
 
 ## 4.0.4 - 2022-06-03
 

--- a/src/templates/_components/fieldtypes/Number/input.twig
+++ b/src/templates/_components/fieldtypes/Number/input.twig
@@ -8,7 +8,7 @@
 {%- set hasSuffix = suffix is not same as(false) %}
 
 {% if formatNumber %}
-    {{ hiddenInput("#{field.handle}[locale]", craft.app.formattingLocale.id) }}
+    {{ hiddenInput("#{field.handle}[locale]", currentUser.getPreferredLocale()) }}
 {% endif %}
 
 {% if hasPrefix or hasSuffix %}
@@ -32,7 +32,7 @@
         {{ text({
             id: id,
             name: formatNumber ? "#{field.handle}[value]" : field.handle,
-            value: value,
+            value: formatNumber ? value|number : value,
             inputmode: field.decimals ? 'decimal' : 'numeric',
             size: field.size,
             describedBy: [describedBy ?? null, hasPrefix or hasSuffix ? descriptionId : null]|filter|join(' ') ?: false,


### PR DESCRIPTION
### Description
If you have your user's formatting locale set to something different than the app and try to enter a localized number the value is saved incorrectly.