### PR TITLE
Feature/dev 1022 elementcollection w ids

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -27,6 +27,7 @@
 - Added `craft\elements\actions\Restore::$restorableElementsOnly`.
 - Added `craft\elements\conditions\assets\EditableConditionRule`.
 - Added `craft\elements\conditions\entries\EditableConditionRule`.
+- Added `craft\elements\ElementCollection`, which extends `Illuminate\Support\Collection` with `ids()` and `with()` methods. ([#12113](https://github.com/craftcms/cms/discussions/12113))
 - Added `craft\events\AuthorizationCheckEvent::$element`.
 - Added `craft\events\CreateTwigEvent`.
 - Added `craft\events\DefineAddressFieldLabelEvent`.
@@ -110,6 +111,7 @@
 - `{% cache %}` tags now store any HTML registered with `{% html %}` tags. ([#11811](https://github.com/craftcms/cms/discussions/11811))
 - `{% cache %}` tags and GraphQL query caches now get a max cache duration based on the fetched/referenced entries’ expiry dates. ([#8525](https://github.com/craftcms/cms/discussions/8525), [#11901](https://github.com/craftcms/cms/pull/11901))
 - Control panel `.twig` templates are now prioritized over `.html`. ([#11809](https://github.com/craftcms/cms/discussions/11809), [#11840](https://github.com/craftcms/cms/pull/11840))
+- `craft\elements\db\ElementQuery::collect()` and `craft\base\Element::getEagerLoadedElements()` now return `craft\elements\ElementCollection` instances. ([#12113](https://github.com/craftcms/cms/discussions/12113))
 - `craft\events\DraftEvent::$creatorId` is now nullable. ([#11904](https://github.com/craftcms/cms/issues/11904))
 - `craft\fieldlayoutelements\BaseField::statusClass()` and `statusLabel()` now return status info from the element for the attribute specified by `attribute()`.
 - `craft\helpers\Component::iconSvg()` now namespaces the SVG contents, and adds `aria-hidden="true"`. ([#11703](https://github.com/craftcms/cms/pull/11703))

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -23,6 +23,7 @@ use craft\elements\conditions\ElementCondition;
 use craft\elements\conditions\ElementConditionInterface;
 use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
+use craft\elements\ElementCollection;
 use craft\elements\exporters\Expanded;
 use craft\elements\exporters\Raw;
 use craft\elements\User;
@@ -1864,14 +1865,14 @@ abstract class Element extends Component implements ElementInterface
     private ElementInterface|false|null $_nextSibling = null;
 
     /**
-     * @var Collection[]
+     * @var array<string,Collection>
      * @see getEagerLoadedElements()
      * @see setEagerLoadedElements()
      */
     private array $_eagerLoadedElements = [];
 
     /**
-     * @var array
+     * @var array<string,int>
      * @see getEagerLoadedElementCount()
      * @see setEagerLoadedElementCount
      */
@@ -4078,7 +4079,7 @@ abstract class Element extends Component implements ElementInterface
                 $this->trigger(self::EVENT_SET_EAGER_LOADED_ELEMENTS, $event);
                 if (!$event->handled) {
                     // No takers. Just store it in the internal array then.
-                    $this->_eagerLoadedElements[$handle] = Collection::make($elements);
+                    $this->_eagerLoadedElements[$handle] = ElementCollection::make($elements);
                 }
         }
     }

--- a/src/db/Query.php
+++ b/src/db/Query.php
@@ -10,6 +10,7 @@ namespace craft\db;
 use ArrayAccess;
 use ArrayIterator;
 use craft\base\ClonefixTrait;
+use craft\elements\ElementCollection;
 use craft\events\DefineBehaviorsEvent;
 use craft\helpers\ArrayHelper;
 use Illuminate\Support\Collection;
@@ -260,7 +261,7 @@ class Query extends \yii\db\Query implements ArrayAccess, IteratorAggregate
      */
     public function collect(?YiiConnection $db = null): Collection
     {
-        return Collection::make($this->all($db));
+        return ElementCollection::make($this->all($db));
     }
 
     /**

--- a/src/elements/ElementCollection.php
+++ b/src/elements/ElementCollection.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\elements;
+
+use Craft;
+use craft\base\ElementInterface;
+use Illuminate\Support\Collection;
+
+/**
+ * ElementCollection represents a collection of elements.
+ *
+ * @template TKey of array-key
+ * @template TValue of ElementInterface
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.3.0
+ */
+class ElementCollection extends Collection
+{
+    /**
+     * Returns a collection of the elements’ IDs.
+     *
+     * @return Collection<TKey,int>
+     */
+    public function ids(): Collection
+    {
+        return Collection::make(array_map(fn(ElementInterface $element): int => $element->id, $this->items));
+    }
+
+    /**
+     * Eager-loads related elements for the collected elements.
+     *
+     * See [Eager-Loading Elements](https://craftcms.com/docs/4.x/dev/eager-loading-elements.html) for a full explanation of how to work with this parameter.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch entries and eager-load the "Related" field’s relations onto them #}
+     * {% set entries = craft.entries()
+     *   .collect()
+     *   .with(['related']) %}
+     * ```
+     *
+     * ```php
+     * // Fetch entries and eager-load the "Related" field’s relations onto them
+     * $entries = Entry::find()
+     *     ->collect()
+     *     ->with(['related']);
+     * ```
+     *
+     * @param array|string $with The property value
+     * @return $this
+     */
+    public function with(array|string $with): static
+    {
+        $first = $this->first();
+        if ($first instanceof ElementInterface) {
+            Craft::$app->getElements()->eagerLoadElements(get_class($first), $this->items, $with);
+        }
+        return $this;
+    }
+}

--- a/src/elements/MatrixBlock.php
+++ b/src/elements/MatrixBlock.php
@@ -393,7 +393,7 @@ class MatrixBlock extends Element implements BlockElementInterface
         $blockTypeHandle = $this->getType()->handle . ':' . $handle;
 
         if (isset($this->_eagerLoadedBlockTypeElements[$blockTypeHandle])) {
-            return Collection::make($this->_eagerLoadedBlockTypeElements[$blockTypeHandle]);
+            return ElementCollection::make($this->_eagerLoadedBlockTypeElements[$blockTypeHandle]);
         }
 
         return parent::getEagerLoadedElements($handle);


### PR DESCRIPTION
### Description

Adds a new `craft\elements\ElementCollection` class, which extends `Illuminate\Support\Collection` specifically for collecting element instances, and adds two new methods:

- `ids()` – returns a new collection of the IDs of each of the collected elements. ([#12113](https://github.com/craftcms/cms/discussions/12113))
- `with()` - eager-loads additional elements onto the collected elements and then returns the same `ElementCollection` object.

`craft\elements\db\ElementQuery::collect()` and `craft\base\Element::getEagerLoadedElements()` have both been updated to return new `ElementCollection` instances rather than `Collection`, so the following are now possible:

```twig
{% set ids = craft.entries()
  .collect()
  .ids() %}
```

```twig
{% set entries = craft.entries()
  .collect()
  .with(['eagerLoadingHandle']) %}

{% for entry in entries %}
  {% set eagerLoadedIds = entry.eagerLoadingHandle.ids() %}
{% endfor %}
```

### Related issues

- #12113