### PR TITLE
Return `static` from element query methods

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -4,3 +4,4 @@
 - Craft now requires PHP 8.1 or later.
 - The `defaultTemplateExtensions` config setting now lists `twig` before `html` by default. ([#11809](https://github.com/craftcms/cms/discussions/11809))
 - Control panel templates referenced without a file extension now resolve `.twig` over `.html`. ([#11809](https://github.com/craftcms/cms/discussions/11809))
+- All core element query param methods now return `static` instead of `self`. ([#11868](https://github.com/craftcms/cms/pull/11868))

--- a/src/elements/db/AddressQuery.php
+++ b/src/elements/db/AddressQuery.php
@@ -106,10 +106,10 @@ class AddressQuery extends ElementQuery
      * ```
      *
      * @param string|string[]|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $administrativeArea
      */
-    public function administrativeArea(array|string|null $value): self
+    public function administrativeArea(array|string|null $value): static
     {
         $this->administrativeArea = $value;
 
@@ -136,10 +136,10 @@ class AddressQuery extends ElementQuery
      * ```
      *
      * @param ElementInterface $owner The owner element
-     * @return self self reference
+     * @return static self reference
      * @uses $ownerId
      */
-    public function owner(ElementInterface $owner): self
+    public function owner(ElementInterface $owner): static
     {
         $this->ownerId = [$owner->id];
         return $this;
@@ -172,10 +172,10 @@ class AddressQuery extends ElementQuery
      * ```
      *
      * @param int|int[]|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $ownerId
      */
-    public function ownerId(array|int|null $value): self
+    public function ownerId(array|int|null $value): static
     {
         $this->ownerId = $value;
         return $this;
@@ -210,10 +210,10 @@ class AddressQuery extends ElementQuery
      * ```
      *
      * @param string|string[]|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $countryCode
      */
-    public function countryCode(array|string|null $value): self
+    public function countryCode(array|string|null $value): static
     {
         $this->countryCode = $value;
 

--- a/src/elements/db/AssetQuery.php
+++ b/src/elements/db/AssetQuery.php
@@ -262,10 +262,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $volumeId
      */
-    public function volume(mixed $value): self
+    public function volume(mixed $value): static
     {
         if (Db::normalizeParam($value, function($item) {
             if (is_string($item)) {
@@ -318,10 +318,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $volumeId
      */
-    public function volumeId(mixed $value): self
+    public function volumeId(mixed $value): static
     {
         $this->volumeId = $value;
         return $this;
@@ -362,10 +362,10 @@ class AssetQuery extends ElementQuery
      * :::
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $folderId
      */
-    public function folderId(mixed $value): self
+    public function folderId(mixed $value): static
     {
         $this->folderId = $value;
         return $this;
@@ -398,11 +398,11 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param int|User|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $uploaderId
      * @since 3.4.0
      */
-    public function uploader(int|User|null $value): self
+    public function uploader(int|User|null $value): static
     {
         if ($value instanceof User) {
             $this->uploaderId = $value->id;
@@ -446,10 +446,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $filename
      */
-    public function filename(mixed $value): self
+    public function filename(mixed $value): static
     {
         $this->filename = $value;
         return $this;
@@ -505,10 +505,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $kind
      */
-    public function kind(mixed $value): self
+    public function kind(mixed $value): static
     {
         $this->kind = $value;
         return $this;
@@ -518,10 +518,10 @@ class AssetQuery extends ElementQuery
      * Narrows the query results based on whether the assets have alternative text.
      *
      * @param bool|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $hasAlt
      */
-    public function hasAlt(?bool $value = true): self
+    public function hasAlt(?bool $value = true): static
     {
         $this->hasAlt = $value;
         return $this;
@@ -557,10 +557,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $width
      */
-    public function width(mixed $value): self
+    public function width(mixed $value): static
     {
         $this->width = $value;
         return $this;
@@ -596,10 +596,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $height
      */
-    public function height(mixed $value): self
+    public function height(mixed $value): static
     {
         $this->height = $value;
         return $this;
@@ -633,10 +633,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $size
      */
-    public function size(mixed $value): self
+    public function size(mixed $value): static
     {
         $this->size = $value;
         return $this;
@@ -674,10 +674,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $dateModified
      */
-    public function dateModified(mixed $value): self
+    public function dateModified(mixed $value): static
     {
         $this->dateModified = $value;
         return $this;
@@ -711,10 +711,10 @@ class AssetQuery extends ElementQuery
      * :::
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $includeSubfolders
      */
-    public function includeSubfolders(bool $value = true): self
+    public function includeSubfolders(bool $value = true): static
     {
         $this->includeSubfolders = $value;
         return $this;
@@ -750,11 +750,11 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $folderPath
      * @since 3.7.39
      */
-    public function folderPath(mixed $value): self
+    public function folderPath(mixed $value): static
     {
         $this->folderPath = $value;
         return $this;
@@ -804,10 +804,10 @@ class AssetQuery extends ElementQuery
      * ```
      *
      * @param string|array|null $value The transforms to include.
-     * @return self The query object itself
+     * @return static The query object itself
      * @uses $withTransforms
      */
-    public function withTransforms(string|array|null $value = null): self
+    public function withTransforms(string|array|null $value = null): static
     {
         $this->withTransforms = $value;
         return $this;

--- a/src/elements/db/CategoryQuery.php
+++ b/src/elements/db/CategoryQuery.php
@@ -86,10 +86,10 @@ class CategoryQuery extends ElementQuery
      * Sets the [[$editable]] property.
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $editable
      */
-    public function editable(bool $value = true): self
+    public function editable(bool $value = true): static
     {
         $this->editable = $value;
         return $this;
@@ -125,10 +125,10 @@ class CategoryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $groupId
      */
-    public function group(mixed $value): self
+    public function group(mixed $value): static
     {
         if ($value instanceof CategoryGroup) {
             // Special case for a single category group, since we also want to capture the structure ID
@@ -181,10 +181,10 @@ class CategoryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $groupId
      */
-    public function groupId(mixed $value): self
+    public function groupId(mixed $value): static
     {
         $this->groupId = $value;
         return $this;

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -560,7 +560,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $inReverse
      */
-    public function inReverse(bool $value = true): self
+    public function inReverse(bool $value = true): static
     {
         $this->inReverse = $value;
         return $this;
@@ -570,7 +570,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $asArray
      */
-    public function asArray(bool $value = true): self
+    public function asArray(bool $value = true): static
     {
         $this->asArray = $value;
         return $this;
@@ -580,7 +580,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $asArray
      */
-    public function ignorePlaceholders(bool $value = true): self
+    public function ignorePlaceholders(bool $value = true): static
     {
         $this->ignorePlaceholders = $value;
         return $this;
@@ -590,7 +590,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $drafts
      */
-    public function drafts(?bool $value = true): self
+    public function drafts(?bool $value = true): static
     {
         $this->drafts = $value;
         return $this;
@@ -601,7 +601,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $draftId
      * @uses $drafts
      */
-    public function draftId(?int $value = null): self
+    public function draftId(?int $value = null): static
     {
         $this->draftId = $value;
         if ($value !== null && $this->drafts === false) {
@@ -615,7 +615,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $draftOf
      * @uses $drafts
      */
-    public function draftOf($value): self
+    public function draftOf($value): static
     {
         if ($value instanceof ElementInterface) {
             $this->draftOf = $value->getCanonicalId();
@@ -635,7 +635,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $draftCreator
      * @uses $drafts
      */
-    public function draftCreator($value): self
+    public function draftCreator($value): static
     {
         if ($value instanceof User) {
             $this->draftCreator = $value->id;
@@ -655,7 +655,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $provisionalDrafts
      * @uses $drafts
      */
-    public function provisionalDrafts(?bool $value = true): self
+    public function provisionalDrafts(?bool $value = true): static
     {
         $this->provisionalDrafts = $value;
         if ($value === true && $this->drafts === false) {
@@ -668,7 +668,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $savedDraftsOnly
      */
-    public function savedDraftsOnly(bool $value = true): self
+    public function savedDraftsOnly(bool $value = true): static
     {
         $this->savedDraftsOnly = $value;
         return $this;
@@ -678,7 +678,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $revisions
      */
-    public function revisions(?bool $value = true): self
+    public function revisions(?bool $value = true): static
     {
         $this->revisions = $value;
         return $this;
@@ -689,7 +689,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $revisionId
      * @uses $revisions
      */
-    public function revisionId(?int $value = null): self
+    public function revisionId(?int $value = null): static
     {
         $this->revisionId = $value;
         if ($value !== null && $this->revisions === false) {
@@ -703,7 +703,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $revisionOf
      * @uses $revisions
      */
-    public function revisionOf($value): self
+    public function revisionOf($value): static
     {
         if ($value instanceof ElementInterface) {
             $this->revisionOf = $value->getCanonicalId();
@@ -723,7 +723,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $revisionCreator
      * @uses $revisions
      */
-    public function revisionCreator($value): self
+    public function revisionCreator($value): static
     {
         if ($value instanceof User) {
             $this->revisionCreator = $value->id;
@@ -742,7 +742,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $id
      */
-    public function id($value): self
+    public function id($value): static
     {
         $this->id = $value;
         return $this;
@@ -752,7 +752,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $uid
      */
-    public function uid($value): self
+    public function uid($value): static
     {
         $this->uid = $value;
         return $this;
@@ -762,7 +762,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $siteSettingsId
      */
-    public function siteSettingsId($value): self
+    public function siteSettingsId($value): static
     {
         $this->siteSettingsId = $value;
         return $this;
@@ -772,7 +772,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $fixedOrder
      */
-    public function fixedOrder(bool $value = true): self
+    public function fixedOrder(bool $value = true): static
     {
         $this->fixedOrder = $value;
         return $this;
@@ -782,7 +782,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $orderBy
      */
-    public function orderBy($columns): self
+    public function orderBy($columns): static
     {
         parent::orderBy($columns);
 
@@ -798,7 +798,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $orderBy
      */
-    public function addOrderBy($columns): self
+    public function addOrderBy($columns): static
     {
         // If orderBy is an empty, non-null value (leaving it up to the element query class to decide),
         // then treat this is an orderBy() call.
@@ -820,7 +820,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $status
      */
-    public function status(array|string|null $value): self
+    public function status(array|string|null $value): static
     {
         $this->status = $value;
         return $this;
@@ -830,7 +830,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $archived
      */
-    public function archived(bool $value = true): self
+    public function archived(bool $value = true): static
     {
         $this->archived = $value;
         return $this;
@@ -840,7 +840,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $trashed
      */
-    public function trashed(?bool $value = true): self
+    public function trashed(?bool $value = true): static
     {
         $this->trashed = $value;
         return $this;
@@ -850,7 +850,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $dateCreated
      */
-    public function dateCreated(mixed $value): self
+    public function dateCreated(mixed $value): static
     {
         $this->dateCreated = $value;
         return $this;
@@ -860,7 +860,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $dateUpdated
      */
-    public function dateUpdated(mixed $value): self
+    public function dateUpdated(mixed $value): static
     {
         $this->dateUpdated = $value;
         return $this;
@@ -871,7 +871,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @throws InvalidArgumentException if $value is invalid
      * @uses $siteId
      */
-    public function site($value): self
+    public function site($value): static
     {
         if ($value === null) {
             $this->siteId = null;
@@ -907,7 +907,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $siteId
      */
-    public function siteId($value): self
+    public function siteId($value): static
     {
         if (is_array($value) && strtolower(reset($value)) === 'not') {
             array_shift($value);
@@ -929,7 +929,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $unique
      * @since 3.2.0
      */
-    public function unique(bool $value = true): self
+    public function unique(bool $value = true): static
     {
         $this->unique = $value;
         return $this;
@@ -940,7 +940,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @uses $preferSites
      * @since 3.2.0
      */
-    public function preferSites(?array $value = null): self
+    public function preferSites(?array $value = null): static
     {
         $this->preferSites = $value;
         return $this;
@@ -950,7 +950,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $relatedTo
      */
-    public function relatedTo($value): self
+    public function relatedTo($value): static
     {
         $this->relatedTo = $value;
         return $this;
@@ -961,7 +961,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @throws NotSupportedException
      * @uses $relatedTo
      */
-    public function andRelatedTo($value): self
+    public function andRelatedTo($value): static
     {
         if (!$value) {
             return $this;
@@ -989,7 +989,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $title
      */
-    public function title($value): self
+    public function title($value): static
     {
         $this->title = $value;
         return $this;
@@ -999,7 +999,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $slug
      */
-    public function slug($value): self
+    public function slug($value): static
     {
         $this->slug = $value;
         return $this;
@@ -1009,7 +1009,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $uri
      */
-    public function uri($value): self
+    public function uri($value): static
     {
         $this->uri = $value;
         return $this;
@@ -1019,7 +1019,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $search
      */
-    public function search($value): self
+    public function search($value): static
     {
         $this->search = $value;
         return $this;
@@ -1029,7 +1029,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $ref
      */
-    public function ref($value): self
+    public function ref($value): static
     {
         $this->ref = $value;
         return $this;
@@ -1039,7 +1039,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $with
      */
-    public function with(array|string|null $value): self
+    public function with(array|string|null $value): static
     {
         $this->with = $value;
         return $this;
@@ -1049,7 +1049,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $with
      */
-    public function andWith(array|string|null $value): self
+    public function andWith(array|string|null $value): static
     {
         if (empty($this->with)) {
             $this->with = [$value];
@@ -1066,7 +1066,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $withStructure
      */
-    public function withStructure(bool $value = true): self
+    public function withStructure(bool $value = true): static
     {
         $this->withStructure = $value;
         return $this;
@@ -1076,7 +1076,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $structureId
      */
-    public function structureId(?int $value = null): self
+    public function structureId(?int $value = null): static
     {
         $this->structureId = $value;
         return $this;
@@ -1086,7 +1086,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $level
      */
-    public function level($value = null): self
+    public function level($value = null): static
     {
         $this->level = $value;
         return $this;
@@ -1096,7 +1096,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $hasDescendants
      */
-    public function hasDescendants(bool $value = true): self
+    public function hasDescendants(bool $value = true): static
     {
         $this->hasDescendants = $value;
         return $this;
@@ -1106,7 +1106,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $leaves
      */
-    public function leaves(bool $value = true): self
+    public function leaves(bool $value = true): static
     {
         $this->leaves = $value;
         return $this;
@@ -1116,7 +1116,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $ancestorOf
      */
-    public function ancestorOf(ElementInterface|int|null $value): self
+    public function ancestorOf(ElementInterface|int|null $value): static
     {
         $this->ancestorOf = $value;
         return $this;
@@ -1126,7 +1126,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $ancestorDist
      */
-    public function ancestorDist(?int $value = null): self
+    public function ancestorDist(?int $value = null): static
     {
         $this->ancestorDist = $value;
         return $this;
@@ -1136,7 +1136,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $descendantOf
      */
-    public function descendantOf(ElementInterface|int|null $value): self
+    public function descendantOf(ElementInterface|int|null $value): static
     {
         $this->descendantOf = $value;
         return $this;
@@ -1146,7 +1146,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $descendantDist
      */
-    public function descendantDist(?int $value = null): self
+    public function descendantDist(?int $value = null): static
     {
         $this->descendantDist = $value;
         return $this;
@@ -1156,7 +1156,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $siblingOf
      */
-    public function siblingOf(ElementInterface|int|null $value): self
+    public function siblingOf(ElementInterface|int|null $value): static
     {
         $this->siblingOf = $value;
         return $this;
@@ -1166,7 +1166,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $prevSiblingOf
      */
-    public function prevSiblingOf(ElementInterface|int|null $value): self
+    public function prevSiblingOf(ElementInterface|int|null $value): static
     {
         $this->prevSiblingOf = $value;
         return $this;
@@ -1176,7 +1176,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $nextSiblingOf
      */
-    public function nextSiblingOf(ElementInterface|int|null $value): self
+    public function nextSiblingOf(ElementInterface|int|null $value): static
     {
         $this->nextSiblingOf = $value;
         return $this;
@@ -1186,7 +1186,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $positionedBefore
      */
-    public function positionedBefore(ElementInterface|int|null $value): self
+    public function positionedBefore(ElementInterface|int|null $value): static
     {
         $this->positionedBefore = $value;
         return $this;
@@ -1196,7 +1196,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @inheritdoc
      * @uses $positionedAfter
      */
-    public function positionedAfter(ElementInterface|int|null $value): self
+    public function positionedAfter(ElementInterface|int|null $value): static
     {
         $this->positionedAfter = $value;
         return $this;
@@ -1205,11 +1205,11 @@ class ElementQuery extends Query implements ElementQueryInterface
     /**
      * Sets the [[status()|status]] param to `null`.
      *
-     * @return self self reference
+     * @return static self reference
      * @since 3.0.17
      * @deprecated in 4.0.0. `status(null)` should be used instead.
      */
-    public function anyStatus(): self
+    public function anyStatus(): static
     {
         $this->status = null;
         return $this;

--- a/src/elements/db/ElementQueryInterface.php
+++ b/src/elements/db/ElementQueryInterface.php
@@ -47,9 +47,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function inReverse(bool $value = true): self;
+    public function inReverse(bool $value = true): static;
 
     /**
      * Causes the query to return matching {elements} as arrays of data, rather than [[{element-class}]] objects.
@@ -71,19 +71,19 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      */
-    public function asArray(bool $value = true): self;
+    public function asArray(bool $value = true): static;
 
     /**
      * Causes the query to return matching {elements} as they are stored in the database, ignoring matching placeholder
      * elements that were set by [[\craft\services\Elements::setPlaceholderElement()]].
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.9
      */
-    public function ignorePlaceholders(bool $value = true): self;
+    public function ignorePlaceholders(bool $value = true): static;
 
     /**
      * Narrows the query results to only drafts {elements}.
@@ -107,10 +107,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool|null $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function drafts(?bool $value = true): self;
+    public function drafts(?bool $value = true): static;
 
     /**
      * Narrows the query results based on the {elements}’ draft’s ID (from the `drafts` table).
@@ -138,10 +138,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function draftId(?int $value = null): self;
+    public function draftId(?int $value = null): static;
 
     /**
      * Narrows the query results to only drafts of a given {element}.
@@ -172,10 +172,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function draftOf(mixed $value): self;
+    public function draftOf(mixed $value): static;
 
     /**
      * Narrows the query results to only drafts created by a given user.
@@ -204,10 +204,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function draftCreator(mixed $value): self;
+    public function draftCreator(mixed $value): static;
 
     /**
      * Narrows the query results to only provisional drafts.
@@ -231,10 +231,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.7.0
      */
-    public function provisionalDrafts(?bool $value = true): self;
+    public function provisionalDrafts(?bool $value = true): static;
 
     /**
      * Narrows the query results to only unpublished drafts which have been saved after initial creation.
@@ -258,10 +258,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @since 3.6.6
      */
-    public function savedDraftsOnly(bool $value = true): self;
+    public function savedDraftsOnly(bool $value = true): static;
 
     /**
      * Narrows the query results to only revision {elements}.
@@ -285,10 +285,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool|null $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function revisions(?bool $value = true): self;
+    public function revisions(?bool $value = true): static;
 
     /**
      * Narrows the query results based on the {elements}’ revision’s ID (from the `revisions` table).
@@ -316,10 +316,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function revisionId(?int $value = null): self;
+    public function revisionId(?int $value = null): static;
 
     /**
      * Narrows the query results to only revisions of a given {element}.
@@ -348,10 +348,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function revisionOf(mixed $value): self;
+    public function revisionOf(mixed $value): static;
 
     /**
      * Narrows the query results to only revisions created by a given user.
@@ -380,10 +380,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function revisionCreator(mixed $value): self;
+    public function revisionCreator(mixed $value): static;
 
     /**
      * Narrows the query results based on the {elements}’ IDs.
@@ -420,9 +420,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * :::
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function id(mixed $value): self;
+    public function id(mixed $value): static;
 
     /**
      * Narrows the query results based on the {elements}’ UIDs.
@@ -444,9 +444,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function uid(mixed $value): self;
+    public function uid(mixed $value): static;
 
     /**
      * Narrows the query results based on the {elements}’ IDs in the `elements_sites` table.
@@ -477,10 +477,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.7.0
      */
-    public function siteSettingsId(mixed $value): self;
+    public function siteSettingsId(mixed $value): static;
 
     /**
      * Causes the query results to be returned in the order specified by [[id()]].
@@ -508,9 +508,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      */
-    public function fixedOrder(bool $value = true): self;
+    public function fixedOrder(bool $value = true): static;
 
     /**
      * Narrows the query results based on the {elements}’ statuses.
@@ -540,17 +540,17 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param string|string[]|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function status(array|string|null $value): self;
+    public function status(array|string|null $value): static;
 
     /**
      * Sets the [[$archived]] property.
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      */
-    public function archived(bool $value = true): self;
+    public function archived(bool $value = true): static;
 
     /**
      * Narrows the query results to only {elements} that have been soft-deleted.
@@ -572,10 +572,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool|null $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @since 3.1.0
      */
-    public function trashed(?bool $value = true): self;
+    public function trashed(?bool $value = true): static;
 
     /**
      * Narrows the query results based on the {elements}’ creation dates.
@@ -611,9 +611,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function dateCreated(mixed $value): self;
+    public function dateCreated(mixed $value): static;
 
     /**
      * Narrows the query results based on the {elements}’ last-updated dates.
@@ -647,9 +647,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function dateUpdated(mixed $value): self;
+    public function dateUpdated(mixed $value): static;
 
     /**
      * Determines which site(s) the {elements} should be queried in.
@@ -688,9 +688,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function site(mixed $value): self;
+    public function site(mixed $value): static;
 
     /**
      * Determines which site(s) the {elements} should be queried in, per the site’s ID.
@@ -723,9 +723,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function siteId(mixed $value): self;
+    public function siteId(mixed $value): static;
 
     /**
      * Determines whether only elements with unique IDs should be returned by the query.
@@ -752,10 +752,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function unique(bool $value = true): self;
+    public function unique(bool $value = true): static;
 
     /**
      * If [[unique()]] is set, this determines which site should be selected when querying multi-site elements.
@@ -787,10 +787,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param array|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.2.0
      */
-    public function preferSites(?array $value = null): self;
+    public function preferSites(?array $value = null): static;
 
     /**
      * Narrows the query results to only {elements} that are related to certain other elements.
@@ -814,9 +814,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function relatedTo(mixed $value): self;
+    public function relatedTo(mixed $value): static;
 
     /**
      * Narrows the query results to only {elements} that are related to certain other elements.
@@ -842,10 +842,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.6.11
      */
-    public function andRelatedTo(mixed $value): self;
+    public function andRelatedTo(mixed $value): static;
 
     /**
      * Narrows the query results based on the {elements}’ titles.
@@ -879,9 +879,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function title(mixed $value): self;
+    public function title(mixed $value): static;
 
     /**
      * Narrows the query results based on the {elements}’ slugs.
@@ -921,9 +921,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function slug(mixed $value): self;
+    public function slug(mixed $value): static;
 
     /**
      * Narrows the query results based on the {elements}’ URIs.
@@ -963,9 +963,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function uri(mixed $value): self;
+    public function uri(mixed $value): static;
 
     /**
      * Narrows the query results to only {elements} that match a search query.
@@ -995,17 +995,17 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function search(mixed $value): self;
+    public function search(mixed $value): static;
 
     /**
      * Narrows the query results based on a reference string.
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function ref(mixed $value): self;
+    public function ref(mixed $value): static;
 
     /**
      * Causes the query to return matching {elements} eager-loaded with related elements.
@@ -1029,34 +1029,34 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param array|string|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function with(array|string|null $value): self;
+    public function with(array|string|null $value): static;
 
     /**
      * Causes the query to return matching {elements} eager-loaded with related elements, in addition to the elements that were already specified by [[with()]]..
      *
      * @param array|string|null $value The property value to append
-     * @return self self reference
+     * @return static self reference
      * @since 3.0.9
      */
-    public function andWith(array|string|null $value): self;
+    public function andWith(array|string|null $value): static;
 
     /**
      * Explicitly determines whether the query should join in the structure data.
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      */
-    public function withStructure(bool $value = true): self;
+    public function withStructure(bool $value = true): static;
 
     /**
      * Determines which structure data should be joined into the query.
      *
      * @param int|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function structureId(?int $value = null): self;
+    public function structureId(?int $value = null): static;
 
     /**
      * Narrows the query results based on the {elements}’ level within the structure.
@@ -1088,9 +1088,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function level(mixed $value = null): self;
+    public function level(mixed $value = null): static;
 
     /**
      * Narrows the query results based on whether the {elements} have any descendants in their structure.
@@ -1114,10 +1114,10 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool $value The property value
-     * @return self self reference
+     * @return static self reference
      * @since 3.0.4
      */
-    public function hasDescendants(bool $value = true): self;
+    public function hasDescendants(bool $value = true): static;
 
     /**
      * Narrows the query results based on whether the {elements} are “leaves” ({elements} with no descendants).
@@ -1141,9 +1141,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param bool $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function leaves(bool $value = true): self;
+    public function leaves(bool $value = true): static;
 
     /**
      * Narrows the query results to only {elements} that are ancestors of another {element} in its structure.
@@ -1178,9 +1178,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * :::
      *
      * @param int|ElementInterface|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function ancestorOf(ElementInterface|int|null $value): self;
+    public function ancestorOf(ElementInterface|int|null $value): static;
 
     /**
      * Narrows the query results to only {elements} that are up to a certain distance away from the {element} specified by [[ancestorOf()]].
@@ -1204,9 +1204,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function ancestorDist(?int $value = null): self;
+    public function ancestorDist(?int $value = null): static;
 
     /**
      * Narrows the query results to only {elements} that are descendants of another {element} in its structure.
@@ -1241,9 +1241,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * :::
      *
      * @param int|ElementInterface|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function descendantOf(ElementInterface|int|null $value): self;
+    public function descendantOf(ElementInterface|int|null $value): static;
 
     /**
      * Narrows the query results to only {elements} that are up to a certain distance away from the {element} specified by [[descendantOf()]].
@@ -1267,9 +1267,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function descendantDist(?int $value = null): self;
+    public function descendantDist(?int $value = null): static;
 
     /**
      * Narrows the query results to only {elements} that are siblings of another {element} in its structure.
@@ -1298,9 +1298,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|ElementInterface|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function siblingOf(ElementInterface|int|null $value): self;
+    public function siblingOf(ElementInterface|int|null $value): static;
 
     /**
      * Narrows the query results to only the {element} that comes immediately before another {element} in its structure.
@@ -1329,9 +1329,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|ElementInterface|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function prevSiblingOf(ElementInterface|int|null $value): self;
+    public function prevSiblingOf(ElementInterface|int|null $value): static;
 
     /**
      * Narrows the query results to only the {element} that comes immediately after another {element} in its structure.
@@ -1360,9 +1360,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|ElementInterface|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function nextSiblingOf(ElementInterface|int|null $value): self;
+    public function nextSiblingOf(ElementInterface|int|null $value): static;
 
     /**
      * Narrows the query results to only {elements} that are positioned before another {element} in its structure.
@@ -1391,9 +1391,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|ElementInterface|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function positionedBefore(ElementInterface|int|null $value): self;
+    public function positionedBefore(ElementInterface|int|null $value): static;
 
     /**
      * Narrows the query results to only {elements} that are positioned after another {element} in its structure.
@@ -1422,9 +1422,9 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      * ```
      *
      * @param int|ElementInterface|null $value The property value
-     * @return self self reference
+     * @return static self reference
      */
-    public function positionedAfter(ElementInterface|int|null $value): self;
+    public function positionedAfter(ElementInterface|int|null $value): static;
 
     // Query preparation/execution
     // -------------------------------------------------------------------------

--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -247,10 +247,10 @@ class EntryQuery extends ElementQuery
      * Sets the [[$editable]] property.
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $editable
      */
-    public function editable(bool $value = true): self
+    public function editable(bool $value = true): static
     {
         $this->editable = $value;
         return $this;
@@ -286,10 +286,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $sectionId
      */
-    public function section(mixed $value): self
+    public function section(mixed $value): static
     {
         // If the value is a section handle, swap it with the section
         if (is_string($value) && ($section = Craft::$app->getSections()->getSectionByHandle($value))) {
@@ -351,10 +351,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $sectionId
      */
-    public function sectionId(mixed $value): self
+    public function sectionId(mixed $value): static
     {
         $this->sectionId = $value;
         return $this;
@@ -392,10 +392,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $typeId
      */
-    public function type(mixed $value): self
+    public function type(mixed $value): static
     {
         if (Db::normalizeParam($value, function($item) {
             if (is_string($item)) {
@@ -444,10 +444,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $typeId
      */
-    public function typeId(mixed $value): self
+    public function typeId(mixed $value): static
     {
         $this->typeId = $value;
         return $this;
@@ -482,10 +482,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $authorId
      */
-    public function authorId(mixed $value): self
+    public function authorId(mixed $value): static
     {
         $this->authorId = $value;
         return $this;
@@ -522,10 +522,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $authorGroupId
      */
-    public function authorGroup(mixed $value): self
+    public function authorGroup(mixed $value): static
     {
         if ($value instanceof UserGroup) {
             $this->authorGroupId = $value->id;
@@ -582,10 +582,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $authorGroupId
      */
-    public function authorGroupId(mixed $value): self
+    public function authorGroupId(mixed $value): static
     {
         $this->authorGroupId = $value;
         return $this;
@@ -625,10 +625,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $postDate
      */
-    public function postDate(mixed $value): self
+    public function postDate(mixed $value): static
     {
         $this->postDate = $value;
         return $this;
@@ -665,10 +665,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $before
      */
-    public function before(mixed $value): self
+    public function before(mixed $value): static
     {
         $this->before = $value;
         return $this;
@@ -705,10 +705,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $after
      */
-    public function after(mixed $value): self
+    public function after(mixed $value): static
     {
         $this->after = $value;
         return $this;
@@ -748,10 +748,10 @@ class EntryQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $expiryDate
      */
-    public function expiryDate(mixed $value): self
+    public function expiryDate(mixed $value): static
     {
         $this->expiryDate = $value;
         return $this;
@@ -787,9 +787,9 @@ class EntryQuery extends ElementQuery
      *     ->all();
      * ```
      */
-    public function status(array|string|null $value): self
+    public function status(array|string|null $value): static
     {
-        /** @var self */
+        /** @var static */
         return parent::status($value);
     }
 

--- a/src/elements/db/GlobalSetQuery.php
+++ b/src/elements/db/GlobalSetQuery.php
@@ -55,10 +55,10 @@ class GlobalSetQuery extends ElementQuery
      * Sets the [[$editable]] property.
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $editable
      */
-    public function editable(bool $value = true): self
+    public function editable(bool $value = true): static
     {
         $this->editable = $value;
         return $this;
@@ -93,10 +93,10 @@ class GlobalSetQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $handle
      */
-    public function handle(mixed $value): self
+    public function handle(mixed $value): static
     {
         $this->handle = $value;
         return $this;

--- a/src/elements/db/MatrixBlockQuery.php
+++ b/src/elements/db/MatrixBlockQuery.php
@@ -164,11 +164,11 @@ class MatrixBlockQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $fieldId
      * @since 3.4.0
      */
-    public function field(mixed $value): self
+    public function field(mixed $value): static
     {
         if (Db::normalizeParam($value, function($item) {
             if (is_string($item)) {
@@ -218,10 +218,10 @@ class MatrixBlockQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $fieldId
      */
-    public function fieldId(mixed $value): self
+    public function fieldId(mixed $value): static
     {
         $this->fieldId = $value;
         return $this;
@@ -256,11 +256,11 @@ class MatrixBlockQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $primaryOwnerId
      * @since 4.0.0
      */
-    public function primaryOwnerId(mixed $value): self
+    public function primaryOwnerId(mixed $value): static
     {
         $this->primaryOwnerId = $value;
         return $this;
@@ -286,11 +286,11 @@ class MatrixBlockQuery extends ElementQuery
      * ```
      *
      * @param ElementInterface $primaryOwner The primary owner element
-     * @return self self reference
+     * @return static self reference
      * @uses $primaryOwnerId
      * @since 4.0.0
      */
-    public function primaryOwner(ElementInterface $primaryOwner): self
+    public function primaryOwner(ElementInterface $primaryOwner): static
     {
         $this->primaryOwnerId = [$primaryOwner->id];
         $this->siteId = $primaryOwner->siteId;
@@ -326,10 +326,10 @@ class MatrixBlockQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $ownerId
      */
-    public function ownerId(mixed $value): self
+    public function ownerId(mixed $value): static
     {
         $this->ownerId = $value;
         return $this;
@@ -355,10 +355,10 @@ class MatrixBlockQuery extends ElementQuery
      * ```
      *
      * @param ElementInterface $owner The owner element
-     * @return self self reference
+     * @return static self reference
      * @uses $ownerId
      */
-    public function owner(ElementInterface $owner): self
+    public function owner(ElementInterface $owner): static
     {
         $this->ownerId = [$owner->id];
         $this->siteId = $owner->siteId;
@@ -376,11 +376,11 @@ class MatrixBlockQuery extends ElementQuery
      * | `false` | which cannot belong to a draft.
      *
      * @param bool|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $allowOwnerDrafts
      * @since 3.3.10
      */
-    public function allowOwnerDrafts(?bool $value = true): self
+    public function allowOwnerDrafts(?bool $value = true): static
     {
         $this->allowOwnerDrafts = $value;
         return $this;
@@ -397,11 +397,11 @@ class MatrixBlockQuery extends ElementQuery
      * | `false` | which cannot belong to a revision.
      *
      * @param bool|null $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $allowOwnerDrafts
      * @since 3.3.10
      */
-    public function allowOwnerRevisions(?bool $value = true): self
+    public function allowOwnerRevisions(?bool $value = true): static
     {
         $this->allowOwnerRevisions = $value;
         return $this;
@@ -437,10 +437,10 @@ class MatrixBlockQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $typeId
      */
-    public function type(mixed $value): self
+    public function type(mixed $value): static
     {
         if ($value instanceof MatrixBlockType) {
             $this->typeId = $value->id;
@@ -486,10 +486,10 @@ class MatrixBlockQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $typeId
      */
-    public function typeId(mixed $value): self
+    public function typeId(mixed $value): static
     {
         $this->typeId = $value;
         return $this;

--- a/src/elements/db/TagQuery.php
+++ b/src/elements/db/TagQuery.php
@@ -108,10 +108,10 @@ class TagQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $groupId
      */
-    public function group(mixed $value): self
+    public function group(mixed $value): static
     {
         if (Db::normalizeParam($value, function($item) {
             if (is_string($item)) {
@@ -160,10 +160,10 @@ class TagQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $groupId
      */
-    public function groupId(mixed $value): self
+    public function groupId(mixed $value): static
     {
         $this->groupId = $value;
         return $this;

--- a/src/elements/db/UserQuery.php
+++ b/src/elements/db/UserQuery.php
@@ -252,10 +252,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $admin
      */
-    public function admin(bool $value = true): self
+    public function admin(bool $value = true): static
     {
         $this->admin = $value;
         return $this;
@@ -281,11 +281,11 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param bool|null $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $authors
      * @since 4.0.0
      */
-    public function authors(?bool $value = true): self
+    public function authors(?bool $value = true): static
     {
         $this->authors = $value;
         return $this;
@@ -311,11 +311,11 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param bool|null $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $assetUploaders
      * @since 4.0.0
      */
-    public function assetUploaders(?bool $value = true): self
+    public function assetUploaders(?bool $value = true): static
     {
         $this->assetUploaders = $value;
         return $this;
@@ -341,10 +341,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $hasPhoto
      */
-    public function hasPhoto(bool $value = true): self
+    public function hasPhoto(bool $value = true): static
     {
         $this->hasPhoto = $value;
         return $this;
@@ -372,10 +372,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $can
      */
-    public function can(mixed $value): self
+    public function can(mixed $value): static
     {
         $this->can = $value;
         return $this;
@@ -412,10 +412,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $groupId
      */
-    public function group(mixed $value): self
+    public function group(mixed $value): static
     {
         // If the value is a group handle, swap it with the user group
         if (is_string($value) && ($group = Craft::$app->getUserGroups()->getGroupByHandle($value))) {
@@ -471,10 +471,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $groupId
      */
-    public function groupId(mixed $value): self
+    public function groupId(mixed $value): static
     {
         $this->groupId = $value;
         return $this;
@@ -508,10 +508,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $email
      */
-    public function email(mixed $value): self
+    public function email(mixed $value): static
     {
         $this->email = $value;
         return $this;
@@ -550,10 +550,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $username
      */
-    public function username(mixed $value): self
+    public function username(mixed $value): static
     {
         $this->username = $value;
         return $this;
@@ -586,11 +586,11 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $fullName
      * @since 4.0.0
      */
-    public function fullName(mixed $value): self
+    public function fullName(mixed $value): static
     {
         $this->fullName = $value;
         return $this;
@@ -623,10 +623,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $firstName
      */
-    public function firstName(mixed $value): self
+    public function firstName(mixed $value): static
     {
         $this->firstName = $value;
         return $this;
@@ -659,10 +659,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $lastName
      */
-    public function lastName(mixed $value): self
+    public function lastName(mixed $value): static
     {
         $this->lastName = $value;
         return $this;
@@ -700,10 +700,10 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param mixed $value The property value
-     * @return self self reference
+     * @return static self reference
      * @uses $lastLoginDate
      */
-    public function lastLoginDate(mixed $value): self
+    public function lastLoginDate(mixed $value): static
     {
         $this->lastLoginDate = $value;
         return $this;
@@ -741,9 +741,9 @@ class UserQuery extends ElementQuery
      *     ->all();
      * ```
      */
-    public function status(array|string|null $value): self
+    public function status(array|string|null $value): static
     {
-        /** @var self */
+        /** @var static */
         return parent::status($value);
     }
 
@@ -775,11 +775,11 @@ class UserQuery extends ElementQuery
      * ```
      *
      * @param bool $value The property value (defaults to true)
-     * @return self self reference
+     * @return static self reference
      * @uses $withGroups
      * @since 3.6.0
      */
-    public function withGroups(bool $value = true): self
+    public function withGroups(bool $value = true): static
     {
         $this->withGroups = $value;
         return $this;

--- a/src/test/mockclasses/elements/MockElementQuery.php
+++ b/src/test/mockclasses/elements/MockElementQuery.php
@@ -80,9 +80,9 @@ class MockElementQuery extends ElementQuery
      * Set the return values.
      *
      * @param array $values
-     * @return self
+     * @return static
      */
-    public function setReturnValues(array $values = []): self
+    public function setReturnValues(array $values = []): static
     {
         $this->returnValues = $values;
         return $this;
@@ -126,9 +126,9 @@ class MockElementQuery extends ElementQuery
      *
      * @param string $name
      * @param array $params
-     * @return self
+     * @return static
      */
-    public function __call($name, $params): self
+    public function __call($name, $params): static
     {
         $this->properties[$name] = reset($params);
         return $this;


### PR DESCRIPTION
All element query methods now return `static` rather than `self`, making it easier for IDEs and code analysys tools to understand chained fluent methods that jump between element query classes.