### PR TITLE
More textual condition rule operators

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -93,6 +93,7 @@
 - Notifications are now shown after executing folder actions on the Assets index page. ([#11906/](https://github.com/craftcms/cms/pull/11906))
 - Date range condition rules now support “Today”, “This week”, “This month”, “This year”, “Past 7 days”, “Past 30 days”, “Past 30 days”, “Past year”, “Before…”, and “After…” relative range types, in addition to specifying a custom date range. ([#11888](https://github.com/craftcms/cms/pull/11888))
 - Number condition rules now support an “is between…” operator. ([#11950](https://github.com/craftcms/cms/pull/11950))
+- All text, number, and date range condition rules now support “has a value” and “is empty” operators. ([#11070](https://github.com/craftcms/cms/discussions/11070))
 - If Live Preview is triggered while a draft is saving, it will now wait until the save completes before opening. ([#11858](https://github.com/craftcms/cms/issues/11858), [#11895](https://github.com/craftcms/cms/pull/11895))
 - Addresses now support change tracking.
 - It’s now possible to restore assets that were deleted programmatically with `craft\elements\Asset::$keepFile` set to `true`. ([#11761](https://github.com/craftcms/cms/issues/11761))

--- a/src/base/conditions/BaseDateRangeConditionRule.php
+++ b/src/base/conditions/BaseDateRangeConditionRule.php
@@ -139,6 +139,8 @@ abstract class BaseDateRangeConditionRule extends BaseConditionRule
                 DateRange::TYPE_RANGE,
             ])) {
                 $index = 1;
+            } elseif (in_array($value, [self::OPERATOR_NOT_EMPTY, self::OPERATOR_EMPTY])) {
+                $index = 2;
             } else {
                 $index = 0;
             }
@@ -273,6 +275,8 @@ JS,
             DateRange::TYPE_BEFORE => Craft::t('app', 'Before…'),
             DateRange::TYPE_AFTER => Craft::t('app', 'After…'),
             DateRange::TYPE_RANGE => Craft::t('app', 'Range…'),
+            self::OPERATOR_NOT_EMPTY => Craft::t('app', 'has a value'),
+            self::OPERATOR_EMPTY => Craft::t('app', 'is empty'),
         ];
     }
 
@@ -335,6 +339,12 @@ JS,
                 return ($this->rangeType === DateRange::TYPE_AFTER ? '>=' : '<') . ' ' .
                     DateTimeHelper::toIso8601(DateTimeHelper::now()->add($dateInterval));
 
+            case self::OPERATOR_EMPTY:
+                return ':empty:';
+
+            case self::OPERATOR_NOT_EMPTY:
+                return 'not :empty:';
+
             default:
                 [$startDate, $endDate] = DateRange::dateRangeByType($this->rangeType);
                 $startDate = DateTimeHelper::toIso8601($startDate);
@@ -372,6 +382,12 @@ JS,
                 }
 
                 return $value && $value < $date;
+
+            case self::OPERATOR_EMPTY:
+                return !$value;
+
+            case self::OPERATOR_NOT_EMPTY:
+                return (bool)$value;
 
             default:
                 [$startDate, $endDate] = DateRange::dateRangeByType($this->rangeType);

--- a/src/base/conditions/BaseNumberConditionRule.php
+++ b/src/base/conditions/BaseNumberConditionRule.php
@@ -54,6 +54,8 @@ abstract class BaseNumberConditionRule extends BaseTextConditionRule
             self::OPERATOR_GT,
             self::OPERATOR_GTE,
             self::OPERATOR_BETWEEN,
+            self::OPERATOR_NOT_EMPTY,
+            self::OPERATOR_EMPTY,
         ];
     }
 

--- a/src/base/conditions/BaseTextConditionRule.php
+++ b/src/base/conditions/BaseTextConditionRule.php
@@ -48,6 +48,8 @@ abstract class BaseTextConditionRule extends BaseConditionRule
             self::OPERATOR_BEGINS_WITH,
             self::OPERATOR_ENDS_WITH,
             self::OPERATOR_CONTAINS,
+            self::OPERATOR_NOT_EMPTY,
+            self::OPERATOR_EMPTY,
         ];
     }
 
@@ -106,6 +108,13 @@ abstract class BaseTextConditionRule extends BaseConditionRule
      */
     protected function paramValue(): ?string
     {
+        switch ($this->operator) {
+            case self::OPERATOR_EMPTY:
+                return ':empty:';
+            case self::OPERATOR_NOT_EMPTY:
+                return 'not :empty:';
+        }
+
         if ($this->value === '') {
             return null;
         }
@@ -128,6 +137,13 @@ abstract class BaseTextConditionRule extends BaseConditionRule
      */
     protected function matchValue(mixed $value): bool
     {
+        switch ($this->operator) {
+            case self::OPERATOR_EMPTY:
+                return !$value;
+            case self::OPERATOR_NOT_EMPTY:
+                return (bool)$value;
+        }
+
         if ($this->value === '') {
             return true;
         }


### PR DESCRIPTION
### Description

Adds “has a value” and “is empty” operators to all text, number, and date range condition rules.

### Related issues

- #11070