### PR TITLE
Allow overriding the db server version

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -12,7 +12,9 @@
 - Added the `|integer` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added the `|string` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added support for the `CRAFT_DOTENV_PATH` PHP constant. ([#11894](https://github.com/craftcms/cms/discussions/11894)) 
+- Added the `version` database connection setting. ([#11900](https://github.com/craftcms/cms/pull/11900))
 - Added `craft\db\ActiveQuery::collect()`. ([#11842](https://github.com/craftcms/cms/pull/11842))
+- Added `craft\db\SchemaTrait`.
 - Added `craft\elements\actions\Restore::$restorableElementsOnly`.
 - Added `craft\enums\DateRangeType`.
 - Added `craft\events\AuthorizationCheckEvent::$element`.

--- a/src/config/DbConfig.php
+++ b/src/config/DbConfig.php
@@ -128,6 +128,24 @@ class DbConfig extends BaseConfig
     public ?string $dsn = null;
 
     /**
+     * @var string|null The database server version in use.
+     *
+     * This should only be set if `PDO::ATTR_SERVER_VERSION` is returning the incorrect version.
+     *
+     * ::: code
+     * ```php Static Config
+     * 'version' => '8.0.31',
+     * ```
+     * ```shell Environment Override
+     * CRAFT_DB_VERSION=8.0.31
+     * ```
+     * :::
+     *
+     * @since 4.3.0
+     */
+    public ?string $version = null;
+
+    /**
      * @var string The database password to connect with.
      *
      * ::: code
@@ -455,6 +473,26 @@ class DbConfig extends BaseConfig
             $this->database = $parsed['dbname'] ?? null;
         }
 
+        return $this;
+    }
+
+    /**
+     * The database server version in use.
+     *
+     * This should only be set if `PDO::ATTR_SERVER_VERSION` is returning the incorrect version.
+     *
+     * ```php
+     * ->version('8.0.31')
+     * ```
+     *
+     * @param string $value
+     * @return self
+     * @see $version
+     * @since 4.3.0
+     */
+    public function version(string $value): self
+    {
+        $this->version = $value;
         return $this;
     }
 

--- a/src/db/SchemaTrait.php
+++ b/src/db/SchemaTrait.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\db;
+
+use Craft;
+use craft\db\mysql\Schema as MysqlSchema;
+use craft\db\pgsql\Schema as PgsqlSchema;
+use craft\helpers\Db;
+use DateTime;
+use yii2tech\ar\softdelete\SoftDeleteBehavior;
+
+/**
+ * SchemaTrait
+ *
+ * @mixin MysqlSchema
+ * @mixin PgsqlSchema
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.3.0
+ */
+trait SchemaTrait
+{
+    /**
+     * @see getServerVersion()
+     * @see setServerVersion()
+     */
+    private ?string $version = null;
+
+    /**
+     * Returns the database server version.
+     *
+     * @return string
+     */
+    public function getServerVersion(): string
+    {
+        return $this->version ?? parent::getServerVersion();
+    }
+
+    /**
+     * Sets the database server version.
+     *
+     * @param string $version
+     */
+    public function setServerVersion(string $version): void
+    {
+        $this->version = $version;
+    }
+}

--- a/src/db/SchemaTrait.php
+++ b/src/db/SchemaTrait.php
@@ -7,12 +7,8 @@
 
 namespace craft\db;
 
-use Craft;
 use craft\db\mysql\Schema as MysqlSchema;
 use craft\db\pgsql\Schema as PgsqlSchema;
-use craft\helpers\Db;
-use DateTime;
-use yii2tech\ar\softdelete\SoftDeleteBehavior;
 
 /**
  * SchemaTrait

--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -10,6 +10,7 @@ namespace craft\db\mysql;
 use Composer\Util\Platform;
 use Craft;
 use craft\db\Connection;
+use craft\db\SchemaTrait;
 use craft\db\TableSchema;
 use craft\helpers\App;
 use craft\helpers\Db;
@@ -30,6 +31,8 @@ use yii\db\Exception;
  */
 class Schema extends \yii\db\mysql\Schema
 {
+    use SchemaTrait;
+
     public const TYPE_TINYTEXT = 'tinytext';
     public const TYPE_MEDIUMTEXT = 'mediumtext';
     public const TYPE_LONGTEXT = 'longtext';

--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -10,6 +10,7 @@ namespace craft\db\pgsql;
 use Composer\Util\Platform;
 use Craft;
 use craft\db\Connection;
+use craft\db\SchemaTrait;
 use craft\db\TableSchema;
 use yii\db\Exception;
 
@@ -22,6 +23,8 @@ use yii\db\Exception;
  */
 class Schema extends \yii\db\pgsql\Schema
 {
+    use SchemaTrait;
+
     /**
      * @var int The maximum length that objects' names can be.
      */

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -803,6 +803,10 @@ class App
             ];
         }
 
+        if ($dbConfig->version) {
+            $schemaConfig['serverVersion'] = $dbConfig->version;
+        }
+
         $config = [
             'class' => Connection::class,
             'driverName' => $driver,


### PR DESCRIPTION
### Description

Azure has you connect to a DB server that is actually just a proxy for the real database, and has a bug where `PDO::ATTR_SERVER_VERSION` doesn’t accurately report the real DB server version.

This works around the bug by adding a new `version` database connection setting, which can be used to override whatever `PDO::ATTR_SERVER_VERSION` says when calling `Craft::$app->db->schema->serverVersion`. (Similar to what Laravel does: laravel/framework#32708)

### Related issues

- craftcms/server-check#19