### PR TITLE
Rename folder with duplicate name shows wrong folder in alert message

### DIFF
--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -265,7 +265,7 @@ class Assets extends Component
 
         if ($conflictingFolder) {
             throw new FsObjectExistsException(Craft::t('app', 'A folder with the name “{folderName}” already exists in the folder.', [
-                'folderName' => $folder->name,
+                'folderName' => $newName,
             ]));
         }
 


### PR DESCRIPTION
A folder with the name “{folderName}” already exists in the folder.
This displays the name of the current folder not the duplicate one.
