### PR TITLE
Bugfix/animated webp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Craft CMS 3.x
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where image transforms weren’t always getting applied properly to all animation frames. ([#11937](https://github.com/craftcms/cms/pull/11937))
+- Fixed a bug where animated WebP images would lose their animation frames when transformed. ([#11937](https://github.com/craftcms/cms/pull/11937))
+
 ## 3.7.54 - 2022-09-13
 
 ### Changed

--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -185,7 +185,7 @@ class Raster extends Image
         $this->_imageSourcePath = $path;
         $this->_extension = pathinfo($path, PATHINFO_EXTENSION);
 
-        if ($this->_extension === 'gif') {
+        if (in_array($this->_extension, ['gif', 'webp'])) {
             if (!$imageService->getIsGd() && $this->_image->layers()) {
                 $this->_isAnimatedGif = true;
             }

--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -47,7 +47,7 @@ class Raster extends Image
     /**
      * @var bool
      */
-    private $_isAnimatedGif = false;
+    private $_isAnimated = false;
 
     /**
      * @var int
@@ -187,7 +187,7 @@ class Raster extends Image
 
         if (in_array($this->_extension, ['gif', 'webp'])) {
             if (!$imageService->getIsGd() && $this->_image->layers()) {
-                $this->_isAnimatedGif = true;
+                $this->_isAnimated = true;
             }
         }
 
@@ -202,7 +202,7 @@ class Raster extends Image
         $width = $x2 - $x1;
         $height = $y2 - $y1;
 
-        if ($this->_isAnimatedGif) {
+        if ($this->_isAnimated) {
             // Create a new image instance to avoid object references messing up our dimensions.
             $newSize = new Box($width, $height);
             $startingPoint = new Point($x1, $y1);
@@ -358,7 +358,7 @@ class Raster extends Image
     {
         $this->normalizeDimensions($targetWidth, $targetHeight);
 
-        if ($this->_isAnimatedGif) {
+        if ($this->_isAnimated) {
             // Create a new image instance to avoid object references messing up our dimensions.
             $newSize = new Box($targetWidth, $targetHeight);
             $gif = $this->_instance->create($newSize);
@@ -614,7 +614,7 @@ class Raster extends Image
      */
     public function disableAnimation()
     {
-        $this->_isAnimatedGif = false;
+        $this->_isAnimated = false;
 
         if ($this->_image->layers()->count() > 1) {
             // Fetching the first layer returns the built-in Imagick object
@@ -706,7 +706,7 @@ class Raster extends Image
 
             case 'gif':
             case 'webp':
-                return ['animated' => $this->_isAnimatedGif];
+                return ['animated' => $this->_isAnimated];
 
             case 'png':
                 // Valid PNG quality settings are 0-9, so normalize and flip, because we're talking about compression

--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -364,6 +364,7 @@ class Raster extends Image
             $gif = $this->_instance->create($newSize);
             $gif->layers()->remove(0);
 
+            $this->_image->layers()->coalesce();
             foreach ($this->_image->layers() as $layer) {
                 $resizedLayer = $layer->resize($newSize, $this->_getResizeFilter());
                 $gif->layers()->add($resizedLayer);


### PR DESCRIPTION
### Description
Two little things I missed in the fix for #11920. 

1. We need to coalesce the animated layers when resizing as well, otherwise the transform is applied incorrectly. 
2. After talking with @Wiejeben via Discord, they noted that animations were getting stripped out when an animated `webp` file was uploaded. This adjusts the `_isAnimatedGif` check to support `webp` and renames it to `_isAnimated`


### Related issues
Fixes #11889 