### PR TITLE
Add inactive user scenario

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1287,7 +1287,7 @@ JS,
             $user->setScenario(Element::SCENARIO_LIVE);
         }
 
-        if (!$user->IsCredentialed) {
+        if (!$user->isCredentialed) {
             $user->setScenario(User::SCENARIO_INACTIVE);
         }
 

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -128,6 +128,7 @@ class User extends Element implements IdentityInterface
 
     public const SCENARIO_REGISTRATION = 'registration';
     public const SCENARIO_PASSWORD = 'password';
+    public const SCENARIO_INACTIVE = 'inactive';
 
     /**
      * @inheritdoc
@@ -937,6 +938,7 @@ class User extends Element implements IdentityInterface
         $scenarios = parent::scenarios();
         $scenarios[self::SCENARIO_PASSWORD] = ['newPassword'];
         $scenarios[self::SCENARIO_REGISTRATION] = ['username', 'email', 'newPassword'];
+        $scenarios[self::SCENARIO_INACTIVE] = [];
 
         return $scenarios;
     }


### PR DESCRIPTION
This allows the usage of `\craft\controllers\UsersController::actionSaveUser` to save inactive/uncredentialed users.

It will look for `inactive` in the post, and if so, set the scenario which won't reqyure username, email, password.