### PR TITLE
Fix serialization error when ElementQuery instances are passed into relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed an error that could occur when editing a draft of an element type that didn’t have change tracking enabled.
+- Fixed an error that caused `ElementQuery` instances to throw a serialization exception. ([#11981](https://github.com/craftcms/cms/issues/11981))
 
 ## 4.2.5.1 - 2022-09-21
 

--- a/src/elements/db/ElementRelationParamParser.php
+++ b/src/elements/db/ElementRelationParamParser.php
@@ -65,6 +65,11 @@ class ElementRelationParamParser extends BaseObject
      */
     public static function normalizeRelatedToParam(mixed $relatedToParam): array
     {
+        // If we have an instance of a query, execute it.
+        if ($relatedToParam instanceof ElementQuery) {
+            $relatedToParam = $relatedToParam->ids();
+        }
+
         // Ensure it's an array
         if (!is_array($relatedToParam)) {
             $relatedToParam = is_string($relatedToParam) ? StringHelper::split($relatedToParam) : [$relatedToParam];


### PR DESCRIPTION
@brandonkelly up to you on if we want to support this or not. When an `ElementQuery` is passed into a `relatedTo` parameter, the check for the glue would result in a serialization error. As far as I can tell passing an `ElementQuery` into `relatedTo` was never explicitly supported, but happened to work in Craft 3. 

### Related issues
Fixes #11981 

