### PR TITLE
[4.x] Only allow entry duplication when user is allowed to create entries

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1387,7 +1387,13 @@ class Entry extends Element
      */
     public function canDuplicate(User $user): bool
     {
-        return $this->getSection()->type !== Section::TYPE_SINGLE;
+        $section = $this->getSection();
+
+        return (
+            $section->type !== Section::TYPE_SINGLE &&
+            $user->can("createEntries:$section->uid") &&
+            $user->can("saveEntries:$section->uid")
+        );
     }
 
     /**


### PR DESCRIPTION
### Description

Currently when a user is not allowed to create entries in a section she nevertheless *can* duplicate an existing entry and thus can actually create a new entry by duplicating an old entry. This PR fixes that.

This PR makes the behaviour consistent with `defineActions`
https://github.com/craftcms/cms/blob/8763add61e9116f8046ac87a440c705910272e76/src/elements/Entry.php#L459-L472
