### PR TITLE
Allow `$dateCreated` and `$dateUpdated` to be `DateTime` objects on `ActiveRecord`

### DIFF
--- a/src/db/ActiveRecord.php
+++ b/src/db/ActiveRecord.php
@@ -12,12 +12,13 @@ use craft\events\DefineBehaviorsEvent;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\StringHelper;
+use DateTime;
 
 /**
  * Active Record base class.
  *
- * @property string $dateCreated Date created
- * @property string $dateUpdated Date updated
+ * @property DateTime|string|null $dateCreated Date created
+ * @property DateTime|string|null $dateUpdated Date updated
  * @property string $uid UUID
  * @method ActiveQuery hasMany(string $class, array $link) See [[\yii\db\BaseActiveRecord::hasMany()]] for more info.
  * @method ActiveQuery hasOne(string $class, array $link) See [[\yii\db\BaseActiveRecord::hasOne()]] for more info.


### PR DESCRIPTION
### Description
Due to the fact that [this line](https://github.com/craftcms/cms/blob/develop/src/db/ActiveRecord.php#L140) will take care of preparing the data for the DB, we can allow these properties to be set to `DateTime` objects.