### PR TITLE
Fixed first entry save custom validation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 - Fixed a bug where `resave/*` commands weren’t respecting the `--set`, `--to`, or `--touch` options when `--queue` was passed. ([#11974](https://github.com/craftcms/cms/issues/11974))
 - Fixed an error that could occur when passing an element query to a `relatedTo` param, if the parent element query contained any closures. ([#11981](https://github.com/craftcms/cms/issues/11981))
+- Fixed a bug where unsaved drafts could be unintentionally deleted when saved, if a plugin or module was blocking the save via `EVENT_BEFORE_SAVE`. ([#12015](https://github.com/craftcms/cms/issues/12015))
 
 ### Security
 - Reduced the amount of system information that’s available to guest users.


### PR DESCRIPTION
### Description
On first save of an entry (when changing from draft to entry), if there's a custom validation added via `EVENT_BEFORE_SAVE` , 404 "Entry not found" `NotFoundHttpException` exception was thrown. Once that was fixed, then validation errors were being added and showing twice.
Duplicate errors were also shown if you tried to add your custom validation via `EVENT_BEFORE_VALIDATE`.


### Related issues

- Fixes #12015
