### PR TITLE
Allow dynamic buttons to have copy-on-click enabled

### DIFF
--- a/src/templates/_includes/forms/copytext.twig
+++ b/src/templates/_includes/forms/copytext.twig
@@ -22,7 +22,7 @@
 
 {% js %}
     {% block js %}
-        $('#{{ buttonId|namespaceInputId|e('js') }}').on('click', function() {
+        $(document).on('click', '#{{ buttonId|namespaceInputId|e('js') }}', function() {
             document.getElementById('{{ id|namespaceInputId|e('js') }}').select();
             document.execCommand('copy');
             Craft.cp.displayNotice("{{ 'Copied to clipboard.'|t('app')|e('js') }}");

--- a/src/templates/_includes/forms/copytextbtn.twig
+++ b/src/templates/_includes/forms/copytextbtn.twig
@@ -22,7 +22,9 @@
 {% js %}
     {% block js %}
         (() => {
-            const $btn = $('#{{ id|namespaceInputId|e('js') }}');
+            {% set selector = '#' ~ id|namespaceInputId|e('js') %}
+
+            const $btn = $('{{ selector }}');
             const $input = $btn.children('input');
             const copyValue = function() {
                 $input[0].select();
@@ -32,8 +34,8 @@
                 $input[0].setSelectionRange(0, 0);
                 $btn.focus();
             };
-            $btn.on('click', copyValue);
-            $btn.on('keydown', ev => {
+            $(document).on('click', '{{ selector }}', copyValue);
+            $(document).on('keydown', '{{ selector }}', ev => {
                 if (ev.keyCode === Garnish.SPACE_KEY) {
                     copyValue();
                     ev.preventDefault();


### PR DESCRIPTION
For some fields ([Vizy](https://github.com/verbb/vizy), [Icon Picker](https://github.com/verbb/icon-picker)) we use Vue to render the field. However, this causes issues with jQuery due to the virtual DOM.

One thing I've noticed is that the click-to-copy of the field handle doesn't work as soon as Vue takes over rendering. This would likely be due to jQuery's event binding - while correctly bound - has bound an event to the real DOM, not the VDOM from Vue.

As such, this fix changes event-binding for these to be bound on the document, and scoped to the selector. You're using IDs so there should be no collisions, and it's [common practice](https://api.jquery.com/on/#direct-and-delegated-events) for dynamically-created elements to bind events in this way. 