### PR TITLE
Craft 4 Typos

### DIFF
--- a/src/gql/base/ElementMutationResolver.php
+++ b/src/gql/base/ElementMutationResolver.php
@@ -188,7 +188,7 @@ abstract class ElementMutationResolver extends MutationResolver
     }
 
     /**
-     * Traverse an argument list revursively and normalize the values.
+     * Traverse an argument list recursively and normalize the values.
      *
      * @param array $argumentDefinitions
      * @param array $mutationArguments

--- a/src/gql/resolvers/mutations/Category.php
+++ b/src/gql/resolvers/mutations/Category.php
@@ -19,7 +19,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use Throwable;
 
 /**
- * Class Categoy
+ * Class Category
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.5.0

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -423,7 +423,7 @@ class App
      * Retrieves a bool PHP config setting and normalizes it to an actual bool.
      *
      * @param string $var The PHP config setting to retrieve.
-     * @return bool Whether it is set to the php.ini equivelant of `true`.
+     * @return bool Whether it is set to the php.ini equivalent of `true`.
      */
     public static function phpConfigValueAsBool(string $var): bool
     {

--- a/src/helpers/Component.php
+++ b/src/helpers/Component.php
@@ -31,7 +31,7 @@ class Component
      * @phpstan-param class-string<ComponentInterface>|null $instanceOf
      * @param bool $throwException Whether an exception should be thrown if an issue is encountered
      * @return bool
-     * @throws InvalidConfigException if $config doesn’t contain a `type` value, or the type isn’s compatible with|null $instanceOf.
+     * @throws InvalidConfigException if $config doesn’t contain a `type` value, or the type isn’t compatible with|null $instanceOf.
      * @throws MissingComponentException if the class specified by $config doesn’t exist, or belongs to an uninstalled plugin
      * @since 3.2.0
      */
@@ -90,7 +90,7 @@ class Component
      * @param string|null $instanceOf The class or interface that the component must be an instance of.
      * @phpstan-param class-string<T>|null $instanceOf
      * @return T The component
-     * @throws InvalidConfigException if $config doesn’t contain a `type` value, or the type isn’s compatible with|null $instanceOf.
+     * @throws InvalidConfigException if $config doesn’t contain a `type` value, or the type isn’t compatible with|null $instanceOf.
      * @throws MissingComponentException if the class specified by $config doesn’t exist, or belongs to an uninstalled plugin
      */
     public static function createComponent(string|array $config, ?string $instanceOf = null): ComponentInterface

--- a/src/helpers/Console.php
+++ b/src/helpers/Console.php
@@ -148,7 +148,7 @@ class Console extends \yii\helpers\Console
      * @param string[]|array[] $headers The table headers
      * @param array[] $data The table data
      * @param array $options
-     * @throwns InvalidValueException if an `align` value is invalid
+     * @throws InvalidValueException if an `align` value is invalid
      * @since 3.7.23
      */
     public static function table(array $headers, array $data, array $options = []): void

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -1680,7 +1680,7 @@ class StringHelper extends \yii\helpers\StringHelper
     }
 
     /**
-     * Converts an object to its string representation. If the object is an array, will glue the array elements togeter
+     * Converts an object to its string representation. If the object is an array, will glue the array elements together
      * with the $glue param. Otherwise will cast the object to a string.
      *
      * @param mixed $object The object to convert to a string.

--- a/src/records/AssetIndexingSession.php
+++ b/src/records/AssetIndexingSession.php
@@ -18,7 +18,7 @@ use craft\db\Table;
  * @property int|null $totalEntries The total amount of entries.
  * @property int|null $processedEntries The number of processed entries.
  * @property bool $cacheRemoteImages Whether remote images should be cached locally.
- * @property bool $isCli Whether indeing is run via CLI.
+ * @property bool $isCli Whether indexing is run via CLI.
  * @property bool $actionRequired Whether action is required.
  * @property string $dateUpdated Time when indexing session was last updated.
  * @property string $dateCreated Time when indexing session was last updated.

--- a/src/web/assets/pluginstore/.env.example
+++ b/src/web/assets/pluginstore/.env.example
@@ -3,7 +3,7 @@ DEV_SERVER_PUBLIC="http://localhost:8085/"
 DEV_SERVER_PORT="8085"
 DEV_SERVER_LOOPBACK="http://host.docker.internal:8085"
 
-# Runnning webpack-dev-server within container
+# Running webpack-dev-server within container
 # DEV_SERVER_PUBLIC="http://craft.ddev.site:3000/"
 # DEV_SERVER_PORT="3000"
 # DEV_SERVER_HOST="0.0.0.0"


### PR DESCRIPTION
**Description**
Found some typos via Code Spell Checker for Visual Studio Code and fixed for v4
Fixes for v3 branch: https://github.com/craftcms/cms/pull/12342

