### PR TITLE
Allow animated webp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed a bug where it was possible to save an asset with a focal point outside its cropped area. ([#11875](https://github.com/craftcms/cms/issues/11875))
 - Fixed a bug where the Assets index page wasn’t handling failed uploads properly. ([#11866](https://github.com/craftcms/cms/issues/11866))
 - Fixed a UI bug where renaming a newly-created volume subfolder didn’t appear to have any effect.
+- Fixed an issue where gif files couldn't be transformed to an animated webp file. ([#11889](https://github.com/craftcms/cms/issues/11889))
 
 ## 3.7.53.1 - 2022-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed a bug where the Assets index page wasn’t handling failed uploads properly. ([#11866](https://github.com/craftcms/cms/issues/11866))
 - Fixed a UI bug where renaming a newly-created volume subfolder didn’t appear to have any effect.
 - Fixed a bug where empty URL fields would be marked as changed, even when no change was made to them. ([#11908](https://github.com/craftcms/cms/issues/11908))
-- Fixed an issue where gif files couldn't be transformed to an animated webp file. ([#11889](https://github.com/craftcms/cms/issues/11889))
+- Fixed a bug where transforming an animated GIF into a WebP file would only include the first frame. ([#11889](https://github.com/craftcms/cms/issues/11889))
 
 ## 3.7.53.1 - 2022-08-26
 

--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -209,6 +209,7 @@ class Raster extends Image
             $gif = $this->_instance->create($newSize);
             $gif->layers()->remove(0);
 
+            $this->_image->layers()->coalesce();
             foreach ($this->_image->layers() as $layer) {
                 $croppedLayer = $layer->crop($startingPoint, $newSize);
                 $gif->layers()->add($croppedLayer);
@@ -703,6 +704,7 @@ class Raster extends Image
                 return ['jpeg_quality' => $quality, 'flatten' => true];
 
             case 'gif':
+            case 'webp':
                 return ['animated' => $this->_isAnimatedGif];
 
             case 'png':


### PR DESCRIPTION
### Description
Fixed an issue where an animated `.gif` wouldn't translate to an animated `.webp` file


### Related issues
- Fixes #11889
