### PR TITLE
Allow existing assets for user photo

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -2191,6 +2191,23 @@ JS,
                 FileHelper::writeToFile($fileLocation, $data);
                 $newPhoto = true;
             }
+        } elseif ($photoId = $this->request->getBodyParam('photoId')) {
+
+            /** @var ?Asset $asset */
+            $asset = Asset::find()->id($photoId)->one();
+
+            if ($asset) {
+                if ($asset->kind === Asset::KIND_IMAGE) {
+                    $user->setPhoto($asset);
+                } else {
+                    $user->addError('photo', Craft::t('app', 'The user photo provided is not an image.'));
+                }
+            } else {
+                $user->addError('photo', Craft::t('app', 'The user photo could not be found.'));
+            }
+
+            Craft::$app->getElements()->saveElement($user);
+            return;
         }
 
         if ($newPhoto) {


### PR DESCRIPTION
### Description
With the current controller, the only way to update a user photo is with an upload.
This allows you to set it with an existing asset via the `photoId` body param.