### PR TITLE
fix for renamed asset titles for non-primary sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed a bug where custom log targets were getting removed when processing queue jobs. ([#12109](https://github.com/craftcms/cms/pull/12109))
 - Fixed a bug where Money fields weren’t distinguishing between `0` and empty values. ([#12122](https://github.com/craftcms/cms/issues/12122), [#12132](https://github.com/craftcms/cms/pull/12132))
 - Fixed an error that could occur in the control panel. ([#12133](https://github.com/craftcms/cms/issues/12133))
+- Fixed a bug where assets uploaded from Assets fields weren’t retaining their original filename for all but the initial site. ([#12142](https://github.com/craftcms/cms/pull/12142))
 
 ## 4.2.7 - 2022-10-11
 

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -247,6 +247,9 @@ class AssetsController extends Controller
             $asset->setVolumeId($folder->volumeId);
             $asset->uploaderId = Craft::$app->getUser()->getId();
             $asset->avoidFilenameConflicts = true;
+            if (isset($originalFilename)) {
+                $asset->title = Assets::filename2Title(pathinfo($originalFilename, PATHINFO_FILENAME));
+            }
             $asset->setScenario(Asset::SCENARIO_CREATE);
 
             $result = $elementsService->saveElement($asset);
@@ -268,7 +271,6 @@ class AssetsController extends Controller
 
                 if (isset($originalFilename, $originalFolder)) {
                     // move it into the original target destination
-                    $asset->title = Assets::filename2Title(pathinfo($originalFilename, PATHINFO_FILENAME));
                     $asset->newFilename = $originalFilename;
                     $asset->newFolderId = $originalFolder->id;
                     $asset->setScenario(Asset::SCENARIO_MOVE);

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -247,11 +247,12 @@ class AssetsController extends Controller
             $asset->setVolumeId($folder->volumeId);
             $asset->uploaderId = Craft::$app->getUser()->getId();
             $asset->avoidFilenameConflicts = true;
+
             if (isset($originalFilename)) {
                 $asset->title = Assets::filename2Title(pathinfo($originalFilename, PATHINFO_FILENAME));
             }
-            $asset->setScenario(Asset::SCENARIO_CREATE);
 
+            $asset->setScenario(Asset::SCENARIO_CREATE);
             $result = $elementsService->saveElement($asset);
 
             // In case of error, let user know about it.


### PR DESCRIPTION
### Description
Fix for issue where uploading an asset via Asset field 'Upload Files' was renaming title of the asset to "AssetXXX..." on non-primary sites. Moved Tim's fix higher up, so that it gets applied on initial creation and propagation of the asset.

### Related issues
- Fixes #12142
- Fixes #11530  
