### PR TITLE
Fixed database config from url

### DIFF
--- a/src/config/DbConfig.php
+++ b/src/config/DbConfig.php
@@ -610,7 +610,10 @@ class DbConfig extends BaseConfig
     public function url(?string $value): self
     {
         if ($value) {
-            Craft::configure($this, Db::url2config($value));
+            $config = Db::url2config($value);
+            foreach ($config as $configKey => $configValue) {
+                $this->{$configKey}($configValue);
+            }
             $this->_updateDsn();
         }
 

--- a/tests/unit/config/DbConfigTest.php
+++ b/tests/unit/config/DbConfigTest.php
@@ -51,4 +51,26 @@ class DbConfigTest extends Unit
         $this->assertEquals('db2', $config->database);
         $this->assertEquals(5432, $config->port);
     }
+
+    /**
+     * Test DbConfig::url()
+     */
+    public function testUrl(): void
+    {
+        $config = DbConfig::create()
+            ->url('mysql://127.0.0.1:3306/db');
+        $this->assertEquals('db', $config->database);
+        $this->assertEquals("mysql:host=127.0.0.1;dbname=db;port=3306", $config->dsn);
+
+        $config = DbConfig::create()
+            ->url('pgsql://127.0.0.1:5432/db');
+        $this->assertEquals('db', $config->database);
+        $this->assertEquals("pgsql:host=127.0.0.1;dbname=db;port=5432", $config->dsn);
+
+        $config = DbConfig::create()
+            ->url('pgsql://127.0.0.1:5432/db')
+            ->database('db2');
+        $this->assertEquals('db2', $config->database);
+        $this->assertEquals("pgsql:host=127.0.0.1;dbname=db2;port=5432", $config->dsn);
+    }
 }


### PR DESCRIPTION
### Description

Ensure that necessary database config properties are set from the resulting config when setting `url`.

`Db::url2config($value)` returns an array with a `dsn` key, and it's important it's set using the  `DbConfig::dsn($value)` method (instead of just being assigned to the `dsn` property), because that function sets a bunch of properties from the dsn.

### Related issues

#11735 