### PR TITLE
EVENT_AFTER_CREATE_TWIG

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,7 +1,9 @@
 # Release Notes for Craft CMS 4.3 (WIP)
 
 ### Added
+- Added `craft\events\CreateTwigEvent`.
 - Added `craft\web\Controller::getCurrentUser()`. ([#11754](https://github.com/craftcms/cms/pull/11754))
+- Added `craft\web\View::EVENT_AFTER_CREATE_TWIG`. ([#11774](https://github.com/craftcms/cms/pull/11774))
 
 ### Changed
 - Improved the control panel accessibility. ([#11534](https://github.com/craftcms/cms/pull/11534), [#11565](https://github.com/craftcms/cms/pull/11565), [#11578](https://github.com/craftcms/cms/pull/11578), [#11589](https://github.com/craftcms/cms/pull/11589), [#11610](https://github.com/craftcms/cms/pull/11610), [#11613](https://github.com/craftcms/cms/pull/11613), [#11768](https://github.com/craftcms/cms/pull/11768))

--- a/src/events/CreateTwigEvent.php
+++ b/src/events/CreateTwigEvent.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use craft\web\twig\Environment;
+use yii\base\Event;
+
+/**
+ * CreateTwigEvent event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.3.0
+ */
+class CreateTwigEvent extends Event
+{
+    /**
+     * @var string The template mode Twig is being created for (`site` or `cp`)
+     */
+    public string $templateMode;
+
+    /**
+     * @var Environment The Twig environment
+     */
+    public Environment $twig;
+}

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -8,6 +8,7 @@
 namespace craft\web;
 
 use Craft;
+use craft\events\CreateTwigEvent;
 use craft\events\RegisterTemplateRootsEvent;
 use craft\events\TemplateEvent;
 use craft\helpers\App;
@@ -57,6 +58,13 @@ use yii\web\AssetBundle as YiiAssetBundle;
  */
 class View extends \yii\web\View
 {
+    /**
+     * @event CreateTwigEvent The event that is triggered when a Twig environment is created.
+     * @see createTwig()
+     * @since 4.3.0
+     */
+    public const EVENT_AFTER_CREATE_TWIG = 'afterCreateTwig';
+
     /**
      * @event RegisterTemplateRootsEvent The event that is triggered when registering control panel template roots
      */
@@ -355,6 +363,14 @@ class View extends \yii\web\View
         /** @var CoreExtension $core */
         $core = $twig->getExtension(CoreExtension::class);
         $core->setTimezone(Craft::$app->getTimeZone());
+
+        // Fire a afterCreateTwig event
+        if ($this->hasEventHandlers(self::EVENT_AFTER_CREATE_TWIG)) {
+            $this->trigger(self::EVENT_AFTER_CREATE_TWIG, new CreateTwigEvent([
+                'templateMode' => $this->_templateMode ?? self::TEMPLATE_MODE_SITE,
+                'twig' => $twig,
+            ]));
+        }
 
         return $twig;
     }


### PR DESCRIPTION
Adds an `EVENT_AFTER_CREATE_TWIG` event to `craft\web\View::createTwig()`, which can be called by plugins if they need to fire at the moment a Twig environment is created.

Since Craft creates separate Twig environments for control panel and site templates, the event class has a `templateMode` property which will either be set to `cp` or `site` depending on the active template mode, in case it’s relevant to the handler.

```php
use craft\events\CreateTwigEvent;
use craft\web\View;
use yii\base\Event;

Event::on(
    View::class,
    View::EVENT_AFTER_CREATE_TWIG,
    function(CreateTwigEvent $event) {
        if ($event->templateMode === View::TEMPLATE_MODE_SITE) {
            $event->twig->addGlobal('myGlobalVariable', 'foo');
        }
    }
);
```