### PR TITLE
Fixed a bug with running the `craft index-assets` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed a bug where newly-added condition rules’ types were still selectable for preexisting condition rules, when they shouldn’t have been.
 - Fixed a bug where field layout designers were checking the wrong setting when determining whether to include UI elements (`customizableTabs` instead of `customizableUi`).
 - Fixed a bug where the Asset Indexes utility was analyzing image transform directories and files. ([#11362](https://github.com/craftcms/cms/issues/11362), [#11384](https://github.com/craftcms/cms/pull/11384))
+- Fixed a bug where running `craft index-assets` command would unexpectedly output messages about missing files. ([#11194](https://github.com/craftcms/cms/issues/11194)).
 
 ## 4.0.4 - 2022-06-03
 

--- a/src/services/AssetIndexer.php
+++ b/src/services/AssetIndexer.php
@@ -529,7 +529,10 @@ class AssetIndexer extends Component
             'completed' => false,
         ]);
 
-        return $this->indexFileByEntry($indexEntry, $cacheImages, $createIfMissing);
+        $asset = $this->indexFileByEntry($indexEntry, $cacheImages, $createIfMissing);
+        $indexEntry->recordId = $asset->id;
+        $this->storeIndexEntry($indexEntry);
+        return $asset;
     }
 
     /**
@@ -558,7 +561,35 @@ class AssetIndexer extends Component
             'completed' => false,
         ]);
 
-        return $this->indexFolderByEntry($indexEntry, $createIfMissing);
+        $folder = $this->indexFolderByEntry($indexEntry, $createIfMissing);
+        $indexEntry->recordId = $folder->id;
+        $this->storeIndexEntry($indexEntry);
+        return $folder;
+    }
+
+    /**
+     * Store a single index entry.
+     *
+     * @param AssetIndexData $indexEntry
+     * @throws \yii\db\Exception
+     */
+    protected function storeIndexEntry(AssetIndexData $indexEntry)
+    {
+        $data = $indexEntry->toArray([
+            'id',
+            'sessionId',
+            'volumeId',
+            'uri',
+            'size',
+            'timestamp',
+            'isDir',
+            'recordId',
+            'isSkipped',
+            'inProgress',
+            'completed'
+        ]);
+        Db::insert(Table::ASSETINDEXDATA, $data);
+
     }
 
     /**


### PR DESCRIPTION

### Description
Fixed a bug where running the `craft index-assets` command would unexpectedly output messages about missing files.


### Related issues
Resolves #11194

