### PR TITLE
Fix @param types in `Message` methods

### DIFF
--- a/src/mail/Message.php
+++ b/src/mail/Message.php
@@ -42,7 +42,7 @@ class Message extends \yii\symfonymailer\Message
     /**
      * Sets the message sender.
      *
-     * @param string|array|User|User[] $from The sender’s email address, or their
+     * @param string|array<User|string>|User $from The sender’s email address, or their
      * user model(s). You may pass an array of addresses if this message is from
      * multiple people. You may also specify sender name in addition to email
      * address using format: `[email => name]`.
@@ -57,7 +57,7 @@ class Message extends \yii\symfonymailer\Message
     /**
      * Sets the Reply-To email.
      *
-     * @param string|array|User|User[] $replyTo The Reply-To email address, or their
+     * @param string|array<User|string>|User $replyTo The Reply-To email address, or their
      * user model(s). You may pass an array of addresses if this message is from
      * multiple people. You may also specify Reply-To name in addition to email
      * address using format: `[email => name]`.
@@ -73,7 +73,7 @@ class Message extends \yii\symfonymailer\Message
     /**
      * Sets the message recipient(s).
      *
-     * @param string|array|User|User[] $to The receiver’s email address, or their
+     * @param string|array<User|string>|User $to The receiver’s email address, or their
      * user model(s). You may pass an array of addresses if multiple recipients
      * should receive this message. You may also specify receiver name in addition
      * to email address using format: `[email => name]`.
@@ -96,7 +96,7 @@ class Message extends \yii\symfonymailer\Message
     /**
      * Sets the CC (additional copy receiver) addresses of this message.
      *
-     * @param string|array|User|User[] $cc The copied receiver’s email address, or their user model(s).
+     * @param string|array<User|string>|User $cc The copied receiver’s email address, or their user model(s).
      * You may pass an array of addresses if multiple recipients should receive this message.
      * You may also specify receiver name in addition to email address using format:
      * `[email => name]`.
@@ -111,7 +111,7 @@ class Message extends \yii\symfonymailer\Message
     /**
      * Sets the BCC (hidden copy receiver) addresses of this message.
      *
-     * @param string|array|User|User[]|null $bcc The hidden copied receiver’s email address, or their user model(s).
+     * @param string|array<User|string>|User|null $bcc The hidden copied receiver’s email address, or their user model(s).
      * You may pass an array of addresses if multiple recipients should receive this message.
      * You may also specify receiver name in addition to email address using format:
      * `[email => name]`.


### PR DESCRIPTION
### Description
Methods in `Message` allow the passing of arrays of `User` elements or an array of key/value (email/name) pairs.

At the moment both `array` and `User[]` are specified in the `@param` phpdoc. This causes an issue and only takes the last value (in this case `User[]`). Removing both of these and replacing them with one `array<User|string>` solves the issue and allows the passing of either.

This was picked up by PHPStan and an example of the error can be seen here: https://phpstan.org/r/0470633c-8562-4c3a-917c-a89f0fc34642