### PR TITLE
Element authorization improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,11 +1,18 @@
 # Release Notes for Craft CMS 4.3 (WIP)
 
 ### Added
+- Added the `canCreateDrafts()` Twig function. ([#11797](https://github.com/craftcms/cms/discussions/11797), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added the `canDelete()` Twig function. ([#11797](https://github.com/craftcms/cms/discussions/11797), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added the `canDeleteForSite()` Twig function. ([#11797](https://github.com/craftcms/cms/discussions/11797), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added the `canDuplicate()` Twig function. ([#11797](https://github.com/craftcms/cms/discussions/11797), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added the `canSave()` Twig function. ([#11797](https://github.com/craftcms/cms/discussions/11797), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added the `canView()` Twig function. ([#11797](https://github.com/craftcms/cms/discussions/11797), [#11808](https://github.com/craftcms/cms/pull/11808))
 - Added the `|boolean` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added the `|float` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added the `|integer` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added the `|string` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added `craft\elements\actions\Restore::$restorableElementsOnly`.
+- Added `craft\events\AuthorizationCheckEvent::$element`.
 - Added `craft\events\CreateTwigEvent`.
 - Added `craft\events\DefineAddressFieldLabelEvent`.
 - Added `craft\events\DefineAddressFieldsEvent`.
@@ -20,6 +27,18 @@
 - Added `craft\services\Addresses::getFieldLabel()`.
 - Added `craft\services\Addresses::getUsedFields()`.
 - Added `craft\services\Addresses::getUsedSubdivisionFields()`.
+- Added `craft\services\Elements::EVENT_AUTHORIZE_CREATE_DRAFTS`. ([#11759](https://github.com/craftcms/cms/discussions/11759), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added `craft\services\Elements::EVENT_AUTHORIZE_DELETE_FOR_SITE`. ([#11759](https://github.com/craftcms/cms/discussions/11759), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added `craft\services\Elements::EVENT_AUTHORIZE_DELETE`. ([#11759](https://github.com/craftcms/cms/discussions/11759), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added `craft\services\Elements::EVENT_AUTHORIZE_DUPLICATE`. ([#11759](https://github.com/craftcms/cms/discussions/11759), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added `craft\services\Elements::EVENT_AUTHORIZE_SAVE`. ([#11759](https://github.com/craftcms/cms/discussions/11759), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added `craft\services\Elements::EVENT_AUTHORIZE_VIEW`. ([#11759](https://github.com/craftcms/cms/discussions/11759), [#11808](https://github.com/craftcms/cms/pull/11808))
+- Added `craft\services\Elements::canCreateDrafts()`.
+- Added `craft\services\Elements::canDelete()`.
+- Added `craft\services\Elements::canDeleteForSite()`.
+- Added `craft\services\Elements::canDuplicate()`.
+- Added `craft\services\Elements::canSave()`.
+- Added `craft\services\Elements::canView()`.
 - Added `craft\web\Controller::getCurrentUser()`. ([#11754](https://github.com/craftcms/cms/pull/11754))
 - Added `craft\web\View::EVENT_AFTER_CREATE_TWIG`. ([#11774](https://github.com/craftcms/cms/pull/11774))
 - Added the `Craft.useMobileStyles()` JavaScript method. ([#11636](https://github.com/craftcms/cms/pull/11636))
@@ -36,4 +55,10 @@
 - `checkboxSelect` inputs without `showAllOption: true` now post an empty value if no options were selected. ([#11748](https://github.com/craftcms/cms/issues/11748))
 
 ### Deprecated
+- Deprecated `craft\base\Element::EVENT_AUTHORIZE_CREATE_DRAFTS`. `craft\services\Elements::EVENT_AUTHORIZE_CREATE_DRAFTS` should be used instead.
+- Deprecated `craft\base\Element::EVENT_AUTHORIZE_DELETE_FOR_SITE`. `craft\services\Elements::EVENT_AUTHORIZE_DELETE_FOR_SITE` should be used instead.
+- Deprecated `craft\base\Element::EVENT_AUTHORIZE_DELETE`. `craft\services\Elements::EVENT_AUTHORIZE_DELETE` should be used instead.
+- Deprecated `craft\base\Element::EVENT_AUTHORIZE_DUPLICATE`. `craft\services\Elements::EVENT_AUTHORIZE_DUPLICATE` should be used instead.
+- Deprecated `craft\base\Element::EVENT_AUTHORIZE_SAVE`. `craft\services\Elements::EVENT_AUTHORIZE_SAVE` should be used instead.
+- Deprecated `craft\base\Element::EVENT_AUTHORIZE_VIEW`. `craft\services\Elements::EVENT_AUTHORIZE_VIEW` should be used instead.
 - Deprecated `craft\elements\Address::addressAttributeLabel()`. `craft\services\Addresses::getFieldLabel()` should be used instead.

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -370,6 +370,7 @@ abstract class Element extends Component implements ElementInterface
      *
      * @see canView()
      * @since 4.0.0
+     * @deprecated in 4.3.0. [[\craft\services\Elements::EVENT_AUTHORIZE_VIEW]] should be used instead.
      */
     public const EVENT_AUTHORIZE_VIEW = 'authorizeView';
 
@@ -390,6 +391,7 @@ abstract class Element extends Component implements ElementInterface
      *
      * @see canSave()
      * @since 4.0.0
+     * @deprecated in 4.3.0. [[\craft\services\Elements::EVENT_AUTHORIZE_SAVE]] should be used instead.
      */
     public const EVENT_AUTHORIZE_SAVE = 'authorizeSave';
 
@@ -410,6 +412,7 @@ abstract class Element extends Component implements ElementInterface
      *
      * @see canCreateDrafts()
      * @since 4.0.0
+     * @deprecated in 4.3.0. [[\craft\services\Elements::EVENT_AUTHORIZE_CREATE_DRAFTS]] should be used instead.
      */
     public const EVENT_AUTHORIZE_CREATE_DRAFTS = 'authorizeCreateDrafts';
 
@@ -430,6 +433,7 @@ abstract class Element extends Component implements ElementInterface
      *
      * @see canDuplicate()
      * @since 4.0.0
+     * @deprecated in 4.3.0. [[\craft\services\Elements::EVENT_AUTHORIZE_DUPLICATE]] should be used instead.
      */
     public const EVENT_AUTHORIZE_DUPLICATE = 'authorizeDuplicate';
 
@@ -450,6 +454,7 @@ abstract class Element extends Component implements ElementInterface
      *
      * @see canDelete()
      * @since 4.0.0
+     * @deprecated in 4.3.0. [[\craft\services\Elements::EVENT_AUTHORIZE_DELETE]] should be used instead.
      */
     public const EVENT_AUTHORIZE_DELETE = 'authorizeDelete';
 
@@ -470,6 +475,7 @@ abstract class Element extends Component implements ElementInterface
      *
      * @see canDeleteForSite()
      * @since 4.0.0
+     * @deprecated in 4.3.0. [[\craft\services\Elements::EVENT_AUTHORIZE_DELETE_FOR_SITE]] should be used instead.
      */
     public const EVENT_AUTHORIZE_DELETE_FOR_SITE = 'authorizeDeleteForSite';
 
@@ -2820,6 +2826,10 @@ abstract class Element extends Component implements ElementInterface
      */
     public function canView(User $user): bool
     {
+        if (!$this->hasEventHandlers(self::EVENT_AUTHORIZE_VIEW)) {
+            return false;
+        }
+
         $event = new AuthorizationCheckEvent($user);
         $this->trigger(self::EVENT_AUTHORIZE_VIEW, $event);
         return $event->authorized;
@@ -2830,6 +2840,10 @@ abstract class Element extends Component implements ElementInterface
      */
     public function canSave(User $user): bool
     {
+        if (!$this->hasEventHandlers(self::EVENT_AUTHORIZE_SAVE)) {
+            return false;
+        }
+
         $event = new AuthorizationCheckEvent($user);
         $this->trigger(self::EVENT_AUTHORIZE_SAVE, $event);
         return $event->authorized;
@@ -2840,6 +2854,10 @@ abstract class Element extends Component implements ElementInterface
      */
     public function canDuplicate(User $user): bool
     {
+        if (!$this->hasEventHandlers(self::EVENT_AUTHORIZE_DUPLICATE)) {
+            return false;
+        }
+
         $event = new AuthorizationCheckEvent($user);
         $this->trigger(self::EVENT_AUTHORIZE_DUPLICATE, $event);
         return $event->authorized;
@@ -2850,6 +2868,10 @@ abstract class Element extends Component implements ElementInterface
      */
     public function canDelete(User $user): bool
     {
+        if (!$this->hasEventHandlers(self::EVENT_AUTHORIZE_DELETE)) {
+            return false;
+        }
+
         $event = new AuthorizationCheckEvent($user);
         $this->trigger(self::EVENT_AUTHORIZE_DELETE, $event);
         return $event->authorized;
@@ -2860,6 +2882,10 @@ abstract class Element extends Component implements ElementInterface
      */
     public function canDeleteForSite(User $user): bool
     {
+        if (!$this->hasEventHandlers(self::EVENT_AUTHORIZE_DELETE_FOR_SITE)) {
+            return false;
+        }
+
         $event = new AuthorizationCheckEvent($user);
         $this->trigger(self::EVENT_AUTHORIZE_DELETE_FOR_SITE, $event);
         return $event->authorized;
@@ -2870,6 +2896,10 @@ abstract class Element extends Component implements ElementInterface
      */
     public function canCreateDrafts(User $user): bool
     {
+        if (!$this->hasEventHandlers(self::EVENT_AUTHORIZE_CREATE_DRAFTS)) {
+            return false;
+        }
+
         $event = new AuthorizationCheckEvent($user);
         $this->trigger(self::EVENT_AUTHORIZE_CREATE_DRAFTS, $event);
         return $event->authorized;

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -812,7 +812,7 @@ interface ElementInterface extends ComponentInterface
     public function canDeleteForSite(User $user): bool;
 
     /**
-     * Returns whether the given user is authorized to create drafts for thisc element.
+     * Returns whether the given user is authorized to create drafts for this element.
      *
      * This will only be called if the element can be [[canView()|viewed]].
      *

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -770,8 +770,6 @@ interface ElementInterface extends ComponentInterface
     /**
      * Returns whether the given user is authorized to save this element in its current form.
      *
-     * This will only be called if the element can be [[canView()|viewed]].
-     *
      * @param User $user
      * @return bool
      * @since 4.0.0
@@ -780,8 +778,6 @@ interface ElementInterface extends ComponentInterface
 
     /**
      * Returns whether the given user is authorized to duplicate this element.
-     *
-     * This will only be called if the element can be [[canSave()|viewed]] and [[canSave()|saved]].
      *
      * @param User $user
      * @return bool
@@ -803,8 +799,6 @@ interface ElementInterface extends ComponentInterface
     /**
      * Returns whether the given user is authorized to delete this element for its current site.
      *
-     * This will only be called if the element can be [[canView()|viewed]] and [[canDelete()|deleted]].
-     *
      * @param User $user
      * @return bool
      * @since 4.0.0
@@ -813,8 +807,6 @@ interface ElementInterface extends ComponentInterface
 
     /**
      * Returns whether the given user is authorized to create drafts for this element.
-     *
-     * This will only be called if the element can be [[canView()|viewed]].
      *
      * @param User $user
      * @return bool

--- a/src/controllers/AddressesController.php
+++ b/src/controllers/AddressesController.php
@@ -48,7 +48,7 @@ class AddressesController extends Controller
             throw new BadRequestHttpException("Invalid address ID: $addressId");
         }
 
-        if (!$address->canView($this->getCurrentUser())) {
+        if (!Craft::$app->getElements()->canView($address)) {
             throw new ForbiddenHttpException('User not authorized to view this address.');
         }
 

--- a/src/controllers/BaseEntriesController.php
+++ b/src/controllers/BaseEntriesController.php
@@ -75,14 +75,14 @@ abstract class BaseEntriesController extends Controller
             $entry->id = null;
         }
 
-        try {
-            if (!$entry->canSave($this->getCurrentUser())) {
-                throw new ForbiddenHttpException('User is not authorized to perform this action.');
-            }
-        } finally {
-            if ($duplicate) {
-                $entry->id = $id;
-            }
+        $canSave = Craft::$app->getElements()->canSave($entry);
+
+        if ($duplicate) {
+            $entry->id = $id;
+        }
+
+        if (!$canSave) {
+            throw new ForbiddenHttpException('User is not authorized to perform this action.');
         }
     }
 

--- a/src/controllers/CategoriesController.php
+++ b/src/controllers/CategoriesController.php
@@ -254,8 +254,6 @@ class CategoriesController extends Controller
             throw new ForbiddenHttpException('User not authorized to edit content in any sites.');
         }
 
-        $user = $this->getCurrentUser();
-
         // Create & populate the draft
         $category = Craft::createObject(Category::class);
         $category->siteId = $site->id;
@@ -268,7 +266,7 @@ class CategoriesController extends Controller
         }
 
         // Make sure the user is allowed to create this category
-        if (!$category->canSave($user)) {
+        if (!Craft::$app->getElements()->canSave($category)) {
             throw new ForbiddenHttpException('User not authorized to save this category.');
         }
 

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -134,7 +134,7 @@ class EntriesController extends BaseEntriesController
         }
 
         // Make sure the user is allowed to create this entry
-        if (!$entry->canSave($user)) {
+        if (!Craft::$app->getElements()->canSave($entry, $user)) {
             throw new ForbiddenHttpException('User not authorized to save this entry.');
         }
 

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1861,6 +1861,7 @@ JS,
      */
     public function actionSaveAddress(): ?Response
     {
+        $elementsService = Craft::$app->getElements();
         $user = $this->getCurrentUser();
         $userId = (int)($this->request->getBodyParam('userId') ?? $user->id);
         $addressId = $this->request->getBodyParam('addressId');
@@ -1881,7 +1882,7 @@ JS,
             ]);
         }
 
-        if (!$address->canSave($user)) {
+        if (!$elementsService->canSave($address, $user)) {
             throw new ForbiddenHttpException('User is not permitted to edit this address.');
         }
 
@@ -1902,7 +1903,7 @@ JS,
         $fieldsLocation = $this->request->getParam('fieldsLocation') ?? 'fields';
         $address->setFieldValuesFromRequest($fieldsLocation);
 
-        if (!Craft::$app->getElements()->saveElement($address)) {
+        if (!$elementsService->saveElement($address)) {
             return $this->asModelFailure($address, Craft::t('app', 'Couldn’t save {type}.', [
                 'type' => Address::lowerDisplayName(),
             ]), 'address');
@@ -1921,20 +1922,20 @@ JS,
      */
     public function actionDeleteAddress(): ?Response
     {
-        $user = $this->getCurrentUser();
         $addressId = $this->request->getRequiredBodyParam('addressId');
-
         $address = Address::findOne($addressId);
 
         if (!$address) {
             throw new BadRequestHttpException("Invalid address ID: $addressId");
         }
 
-        if (!$address->canDelete($user)) {
+        $elementsService = Craft::$app->getElements();
+
+        if (!$elementsService->canDelete($address)) {
             throw new ForbiddenHttpException('User is not permitted to delete this address.');
         }
 
-        if (!Craft::$app->getElements()->deleteElement($address)) {
+        if (!$elementsService->deleteElement($address)) {
             return $this->asModelFailure($address, Craft::t('app', 'Couldn’t delete {type}.', [
                 'type' => Address::lowerDisplayName(),
             ]), 'address');

--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -300,10 +300,16 @@ class Address extends Element implements AddressInterface, BlockElementInterface
      */
     public function canView(User $user): bool
     {
-        return (
-            parent::canView($user) ||
-            ($this->getOwner()?->getCanonical(true)->canView($user) ?? false)
-        );
+        if (parent::canView($user)) {
+            return true;
+        }
+
+        $owner = $this->getOwner()?->getCanonical(true);
+        if (!$owner) {
+            return false;
+        }
+
+        return Craft::$app->getElements()->canView($owner, $user);
     }
 
     /**
@@ -311,10 +317,16 @@ class Address extends Element implements AddressInterface, BlockElementInterface
      */
     public function canSave(User $user): bool
     {
-        return (
-            parent::canSave($user) ||
-            ($this->getOwner()?->getcanonical(true)->canSave($user) ?? false)
-        );
+        if (parent::canSave($user)) {
+            return true;
+        }
+
+        $owner = $this->getOwner()?->getCanonical(true);
+        if (!$owner) {
+            return false;
+        }
+
+        return Craft::$app->getElements()->canSave($owner, $user);
     }
 
     /**
@@ -322,10 +334,16 @@ class Address extends Element implements AddressInterface, BlockElementInterface
      */
     public function canDelete(User $user): bool
     {
-        return (
-            parent::canDelete($user) ||
-            ($this->getOwner()?->getCanonical(true)->canSave($user) ?? false)
-        );
+        if (parent::canDelete($user)) {
+            return true;
+        }
+
+        $owner = $this->getOwner()?->getCanonical(true);
+        if (!$owner) {
+            return false;
+        }
+
+        return Craft::$app->getElements()->canDelete($owner, $user);
     }
 
     /**

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -604,9 +604,11 @@ class Category extends Element
             ],
         ];
 
+        $elementsService = Craft::$app->getElements();
         $user = Craft::$app->getUser()->getIdentity();
+
         foreach ($this->getCanonical()->getAncestors()->all() as $ancestor) {
-            if ($ancestor->canView($user)) {
+            if ($elementsService->canView($ancestor, $user)) {
                 $crumbs[] = [
                     'label' => $ancestor->title,
                     'url' => $ancestor->getCpEditUrl(),

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1454,9 +1454,11 @@ class Entry extends Element
             ];
 
             if ($section->type === Section::TYPE_STRUCTURE) {
+                $elementsService = Craft::$app->getElements();
                 $user = Craft::$app->getUser()->getIdentity();
+
                 foreach ($this->getCanonical()->getAncestors()->all() as $ancestor) {
-                    if ($ancestor->canView($user)) {
+                    if ($elementsService->canView($ancestor, $user)) {
                         $crumbs[] = [
                             'label' => $ancestor->title,
                             'url' => $ancestor->getCpEditUrl(),

--- a/src/elements/actions/Delete.php
+++ b/src/elements/actions/Delete.php
@@ -174,13 +174,13 @@ JS, [static::class]);
         $user = Craft::$app->getUser()->getIdentity();
 
         foreach ($query->all() as $element) {
-            if (!$element->canDelete($user)) {
+            if (!$elementsService->canDelete($element, $user)) {
                 continue;
             }
             if (!isset($deletedElementIds[$element->id])) {
                 if ($withDescendants) {
                     foreach ($element->getDescendants()->all() as $descendant) {
-                        if (!isset($deletedElementIds[$descendant->id]) && $descendant->canDelete($user)) {
+                        if (!isset($deletedElementIds[$descendant->id]) && $elementsService->canDelete($descendant, $user)) {
                             $elementsService->deleteElement($descendant);
                             $deletedElementIds[$descendant->id] = true;
                         }

--- a/src/elements/actions/DeleteAssets.php
+++ b/src/elements/actions/DeleteAssets.php
@@ -81,7 +81,7 @@ JS, [static::class]);
 
         try {
             foreach ($query->all() as $asset) {
-                if ($asset->canDelete($user)) {
+                if ($elementsService->canDelete($asset, $user)) {
                     $elementsService->deleteElement($asset);
                 }
             }

--- a/src/elements/actions/DeleteForSite.php
+++ b/src/elements/actions/DeleteForSite.php
@@ -119,7 +119,7 @@ JS, [static::class]);
 
             // Resave the elements
             foreach ($otherSiteElements as $element) {
-                if (!$element->canDelete($user)) {
+                if (!$elementsService->canDelete($element, $user)) {
                     continue;
                 }
 
@@ -135,11 +135,9 @@ JS, [static::class]);
             ->all();
 
         foreach ($singleSiteElements as $element) {
-            if (!$element->canDelete($user)) {
-                continue;
+            if ($elementsService->canDelete($element, $user)) {
+                $elementsService->deleteElement($element);
             }
-
-            $elementsService->deleteElement($element);
         }
 
         if (isset($this->successMessage)) {

--- a/src/events/AuthorizationCheckEvent.php
+++ b/src/events/AuthorizationCheckEvent.php
@@ -7,6 +7,7 @@
 
 namespace craft\events;
 
+use craft\base\ElementInterface;
 use craft\elements\User;
 use yii\base\Event;
 
@@ -31,12 +32,21 @@ class AuthorizationCheckEvent extends Event
     }
 
     /**
+     * @var ElementInterface|null The element being authorized.
+     *
+     * This will only be set if the event was triggered from [[\craft\services\Elements]].
+     *
+     * @since 4.3.0
+     */
+    public ?ElementInterface $element = null;
+
+    /**
      * @var User The user to be authorized.
      */
     public User $user;
 
     /**
-     * @var bool Whether the user is authorized.
+     * @var bool|null Whether the user is authorized.
      */
-    public bool $authorized = false;
+    public ?bool $authorized = false;
 }

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -356,16 +356,18 @@ class Cp
         $user = Craft::$app->getUser()->getIdentity();
 
         if ($user) {
-            if ($element->canView($user)) {
+            $elementsService = Craft::$app->getElements();
+
+            if ($elementsService->canView($element, $user)) {
                 $attributes['data']['editable'] = true;
             }
 
             if ($context === 'index') {
-                if ($element->canSave($user)) {
+                if ($elementsService->canSave($element, $user)) {
                     $attributes['data']['savable'] = true;
                 }
 
-                if ($element->canDelete($user)) {
+                if ($elementsService->canDelete($element, $user)) {
                     $attributes['data']['deletable'] = true;
                 }
             }
@@ -1180,7 +1182,7 @@ JS, [
             'name' => null,
         ];
 
-        $canDelete = $address->canDelete(Craft::$app->getUser()->getIdentity());
+        $canDelete = Craft::$app->getElements()->canDelete($address);
         $actionMenuId = sprintf('address-card-action-menu-%s', mt_rand());
 
         return

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -347,7 +347,7 @@ class ElementHelper
     {
         $user = Craft::$app->getUser()->getIdentity();
 
-        if ($element->canView($user)) {
+        if ($user && Craft::$app->getElements()->canView($element, $user)) {
             if (!Craft::$app->getIsMultiSite()) {
                 return true;
             }
@@ -373,7 +373,7 @@ class ElementHelper
         $siteIds = [];
         $user = Craft::$app->getUser()->getIdentity();
 
-        if ($element->canView($user)) {
+        if ($user && Craft::$app->getElements()->canView($element, $user)) {
             if (Craft::$app->getIsMultiSite()) {
                 foreach (static::supportedSitesForElement($element) as $siteInfo) {
                     if ($user->can(sprintf('editSite:%s', $siteInfo['siteUid']))) {

--- a/src/templates/_includes/revisionmenu.twig
+++ b/src/templates/_includes/revisionmenu.twig
@@ -13,7 +13,7 @@
     .status(null)
     .orderBy({dateUpdated: SORT_DESC})
     .with(['draftCreator'])
-    .all()|filter(d => craft.app.elements.canView(d)) : [] %}
+    .all()|filter(d => canView(d)) : [] %}
 
 {% set maxRevisions = craft.app.config.general.maxRevisions %}
 {% if element.id and (not maxRevisions or maxRevisions > 1) %}

--- a/src/templates/_includes/revisionmenu.twig
+++ b/src/templates/_includes/revisionmenu.twig
@@ -13,7 +13,7 @@
     .status(null)
     .orderBy({dateUpdated: SORT_DESC})
     .with(['draftCreator'])
-    .all()|filter(d => d.canView(currentUser)) : [] %}
+    .all()|filter(d => craft.app.elements.canView(d)) : [] %}
 
 {% set maxRevisions = craft.app.config.general.maxRevisions %}
 {% if element.id and (not maxRevisions or maxRevisions > 1) %}

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -10,10 +10,12 @@ namespace craft\web\twig;
 use CommerceGuys\Addressing\Formatter\FormatterInterface;
 use Countable;
 use Craft;
+use craft\base\ElementInterface;
 use craft\base\MissingComponentInterface;
 use craft\base\PluginInterface;
 use craft\elements\Address;
 use craft\elements\Asset;
+use craft\elements\User;
 use craft\errors\AssetException;
 use craft\helpers\App;
 use craft\helpers\ArrayHelper;
@@ -1242,6 +1244,14 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFunction('shuffle', [$this, 'shuffleFunction']),
             new TwigFunction('siteUrl', [UrlHelper::class, 'siteUrl']),
             new TwigFunction('url', [UrlHelper::class, 'url']),
+
+            // Element authorization functions
+            new TwigFunction('canCreateDrafts', fn(ElementInterface $element, ?User $user = null) => Craft::$app->getElements()->canCreateDrafts($element, $user)),
+            new TwigFunction('canDelete', fn(ElementInterface $element, ?User $user = null) => Craft::$app->getElements()->canDelete($element, $user)),
+            new TwigFunction('canDeleteForSite', fn(ElementInterface $element, ?User $user = null) => Craft::$app->getElements()->canDeleteForSite($element, $user)),
+            new TwigFunction('canDuplicate', fn(ElementInterface $element, ?User $user = null) => Craft::$app->getElements()->canDuplicate($element, $user)),
+            new TwigFunction('canSave', fn(ElementInterface $element, ?User $user = null) => Craft::$app->getElements()->canSave($element, $user)),
+            new TwigFunction('canView', fn(ElementInterface $element, ?User $user = null) => Craft::$app->getElements()->canView($element, $user)),
 
             // HTML generation functions
             new TwigFunction('actionInput', [Html::class, 'actionInput'], ['is_safe' => ['html']]),


### PR DESCRIPTION
This PR adds element authorization-check methods and events to the Elements service, with the same names as their `craft\base\Element` counterparts:

- `craft\services\Elements::canView()` + `EVENT_AUTHORIZE_VIEW`
- `craft\services\Elements::canSave()` + `EVENT_AUTHORIZE_SAVE`
- `craft\services\Elements::canDuplicate()` + `EVENT_AUTHORIZE_DUPLICATE`
- `craft\services\Elements::canDelete()` + `EVENT_AUTHORIZE_DELETE`
- `craft\services\Elements::canDeleteForSite()` + `EVENT_AUTHORIZE_DELETE_FOR_SITE`
- `craft\services\Elements::canCreateDrafts()` + `EVENT_AUTHORIZE_CREATE_DRAFTS`

There are two notable differences between these and the authorization methods/events on `craft\base\Element`:

- The methods’ `$user` argument is optional. If `null`, it will default to the currently logged-in user, or return `false` if there isn’t one.
- `AuthorizationCheckEvent::$authorized` is set to `null` by default, and the methods will only defer to the element’s corresponding `canX()` method if an event handler hasn’t explicitly set it to `true` or `false`. Which means event handlers have the ability to _prevent_ users from being authorized for certain actions, as opposed to only being able to authorize them (see #11759).

All internal authorization checks have been updated to call the new Elements service methods. And the old events on `craft\base\Element` are now deprecated, since they’re redundant and less useful.

Finally, there’s new global Twig functions that wrap the new Elements service methods, making it a lot easier to check if the current user is authorized to do something with an element: (#11797)

```twig
{% if not canView(entry) %}
    {% redirect siteUrl %}
{% endif %}
```