### PR TITLE
fix for status condition being overwritten by criteria

### DIFF
--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -562,7 +562,7 @@ class ElementIndexesController extends BaseElementsController
 
             if (!empty($statusCondition)) {
                 $statusCondition = $statusCondition[0];
-                $conditionStatuses = $statusCondition['conditionStatuses'] ?? [];
+                $conditionStatuses = $statusCondition['conditionStatuses'];
                 $conditionOperator = $statusCondition['conditionOperator'];
 
                 // if status condition is set to "is not one of" - invert it,

--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -578,11 +578,11 @@ class ElementIndexesController extends BaseElementsController
         // Override with the request's params
         if ($criteria = $this->request->getBodyParam('criteria')) {
             // if we have a status condition in here, we can't just override it with criteria status
-            if (!empty($conditionStatuses) && array_key_exists('status', $criteria) ) {
+            if (!empty($conditionStatuses) && array_key_exists('status', $criteria)) {
                 // if $criteria['status'] is null, we can show all conditioned results
                 if ($criteria['status'] === null) {
                     unset($criteria['status']);
-                } else if (!in_array($criteria['status'], $conditionStatuses, true)) {
+                } elseif (!in_array($criteria['status'], $conditionStatuses, true)) {
                     // if $criteria['status'] isn't in $conditionStatuses, we can't return any results
                     $query->id(false);
                     return $query;


### PR DESCRIPTION
### Description
Status condition was being overwritten by criteria.

Example: 
If you have an entries selector field set to only accept "live" entries, the selector modal was showing all entries, not just "live" ones. It was happening because after condition was applied, `$criteria['status']` was overwriting it.

This change checks if there's a `StatusConditionRule` in the conditions, and if there is processes `$criteria['status']` in the following way:
- if `$criteria['status']` is `null` - show all conditioned results
- if `$criteria['status']` is not in the selected conditions - don't return any results as none match our criteria
- otherwise allow the `$criteria['status']` to affect things further

Takes "is not one of" condition into consideration.

### Related issues
#12289 
