### PR TITLE
Swappable email config

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '4.2.3',
-    'schemaVersion' => '4.0.0.9',
+    'schemaVersion' => '4.0.0.10',
     'minVersionRequired' => '3.7.11',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -843,6 +843,13 @@ class App
     public static function mailSettings(): MailSettings
     {
         $settings = Craft::$app->getProjectConfig()->get('email') ?? [];
+        $key = $settings['transport'] ?? null;
+        $transport = $settings['transports'][$key] ?? null;
+        $settings['transportType'] = $transport['type'] ?? null;
+        $settings['transportSettings'] = $transport['settings'] ?? null;
+
+        unset($settings['transport'], $settings['transports']);
+
         return new MailSettings($settings);
     }
 

--- a/src/migrations/m220912_042255_add_email_transports.php
+++ b/src/migrations/m220912_042255_add_email_transports.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace craft\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\helpers\App;
+use ReflectionClass;
+
+/**
+ * m220912_042255_add_email_transports migration.
+ */
+class m220912_042255_add_email_transports extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $schemaVersion = Craft::$app->getProjectConfig()->get('system.schemaVersion', true);
+
+        if (version_compare($schemaVersion, '4.0.0.10', '>')) {
+            return true;
+        }
+
+        $mailSettings = App::mailSettings();
+
+        if (!$mailSettings?->transportType) {
+            return true;
+        }
+
+        $transportReflection = new ReflectionClass($mailSettings->transportType);
+        $transportKey = strtolower($transportReflection->getShortName());
+
+        Craft::$app->getProjectConfig()->set("email.transport", $transportKey);
+        Craft::$app->getProjectConfig()->set("email.transports.$transportKey", [
+            'type' => $mailSettings->transportType,
+            'settings' => $mailSettings->transportSettings,
+        ]);
+        Craft::$app->getProjectConfig()->remove('email.transportType');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m220912_042255_add_email_transports cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
This changes the schema of the `email` node in project config, so that you can have multiple configured transports represented, and change the active one.

`email.transportType` and `email.transportSettings` are replaced with `email.transport` and `email.transports`:

```
email:
  fromEmail: support@pixelandtonic.com
  fromName: 'Pixel & Tonic'
  replyToEmail: null
  template: ''
  transport: $EMAIL_TRANSPORT
  transports:
    postmark:
      type: craftcms\postmark\Adapter
      settings:
            token: $POSTMARK_TOKEN
    mailhog:
      type: craft\mail\transportadapters\Smtp
      settings: 
            encryptionMethod: none
            host: localhost
            password: ''
            port: '1025'
            timeout: '10'
            useAuthentication: '0'
            username: ''
```