### PR TITLE
Fixed a potential information leakage issue that could occur on failed queue jobs in certain environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Fixed an error that could occur when saving an entry with Matrix blocks, if the entry had been deleted for a site.
 - Fixed a bug where `resave/*` commands weren’t respecting the `--set`, `--to`, or `--touch` options when `--queue` was passed. ([#11974](https://github.com/craftcms/cms/issues/11974))
 
+### Security
+- Fixed a potential information leakage issue that could occur on failed queue jobs in certain environments.
+
 ## 4.2.5.2 - 2022-10-03
 
 ### Security

--- a/src/queue/Queue.php
+++ b/src/queue/Queue.php
@@ -517,6 +517,12 @@ class Queue extends \yii\queue\cli\Queue implements QueueInterface
         $info = [];
 
         foreach ($results as $result) {
+            if (($errorMessage = $result['error']) && !YII_DEBUG && !Craft::$app->getUser()->getIsAdmin()) {
+                $errorMessage = Craft::t('app','An unknown error occurred.');
+                // Log it for debugging.
+                Craft::error('Queue job failure: ' . $result['error']);
+            }
+
             $info[] = [
                 'id' => $result['id'],
                 'delay' => max(0, $result['timePushed'] + $result['delay'] - time()),
@@ -524,7 +530,7 @@ class Queue extends \yii\queue\cli\Queue implements QueueInterface
                 'progress' => (int)$result['progress'],
                 'progressLabel' => Translation::translate((string)$result['progressLabel']) ?: null,
                 'description' => Translation::translate((string)$result['description']) ?: null,
-                'error' => $result['error'],
+                'error' => $errorMessage,
             ];
         }
 

--- a/src/queue/Queue.php
+++ b/src/queue/Queue.php
@@ -10,6 +10,7 @@ namespace craft\queue;
 use Craft;
 use craft\db\Connection;
 use craft\db\Table;
+use craft\helpers\App;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Db;
 use craft\helpers\Json;
@@ -517,7 +518,7 @@ class Queue extends \yii\queue\cli\Queue implements QueueInterface
         $info = [];
 
         foreach ($results as $result) {
-            if (($errorMessage = $result['error']) && !YII_DEBUG && !Craft::$app->getUser()->getIsAdmin()) {
+            if (($errorMessage = $result['error']) && !App::devMode() && !Craft::$app->getUser()->getIsAdmin()) {
                 $errorMessage = Craft::t('app','An unknown error occurred.');
                 // Log it for debugging.
                 Craft::error('Queue job failure: ' . $result['error']);


### PR DESCRIPTION
The underlying error still displays if the currently logged in user is an admin or devMode is enabled.

