### PR TITLE
Update incorrect German translation

### DIFF
--- a/src/translations/de-CH/app.php
+++ b/src/translations/de-CH/app.php
@@ -445,7 +445,7 @@ return [
     'Date' => 'Datum',
     'Days' => 'Tage',
     'Deactivate users by default' => 'Benutzer standardmässig deaktivieren',
-    'Deactivate…' => 'Wird deaktiviert…',
+    'Deactivate…' => 'Deaktivieren…',
     'Deactivating a user revokes their ability to sign in. Are you sure you want to continue?' => 'Ein deaktivierter Benutzer kann sich nicht mehr anmelden. Wirklich fortfahren?',
     'Decimal Points' => 'Nachkommastellen',
     'Default Color' => 'Standardfarbe',

--- a/src/translations/de/app.php
+++ b/src/translations/de/app.php
@@ -445,7 +445,7 @@ return [
     'Date' => 'Datum',
     'Days' => 'Tage',
     'Deactivate users by default' => 'Benutzer standardmäßig deaktivieren',
-    'Deactivate…' => 'Wird deaktiviert…',
+    'Deactivate…' => 'Deaktivieren…',
     'Deactivating a user revokes their ability to sign in. Are you sure you want to continue?' => 'Ein deaktivierter Benutzer kann sich nicht mehr anmelden. Wirklich fortfahren?',
     'Decimal Points' => 'Nachkommastellen',
     'Default Color' => 'Standardfarbe',


### PR DESCRIPTION
### Description

Found another incorrect translation in German. The action on the user edit page `Deactivate…` is translated as `Wird deaktiviert…`, which means `Deactivating…`, as in `[User] is being deactivated`. Correct translation would be `Deaktivieren…` which is the imperative mood.

The PR fixes this translation in both `de` and `de-CH`.