### PR TITLE
Remove dash in config warning link

### DIFF
--- a/src/templates/settings/general/_index.twig
+++ b/src/templates/settings/general/_index.twig
@@ -18,7 +18,7 @@
 
 {% macro configWarning(setting, file) -%}
     {{ "This is being overridden by the {setting} config setting."|t('app', {
-        setting: '<a href="https://craftcms.com/docs/4.x/config/config-settings.html#-'~setting|lower~'" rel="noopener" target="_blank">'~setting~'</a>'
+        setting: '<a href="https://craftcms.com/docs/4.x/config/config-settings.html#'~setting|lower~'" rel="noopener" target="_blank">'~setting~'</a>'
     })|raw }}
 {%- endmacro %}
 


### PR DESCRIPTION
This PR corrects the docs link structure from `#-allowupdates` to `#allowupdates` in config warning messages.

Before: https://craftcms.com/docs/4.x/config/config-settings.html#-allowupdates

After: https://craftcms.com/docs/4.x/config/config-settings.html#allowupdates