### PR TITLE
Add tempPath to the EVENT_TRANSFORM_IMAGE ImageTransformerOperationEvent

### DIFF
--- a/src/events/ImageTransformerOperationEvent.php
+++ b/src/events/ImageTransformerOperationEvent.php
@@ -39,4 +39,9 @@ class ImageTransformerOperationEvent extends Event
      * The Image instance that was just saved.
      */
     public ?Image $image;
+
+    /**
+     * @var string The temporary file path.
+     */
+    public ?string $tempPath;
 }

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -391,8 +391,11 @@ class ImageTransformer extends Component implements ImageTransformerInterface, E
                 'imageTransformIndex' => $index,
                 'path' => $transformPath,
                 'image' => $image,
+                'tempPath' => $tempPath,
             ]);
             $this->trigger(static::EVENT_TRANSFORM_IMAGE, $event);
+
+            $tempPath = $event->tempPath;
 
             $stream = fopen($tempPath, 'rb');
             $transformFs->writeFileFromStream($transformPath, $stream, []);


### PR DESCRIPTION
### Description

This change makes it possible again to manipulate the image transform before it is saved.

### Related issues

