### PR TITLE
Respect siteId in graphql structure mutations

### DIFF
--- a/src/gql/base/StructureMutationTrait.php
+++ b/src/gql/base/StructureMutationTrait.php
@@ -30,19 +30,20 @@ trait StructureMutationTrait
         }
 
         $structureService = Craft::$app->getStructures();
+        $siteId = $arguments['siteId'] ?? null;
 
         if (!empty($arguments['prependTo'])) {
-            $structureService->prepend($structureId, $element, $this->getRelatedElement($arguments['prependTo']));
+            $structureService->prepend($structureId, $element, $this->getRelatedElement($arguments['prependTo'], $siteId));
         } elseif (!empty($arguments['appendTo'])) {
-            $structureService->append($structureId, $element, $this->getRelatedElement($arguments['appendTo']));
+            $structureService->append($structureId, $element, $this->getRelatedElement($arguments['appendTo'], $siteId));
         } elseif (!empty($arguments['prependToRoot'])) {
             $structureService->prependToRoot($structureId, $element);
         } elseif (!empty($arguments['appendToRoot'])) {
             $structureService->appendToRoot($structureId, $element);
         } elseif (!empty($arguments['insertBefore'])) {
-            $structureService->moveBefore($structureId, $element, $this->getRelatedElement($arguments['insertBefore']));
+            $structureService->moveBefore($structureId, $element, $this->getRelatedElement($arguments['insertBefore'], $siteId));
         } elseif (!empty($arguments['insertAfter'])) {
-            $structureService->moveAfter($structureId, $element, $this->getRelatedElement($arguments['insertAfter']));
+            $structureService->moveAfter($structureId, $element, $this->getRelatedElement($arguments['insertAfter'], $siteId));
         }
     }
 
@@ -50,11 +51,12 @@ trait StructureMutationTrait
      * Get the related element.
      *
      * @param $elementId
+     * @param int|null $siteId
      * @return ElementInterface
      */
-    protected function getRelatedElement($elementId)
+    protected function getRelatedElement($elementId, int $siteId = null): ElementInterface
     {
-        $relatedElement = Craft::$app->getElements()->getElementById($elementId);
+        $relatedElement = Craft::$app->getElements()->getElementById($elementId, null, $siteId);
 
         if (!$relatedElement) {
             throw new Error('Unable to move element in a structure');


### PR DESCRIPTION
### Description
Respects `siteId` when performing structure mutations via graphql. One quirk: due to the order of operations new elements are saved and then "moved" when performing structure operations. This means if your structure is set to a propagation mode where elements are not directly propagated, and you supply a structure operation with a related element ID (`appendTo`, `prependTo`, `insertBefore` or `insertAfter`), an error will be shown but the element will have been created. 

So for example, I have two sites:
| Site ID | Element ID |
|:---|:-----|
| 1 | 150 |
| 2 | 200 |

If I supply a query with a mismatch:

```json
{
  "siteId": 1,
  "appendTo": 200
}
```

The element will get created in site 2 at the end of the list. This is consistent with the current behavior but can be a little confusing.

### Related issues
Fixes #12291
