### PR TITLE
Allow `array` as return type for `prepareElementQuery`

### DIFF
--- a/src/gql/base/ElementResolver.php
+++ b/src/gql/base/ElementResolver.php
@@ -76,7 +76,7 @@ abstract class ElementResolver extends Resolver
      * @param ResolveInfo $resolveInfo
      * @return ElementQuery|Collection
      */
-    protected static function prepareElementQuery(mixed $source, array $arguments, ?array $context, ResolveInfo $resolveInfo): ElementQuery|Collection
+    protected static function prepareElementQuery(mixed $source, array $arguments, ?array $context, ResolveInfo $resolveInfo): ElementQuery|Collection|array
     {
         /** @var ArgumentManager $argumentManager */
         $argumentManager = empty($context['argumentManager']) ? Craft::createObject(['class' => ArgumentManager::class]) : $context['argumentManager'];


### PR DESCRIPTION
There's an issue with GQL queries where [many](https://github.com/craftcms/cms/blob/b87d49b8060014d594b98819ec60bc146a471ea0/src/gql/resolvers/elements/Address.php#L48) of the [resolvers](https://github.com/craftcms/cms/blob/b87d49b8060014d594b98819ec60bc146a471ea0/src/gql/resolvers/elements/Entry.php#L49) return an array.

Which shown as per the below
https://github.com/craftcms/cms/blob/b87d49b8060014d594b98819ec60bc146a471ea0/src/gql/base/ElementResolver.php#L87-L93

If `prepareQuery()` doesn't return an `ElementQuery` then return it.

Otherwise, you'll get the following error: `craft\\gql\\base\\ElementResolver::prepareElementQuery(): Return value must be of type craft\\elements\\db\\ElementQuery|Illuminate\\Support\\Collection, array returned`

I suppose you could either enforce the resolvers to return a collection, or tighten up the `prepareQuery()` return types - take your pick!