### PR TITLE
Fix serialization error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Fixed a bug where `resave/*` commands weren’t respecting the `--set`, `--to`, or `--touch` options when `--queue` was passed. ([#11974](https://github.com/craftcms/cms/issues/11974))
+- Fixed an error that could occur when passing an element query to a `relatedTo` param, if the parent element query contained any closures. ([#11981](https://github.com/craftcms/cms/issues/11981))
 
 ## 3.7.55.3 - 2022-10-03
 

--- a/src/elements/db/ElementRelationParamParser.php
+++ b/src/elements/db/ElementRelationParamParser.php
@@ -71,7 +71,11 @@ class ElementRelationParamParser extends BaseObject
             $relatedToParam = is_string($relatedToParam) ? StringHelper::split($relatedToParam) : [$relatedToParam];
         }
 
-        if (isset($relatedToParam[0]) && in_array($relatedToParam[0], ['and', 'or'])) {
+        if (
+            isset($relatedToParam[0]) &&
+            is_array($relatedToParam[0]) &&
+            in_array((string)$relatedToParam[0], ['and', 'or'])
+        ) {
             $glue = array_shift($relatedToParam);
             if ($glue === 'and' && count($relatedToParam) < 2) {
                 $glue = 'or';
@@ -164,7 +168,11 @@ class ElementRelationParamParser extends BaseObject
                     $elements = is_string($elements) ? StringHelper::split($elements) : [$elements];
                 }
 
-                if (isset($elements[0]) && in_array($elements[0], ['and', 'or'])) {
+                if (
+                    isset($elements[0]) &&
+                    is_array($elements[0]) &&
+                    in_array((string)$elements[0], ['and', 'or'])
+                ) {
                     $glue = array_shift($elements);
                     if ($glue === 'and' && count($elements) < 2) {
                         $glue = 'or';


### PR DESCRIPTION
### Description
Fixes a serialization error that occurs when an ElementQuery is passed into the `normalizeRelatedToParam` method.

### Related issues
Fixes #11981
