### PR TITLE
feat: Add the ability to `.select()` custom fields by their field handle

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1969,7 +1969,6 @@ class ElementQuery extends Query implements ElementQueryInterface
                 if (!empty($select[$handle])) {
                     $column = ElementHelper::fieldColumnFromField($field);
                     if ($column) {
-                        unset($select[$handle]);
                         $select[$handle] = $column;
                     }
                 }

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1968,8 +1968,10 @@ class ElementQuery extends Query implements ElementQueryInterface
                 $handle = $field->handle;
                 if (!empty($select[$handle])) {
                     $column = ElementHelper::fieldColumnFromField($field);
-                    unset($select[$handle]);
-                    $select[$handle] = $column;
+                    if ($column) {
+                        unset($select[$handle]);
+                        $select[$handle] = $column;
+                    }
                 }
             }
         }

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1951,6 +1951,33 @@ class ElementQuery extends Query implements ElementQueryInterface
     }
 
     /**
+     * @inerhitdoc
+     */
+    protected function normalizeSelect($columns)
+    {
+        $select = parent::normalizeSelect($columns);
+        /** @var string|ElementInterface $class */
+        /** @phpstan-var class-string<ElementInterface>|ElementInterface $class */
+        $class = $this->elementType;
+        if ($class::hasContent() && isset($this->contentTable)) {
+            $this->customFields = $this->customFields();
+        }
+        // Swap in the actual field column name for custom fields
+        if (is_array($this->customFields)) {
+            foreach ($this->customFields as $field) {
+                $handle = $field->handle;
+                if (!empty($select[$handle])) {
+                    $column = ElementHelper::fieldColumnFromField($field);
+                    unset($select[$handle]);
+                    $select[$handle] = $column;
+                }
+            }
+        }
+
+        return $select;
+    }
+
+    /**
      * Returns any cache invalidation tags that caches involving this element query should use as dependencies.
      *
      * Use the most specific tag(s) possible, to reduce the likelihood of pointless cache clearing.


### PR DESCRIPTION
### Description

Currently, if you want to do something like:

```twig
    {% set result = craft.entries.section('blog').select(['plainText']).asArray().all() %}
```

...where `plainText` is a custom field handle, it won't work, because field columns in the content table have a prefix, and sometimes a suffix as well.

This makes it nigh impossible to do the above code from Twig, because you need to call `ElementHelper::fieldColumnFromField()` on the field handle to get the column, and `ElementHelper` isn't directly available in Twig.

This makes using `.select()` for optimal queries somewhat limited via Twig, as often what you care about is custom fields.

This PR leverages the existing `yii\db\Query::normalizeSelect()` method to swap in the real column name for custom fields (after Yii2 has already normalized them to an array), so the above "just works" and returns something like this:

```
[
    0 => [
        'plainText' => 'Some plain text'
    ]
]
```

It'll also "just work" via PHP as well. It only affects `ElementQuery`'s, and only when `.select()` is used, so it should be pretty unintrusive.