### PR TITLE
Fix typo in `ImageHelper::targetDimensions()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed an error that could occur when running tests. ([#12088](https://github.com/craftcms/cms/issues/12088))
 - Fixed a bug where the “Your session has ended” modal could be shown on the control panel’s login page. ([#12121](https://github.com/craftcms/cms/issues/12121))
 - Fixed an error that could occur in the control panel. ([#12133](https://github.com/craftcms/cms/issues/12133))
+- Fixed a bug where image transforms that used the `fit` mode but didn’t specify a width or height weren’t getting their missing dimension set on the asset. ([#12137](https://github.com/craftcms/cms/issues/12137))
 
 ## 3.7.56 - 2022-10-11
 

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -10,6 +10,9 @@ namespace craft\helpers;
 use Craft;
 use craft\errors\ImageException;
 use craft\image\Svg;
+use Imagick;
+use Throwable;
+use TypeError;
 use yii\base\InvalidArgumentException;
 
 /**
@@ -102,8 +105,8 @@ class Image
         $imageRatio = $sourceWidth / $sourceHeight;
 
         if ($mode === 'fit' || $imageRatio === $transformRatio) {
-            $targetWidth = min($sourceWidth, $transformWidth, (int)round($sourceWidth / $factor));
-            $targetHeight = min($sourceHeight, $transformHeight, (int)round($sourceHeight / $factor));
+            $targetWidth = min($sourceWidth, $width, (int)round($sourceWidth / $factor));
+            $targetHeight = min($sourceHeight, $height, (int)round($sourceHeight / $factor));
             return [$targetWidth, $targetHeight];
         }
 
@@ -252,7 +255,7 @@ class Image
 
             $image = Craft::$app->getImages()->loadImage($filePath);
             return [$image->getWidth(), $image->getHeight()];
-        } catch (\Throwable $exception) {
+        } catch (Throwable $exception) {
             return [0, 0];
         }
     }
@@ -262,12 +265,12 @@ class Image
      *
      * @param resource $stream
      * @return array|false
-     * @throws \TypeError
+     * @throws TypeError
      */
     public static function imageSizeByStream($stream)
     {
         if (!is_resource($stream)) {
-            throw new \TypeError('Argument passed should be a resource.');
+            throw new TypeError('Argument passed should be a resource.');
         }
 
         $dimensions = [];
@@ -395,9 +398,9 @@ class Image
      * Clean EXIF data from an image loaded inside an Imagick instance, taking
      * care not to wipe the ICC profile.
      *
-     * @param \Imagick $imagick
+     * @param Imagick $imagick
      */
-    public static function cleanExifDataFromImagickImage(\Imagick $imagick)
+    public static function cleanExifDataFromImagickImage(Imagick $imagick)
     {
         $config = Craft::$app->getConfig()->getGeneral();
 


### PR DESCRIPTION
### Description
Fix error from #11962 where I used the `$transformWidth` and `$transformHeight` instead of `$width` / `$height`. At this point in the code `$width` & `$height` have been returned from `Image::calculateMissingDimension()` which has filled in the missing value with a calculation based on the transform. 

### Related issues
- Fixes #12137
