### PR TITLE
fix for conditional fields in globals, users not being saved

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -4021,7 +4021,7 @@ abstract class Element extends Component implements ElementInterface
         $this->setFieldParamNamespace($paramNamespace);
         $values = Craft::$app->getRequest()->getBodyParam($paramNamespace, []);
 
-        foreach ($this->fieldLayoutFields(true) as $field) {
+        foreach ($this->fieldLayoutFields($this->supportsAutosaveDrafts()) as $field) {
             // Do we have any post data for this field?
             if (isset($values[$field->handle])) {
                 $value = $values[$field->handle];
@@ -4961,6 +4961,24 @@ JS,
     public function getLanguage(): string
     {
         return $this->getSite()->language;
+    }
+
+    /**
+     * Check if element supports autosaving drafts.
+     * if autosaveDrafts is disabled via general config - return false
+     * otherwise if element has a draft behavior, then it supports it
+     *
+     * @return bool
+     */
+    public function supportsAutosaveDrafts(): bool
+    {
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+
+        if ($generalConfig->autosaveDrafts === false) {
+            return false;
+        }
+
+        return ($this->getBehavior('draft') !== null);
     }
 
     /**


### PR DESCRIPTION
### Description
Conditional fields in globals aren't saved. This is in fact happening "because `Element::setFieldValuesFromRequest()` is running `Element::fieldLayoutFields($visibleOnly = true)`". 

It doesn't happen for entries because of autosaving drafts being turned on. When your draft is autosaved, it only gets validated against the "essentials" and all values are saved to the DB and then by the time you see the conditioned field, it's already treated as visible. If you were to disable autosaving drafts, you would see the exact same behaviour for entries too (but we do not encourage disabling autosaving drafts).

This issue is happening for Globals, Users and Assets because these elements do not have autosaving functionality.

This change is to check if element on which we're trying to `setFieldValuesFromRequest()` supports autosaving.


### Related issues
#12166 
