### PR TITLE
Feature/dev 69 save as new changes

### DIFF
--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -677,6 +677,18 @@ class ElementsController extends Controller
                     ],
                 ]);
             } else {
+                // save as a new is now available to people who can create drafts
+                $components[] = Html::beginForm() .
+                    Html::actionInput('elements/duplicate') .
+                    Html::redirectInput('{cpEditUrl}') .
+                    Html::hiddenInput('elementId', (string)$canonical->id) .
+                    Html::beginTag('div', ['class' => 'secondary-buttons']) .
+                    Html::button(Craft::t('app', 'Save as a new {type}', ['type' => $element::lowerDisplayName()]), [
+                        'class' => ['btn', 'secondary', 'formsubmit'],
+                    ]) .
+                    Html::endTag('div') .
+                    Html::endForm();
+
                 $components[] = Html::beginForm() .
                     Html::actionInput('elements/save-draft') .
                     Html::redirectInput('{cpEditUrl}') .
@@ -952,7 +964,9 @@ JS, [
             throw new BadRequestHttpException('No element was identified by the request.');
         }
 
-        if (!$element->canDuplicate(Craft::$app->getUser()->getIdentity())) {
+        // this action is called when using "save as a new" option; "save as a new" now creates an unpublished draft
+        // so we can check for canCreateDrafts permission, instead of canDuplicate or canSave
+        if (!$element->canCreateDrafts(Craft::$app->getUser()->getIdentity())) {
             throw new ForbiddenHttpException('User not authorized to duplicate this element.');
         }
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1052,7 +1052,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
 
         if ($element->duplicateOf !== null) {
             // If this is a draft, just duplicate the relations
-            if ($element->getIsDraft()) {
+            if ($element->getIsDraft() && !$element->getIsUnpublishedDraft()) {
                 $matrixService->duplicateOwnership($this, $element->duplicateOf, $element);
             } elseif ($element->getIsRevision()) {
                 $matrixService->createRevisionBlocks($this, $element->duplicateOf, $element);


### PR DESCRIPTION
### Description

- “Save as a new {type}” creates an unpublished draft
- "Save as a new {type}" is available to users with "Create" permission too, (not as currently with "Save" permission)
- If you edit existing e.g. entry (create a provisional draft) and then click “Save as a new {type}” it applies your changes to the new element and discard them from the existing one.

No changes made to the index pages duplicate functions.


### Related issues

- [Dev-69](https://linear.app/craftcms/issue/DEV-69/save-as-a-new-entry-should-create-an-unpublished-draft)
- #10244 
- #9577 
- #11959 
