### PR TITLE
Adds the craft cli as a composer bin file

### DIFF
--- a/bin/craft
+++ b/bin/craft
@@ -1,0 +1,32 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Craft console bootstrap file
+ */
+
+if (!empty($_composer_autoload_path)) {
+    $basePath = dirname($_composer_autoload_path) . '/../';
+}
+else {
+    $basePath = getcwd();
+}
+
+// Define path constants
+define('CRAFT_BASE_PATH', $basePath);
+define('CRAFT_VENDOR_PATH', CRAFT_BASE_PATH . '/vendor');
+
+// Load Composer's autoloader
+require_once CRAFT_VENDOR_PATH . '/autoload.php';
+
+// Load dotenv?
+if (class_exists(Dotenv\Dotenv::class)) {
+    // By default, this will allow .env file values to override environment variables
+    // with matching names. Use `createUnsafeImmutable` to disable this.
+    Dotenv\Dotenv::createUnsafeMutable(CRAFT_BASE_PATH)->safeLoad();
+}
+
+// Load and run Craft
+/** @var craft\console\Application $app */
+$app = require CRAFT_VENDOR_PATH . '/craftcms/cms/bootstrap/console.php';
+$exitCode = $app->run();
+exit($exitCode);

--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,9 @@
     "ext-imagick": "Adds support for more image processing formats and options.",
     "ext-iconv": "Adds support for more character encodings than PHP’s built-in mb_convert_encoding() function, which Craft will take advantage of when converting strings to UTF-8."
   },
+  "bin": [
+    "bin/craft"
+  ],
   "autoload": {
     "psr-4": {
       "craft\\": "src/",


### PR DESCRIPTION
There are some times (specifically during plugin development) where I don't need the full `craftcms/craft` setup and all I really need is the Craft CLI so I can run a queue or execute a one-off task. Adding the `bin` to `composer.json` ships the CLI with the `craftcms/cms` dev so dependent projects can easily run Craft via `./vendor/bin/craft install`, for example.

With the new Craft 4 ENV changes, too, I don't even need any `config/` dir or anything like that.

After this change it is possible (in a new directory) to do something like this and have a full Craft CLI running.

```sh
$ composer require craftcms/cms
$ CRAFT_DB_NAME=craft ./vendor/bin/craft install
```

Optionally, you could explore shortening the `craftcms/craft` CLI even more and just pointing to this in the vendor directory.

This is a proof of concept and for your consideration. There are probably downsides (but I can't think of them) and other changes that must be made before this merges in. Just something I was working on and found helpful of late.