### PR TITLE
Fix type comparison in element condition rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fixed a bug where the control panel wasn’t displaying file upload failure messages.
 - Fixed a bug where `action` query params were taking precedence over `actionTrigger` URI matches, when handling action requests. ([#11435](https://github.com/craftcms/cms/issues/11435))
 - Fixed a bug where image fields within Edit User pages and the Settings → General page weren’t resetting properly after an image was deleted. ([#11436](https://github.com/craftcms/cms/issues/11436))
+- Fixed a bug where element condition rules weren’t matching correctly. ([#11451](https://github.com/craftcms/cms/pull/11451))
 
 ## 4.0.4 - 2022-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Fixed a bug where User Group condition rules set to the “is not one of” operator weren’t being applied to individual elements correctly. ([#11444](https://github.com/craftcms/cms/discussions/11444))
 - Fixed a JavaScript error that occurred on element indexes for users that didn’t have permission to edit any sites.
 - Fixed a bug where users without permission to create new entries in a section could duplicate existing entries. ([#11447](https://github.com/craftcms/cms/pull/11447))
-- Fixed a bug where element condition rules weren’t matching correctly. ([#11451](https://github.com/craftcms/cms/pull/11451))
+- Fixed a bug where element selection condition rules weren’t working if an element ID was provided. ([#11451](https://github.com/craftcms/cms/pull/11451))
 
 ## 4.0.4 - 2022-06-03
 

--- a/src/base/conditions/BaseElementSelectConditionRule.php
+++ b/src/base/conditions/BaseElementSelectConditionRule.php
@@ -190,14 +190,14 @@ abstract class BaseElementSelectConditionRule extends BaseConditionRule
         }
 
         if (is_numeric($value)) {
-            return (int)$value === $elementId;
+            return (int)$value === (int)$elementId;
         }
 
         if (is_array($value)) {
             foreach ($value as $val) {
                 if (
                     $val instanceof ElementInterface && $val->id === $elementId ||
-                    is_numeric($val) && (int)$val === $elementId
+                    is_numeric($val) && (int)$val === (int)$elementId
                 ) {
                     return true;
                 }


### PR DESCRIPTION
Type mismatch on the element ID prevented element condition rules from matching correctly.