### PR TITLE
Set better default port

### DIFF
--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -26,6 +26,7 @@ use craft\models\FieldLayout;
 use craft\queue\BaseJob;
 use craft\queue\Queue;
 use DateTime;
+use Exception;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionException;
 use Throwable;
@@ -467,7 +468,7 @@ class Craft extends Yii2
      * @param string $dateOne
      * @param string $dateTwo
      * @param float $secondsDelta
-     * @throws \Exception
+     * @throws Exception
      */
     public function assertEqualDates(TestInterface $test, string $dateOne, string $dateTwo, float $secondsDelta = 5.0)
     {
@@ -700,12 +701,15 @@ class Craft extends Yii2
         $entryFile = $this->_getConfig('entryScript') ?: basename($entryUrl);
         $entryScript = $this->_getConfig('entryScript') ?: parse_url($entryUrl, PHP_URL_PATH);
 
+        $https = parse_url($entryUrl, PHP_URL_SCHEME) === 'https';
+        $defaultPort = $https ? '443' : '80';
+
         $this->client = new CraftConnector([
             'SCRIPT_FILENAME' => $entryFile,
             'SCRIPT_NAME' => $entryScript,
             'SERVER_NAME' => parse_url($entryUrl, PHP_URL_HOST),
-            'SERVER_PORT' => parse_url($entryUrl, PHP_URL_PORT) ?: '80',
-            'HTTPS' => parse_url($entryUrl, PHP_URL_SCHEME) === 'https',
+            'SERVER_PORT' => parse_url($entryUrl, PHP_URL_PORT) ?: $defaultPort,
+            'HTTPS' => $https,
         ]);
 
         $this->configureClient($this->_getConfig());


### PR DESCRIPTION
### Description
Default to port `443` when your `entryUrl` is set to an `https` domain. 


### Related issues
#12087 

