### PR TITLE
Increase element query performance for structures

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -2315,17 +2315,13 @@ class ElementQuery extends Query implements ElementQueryInterface
                     '[[structureelements.elementId]] = [[subquery.elementsId]]',
                     '[[structureelements.structureId]] = [[subquery.structureId]]',
                 ]);
-            $existsQuery = (new Query())
-                ->from([Table::STRUCTURES])
-                ->where('[[id]] = [[structureelements.structureId]]')
-                ->andWhere(['dateDeleted' => null]);
             $this->subQuery
                 ->addSelect(['structureelements.structureId'])
-                ->leftJoin(['structureelements' => Table::STRUCTUREELEMENTS], [
-                    'and',
-                    '[[structureelements.elementId]] = [[elements.id]]',
-                    ['exists', $existsQuery],
-                ]);
+                ->leftJoin(['structureelements' => Table::STRUCTUREELEMENTS], '[[structureelements.elementId]] = [[elements.id]]');
+            $this->subQuery
+                ->leftJoin(['structures' => Table::STRUCTURES], '[[structures.id]] = [[structureelements.structureId]]');
+            $this->subQuery
+                ->andWhere(['structures.dateDeleted' => null]);
         }
 
         if (isset($this->hasDescendants)) {


### PR DESCRIPTION
Replaced a filtering subquery with a left join for better query performance.

### Description
We started experiencing long load times when editing entries with pretty complex content models. I started doing some digging to see where are the bottlenecks. 

One area that we were able to improve was the element query when structures are involved. It appears that there is a `left join` with `structureelements` with a conditional that is a subquery. 

My understanding of the intent of the subquery is to filter out elements that are associated with structures that has been deleted. So I ended up recreating the same filter with a `left join` and an additional `where` condition that should do the same thing.

The change returns the same dataset across my testing, and performance was pretty dramatic in some cases. I had a query that returned 60 records that was taking 1 second to complete before update, and .02 sec after the update (our content may be overly complex...).

Please take a look at my proposed change and see if there's anything I missed.

