### PR TITLE
Properly calculate height of transformed images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed an error that could occur when upgrading to Craft 4, if any Matrix blocks contained null `sortOrder` values. ([#11843](https://github.com/craftcms/cms/issues/11843))
+- Fixed an issue where image dimensions could be calculated incorrectly when `upscaleImages` was false ([#11837](https://github.com/craftcms/cms/issues/11837))
 
 ## 4.2.3 - 2022-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Fixed an error that could occur when upgrading to Craft 4, if any Matrix blocks contained null `sortOrder` values. ([#11843](https://github.com/craftcms/cms/issues/11843))
-- Fixed an issue where image dimensions could be calculated incorrectly when `upscaleImages` was false ([#11837](https://github.com/craftcms/cms/issues/11837))
+- Fixed an bug where image transform dimensions could be calculated incorrectly when `upscaleImages` was `false`. ([#11837](https://github.com/craftcms/cms/issues/11837))
 
 ## 4.2.3 - 2022-08-26
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2571,7 +2571,7 @@ JS;
                 return [$this->_width, $this->_height];
             }
 
-            return $transformRatio > 1 ? [$this->_width, round($this->_height / $transformRatio)] : [round($this->_width * $transformRatio), $this->_height];
+            return $transformRatio > 1 ? [$this->_width, round($this->_width / $transformRatio)] : [round($this->_width * $transformRatio), $this->_height];
         }
 
         [$width, $height] = Image::calculateMissingDimension($transform->width, $transform->height, $this->_width, $this->_height);


### PR DESCRIPTION
Fixes an issue where the height of a non-cropped image being transformed was being calculated as a percentage of the height rather than of the width.

#11837
