### PR TITLE
Pass ID to field layout tab configs

### DIFF
--- a/src/models/FieldLayoutTab.php
+++ b/src/models/FieldLayoutTab.php
@@ -203,7 +203,7 @@ class FieldLayoutTab extends FieldLayoutComponent
             $this->uid = StringHelper::UUID();
         }
 
-        $config = $this->toArray(['name', 'uid', 'userCondition', 'elementCondition']);
+        $config = $this->toArray(['name', 'id', 'uid', 'userCondition', 'elementCondition']);
         $config['elements'] = $this->getElementConfigs();
         return $config;
     }


### PR DESCRIPTION
### Description
When saving field layout tabs, [the ID is checked](https://github.com/craftcms/cms/blob/cc58802be988d2311722fb0dbf390d8c10653bf0/src/services/Fields.php#L1376-L1380) to see if we have an existing record that needs to update or not. However, the `id` wasn't getting passed up within the POST request.

The result is that DB records in the `fieldlayouttabs` table could drift away from the data stored in project config. As far as I know this only resulted in a lot of error logs, but it's annoying nonetheless.

Running `project-config/apply --force` clears things up as well, but this fix should prevent it from happening in the future.

### Related issues
Fixes #11925






