### PR TITLE
Updated URL/anchor for default autosuggest field instructions

### DIFF
--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -1090,7 +1090,7 @@ class Cp
                     $config['tip'] = Craft::t('app', 'This can be set to an environment variable.');
                 }
                 $config['tip'] .= ' ' .
-                    Html::a(Craft::t('app', 'Learn more'), 'https://craftcms.com/docs/4.x/config/#environmental-configuration', [
+                    Html::a(Craft::t('app', 'Learn more'), 'https://craftcms.com/docs/4.x/config#control-panel-settings', [
                         'class' => 'go',
                     ]);
             } elseif (

--- a/src/templates/_includes/forms.twig
+++ b/src/templates/_includes/forms.twig
@@ -324,7 +324,7 @@
                 tip: ((config.suggestAliases ?? false)
                 ? 'This can be set to an environment variable, or begin with an alias.'|t('app')
                 : 'This can be set to an environment variable.'|t('app')) ~ ' ' ~ tag('a', {
-                    href: 'https://craftcms.com/docs/4.x/config/#environmental-configuration',
+                    href: 'https://craftcms.com/docs/4.x/config/#control-panel-settings',
                     class: 'go',
                     text: 'Learn more'|t('app'),
                 }),


### PR DESCRIPTION
This should only be merged after craftcms/docs#411 is merged and live!

### Description

I've reorganized or renamed a number of headings in the configuration documentation, and this ended up with a new anchor/ID.

### Related issues
- craftcms/docs#411
