### PR TITLE
Fixed WDS issue with ssl and running it outside the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+### Fixed
+- Fixed a bug that could occur when using SSL to serve asset bundles via `webpack-dev-server` outside of a container.
+
 ## 4.2.1 - 2022-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-- Fixed a bug that could occur when using SSL to serve asset bundles via `webpack-dev-server` outside of a container.
+- Fixed a bug where it wasn’t always possible to serve asset bundles via `webpack-dev-server` over SSL. ([#11758](https://github.com/craftcms/cms/pull/11758))
 
 ## 4.2.1 - 2022-08-09
 

--- a/src/services/Webpack.php
+++ b/src/services/Webpack.php
@@ -199,11 +199,9 @@ class Webpack extends Component
      * Returns the running status of the webpack dev server.
      *
      * @param string $class
-     * @phpstan-param class-string<AssetBundle> $class
      * @param string $loopback
      * @return bool
      * @throws GuzzleException
-     * @throws ReflectionException
      */
     private function _isDevServerRunning(string $class, string $loopback): bool
     {
@@ -216,7 +214,8 @@ class Webpack extends Component
             return $this->_isDevServerRunning[$class] = $this->_matchAsset($this->_serverResponse[$loopback], $class);
         }
 
-        $client = Craft::createGuzzleClient();
+        // Make sure the request isn't too strict for people running the dev server using https and outside the container
+        $client = Craft::createGuzzleClient(['verify' => false]);
         try {
             $res = $client->get(StringHelper::ensureRight($loopback, '/') . 'which-asset');
             if ($res->getStatusCode() !== 200) {


### PR DESCRIPTION
### Description
When running `webpack-dev-server`, via SSL, to serve an asset bundle the bundle would never be used as the check to see if the server was running would fail due to a certificate error.

This PR fixes that issue.