### PR TITLE
Ensure the setup/keys command generates an app ID

### DIFF
--- a/src/console/controllers/SetupController.php
+++ b/src/console/controllers/SetupController.php
@@ -183,7 +183,7 @@ EOD;
     {
         $didSomething = false;
 
-        if (Craft::$app->id === 'CraftCMS' && !App::env('CRAFT_APP_ID')) {
+        if (in_array(Craft::$app->id, ['CraftCMS', '']) && !App::env('CRAFT_APP_ID')) {
             $this->run('app-id');
             $didSomething = true;
         }


### PR DESCRIPTION
### Description

The `setup/keys` command checks if the current app ID is the default (`CraftCMS`) and no environment variable exists, then executes the `setup/app-id` command. This works for the default config in the `craftcms/cms` starter project:

```php
// config/app.php
return [
    'id' => App::env('CRAFT_APP_ID') ?: 'CraftCMS',
];
```

But it will _not_ work if you're using either of those forms:

```php
// config/app.php
return [
    // null coalesce
    'id' => App::env('CRAFT_APP_ID') ?? 'CraftCMS',

    // no fallback
    'id' => App::env('CRAFT_APP_ID'),
];
```

Either of those will result in the app ID being an empty string if the `CRAFT_APP_ID` is empty in the `.env` file. In this case, the `setup/keys` command will _not_ generate an app ID. This PR fixes the condition in the command to also run the `app-id` command in those cases.