### PR TITLE
Support mapped columns in element query SELECTs

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -26,6 +26,7 @@
 - `users/session-info` responses now include a `csrfTokenName` key. ([#11706](https://github.com/craftcms/cms/pull/11706), [#11767](https://github.com/craftcms/cms/pull/11767))
 - Twig templates now have `today`, `tomorrow`, and `yesterday` global variables available to them.
 - Element query date params now support passing `today`, `tomorrow`, and `yesterday`. ([#10485](https://github.com/craftcms/cms/issues/10485))
+- Element queries now support passing ambiguous column names (e.g. `dateCreated`) and field handles into `select()`. ([#11790](https://github.com/craftcms/cms/pull/11790), [#11800](https://github.com/craftcms/cms/pull/11800))
 - `craft\helpers\Component::iconSvg()` now namespaces the SVG contents, and adds `aria-hidden="true"`. ([#11703](https://github.com/craftcms/cms/pull/11703))
 - `craft\services\Search::EVENT_BEFORE_INDEX_KEYWORDS` is now cancellable by setting `$event->isValid` to `false`. ([#11705](https://github.com/craftcms/cms/discussions/11705))
 - `checkboxSelect` inputs without `showAllOption: true` now post an empty value if no options were selected. ([#11748](https://github.com/craftcms/cms/issues/11748))

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -2756,16 +2756,21 @@ class ElementQuery extends Query implements ElementQueryInterface
         $select = [];
         $includeDefaults = false;
 
-        foreach ((array)$this->select as $key => $column) {
-            if ($key === '**') {
+        foreach ((array)$this->select as $alias => $column) {
+            if ($alias === '**') {
                 $includeDefaults = true;
             } else {
                 // Is this a mapped column name (without a custom alias)?
-                if ($key === $column && isset($columnMap[$key])) {
-                    $key = $column = $columnMap[$key];
+                if ($alias === $column && isset($columnMap[$alias])) {
+                    $column = $columnMap[$alias];
+
+                    // Completely ditch the mapped name if instantiated elements are going to be returned
+                    if (!$this->asArray) {
+                        $alias = $columnMap[$alias];
+                    }
                 }
 
-                $select[$key] = $column;
+                $select[$alias] = $column;
             }
         }
 


### PR DESCRIPTION
### Description

Element queries’ `orderBy()` methods currently support passing in “column names” that would cause an “ambiguous column” SQL error (e.g. `dateCreated` could refer to `elements.dateCreated` or `entries.dateCreated`) as well as custom field handles rather than the full field column name (`fooBar` instead of `field_fooBar_xxxxxxxx`), by mapping the ambiguous/incomplete column names to the correct ones.

This PR extends the same column mapping support to element queries’ `select()` methods, so the following would be possible:

```php
craft\elements\Entry::find()
    ->select(['dateCreated', 'fooBar'])
    ->asArray()
    ->all()
```

### Related issues

- #11790