### PR TITLE
`project-config/export` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft CMS 3.x
 
+## Unreleased
+
+### Added
+- Added the `project-config/export` command. ([#11733](https://github.com/craftcms/cms/pull/11733))
+
 ## 3.7.50 - 2022-07-26
 
 ### Changed


### PR DESCRIPTION
Adds a new `project-config/export` command, which can be used to generated a cleansed, consolidated project config YAML file, either for the internal or external (`config/project/`) config.

When run for both, the results can be fed into a comparison tool like Kaleidoscope:

<img width="1286" alt="A screenshot of Kaleidoscope comparing two YAML files, and a terminal window showing how the new project-config/export command was used to generate old.yaml and new.yaml files, and launch Kaleidoscope using the ksdiff command." src="https://user-images.githubusercontent.com/47792/182464217-3517c7b3-e494-4f9b-8529-499fa92b23ea.png">

