### PR TITLE
Use index hints to specify index so Mysql does not select the less pe…

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -2315,8 +2315,16 @@ class ElementQuery extends Query implements ElementQueryInterface
                     '[[structureelements.elementId]] = [[subquery.elementsId]]',
                     '[[structureelements.structureId]] = [[subquery.structureId]]',
                 ]);
-            $existsQuery = (new Query())
-                ->from([Table::STRUCTURES])
+            // Use index hints to specify index so Mysql does not select the less
+            // performant index.
+            if (Craft::$app->getDb()->getIsMysql()) {
+                $existsQuery = (new Query())
+                    ->from([new Expression('[[structures]] use index(primary)')]);
+            } else {
+                $existsQuery = (new Query())
+                    ->from([Table::STRUCTURES]);
+            }
+            $existsQuery
                 ->where('[[id]] = [[structureelements.structureId]]')
                 ->andWhere(['dateDeleted' => null]);
             $this->subQuery

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -2316,7 +2316,7 @@ class ElementQuery extends Query implements ElementQueryInterface
                     '[[structureelements.structureId]] = [[subquery.structureId]]',
                 ]);
             // Use index hints to specify index so Mysql does not select the less
-            // performant index.
+            // performant one (dateDeleted).
             if (Craft::$app->getDb()->getIsMysql()) {
                 $existsQuery = (new Query())
                     ->from([new Expression('[[structures]] use index(primary)')]);


### PR DESCRIPTION
…rformant index.

### Description
Mysql is using the wrong index in a subquery for `structures` table when there are a lot of records. The result is that the overall query gets super slow to complete. This is compounded by the fact that the subquery is used in multiple places in the control panel, and sometimes multiple times in a single request.

The recent entries widget is one place where the query is used and below is an example of load time:
![6iiKw (1)](https://user-images.githubusercontent.com/669140/186461554-63e3726a-8dab-4000-9e6c-1288384f2734.png)

And here is the difference after applying index hint:
![image](https://user-images.githubusercontent.com/669140/186461915-2e9f063f-8fbe-4b68-8b23-183bf59fcbe4.png)

To be fair, the above example is an extreme one, but I'm seeing improvement in other problematic areas as well (edit pages of complex entries).

The proposed code change should not be very disruptive, and should be very specific to the `exist` subquery and also only when using MySQL db.
