### PR TITLE
feat: v4 -Add Twigfield integration for fields that render as object temp…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "mikehaertl/php-shellcommand": "^1.6.3",
     "moneyphp/money": "^4.0",
     "monolog/monolog": "^2.3",
+    "nystudio107/craft-twigfield": "^1.0.13",
     "pixelandtonic/imagine": "~1.2.4.1",
     "samdark/yii2-psr-log-target": "^1.1",
     "seld/cli-prompt": "^1.0.4",

--- a/src/templates/_components/fieldtypes/Assets/settings.twig
+++ b/src/templates/_components/fieldtypes/Assets/settings.twig
@@ -1,8 +1,11 @@
 {% extends "_components/fieldtypes/elementfieldsettings" %}
 {% import "_includes/forms" as forms %}
 
+{% import "twigfield/twigfield" as twigfield %}
+
 {% macro uploadLocationField(config) %}
     {% embed '_includes/forms/field' with config %}
+        {% import "twigfield/twigfield" as twigfield %}
         {% block input %}
             {% import '_includes/forms' as forms %}
             <div class="flex flex-nowrap">
@@ -15,12 +18,17 @@
                     }) }}
                 </div>
                 <div class="flex-grow">
-                    {{ forms.text({
+                    {{ twigfield.text({
+                        id: config.id,
                         class: 'ltr',
                         name: "#{config.name}Subpath",
                         value: config.subpathValue,
                         placeholder: "path/to/subfolder"|t('app'),
                         describedBy: describedBy,
+                    }, "Twigfield", "monaco-editor-background-frame", {
+                        'fontSize': 13,
+                    }, {
+                        'SectionShorthandFields': 0,
                     }) }}
                 </div>
             </div>
@@ -51,6 +59,7 @@
         class: not field.restrictLocation ? 'hidden' : false,
     } %}
         {{ _self.uploadLocationField({
+            id: 'restrictedLocation',
             label: 'Asset Location'|t('app'),
             instructions: 'The location where assets can be selected from.'|t('app'),
             tip: dynamicPathTip,
@@ -72,7 +81,8 @@
             id: 'allow-subfolders-settings',
             class: not field.allowSubfolders ? 'hidden' : false,
         } %}
-            {{ forms.textField({
+            {{ twigfield.textField({
+                id: 'restrictedDefaultUploadSubpath',
                 class: 'ltr',
                 name: 'restrictedDefaultUploadSubpath',
                 label: 'Default Upload Location'|t('app'),
@@ -80,6 +90,10 @@
                 instructions: 'Where assets should be stored (relative to **Asset Location**) when they are uploaded directly to the field.'|t('app'),
                 tip: dynamicPathTip,
                 placeholder: 'path/to/subfolder'|t('app'),
+            }, "Twigfield", "monaco-editor-background-frame", {
+                'fontSize': 13,
+            }, {
+                'SectionShorthandFields': 0,
             }) }}
         {% endtag %}
     {% endtag %}
@@ -91,6 +105,7 @@
         {{ block('sourcesField') }}
 
         {{ _self.uploadLocationField({
+            id: 'defaultUploadLocation',
             label: 'Default Upload Location'|t('app'),
             instructions: 'Where assets should be stored when they are uploaded directly to the field.'|t('app'),
             tip: dynamicPathTip,

--- a/src/templates/_includes/forms/editableTable.twig
+++ b/src/templates/_includes/forms/editableTable.twig
@@ -17,6 +17,8 @@
     {{ hiddenInput(name, '') }}
 {% endif %}
 
+{% import "twigfield/twigfield" as twigfield %}
+
 {% macro cellClass(fullWidth, col, class) %}
     {{- (class is iterable ? class : [class])|merge([
         "#{col.type}-cell",
@@ -96,7 +98,7 @@
                         {% set headingId = "#{id}-heading-#{loop.index}" %}
                         {% set hasErrors = cell.hasErrors ?? false %}
                         {% set cellName = name~'['~rowId~']['~colId~']' %}
-                        {% set isCode = (col.code ?? false) or col.type == 'color' %}
+                        {% set isCode = ((col.code ?? false) or col.type == 'color') and not col.type == 'twigfield' %}
                         <td class="{{ _self.cellClass(fullWidth, col, col.class ?? []) }} {% if isCode %}code{% endif %} {% if hasErrors %}error{% endif %}"{% if col.width ?? false %} width="{{ col.width }}"{% endif %}>
                             {% block tablecell %}
                                 {%- switch col.type -%}
@@ -177,6 +179,20 @@
                                             labelledBy: headingId,
                                             describedBy: describedBy,
                                         } only %}
+                                    {%- case 'twigfield' -%}
+                                        {% set fieldId = "#{id}-twigfield-#{rowNumber}-#{loop.index}" %}
+                                        {{ twigfield.text({
+                                            id: fieldId,
+                                            name: "{{ cellName }}",
+                                            value: value,
+                                            labelledBy: headingId,
+                                            describedBy: describedBy,
+                                            placeholder: col.placeholder ?? '',
+                                        }, "Twigfield", "monaco-editor-inline-frame", {
+                                            'fontSize': 13,
+                                        }, {
+                                            'SectionShorthandFields': section.id,
+                                        }) }}
                                     {%- default -%}
                                         {% if static %}
                                             <pre class="disabled">{{ value }}</pre>

--- a/src/templates/settings/sections/_edit.twig
+++ b/src/templates/settings/sections/_edit.twig
@@ -151,19 +151,20 @@
                 class: ['single-uri', 'type-single', section.type != 'single' ? 'hidden']|filter
             },
             uriFormat: {
-                type: 'singleline',
+                type: 'twigfield',
                 heading: "Entry URI Format"|t('app'),
                 info: "What entry URIs should look like for the site. Leave blank if entries don’t have URLs."|t('app'),
                 placeholder: 'Leave blank if entries don’t have URLs'|t('app'),
                 code: true,
-                width: headlessMode ? 500,
+                width: headlessMode ? 500 : '40%',
                 class: ['type-channel', 'type-structure', section.type == 'single' ? ' hidden']|filter
             },
             template: not headlessMode ? {
                 type: 'template',
                 heading: "Template"|t('app'),
                 info: "Which template should be loaded when an entry’s URL is requested."|t('app'),
-                code: true
+                code: true,
+                width: '40%',
             },
             enabledByDefault: {
                 type: 'lightswitch',
@@ -177,6 +178,7 @@
         allowAdd: false,
         allowDelete: false,
         allowReorder: false,
+        section: section,
         errors: siteErrors|unique
     }) }}
 

--- a/src/templates/settings/sections/_entrytypes/edit.twig
+++ b/src/templates/settings/sections/_entrytypes/edit.twig
@@ -11,6 +11,7 @@
 
 {% import "_includes/forms" as forms %}
 
+{% import "twigfield/twigfield" as twigfield %}
 
 {% block content %}
     {{ actionInput('sections/save-entry-type') }}
@@ -99,7 +100,7 @@
     {% endif %}
 
     <div id="titleFormat-container"{% if entryType.hasTitleField %} class="hidden"{% endif %}>
-        {{ forms.textField({
+        {{ twigfield.textField({
             label: "Title Format"|t('app'),
             instructions: "What the auto-generated entry titles should look like. You can include tags that output entry properties, such as {ex}."|t('app', { ex: '<code>{myCustomField}</code>' }),
             id: 'titleFormat',
@@ -108,6 +109,10 @@
             value: entryType.titleFormat,
             errors: entryType.getErrors('titleFormat'),
             required: true
+        }, "Twigfield", "monaco-editor-background-frame", {
+            'fontSize': 13,
+        }, {
+            'SectionShorthandFields': section.id,
         }) }}
     </div>
 


### PR DESCRIPTION
This PR is for Craft CMS v4

This PR adds integration with [craft-twigfield](https://github.com/nystudio107/craft-twigfield) to provide a Twig editor for fields in Craft CMS that are rendered as Twig object templates.

### Description

Autocomplete is provided for:

* Twig syntax
* Twig filters, functions, and tags
* The Craft API, and any installed plugins
* Section layout shorthand syntax (e.g.: `{title}`

It is provided in 3 places:

#### Editing Sections

In the **Site Settings** table field:

https://user-images.githubusercontent.com/7570798/195686357-db18d9ad-91f9-4931-b174-ea3457e65531.mov

#### Editing Entry Types

In the **Title Format** field:

https://user-images.githubusercontent.com/7570798/195686665-e59c54bc-56e4-4c28-aac8-c3d1b96c0db8.mov

#### Assets field settings

In the **Default Upload Location**, ** Asset Location**, & **Allow Sub-folders** fields:

https://user-images.githubusercontent.com/7570798/195688351-8141ad3b-7b4d-4a37-9d20-d48f4397e88d.mov
