### PR TITLE
Handle more edge cases

### DIFF
--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -108,8 +108,8 @@ class Image
         }
 
         // Since we don't want to upscale, make sure the calculated ratios aren't bigger than the actual image size.
-        $newHeight = min($sourceHeight, (int)round($sourceWidth / $transformRatio));
-        $newWidth = min($sourceWidth, (int)round($sourceHeight * $transformRatio));
+        $newWidth = min($sourceWidth, $transformWidth, (int)round($sourceHeight * $transformRatio));
+        $newHeight = min($sourceHeight, $transformHeight, (int)round($sourceWidth / $transformRatio));
 
         return [$newWidth, $newHeight];
     }

--- a/tests/unit/helpers/ImageHelperTest.php
+++ b/tests/unit/helpers/ImageHelperTest.php
@@ -103,6 +103,9 @@ class ImageHelperTest extends Unit
             'crop9' => [200, 100, 40, 60, 200, 100, 'crop', true],
             'crop10' => [40, 20, 40, 60, 200, 100, 'crop', false],
 
+            // https://github.com/craftcms/cms/issues/11837#issuecomment-1249186697
+            'crop11' => [1280, 720, 3600, 2400, 1280, 720, 'crop', false],
+
             'stretch1' => [200, 100, 600, 400, 200, 100, 'stretch', true],
             'stretch2' => [200, 100, 60, 40, 200, 100, 'stretch', true],
             'stretch3' => [200, 133, 60, 40, 200, null, 'stretch', true],


### PR DESCRIPTION
### Description
Handles a case when the source is larger than the transform and caused the source size to be output instead of the smaller, transform size.

### Related issues
#11837 
