### PR TITLE
Fixes #12161 - Add `countryCode` validation to addresses

### DIFF
--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -499,6 +499,12 @@ class Address extends Element implements AddressInterface, BlockElementInterface
         $rules = parent::defineRules();
         $rules[] = [['ownerId'], 'number'];
         $rules[] = [['countryCode'], 'required'];
+        $rules[] = [['countryCode'], function ($attribute, $params, $validator) {
+            $countryCodes = array_keys(Craft::$app->getAddresses()->getCountryRepository()->getList());
+            if (!in_array($this->$attribute, $countryCodes)) {
+                $this->addError($attribute, Craft::t('app', 'Not a valid country.'));
+            }
+        }];
 
         foreach (self::_addressAttributes() as $attr) {
             if ($attr === 'countryCode') {
@@ -510,7 +516,7 @@ class Address extends Element implements AddressInterface, BlockElementInterface
                 $attr,
                 'required',
                 'on' => self::SCENARIO_LIVE,
-                'when' => function(Address $model, string $attribute) {
+                'when' => function (Address $model, string $attribute) {
                     $formatter = Craft::$app->getAddresses()->getAddressFormatRepository()->get($this->countryCode);
                     return in_array($attribute, $formatter->getRequiredFields());
                 },

--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -499,7 +499,7 @@ class Address extends Element implements AddressInterface, BlockElementInterface
         $rules = parent::defineRules();
         $rules[] = [['ownerId'], 'number'];
         $rules[] = [['countryCode'], 'required'];
-        $rules[] = [['countryCode'], function ($attribute, $params, $validator) {
+        $rules[] = [['countryCode'], function($attribute, $params, $validator) {
             $countryCodes = array_keys(Craft::$app->getAddresses()->getCountryRepository()->getList());
             if (!in_array($this->$attribute, $countryCodes)) {
                 $this->addError($attribute, Craft::t('app', 'Not a valid country.'));
@@ -516,7 +516,7 @@ class Address extends Element implements AddressInterface, BlockElementInterface
                 $attr,
                 'required',
                 'on' => self::SCENARIO_LIVE,
-                'when' => function (Address $model, string $attribute) {
+                'when' => function(Address $model, string $attribute) {
                     $formatter = Craft::$app->getAddresses()->getAddressFormatRepository()->get($this->countryCode);
                     return in_array($attribute, $formatter->getRequiredFields());
                 },


### PR DESCRIPTION
This PR adds `countryCode` validation against the list of country codes in the addressing library.

TODO

- [ ] Add changelog entry
- [ ] @AugustMiller / @brandonkelly to review the error message. Should it be "Invalid country" or "Not a valid country"?