### PR TITLE
Updates $onAssetElementList check to handle arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where asset transforms were lost after transforming multiple times ([#11982](https://github.com/craftcms/cms/issues/11982))
+
+
 ## 4.2.5.1 - 2022-09-21
 
 ### Fixed

--- a/src/gql/directives/Transform.php
+++ b/src/gql/directives/Transform.php
@@ -70,7 +70,7 @@ class Transform extends Directive
     public static function apply(mixed $source, mixed $value, array $arguments, ResolveInfo $resolveInfo): mixed
     {
         $onAssetElement = $value instanceof Asset;
-        $onAssetElementList = $value instanceof Collection && !$value->isEmpty();
+        $onAssetElementList = ($value instanceof Collection && !$value->isEmpty()) || (is_array($value) && !empty($value));
         $onApplicableAssetField = $source instanceof Asset && in_array($resolveInfo->fieldName, ['height', 'width', 'url']);
 
         if (!($onAssetElement || $onAssetElementList || $onApplicableAssetField) || empty($arguments)) {


### PR DESCRIPTION
### Description
I'm not sure _exactly_ why but in the `apply` function, `$value` can sometimes be an array. My best guess is that when an asset field is used twice, the second time it comes through as an array instead of a collection.

### Related issues
Fixes #11982
