### PR TITLE
Prevent lazy loading relationships

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -5199,7 +5199,7 @@ class GeneralConfig extends BaseConfig
      * @see $preventLazyLoading
      * @since 4.3.0
      */
-    public function preventLazyLoading(bool $value = false): self
+    public function preventLazyLoading(bool $value = true): self
     {
         $this->preventLazyLoading = $value;
         return $this;

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1998,6 +1998,26 @@ class GeneralConfig extends BaseConfig
     public bool $preserveImageColorProfiles = true;
 
     /**
+     * @var bool When set to `true`, Craft will not allow relationship fields to be lazy loaded. If a relationship field is accessed lazily while
+     * set to `true` an exception will be thrown. When set to `false` relationships may be loaded lazily.
+     *
+     * Commonly you will set this based on your environment to disable lazy loading during development but allow it in production so that production
+     * doesn't error out if one slips through.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->preventLazyLoading(true)
+     * ```
+     * ```shell Environment Override
+     * CRAFT_PREVENT_LAZY_LOADING=1
+     * ```
+     * :::
+     *
+     * @group System
+     */
+    public bool $preventLazyLoading = false;
+
+    /**
      * @var bool When `true`, Craft will always return a successful response in the “forgot password” flow, making it difficult to enumerate users.
      *
      * When set to `false` and you go through the “forgot password” flow from the control panel login page, you’ll get distinct messages indicating
@@ -5159,6 +5179,29 @@ class GeneralConfig extends BaseConfig
     public function preserveImageColorProfiles(bool $value = true): self
     {
         $this->preserveImageColorProfiles = $value;
+        return $this;
+    }
+
+    /**
+     * When set to `true`, Craft will not allow relationship fields to be lazy loaded. If a relationship field is accessed lazily while
+     * set to `true` an exception will be thrown. When set to `false` relationships may be loaded lazily.
+     *
+     * Commonly you will set this based on your environment to disable lazy loading during development but allow it in production so that production
+     * doesn't error out if one slips through.
+     *
+     * ```php
+     * ->preventLazyLoading(true)
+     * ```
+     *
+     * @group System
+     * @param bool $value
+     * @return self
+     * @see $preventLazyLoading
+     * @since 4.3.0
+     */
+    public function preventLazyLoading(bool $value = false): self
+    {
+        $this->preventLazyLoading = $value;
         return $this;
     }
 


### PR DESCRIPTION
For your consideration, this adds a new general config named `->preventLazyLoading(true)` which is copied from Laravel's similarly named feature: https://twitter.com/taylorotwell/status/1395087054254526474.

I've personally seen a number of projects ship that could be _so_ much faster if the developers had been better about eager loading their relationships. For small sites it doesn't matter much because the DB is faster than they really need. But for larger sites with more complex relationships not eager loading is a dealbreaker for me. This is an opt-in feature that developers could choose to enable per-environment depending on their needs/site.

The implementation happens in `craft\base\Element` since most everything is an element. I don't know that you can eager load non-element items so this seemed like a safe place to do it. But, if there's a higher class that this should be in, let me know.

The actual logic is relatively simple. Since `__get()` already early-exits on eager loaded values I put the check below that and `throw` if the field _should have been_ eager loaded. The logic for determining if a field should have been lazy loaded is checking if it's a pre-defined field (like entry authors) or an extension of the `BaseRelationField` (plus `Matrix`). There may be more eager loadable fields, but I couldn't find a good comprehensive list so I started here. For example, I'm actually not sure if you can eager load asset volumes or element ancestors… so fields like that may need to be added if they're eligible for eager loading.

Happy to iterate on this more if you find it useful. I assume it'd need a more comprehensive list of eagerloadable fields as well as some unit tests.