### PR TITLE
ActiveQuery::collect()

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -11,6 +11,7 @@
 - Added the `|float` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added the `|integer` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added the `|string` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
+- Added `craft\db\ActiveQuery::collect()`. ([#11842](https://github.com/craftcms/cms/pull/11842))
 - Added `craft\elements\actions\Restore::$restorableElementsOnly`.
 - Added `craft\events\AuthorizationCheckEvent::$element`.
 - Added `craft\events\CreateTwigEvent`.

--- a/src/db/ActiveQuery.php
+++ b/src/db/ActiveQuery.php
@@ -7,6 +7,9 @@
 
 namespace craft\db;
 
+use Illuminate\Support\Collection;
+use yii\db\Connection as YiiConnection;
+
 /**
  * Active Query class.
  *
@@ -16,6 +19,19 @@ namespace craft\db;
  */
 class ActiveQuery extends \yii\db\ActiveQuery
 {
+    /**
+     * Executes the query and returns all results as a collection.
+     *
+     * @param YiiConnection|null $db The database connection used to generate the SQL statement.
+     * If null, the DB connection returned by [[modelClass]] will be used.
+     * @return Collection A collection of the resulting records.
+     * @since 4.3.0
+     */
+    public function collect(?YiiConnection $db = null): Collection
+    {
+        return Collection::make($this->all($db));
+    }
+
     /**
      * Returns the table alias for [[modelClass]].
      *


### PR DESCRIPTION
Adds a `collect()` method to `craft\db\ActiveQuery`, which returns a collection of the resulting records, similar to `craft\db\Query::collect()`.

```php
use craft\records\Entry as EntryRecord;

$collection = EntryRecord::find()
    ->where(['sectionId' => 10])
    ->collect();
```