### PR TITLE
Correct isSystemLive config override docblock

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1443,10 +1443,10 @@ class GeneralConfig extends BaseObject
      *
      * ::: code
      * ```php Static Config
-     * 'ipHeaders' => ['X-Forwarded-For', 'CF-Connecting-IP'],
+     * 'isSystemLive' => 1,
      * ```
      * ```shell Environment Override
-     * CRAFT_IP_HEADERS=X-Forwarded-For,CF-Connecting-IP
+     * CRAFT_IS_SYSTEM_LIVE=1
      * ```
      * :::
      *

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1443,10 +1443,10 @@ class GeneralConfig extends BaseObject
      *
      * ::: code
      * ```php Static Config
-     * 'isSystemLive' => 1,
+     * 'isSystemLive' => true,
      * ```
      * ```shell Environment Override
-     * CRAFT_IS_SYSTEM_LIVE=1
+     * CRAFT_IS_SYSTEM_LIVE=true
      * ```
      * :::
      *


### PR DESCRIPTION
### Description

Corrects the docblock for the `isSystemLive` config override that previously incorrectly referenced the `ipHeaders` override.

### Related issues

N/A