### PR TITLE
number formatting in plain text field - index page

### DIFF
--- a/src/fields/PlainText.php
+++ b/src/fields/PlainText.php
@@ -14,6 +14,7 @@ use craft\base\PreviewableFieldInterface;
 use craft\base\SortableFieldInterface;
 use craft\fields\conditions\TextFieldConditionRule;
 use craft\helpers\Db;
+use craft\helpers\ElementHelper;
 use LitEmoji\LitEmoji;
 use yii\db\Schema;
 
@@ -258,5 +259,13 @@ class PlainText extends Field implements PreviewableFieldInterface, SortableFiel
     public function getElementConditionRuleType(): ?string
     {
         return TextFieldConditionRule::class;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTableAttributeHtml(mixed $value, ElementInterface $element): string
+    {
+        return ElementHelper::attributeHtml($value, true);
     }
 }

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -713,10 +713,11 @@ class ElementHelper
      * Returns the HTML for a given attribute value, to be shown in an element index view.
      *
      * @param mixed $value The field value
+     * @param ?bool $plainText Is the field, for which we have the value, a plain text field?
      * @return string
      * @since 4.3.0
      */
-    public static function attributeHtml(mixed $value): string
+    public static function attributeHtml(mixed $value, ?bool $plainText = false): string
     {
         if ($value instanceof DateTime) {
             $formatter = Craft::$app->getFormatter();
@@ -741,7 +742,7 @@ class ElementHelper
             ]);
         }
 
-        if (Number::isIntOrFloat($value)) {
+        if (Number::isIntOrFloat($value) && !$plainText) {
             return Craft::$app->getFormatter()->asDecimal($value);
         }
 


### PR DESCRIPTION
### Description
Numbers in a plain text field on an element index page shouldn't get numeric formatting applied.

For C5 we should consider changing `src/base/Field.php` `getTableAttributeHtml()` (and other implementations of it) to accept the field and pass it along, so that we can act on that information in places like `ElementHelper::attributeHtml()`. Doing it now would introduce breaking changes for some plugins (e.g. besteadfast/craft-preparse-field).


### Related issues
#12205 
