### PR TITLE
Set default interlace type

### DIFF
--- a/src/helpers/ImageTransforms.php
+++ b/src/helpers/ImageTransforms.php
@@ -62,7 +62,7 @@ class ImageTransforms
             'mode' => $matches['mode'],
             'position' => $matches['position'],
             'quality' => $matches['quality'] ?? null,
-            'interlace' => $matches['interlace'],
+            'interlace' => $matches['interlace'] ?? 'none',
             'transformer' => ImageTransform::DEFAULT_TRANSFORMER,
         ]);
     }


### PR DESCRIPTION
### Description

If you have old transformation strings in your imagetransformationindex table, which do not include the interlace type, the transformation fails with an exception. With the default value the transformation is processed as expected.
