### PR TITLE
BaseOptionsField::EVENT_SET_INPUT_OPTIONS

### DIFF
--- a/src/events/InputOptionsEvent.php
+++ b/src/events/InputOptionsEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace craft\events;
+
+use craft\base\ElementInterface;
+use craft\elements\MatrixBlock;
+use yii\base\Event;
+
+class InputOptionsEvent extends Event
+{
+    /**
+     * @var array The options that will be available for the current field
+     */
+    public array $options;
+
+    /**
+     * @var ElementInterface|null The element that the field is generating an input for.
+     */
+    public ?ElementInterface $element = null;
+
+    /**
+     * @var mixed The current value of the field.
+     */
+    public mixed $value;
+}

--- a/src/fields/Checkboxes.php
+++ b/src/fields/Checkboxes.php
@@ -63,7 +63,7 @@ class Checkboxes extends BaseOptionsField
             'describedBy' => $this->describedBy,
             'name' => $this->handle,
             'values' => $this->encodeValue($value),
-            'options' => $this->translatedOptions(true),
+            'options' => $this->inputOptions($value, $element, true),
         ]);
     }
 

--- a/src/fields/Dropdown.php
+++ b/src/fields/Dropdown.php
@@ -48,14 +48,14 @@ class Dropdown extends BaseOptionsField implements SortableFieldInterface
     protected function inputHtml(mixed $value, ?ElementInterface $element = null): string
     {
         /** @var SingleOptionFieldData $value */
-        $options = $this->translatedOptions(true);
+        $options = $this->inputOptions($value, $element, true);
 
         if (!$value->valid) {
             Craft::$app->getView()->setInitialDeltaValue($this->handle, $this->encodeValue($value->value));
             $value = null;
 
             // Add a blank option to the beginning if one doesn't already exist
-            if (!ArrayHelper::contains($options, function($option) {
+            if (!ArrayHelper::contains($options, function ($option) {
                 return isset($option['value']) && $option['value'] === '';
             })) {
                 array_unshift($options, ['label' => '', 'value' => '']);

--- a/src/fields/MultiSelect.php
+++ b/src/fields/MultiSelect.php
@@ -61,7 +61,7 @@ class MultiSelect extends BaseOptionsField
             'describedBy' => $this->describedBy,
             'name' => $this->handle,
             'values' => $this->encodeValue($value),
-            'options' => $this->translatedOptions(true),
+            'options' => $this->inputOptions($value, $element, true),
         ]);
     }
 

--- a/src/fields/RadioButtons.php
+++ b/src/fields/RadioButtons.php
@@ -58,7 +58,7 @@ class RadioButtons extends BaseOptionsField implements SortableFieldInterface
             'describedBy' => $this->describedBy,
             'name' => $this->handle,
             'value' => $this->encodeValue($value),
-            'options' => $this->translatedOptions(true),
+            'options' => $this->inputOptions($value, $element, true),
         ]);
     }
 


### PR DESCRIPTION
Adds an event, and a slight change to surrounding code, to option fields. This allows plugins and modules to modify the options that are rendered for the input.

**Related discussion:** #12212