### PR TITLE
Close [GHSA-mw37-wx8p-gp45] for Craft CMS v3.7

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -4086,7 +4086,7 @@ abstract class Element extends Component implements ElementInterface
                 }
                 /** @var RevisionBehavior $behavior */
                 $behavior = $revision->getBehavior('revision');
-                return $behavior->revisionNotes ?: false;
+                return Html::encode($behavior->revisionNotes) ?: false;
             },
         ]);
     }


### PR DESCRIPTION
### Description
This pull request transfer the security fix from [GHSA-mw37-wx8p-gp45] Craft CMS vulnerable to Cross-site Scripting via Drafts (Commit https://github.com/craftcms/cms/commit/919c9074ff8596bf30a629b0888c529793e9a903) to Craft v3.7.

(see also https://github.com/github/advisory-database/pull/698)


### Related issues

https://github.com/craftcms/cms/issues/11983