### PR TITLE
Fix bug in DateTimeHelper::toDateInterval

### DIFF
--- a/src/helpers/DateTimeHelper.php
+++ b/src/helpers/DateTimeHelper.php
@@ -488,8 +488,8 @@ class DateTimeHelper
         if (is_numeric($value)) {
             // Use DateTime::diff() so the years/months/days/hours/minutes values are all populated correctly
             $now = static::now();
-            $then = (clone $now)->modify("-$value seconds");
-            return $then->diff($now);
+            $then = (clone $now)->modify("+$value seconds");
+            return $now->diff($then);
         }
 
         if (is_string($value)) {

--- a/src/helpers/DateTimeHelper.php
+++ b/src/helpers/DateTimeHelper.php
@@ -488,7 +488,7 @@ class DateTimeHelper
         if (is_numeric($value)) {
             // Use DateTime::diff() so the years/months/days/hours/minutes values are all populated correctly
             $now = static::now();
-            $then = (clone $now)->modify("+$value seconds");
+            $then = (clone $now)->modify("-$value seconds");
             return $then->diff($now);
         }
 

--- a/tests/unit/helpers/DateTimeHelperTest.php
+++ b/tests/unit/helpers/DateTimeHelperTest.php
@@ -345,6 +345,19 @@ class DateTimeHelperTest extends TestCase
     }
 
     /**
+     * @dataProvider toDateIntervalDataProvider
+     * @param int $shortResult
+     * @param int $longResult
+     * @param int $input
+     */
+    public function testToDateInterval(int $shortResult, int $longResult, int $input): void
+    {
+        $interval = DateTimeHelper::toDateInterval($input);
+        self::assertSame($shortResult, $interval->s);
+        self::assertSame($longResult, (int)$interval->format('%s%d%h%m'));
+    }
+
+    /**
      * @dataProvider secondsToIntervalDataProvider
      * @param int $shortResult
      * @param int $longResult
@@ -690,6 +703,18 @@ class DateTimeHelperTest extends TestCase
             ['27 minutes', 'PT10M999S'],
             ['0 seconds', 0],
             ['less than a minute', 0, false],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function testToDateIntervalDataProvider(): array
+    {
+        return [
+            [10, 10000, 10],
+            [0, 0000, 0],
+            [928172, 928172000, 928172],
         ];
     }
 

--- a/tests/unit/helpers/DateTimeHelperTest.php
+++ b/tests/unit/helpers/DateTimeHelperTest.php
@@ -346,8 +346,7 @@ class DateTimeHelperTest extends TestCase
 
     /**
      * @dataProvider toDateIntervalDataProvider
-     * @param int $shortResult
-     * @param int $longResult
+     * @param int $result
      * @param int $input
      */
     public function testToDateInterval(int $result, int $input): void

--- a/tests/unit/helpers/DateTimeHelperTest.php
+++ b/tests/unit/helpers/DateTimeHelperTest.php
@@ -350,11 +350,10 @@ class DateTimeHelperTest extends TestCase
      * @param int $longResult
      * @param int $input
      */
-    public function testToDateInterval(int $shortResult, int $longResult, int $input): void
+    public function testToDateInterval(int $result, int $input): void
     {
         $interval = DateTimeHelper::toDateInterval($input);
-        self::assertSame($shortResult, $interval->s);
-        self::assertSame($longResult, (int)$interval->format('%s%d%h%m'));
+        self::assertSame($result, DateTimeHelper::intervalToSeconds($interval));
     }
 
     /**
@@ -712,9 +711,7 @@ class DateTimeHelperTest extends TestCase
     public function toDateIntervalDataProvider(): array
     {
         return [
-            [10, 10000, 10],
-            [0, 0000, 0],
-            [928172, 928172000, 928172],
+            [10, 10],
         ];
     }
 

--- a/tests/unit/helpers/DateTimeHelperTest.php
+++ b/tests/unit/helpers/DateTimeHelperTest.php
@@ -709,7 +709,7 @@ class DateTimeHelperTest extends TestCase
     /**
      * @return array
      */
-    public function testToDateIntervalDataProvider(): array
+    public function toDateIntervalDataProvider(): array
     {
         return [
             [10, 10000, 10],


### PR DESCRIPTION
When given an integer, the `DateTimeHelper::toDateInterval` method returns a negative interval (in the past). This can be verified using the following code.

```php
// Outputs -3600 instead of the expected 3600.
Craft::dd(
    DateTimeHelper::intervalToSeconds(
        DateTimeHelper::toDateInterval(3600)
    )
);
```

One of the consequences of this is that the "Keep me signed in" checkbox on the login page has no effect by default. Since `GeneralConfig::rememberedUserSessionDuration` is set to `1209600`, it is evaluated as `-1209600`, which is 2 weeks in the past.

This PR fixes the bug by replacing `$then->diff($now)` with `$now->diff($then)`. I've also added a unit test to validate this.