### PR TITLE
Report proper width & height values for transforms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fixed a bug where image transforms weren’t always getting applied properly to all animation frames. ([#11937](https://github.com/craftcms/cms/pull/11937))
 - Fixed a bug where animated WebP images would lose their animation frames when transformed. ([#11937](https://github.com/craftcms/cms/pull/11937))
+- Fixed a bug where image transform dimensions could be calculated incorrectly when `upscaleImages` was `false`. ([#11837](https://github.com/craftcms/cms/issues/11837))
 
 ## 3.7.54 - 2022-09-13
 
@@ -15,7 +16,6 @@
 - `craft\services\Elements::resaveElements()` now has a `$touch` argument.
 
 ### Fixed
-- Fixed a bug where image transform dimensions could be calculated incorrectly when `upscaleImages` was `false`. ([#11837](https://github.com/craftcms/cms/issues/11837))
 - Fixed a bug where element caches weren’t being invalidated during garbage collection, so hard-deleted elements could appear to still exist.
 - Fixed an error that could occur when rendering front-end templates if there was a problem connecting to the database. ([#11855](https://github.com/craftcms/cms/issues/11855))
 - Fixed a bug where it was possible to save an asset with a focal point outside its cropped area. ([#11875](https://github.com/craftcms/cms/issues/11875))

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2190,11 +2190,7 @@ class Asset extends Element
 
         $transform = Craft::$app->getAssetTransforms()->normalizeTransform($transform);
 
-        if (
-            ($transform->width === null || $this->_width < $transform->width) &&
-            ($transform->height === null || $this->_height < $transform->height) &&
-            !Craft::$app->getConfig()->getGeneral()->upscaleImages
-        ) {
+        if (!Craft::$app->getConfig()->getGeneral()->upscaleImages) {
             if ($transform->width === null || $transform->height === null) {
                 $transformRatio = $this->_width / $this->_height;
             } else {
@@ -2207,7 +2203,11 @@ class Asset extends Element
                 return [$this->_width, $this->_height];
             }
 
-            return $transformRatio > 1 ? [$this->_width, round($this->_width / $transformRatio)] : [round($this->_width * $transformRatio), $this->_height];
+            // Since we don't want to upscale, make sure the calculated ratios aren't bigger than the actual image size.
+            $newHeight = min($this->_height, round($this->_width / $transformRatio));
+            $newWidth = min($this->_width, round($this->_height * $transformRatio));
+
+            return [$newWidth, $newHeight];
         }
 
         [$width, $height] = Image::calculateMissingDimension($transform->width, $transform->height, $this->_width, $this->_height);


### PR DESCRIPTION
### Description
Previously we ran into a few issues. The `Asset::_dimensions()` call would report the width of the source image rather than the width of the generated transformed image specifically if the transform size was smaller than the source size. This updated adjusts the logic to take the smaller of the two between the source width and height and the calculated width and height. 

### Test Sizes

| Image Size | Transform Size | Result |
|:-----|:-----|:-----|
| 1080 x 594 | 1280 x 720 | 1056 x 594 |
| 1080 x 594 | 1280 x 900 | 845 x 594 | 
| 1080 x 594 | 1280 x 500 | 1080 x 422 |
| 1080 x 594 | 600 x 600 | 594 x 594 |

This also adjusts the if statement to only care about if `upscaleImages` is false. Previously it required both the width and height of the image to be smaller than the size of the transform which could result in upscaling if only one of the dimensions of the source was smaller than the transformed size. 

### Related issues
- Fixes #11837 
