### PR TITLE
Bugfix/global extension loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Fixed a bug where image transform dimensions could be calculated incorrectly when `upscaleImages` was `false`. ([#11837](https://github.com/craftcms/cms/issues/11837))
 - Fixed a bug where element caches weren’t being invalidated during garbage collection, so hard-deleted elements could appear to still exist.
+- Prevent loading `\craft\web\twig\GlobalsExtension()` before Craft has been installed ([#11855](https://github.com/craftcms/cms/issues/11855))
 
 ## 3.7.53.1 - 2022-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 - Fixed a bug where image transform dimensions could be calculated incorrectly when `upscaleImages` was `false`. ([#11837](https://github.com/craftcms/cms/issues/11837))
 - Fixed a bug where element caches weren’t being invalidated during garbage collection, so hard-deleted elements could appear to still exist.
-- Prevent loading `\craft\web\twig\GlobalsExtension()` before Craft has been installed ([#11855](https://github.com/craftcms/cms/issues/11855))
+- Fixed an error that could occur when rendering front-end templates if there was a problem connecting to the database. ([#11855](https://github.com/craftcms/cms/issues/11855))
 
 ## 3.7.53.1 - 2022-08-26
 

--- a/src/web/Application.php
+++ b/src/web/Application.php
@@ -568,7 +568,7 @@ class Application extends \yii\web\Application
         // Should they be accessing the installer?
         if (!$isInstalled) {
             if (!$isCpRequest) {
-                throw new ServiceUnavailableHttpException(Craft::t('app', 'Craft isn’t installed yet.'));
+                throw new ServiceUnavailableHttpException();
             }
 
             // Redirect to the installer if Dev Mode is enabled

--- a/src/web/Application.php
+++ b/src/web/Application.php
@@ -568,7 +568,7 @@ class Application extends \yii\web\Application
         // Should they be accessing the installer?
         if (!$isInstalled) {
             if (!$isCpRequest) {
-                throw new ServiceUnavailableHttpException();
+                throw new ServiceUnavailableHttpException(Craft::t('app', 'Craft isn’t installed yet.'));
             }
 
             // Redirect to the installer if Dev Mode is enabled

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -318,7 +318,7 @@ class View extends \yii\web\View
 
         if ($this->_templateMode === self::TEMPLATE_MODE_CP) {
             $twig->addExtension(new CpExtension());
-        } else {
+        } else if (Craft::$app->getIsInstalled()) {
             $twig->addExtension(new GlobalsExtension());
         }
 

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -318,7 +318,7 @@ class View extends \yii\web\View
 
         if ($this->_templateMode === self::TEMPLATE_MODE_CP) {
             $twig->addExtension(new CpExtension());
-        } else if (Craft::$app->getIsInstalled()) {
+        } elseif (Craft::$app->getIsInstalled()) {
             $twig->addExtension(new GlobalsExtension());
         }
 


### PR DESCRIPTION
### Description
Previously it was possible for Craft to load `\craft\web\twig\GlobalsExtension()` before Craft was installed. This would cause multiple error to be thrown and would result in a default "internal server error" being rendered. In cases when the developer has a custom error template this would also ignore the custom error template. 

This fixes the issue by making sure Craft is installed before loading `\craft\web\twig\GlobalsExtension()`

### Related issues
#11855 
