### PR TITLE
Use published browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,8 +1,0 @@
-# Browsers that we support
-
-Chrome >= 63
-Safari >= 11.1
-iOS >= 10.3
-Samsung >= 5
-UCAndroid >= 11.8
-Opera >= 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "yii2-pjax": "~2.0.1"
       },
       "devDependencies": {
+        "@craftcms/browserslist-config": "./packages/craftcms-browserslist-config",
         "@craftcms/webpack": "./packages/craftcms-webpack",
         "@playwright/test": "^1.19.2",
         "husky": "^7.0.4",
@@ -1814,6 +1815,10 @@
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
+    },
+    "node_modules/@craftcms/browserslist-config": {
+      "resolved": "packages/craftcms-browserslist-config",
+      "link": true
     },
     "node_modules/@craftcms/sass": {
       "resolved": "packages/craftcms-sass",
@@ -17563,6 +17568,12 @@
       "resolved": "https://registry.npmjs.org/yii2-pjax/-/yii2-pjax-2.0.7.tgz",
       "integrity": "sha1-/h+DUK7RwRxuzdFNra0DvYsTsZo="
     },
+    "packages/craftcms-browserslist-config": {
+      "name": "@craftcms/browserslist-config",
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/craftcms-sass": {
       "name": "@craftcms/sass",
       "version": "1.0.1",
@@ -18921,6 +18932,9 @@
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
+    },
+    "@craftcms/browserslist-config": {
+      "version": "file:packages/craftcms-browserslist-config"
     },
     "@craftcms/sass": {
       "version": "file:packages/craftcms-sass"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "check-prettier": "prettier --check .",
     "fix-prettier": "prettier --write ."
   },
+  "browserslist": [
+    "extends @craftcms/browserslist-config"
+  ],
   "devDependencies": {
+    "@craftcms/browserslist-config": "./packages/craftcms-browserslist-config",
     "@craftcms/webpack": "./packages/craftcms-webpack",
     "@playwright/test": "^1.19.2",
     "husky": "^7.0.4",

--- a/packages/craftcms-browserslist-config/index.js
+++ b/packages/craftcms-browserslist-config/index.js
@@ -1,0 +1,8 @@
+module.exports = [
+  'Chrome >= 63',
+  'Safari >= 11.1',
+  'iOS >= 10.3',
+  'Samsung >= 5',
+  'UCAndroid >= 11.8',
+  'Opera >= 5',
+];

--- a/packages/craftcms-browserslist-config/package.json
+++ b/packages/craftcms-browserslist-config/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@craftcms/browserslist-config",
+  "version": "1.0.0",
+  "description": "Browserslist config for Craft CMS",
+  "keywords": [
+    "craftcms",
+    "browserslist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "index.js",
+  "author": "Pixel & Tonic, Inc. <support@pixelandtonic.com>",
+  "homepage": "https://craftcms.com",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/craftcms/cms.git"
+  },
+  "bugs": {
+    "url": "https://github.com/craftcms/cms/issues"
+  }
+}

--- a/packages/craftcms-webpack/.browserslistrc
+++ b/packages/craftcms-webpack/.browserslistrc
@@ -1,8 +1,0 @@
-# Browsers that we support
-
-Chrome >= 63
-Safari >= 11.1
-iOS >= 10.3
-Samsung >= 5
-UCAndroid >= 11.8
-Opera >= 5


### PR DESCRIPTION
### Description
Uses `@craftcms/browserslist-config` instead of a local browserslist, so we can share it with other things (eg plugins)