### PR TITLE
Type error on image transform save

### DIFF
--- a/src/controllers/ImageTransformsController.php
+++ b/src/controllers/ImageTransformsController.php
@@ -121,13 +121,9 @@ class ImageTransformsController extends Controller
             $errors = true;
         }
 
-        if (!empty($transform->quality) && (!is_numeric($transform->quality) || $transform->quality > 100 || $transform->quality < 1)) {
+        if ($transform->quality && ($transform->quality > 100 || $transform->quality < 1)) {
             $this->setFailFlash(Craft::t('app', 'Quality must be a number between 1 and 100 (included).'));
             $errors = true;
-        }
-
-        if (empty($transform->quality)) {
-            $transform->quality = null;
         }
 
         if (!empty($transform->format) && !in_array($transform->format, Image::webSafeFormats(), true)) {

--- a/src/controllers/ImageTransformsController.php
+++ b/src/controllers/ImageTransformsController.php
@@ -105,7 +105,7 @@ class ImageTransformsController extends Controller
         $transform->height = $this->request->getBodyParam('height') ?: null;
         $transform->mode = $this->request->getBodyParam('mode');
         $transform->position = $this->request->getBodyParam('position');
-        $transform->quality = $this->request->getBodyParam('quality');
+        $transform->quality = $this->request->getBodyParam('quality') ?: null;
         $transform->interlace = $this->request->getBodyParam('interlace');
         $transform->format = $this->request->getBodyParam('format');
 


### PR DESCRIPTION
When saving with "auto" quality, the template refactoring in 4.3 results in `quality` being posted as `''` vs `'0'`, which results in a `TypeError`.