### PR TITLE
Cache {% html %} tag output

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -50,6 +50,7 @@
 - Twig templates now have `today`, `tomorrow`, and `yesterday` global variables available to them.
 - Element query date params now support passing `today`, `tomorrow`, and `yesterday`. ([#10485](https://github.com/craftcms/cms/issues/10485))
 - Element queries now support passing ambiguous column names (e.g. `dateCreated`) and field handles into `select()`. ([#11790](https://github.com/craftcms/cms/pull/11790), [#11800](https://github.com/craftcms/cms/pull/11800))
+- `{% cache %}` tags now store any HTML registered with `{% html %}` tags. ([#11811](https://github.com/craftcms/cms/discussions/11811))
 - `craft\helpers\Component::iconSvg()` now namespaces the SVG contents, and adds `aria-hidden="true"`. ([#11703](https://github.com/craftcms/cms/pull/11703))
 - `craft\services\Search::EVENT_BEFORE_INDEX_KEYWORDS` is now cancellable by setting `$event->isValid` to `false`. ([#11705](https://github.com/craftcms/cms/discussions/11705))
 - `checkboxSelect` inputs without `showAllOption: true` now post an empty value if no options were selected. ([#11748](https://github.com/craftcms/cms/issues/11748))

--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -62,7 +62,7 @@ class TemplateCaches extends Component
             return null;
         }
 
-        [$body, $tags, $bufferedJs, $bufferedScripts, $bufferedCss, $bufferedJsFiles, $bufferedCssFiles] = array_pad($data, 7, null);
+        [$body, $tags, $bufferedJs, $bufferedScripts, $bufferedCss, $bufferedJsFiles, $bufferedCssFiles, $bufferedHtml] = array_pad($data, 8, null);
 
         // If we're actively collecting element cache tags, add this cache's tags to the collection
         Craft::$app->getElements()->collectCacheTags($tags);
@@ -75,6 +75,7 @@ class TemplateCaches extends Component
                 $bufferedCss ?? [],
                 $bufferedJsFiles ?? [],
                 $bufferedCssFiles ?? [],
+                $bufferedHtml ?? []
             );
         }
 
@@ -86,9 +87,9 @@ class TemplateCaches extends Component
      *
      * @param bool $withResources Whether JS and CSS code registered with [[\craft\web\View::registerJs()]],
      * [[\craft\web\View::registerScript()]], [[\craft\web\View::registerCss()]],
-     * [[\craft\web\View::registerJsFile()]], and [[\craft\web\View::registerCssFile()]] should be captured and
-     * included in the cache. If this is `true`, be sure to pass `$withResources = true` to [[endTemplateCache()]]
-     * as well.
+     * [[\craft\web\View::registerJsFile()]], [[\craft\web\View::registerCssFile()]], and [[\craft\web\View::registerHtml()]]
+     * should be captured and included in the cache. If this is `true`, be sure to pass `$withResources = true`
+     * to [[endTemplateCache()]] as well.
      * @param bool $global Whether the cache should be stored globally.
      */
     public function startTemplateCache(bool $withResources = false, bool $global = false): void
@@ -107,6 +108,7 @@ class TemplateCaches extends Component
             $view->startCssBuffer();
             $view->startJsFileBuffer();
             $view->startCssFileBuffer();
+            $view->startHtmlBuffer();
         }
     }
 
@@ -120,8 +122,8 @@ class TemplateCaches extends Component
      * @param string $body The contents of the cache.
      * @param bool $withResources Whether JS and CSS code registered with [[\craft\web\View::registerJs()]],
      * [[\craft\web\View::registerScript()]], [[\craft\web\View::registerCss()]],
-     * [[\craft\web\View::registerJsFile()]], and [[\craft\web\View::registerCssFile()]] should be captured
-     * and included in the cache.
+     * [[\craft\web\View::registerJsFile()]], [[\craft\web\View::registerCssFile()]], and [[\craft\web\View::registerHtml()]]
+     * should be captured and included in the cache.
      * @throws Exception if this is a console request and `false` is passed to `$global`
      * @throws Throwable
      */
@@ -141,6 +143,7 @@ class TemplateCaches extends Component
             $bufferedCss = $view->clearCssBuffer();
             $bufferedJsFiles = $view->clearJsFileBuffer();
             $bufferedCssFiles = $view->clearCssFileBuffer();
+            $bufferedHtml = $view->clearHtmlBuffer();
         }
 
         // If there are any transform generation URLs in the body, don't cache it.
@@ -162,11 +165,11 @@ class TemplateCaches extends Component
             $bufferedCssFiles = $this->_parseExternalResourceTags($bufferedCssFiles, 'href');
 
             if ($saveCache) {
-                array_push($cacheValue, $bufferedJs, $bufferedScripts, $bufferedCss, $bufferedJsFiles, $bufferedCssFiles);
+                array_push($cacheValue, $bufferedJs, $bufferedScripts, $bufferedCss, $bufferedJsFiles, $bufferedCssFiles, $bufferedHtml);
             }
 
             // Re-register the JS and CSS
-            $this->_registerResources($bufferedJs, $bufferedScripts, $bufferedCss, $bufferedJsFiles, $bufferedCssFiles);
+            $this->_registerResources($bufferedJs, $bufferedScripts, $bufferedCss, $bufferedJsFiles, $bufferedCssFiles, $bufferedHtml);
         }
 
         if (!$saveCache) {
@@ -219,6 +222,7 @@ class TemplateCaches extends Component
         array $bufferedCss,
         array $bufferedJsFiles,
         array $bufferedCssFiles,
+        array $bufferedHtml
     ): void {
         $view = Craft::$app->getView();
 
@@ -247,6 +251,12 @@ class TemplateCaches extends Component
 
         foreach ($bufferedCssFiles as $key => [$url, $options]) {
             $view->registerCssFile($url, $options, $key);
+        }
+
+        foreach ($bufferedHtml as $pos => $tags) {
+            foreach ($tags as $key => $html) {
+                $view->registerHtml($html, $pos, $key);
+            }
         }
     }
 

--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -222,7 +222,7 @@ class TemplateCaches extends Component
         array $bufferedCss,
         array $bufferedJsFiles,
         array $bufferedCssFiles,
-        array $bufferedHtml
+        array $bufferedHtml,
     ): void {
         $view = Craft::$app->getView();
 

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -256,6 +256,13 @@ class View extends \yii\web\View
     private array $_jsFileBuffers = [];
 
     /**
+     * @var array
+     * @see startHtmlBuffer()
+     * @see clearHtmlBuffer()
+     */
+    private array $_htmlBuffers = [];
+
+    /**
      * @var array|null the registered generic `<script>` code blocks
      * @see registerScript()
      */
@@ -265,7 +272,7 @@ class View extends \yii\web\View
      * @var array the registered generic HTML code blocks
      * @see registerHtml()
      */
-    private array $_html;
+    private array $_html = [];
 
     /**
      * @var callable[][]
@@ -1150,6 +1157,34 @@ class View extends \yii\web\View
         }
 
         return $bufferedJsFiles;
+    }
+
+    /**
+     * Starts a buffer for any html tags registered with [[registerHtml()]].
+     *
+     * @return void
+     */
+    public function startHtmlBuffer(): void
+    {
+        $this->_htmlBuffers[] = $this->_html;
+        $this->_html = [];
+    }
+
+    /**
+     * Clears and ends a buffer started via [[startHtmlBuffer()]], returning any html tags that were registered
+     * while the buffer was active.
+     *
+     * @return array|false The html that was registered while the buffer was active or `false` if there wasn't an active buffer.
+     */
+    public function clearHtmlBuffer(): array|false
+    {
+        if (empty($this->_htmlBuffers)) {
+            return false;
+        }
+
+        $bufferedHtml = $this->_html;
+        $this->_html = array_pop($this->_htmlBuffers);
+        return $bufferedHtml;
     }
 
     /**

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -1162,7 +1162,7 @@ class View extends \yii\web\View
     /**
      * Starts a buffer for any html tags registered with [[registerHtml()]].
      *
-     * @return void
+     * @since 4.3.0
      */
     public function startHtmlBuffer(): void
     {
@@ -1175,6 +1175,7 @@ class View extends \yii\web\View
      * while the buffer was active.
      *
      * @return array|false The html that was registered while the buffer was active or `false` if there wasn't an active buffer.
+     * @since 4.3.0
      */
     public function clearHtmlBuffer(): array|false
     {


### PR DESCRIPTION
### Description
Keeps track of `html` tags used within cache tags so they can be output appropriately. 


### Related issues
#11811 