### PR TITLE
Check for `Craft::$app` in BaseConfig

### DIFF
--- a/src/config/BaseConfig.php
+++ b/src/config/BaseConfig.php
@@ -45,7 +45,7 @@ class BaseConfig extends Model
      */
     final public function __construct($config = [])
     {
-        if (class_exists(Craft::class, false)) {
+        if (class_exists(Craft::class, false) && Craft::$app) {
             $this->filename = Craft::$app->getConfig()->getLoadingConfigFile();
         }
 


### PR DESCRIPTION
### Description
When running tests, the config constructor is called after Craft has been autoloaded but before it has been instantiated.

### Related issues
Fixes #12089 

