### PR TITLE
twig sort filter check if arrow is a string

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -490,7 +490,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public function sortFilter(TwigEnvironment $env, $array, $arrow = null): array
     {
-        if (strtolower($arrow) === 'system') {
+        if (is_string($arrow) && strtolower($arrow) === 'system') {
             throw new RuntimeError('The sort filter doesn\'t support sorting by system().');
         }
 


### PR DESCRIPTION
### Description
Check if `$arrow` passwed to the `sortFilter()` is a string before trying to lower-case it.


### Related issues
#12334
[#1204](https://github.com/craftcms/feed-me/issues/1204) (Feed Me)
