### PR TITLE
Animated PNG support

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -241,6 +241,7 @@ class GeneralConfig extends BaseConfig
         'aiff',
         'asc',
         'asf',
+        'apng',
         'avi',
         'avif',
         'bmp',

--- a/src/helpers/Assets.php
+++ b/src/helpers/Assets.php
@@ -508,6 +508,7 @@ class Assets
                     'label' => Craft::t('app', 'Image'),
                     'extensions' => [
                         'avif',
+                        'apng',
                         'bmp',
                         'gif',
                         'jfif',

--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -346,6 +346,23 @@ class FileHelper extends \yii\helpers\FileHelper
     }
 
     /**
+     * Adopted from https://stackoverflow.com/a/4525194
+     * @param string $file
+     * @return bool
+     */
+    public static function isAnimatedPng(string $file): bool
+    {
+        $bytes = @file_get_contents($file);
+        if ($bytes) {
+            if (str_contains(substr($bytes, 0, strpos($bytes, 'IDAT')), 'acTL')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Writes contents to a file.
      *
      * @param string $file the file path

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -143,7 +143,7 @@ class Image
      */
     public static function webSafeFormats(): array
     {
-        return ['jpg', 'jpeg', 'gif', 'png', 'svg', 'webp', 'avif'];
+        return ['jpg', 'jpeg', 'gif', 'apng', 'png', 'svg', 'webp', 'avif'];
     }
 
     /**

--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -190,7 +190,7 @@ class Raster extends Image
         $this->_imageSourcePath = $path;
         $this->_extension = pathinfo($path, PATHINFO_EXTENSION);
 
-        if (in_array($this->_extension, ['gif', 'webp'])) {
+        if (in_array($this->_extension, ['gif', 'webp', 'png', 'apng'])) {
             if (!$imageService->getIsGd() && $this->_image->layers()) {
                 $this->_isAnimated = true;
             }
@@ -707,6 +707,7 @@ class Raster extends Image
                 return ['animated' => $this->_isAnimated];
 
             case 'png':
+            case 'apng':
                 // Valid PNG quality settings are 0-9, so normalize and flip, because we're talking about compression
                 // levels, not quality, like jpg and gif.
                 $normalizedQuality = round(($quality * 9) / 100);
@@ -720,6 +721,7 @@ class Raster extends Image
                 $options = [
                     'png_compression_level' => $normalizedQuality,
                     'flatten' => false,
+                    'animated' => $this->_isAnimated,
                 ];
 
                 if ($this->_imageSourcePath) {

--- a/src/services/Images.php
+++ b/src/services/Images.php
@@ -42,7 +42,7 @@ class Images extends Component
     /**
      * @var array Image formats that can be manipulated.
      */
-    public array $supportedImageFormats = ['jpg', 'jpeg', 'gif', 'png'];
+    public array $supportedImageFormats = ['jpg', 'jpeg', 'gif', 'apng', 'png'];
 
     /**
      * @var string Image driver.
@@ -318,7 +318,7 @@ class Images extends Component
             return;
         }
 
-        if (FileHelper::isGif($filePath) && !Craft::$app->getConfig()->getGeneral()->transformGifs) {
+        if (FileHelper::isGif($filePath) && !Craft::$app->getConfig()->getGeneral()->transformGifs || FileHelper::isAnimatedPng($filePath)) {
             return;
         }
 

--- a/tests/unit/helpers/ImageHelperTest.php
+++ b/tests/unit/helpers/ImageHelperTest.php
@@ -150,7 +150,7 @@ class ImageHelperTest extends TestCase
      */
     public function testWebSafeFormats(): void
     {
-        self::assertSame(['jpg', 'jpeg', 'gif', 'png', 'svg', 'webp', 'avif'], Image::webSafeFormats());
+        self::assertSame(['jpg', 'jpeg', 'gif', 'apng', 'png', 'svg', 'webp', 'avif'], Image::webSafeFormats());
     }
 
     /**


### PR DESCRIPTION
Animated PNGs (APNG) intentionally [disguise themselves as a regular PNG](https://stackoverflow.com/a/4525194) which makes it a little hard to determine an APNG from a boring old PNG.

The main change made here is to add `FileHelper::isAnimatedPng` which will look for the specific characters needed for an animated PNG. When those are present we avoid running `Images::cleanImage` on it as that process will flatten the image.

One note, when uploading an `.apng` file, the file name will automatically get `.png` appended to it. This seems to be something to do with `input[type=file]` itself as it's happening even in a [reduced test case](https://codepen.io/brianjhanson/pen/MWXwPXz?editors=1011)

### Related issues
#12178
