### PR TITLE
Strict installation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed an error that could occur when running tests. ([#12088](https://github.com/craftcms/cms/issues/12088), [#12089](https://github.com/craftcms/cms/issues/12089))
+- Fixed a bug where the `db/restore` command would output a warning about a missing `info` row, even if one existed in the imported database. ([#12101](https://github.com/craftcms/cms/issues/12101))
 
 ## 4.2.7 - 2022-10-11
 

--- a/src/console/Application.php
+++ b/src/console/Application.php
@@ -70,7 +70,7 @@ class Application extends \yii\console\Application
      */
     public function runAction($route, $params = []): int|BaseResponse|null
     {
-        if (!$this->getIsInstalled() && $this->_requireInfoTable($route, $params)) {
+        if (!$this->getIsInstalled(true) && $this->_requireInfoTable($route, $params)) {
             // Is the connection valid at least?
             if (!$this->getIsDbConnectionValid()) {
                 Console::outputWarning('Craft can’t connect to the database. Check your connection settings.');


### PR DESCRIPTION
Previously if you restored the DB and then tried to run another command, Craft would report that it was not yet installed.

The strict test makes sure we're getting an accurage value from `ApplicationTrait::getIsInstalled()` before we show the user a warning

Fixes #12101
