### PR TITLE
Graphql `relatedTo*` children query arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed a UI bug where renaming a newly-created volume subfolder didn’t appear to have any effect.
 - Fixed a bug where empty URL fields would be marked as changed, even when no change was made to them. ([#11908](https://github.com/craftcms/cms/issues/11908))
 - Fixed a bug where transforming an animated GIF into a WebP file would only include the first frame. ([#11889](https://github.com/craftcms/cms/issues/11889))
+- Fixed a bug where `relatedTo*` arguments within `children` fields threw an exception ([#11918](https://github.com/craftcms/cms/issues/11918))
 
 ### Security
 - Password inputs no longer temporarily reveal the password when the <kbd>Alt</kbd> key is pressed. ([#11930](https://github.com/craftcms/cms/issues/11930))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed a bug where animated WebP images would lose their animation frames when transformed. ([#11937](https://github.com/craftcms/cms/pull/11937))
 - Fixed a bug where image transform dimensions could be calculated incorrectly when `upscaleImages` was `false`. ([#11837](https://github.com/craftcms/cms/issues/11837))
 - Fixed an error that occurred when setting a non-numeric `width` or `height` on an image transform. ([#11837](https://github.com/craftcms/cms/issues/11837))
+- Fixed a bug where `relatedTo*` arguments weren’t supported by `children` fields in GraphQL. ([#11918](https://github.com/craftcms/cms/issues/11918))
 
 ## 3.7.54 - 2022-09-13
 
@@ -30,7 +31,6 @@
 - Fixed a UI bug where renaming a newly-created volume subfolder didn’t appear to have any effect.
 - Fixed a bug where empty URL fields would be marked as changed, even when no change was made to them. ([#11908](https://github.com/craftcms/cms/issues/11908))
 - Fixed a bug where transforming an animated GIF into a WebP file would only include the first frame. ([#11889](https://github.com/craftcms/cms/issues/11889))
-- Fixed a bug where `relatedTo*` arguments within `children` fields threw an exception ([#11918](https://github.com/craftcms/cms/issues/11918))
 
 ### Security
 - Password inputs no longer temporarily reveal the password when the <kbd>Alt</kbd> key is pressed. ([#11930](https://github.com/craftcms/cms/issues/11930))

--- a/src/gql/ElementQueryConditionBuilder.php
+++ b/src/gql/ElementQueryConditionBuilder.php
@@ -421,6 +421,13 @@ class ElementQueryConditionBuilder extends Component
                     // Any arguments?
                     $arguments = $this->_extractArguments($subNode->arguments ?? []);
 
+                    // If we have arguments, prepare them.
+                    if (!empty($arguments)) {
+                        /** @var ArgumentManager $argumentManager */
+                        $argumentManager = Craft::createObject(['class' => ArgumentManager::class]);
+                        $arguments = $argumentManager->prepareArguments($arguments);
+                    }
+
                     $transformEagerLoadArguments = [];
 
 

--- a/src/gql/ElementQueryConditionBuilder.php
+++ b/src/gql/ElementQueryConditionBuilder.php
@@ -421,13 +421,6 @@ class ElementQueryConditionBuilder extends Component
                     // Any arguments?
                     $arguments = $this->_extractArguments($subNode->arguments ?? []);
 
-                    // If we have arguments, prepare them.
-                    if (!empty($arguments)) {
-                        /** @var ArgumentManager $argumentManager */
-                        $argumentManager = Craft::createObject(['class' => ArgumentManager::class]);
-                        $arguments = $argumentManager->prepareArguments($arguments);
-                    }
-
                     $transformEagerLoadArguments = [];
 
 
@@ -519,7 +512,7 @@ class ElementQueryConditionBuilder extends Component
                                 return $element->getGqlTypeName() === $wrappingFragment->typeCondition->name->value;
                             };
                         }
-                        $plan->criteria = array_merge_recursive($plan->criteria, $arguments);
+                        $plan->criteria = array_merge_recursive($plan->criteria, $this->_argumentManager->prepareArguments($arguments));
                     }
 
                     // If it has any more selections, build the plans recursively


### PR DESCRIPTION
### Description
Fixes an issue where `releatedTo*` arguments within a `children` GraphQL queries were throwing an error. Previously the arguments weren't getting passed through the argument manager which would result in bad criteria getting passed to the query object. 

### Related issues
Fixes #11918 

