### PR TITLE
Conditionally show require `*` for address fields based on validation rules

### DIFF
--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -1258,6 +1258,7 @@ JS, [
     {
         $formatRepo = Craft::$app->getAddresses()->getAddressFormatRepository()->get($address->countryCode);
 
+        $originalScenario = $address->getScenario();
         $address->setScenario($scenario);
         $activeValidators = $address->getActiveValidators();
 
@@ -1283,6 +1284,8 @@ JS, [
                 $formatRepo->getUsedFields(),
                 $formatRepo->getUsedSubdivisionFields(),
             )) + $requiredFields;
+
+        $address->setScenario($originalScenario);
 
         return
             static::textFieldHtml([


### PR DESCRIPTION
### Description
Now that the validation for addresses is all part of the rules we can try and help the content editor by showing the `*` only when the field is actually required.

This helps when a developer may have changed the default validation rules using the define rules event.