### PR TITLE
Set default value for allowLineBreaks

### DIFF
--- a/src/log/MonologTarget.php
+++ b/src/log/MonologTarget.php
@@ -44,7 +44,7 @@ class MonologTarget extends PsrTarget
     /**
      * @var bool
      */
-    protected bool $allowLineBreaks;
+    protected bool $allowLineBreaks = false;
 
     /**
      * @var string


### PR DESCRIPTION
### Description
This adds a default (production-ready) value for `MonologTarget::allowLineBreaks`. It shouldn't be breaking, as anyone instantiating `MonologTarget` would have had to be explicitly setting it.