### PR TITLE
Improve translation of 'Level'

### DIFF
--- a/src/translations/de/app.php
+++ b/src/translations/de/app.php
@@ -811,7 +811,7 @@ return [
     'Leave blank if the entry doesn’t have a URL' => 'Wenn der Eintrag keine URL hat leer lassen',
     'Leave it uninstalled' => 'Deinstallation beibehalten',
     'Let each entry choose which sites it should be saved to' => 'Lassen Sie jeden Eintrag wählen, zu welchen Websites er gespeichert werden soll',
-    'Level' => 'Höhe',
+    'Level' => 'Ebene',
     'License transferred.' => 'Lizenz übertragen.',
     'License' => 'Lizenz',
     'Licensed' => 'Lizenziert',


### PR DESCRIPTION
When creating a field of type entry in the option 'Selectable Entries Condition' dropdown the word 'Level' should rather be translated to 'Ebene'. Currently it's called 'Höhe' which rather refers to 'Height'. 'Höhe' is actually confusing at that point.
