### PR TITLE
Allow control over input options in `BaseTextConditionRule`

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -17,6 +17,7 @@
 - Added the `|integer` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added the `|string` Twig filter. ([#11792](https://github.com/craftcms/cms/pull/11792))
 - Added support for the `CRAFT_DOTENV_PATH` PHP constant. ([#11894](https://github.com/craftcms/cms/discussions/11894))
+- Added `craft\base\conditions\BaseTextConditionRule::inputOptions()`.
 - Added `craft\base\ExpirableElementInterface`. ([#11901](https://github.com/craftcms/cms/pull/11901))
 - Added `craft\nameparsing\CustomLanguage`.
 - Added `craft\db\ActiveQuery::collect()`. ([#11842](https://github.com/craftcms/cms/pull/11842))

--- a/src/base/conditions/BaseNumberConditionRule.php
+++ b/src/base/conditions/BaseNumberConditionRule.php
@@ -32,4 +32,14 @@ abstract class BaseNumberConditionRule extends BaseTextConditionRule
     {
         return 'number';
     }
+
+    /**
+     * @inheritdoc
+     */
+    protected function inputOptions(): array
+    {
+        return array_merge(parent::inputOptions(), [
+            'step' => '1',
+        ]);
+    }
 }

--- a/src/base/conditions/BaseTextConditionRule.php
+++ b/src/base/conditions/BaseTextConditionRule.php
@@ -68,14 +68,25 @@ abstract class BaseTextConditionRule extends BaseConditionRule
     {
         return
             Html::hiddenLabel(Html::encode($this->getLabel()), 'value') .
-            Cp::textHtml([
-                'type' => $this->inputType(),
-                'id' => 'value',
-                'name' => 'value',
-                'value' => $this->value,
-                'autocomplete' => false,
-                'class' => 'flex-grow flex-shrink',
-            ]);
+            Cp::textHtml($this->inputOptions());
+    }
+
+    /**
+     * Returns the input options that should be used.
+     *
+     * @return array
+     * @since 4.3.0
+     */
+    protected function inputOptions(): array
+    {
+        return [
+            'type' => $this->inputType(),
+            'id' => 'value',
+            'name' => 'value',
+            'value' => $this->value,
+            'autocomplete' => false,
+            'class' => 'flex-grow flex-shrink',
+        ];
     }
 
     /**


### PR DESCRIPTION
### Description
PR adds the `inputOptions()` method to allow the control over the options passed to `Cp::textHtml()` method. As an example, shown in this PR, the number condition rule can now easily pass the `step` attribute without having to override the `inputHtml()` method.

In this situation it could in theory be possible to remove the `inputType()` method, but as it already exists we need to leave it. Possibly could be deprecated in favour of this new method?
