### PR TITLE
Adds the ability to fully disable name parsing

### DIFF
--- a/src/base/NameTrait.php
+++ b/src/base/NameTrait.php
@@ -56,8 +56,9 @@ trait NameTrait
      */
     protected function prepareNamesForSave(): void
     {
-        if ($this->fullName !== null) {
-            $generalConfig = Craft::$app->getConfig()->getGeneral();
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+
+        if (!$generalConfig->disableNameParsing && $this->fullName !== null) {
             $languages = [
                 // Load our custom language file first so config settings can override the defaults
                 new CustomLanguage(

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1275,6 +1275,22 @@ class GeneralConfig extends BaseConfig
     public array $extraNameSuffixes = [];
 
     /**
+     * @var bool Disable parsing of the full name into first and last names.
+     *
+     * ::: code
+     * ```php Static Config
+     * 'disableNameParsing' => true,
+     * ```
+     * ```shell Environment Override
+     * CRAFT_DISABLE_NAME_PARSING=true
+     * ```
+     * :::
+     * @group Users
+     * @since 4.4.0
+     */
+    public bool $disableNameParsing = false;
+
+    /**
      * @var string|false The string to use to separate words when uploading Assets. If set to `false`, spaces will be left alone.
      *
      * ::: code
@@ -3119,8 +3135,7 @@ class GeneralConfig extends BaseConfig
             ->extraAppLocales($this->extraAppLocales)
             // misc
             ->maxUploadFileSize($this->maxUploadFileSize)
-            ->disabledPlugins($this->disabledPlugins)
-        ;
+            ->disabledPlugins($this->disabledPlugins);
     }
 
     /**
@@ -4402,6 +4417,25 @@ class GeneralConfig extends BaseConfig
     public function extraNameSuffixes(array $value): self
     {
         $this->extraNameSuffixes = $value;
+        return $this;
+    }
+
+    /**
+     * Disable name parsing entirely.
+     *
+     * ```php
+     * ->disableNameParsing()
+     * ```
+     *
+     * @group Users
+     * @param bool $value
+     * @return self
+     * @see $extraNameSuffixes
+     * @since 4.4.0
+     */
+    public function disableNameParsing(bool $value = true): self
+    {
+        $this->disableNameParsing = $value;
         return $this;
     }
 

--- a/src/templates/users/_accountfields.twig
+++ b/src/templates/users/_accountfields.twig
@@ -19,16 +19,48 @@
     }) }}
 {% endif %}
 
-{{ forms.textField({
-    label: "Full Name"|t('app'),
-    id: 'fullName',
-    name: 'fullName',
-    value: user.fullName,
-    autocomplete: false,
-    errors: user.getErrors('fullName'),
-    autofocus: craft.app.config.general.useEmailAsUsername,
-    inputAttributes: {
-        data: {lpignore: 'true'},
-    },
-    disabled: static,
-}) }}
+
+{% if craft.app.config.general.disableNameParsing %}
+    {{ forms.textField({
+        fieldClass: 'width-50',
+        label: "First Name"|t('app'),
+        id: 'firstName',
+        name: 'firstName',
+        value: user.firstName,
+        autocomplete: false,
+        errors: user.getErrors('firstName'),
+        autofocus: craft.app.config.general.useEmailAsUsername,
+        inputAttributes: {
+            data: {lpignore: 'true'},
+        },
+        disabled: static,
+    }) }}
+
+    {{ forms.textField({
+        fieldClass: 'width-50',
+        label: "Last Name"|t('app'),
+        id: 'lastName',
+        name: 'lastName',
+        value: user.lastName,
+        autocomplete: false,
+        errors: user.getErrors('lastName'),
+        inputAttributes: {
+            data: {lpignore: 'true'},
+        },
+        disabled: static,
+    }) }}
+{% else %}
+    {{ forms.textField({
+        label: "Full Name"|t('app'),
+        id: 'fullName',
+        name: 'fullName',
+        value: user.fullName,
+        autocomplete: false,
+        errors: user.getErrors('fullName'),
+        autofocus: craft.app.config.general.useEmailAsUsername,
+        inputAttributes: {
+            data: {lpignore: 'true'},
+        },
+        disabled: static,
+    }) }}
+{% endif %}


### PR DESCRIPTION
### Description
When using a front end form with a `firstName` and `lastName` field, you’re able to populate the `firstName` and `lastName` columns in the databse via the form thanks to [a small check in the controller](https://github.com/craftcms/cms/blob/7da93be3ac7eb928a7d95f15708ccfb958c7f441/src/controllers/UsersController.php#L2579-L2581). However, if you edit that user via the CP after the fact, the `firstName` and `lastName` fields will get replaced with the parsed version from `NameTrait::prepareNamesForSave()`.

This addresses that issue by adding a config option to disable the name parsing.

### Related issues
Fixes #12305







