### PR TITLE
fix for drafts not autosaving with matrix custom propagation

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1310,8 +1310,10 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
                     // Duplicate it as a draft. (We'll drop its draft status from `Matrix::saveField()`.)
                     $block = Craft::$app->getDrafts()->createDraft($block, Craft::$app->getUser()->getId(), null, null, [
                         'canonicalId' => $block->id,
-                        'primaryOwnerId' => $element->id,
-                        'owner' => $element,
+                        // #12176 - setting primaryOwnerId and owner causes an infinite loop
+                            // when autosaving drafts, if matrix propagation method is set to custom
+                        //'primaryOwnerId' => $element->id,
+                        //'owner' => $element,
                         'siteId' => $element->siteId,
                         'propagating' => false,
                         'markAsSaved' => false,


### PR DESCRIPTION
### Description

If matrix is set to propagation method: custom with propagation key being as per the last paragraph in the docs (https://craftcms.com/docs/4.x/fields.html#translation-methods), if you set `primaryOwnerId` and `owner` to owner element (e.g. entry) when creating a draft, the draft won't autosave. It causes an infinite loop because of a special check for supported sites (src/services/Matrix.php > getSupportedSiteIds() > line 1139) 
<img width="787" alt="Screenshot 2022-10-25 at 13 43 44" src="https://user-images.githubusercontent.com/4500340/197785707-c95b0e98-a40a-434c-8c31-8561710c0c4a.png">

Not setting the `primaryOwnerId` and `owner` of the matrix block this way, means that the draft version owner is set to the new (draft) element and propagation method checks are carried out correctly.

### Related issues
#12176 
