### PR TITLE
Update image transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed an error that could occur when passing an element query to a `relatedTo` param, if the parent element query contained any closures. ([#11981](https://github.com/craftcms/cms/issues/11981))
 - Fixed a bug where unsaved drafts could be unintentionally deleted when saved, if a plugin or module was blocking the save via `EVENT_BEFORE_SAVE`. ([#12015](https://github.com/craftcms/cms/issues/12015))
 - Fixed a bug where “Propagating tags” jobs would fail if two tags had similar titles.
+- Fixed a bug where image transforms weren’t getting sized correctly in some cases when `upscaleImages` was disabled. ([#12023](https://github.com/craftcms/cms/issues/12023))
 
 ### Security
 - Reduced the amount of system information that’s available to guest users.

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -80,12 +80,12 @@ class Image
         string $mode = 'crop',
         ?bool $upscale = null
     ): array {
-        if ($upscale ?? Craft::$app->getConfig()->getGeneral()->upscaleImages) {
-            [$width, $height] = static::calculateMissingDimension($transformWidth, $transformHeight, $sourceWidth, $sourceHeight);
+        [$width, $height] = static::calculateMissingDimension($transformWidth, $transformHeight, $sourceWidth, $sourceHeight);
+        $factor = max($sourceWidth / $width, $sourceHeight / $height);
 
+        if ($upscale ?? Craft::$app->getConfig()->getGeneral()->upscaleImages) {
             // Special case for 'fit' since that's the only one whose dimensions vary from the transform dimensions
             if ($mode === 'fit') {
-                $factor = max($sourceWidth / $width, $sourceHeight / $height);
                 $width = (int)round($sourceWidth / $factor);
                 $height = (int)round($sourceHeight / $factor);
             }
@@ -102,9 +102,9 @@ class Image
         $imageRatio = $sourceWidth / $sourceHeight;
 
         if ($mode === 'fit' || $imageRatio === $transformRatio) {
-            $targetWidth = min($sourceWidth, $transformWidth);
-            $targetHeight = min($sourceHeight, $transformHeight);
-            return static::calculateMissingDimension($targetWidth, $targetHeight, $sourceWidth, $sourceHeight);
+            $targetWidth = min($sourceWidth, $transformWidth, (int)round($sourceWidth / $factor));
+            $targetHeight = min($sourceHeight, $transformHeight, (int)round($sourceHeight / $factor));
+            return [$targetWidth, $targetHeight];
         }
 
         // Since we don't want to upscale, make sure the calculated ratios aren't bigger than the actual image size.

--- a/tests/unit/helpers/ImageHelperTest.php
+++ b/tests/unit/helpers/ImageHelperTest.php
@@ -127,6 +127,12 @@ class ImageHelperTest extends Unit
             'fit8' => [67, 100, 400, 600, 200, 100, 'fit', true],
             'fit9' => [67, 100, 40, 60, 200, 100, 'fit', true],
             'fit10' => [40, 60, 40, 60, 200, 100, 'fit', false],
+
+            // https://github.com/craftcms/cms/issues/12023
+            'fit11' => [160, 240, 240, 360, 240, 240, 'fit', false],
+            'fit12' => [240, 160, 360, 240, 240, 240, 'fit', false],
+            'fit13' => [160, 240, 240, 360, 240, 240, 'fit', true],
+            'fit14' => [240, 160, 360, 240, 240, 240, 'fit', true],
         ];
     }
 


### PR DESCRIPTION
### Description
Fix an issue where image transforms were off in situations where `upscaleImages` was set to `false` and the transform size was smaller than then source size.

### Related issues
Fixes #12023 
