### PR TITLE
Properly calculate height of transformed images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-- Fixed an issue where image dimensions could be calculated incorrectly. ([#11837](https://github.com/craftcms/cms/issues/11837)) 
+- Fixed an bug where image transform dimensions could be calculated incorrectly when `upscaleImages` was `false`. ([#11837](https://github.com/craftcms/cms/issues/11837))
 
 ## 3.7.53.1 - 2022-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft CMS 3.x
 
+## Unreleased
+
+### Fixed
+- Fixed an issue where image dimensions could be calculated incorrectly. ([#11837](https://github.com/craftcms/cms/issues/11837)) 
+
 ## 3.7.53.1 - 2022-08-26
 
 ### Fixed

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2198,7 +2198,7 @@ class Asset extends Element
                 return [$this->_width, $this->_height];
             }
 
-            return $transformRatio > 1 ? [$this->_width, round($this->_height / $transformRatio)] : [round($this->_width * $transformRatio), $this->_height];
+            return $transformRatio > 1 ? [$this->_width, round($this->_width / $transformRatio)] : [round($this->_width * $transformRatio), $this->_height];
         }
 
         [$width, $height] = Image::calculateMissingDimension($transform->width, $transform->height, $this->_width, $this->_height);


### PR DESCRIPTION
### Description
Fixes an issue where the height of a non-cropped image being transformed was being calculated as a percentage of the height rather than of the width.


### Related issues
#11837
