### PR TITLE
Isolatable CLI commands

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -8,6 +8,7 @@
 
 ### Administration
 - Conditional layout components are now identified using a condition icon within field layout designers. ([#12250](https://github.com/craftcms/cms/issues/12250))
+- All CLI commands now support an `--isolate` option, which ensures the command is run in isolation. ([#12337](https://github.com/craftcms/cms/discussions/12337), [#12350](https://github.com/craftcms/cms/pull/12350))
 
 ### Development
 - Added the `editable` and `savable` asset query params. ([#12266](https://github.com/craftcms/cms/pull/12266))
@@ -15,6 +16,11 @@
 - The `editable` entry query param can now be set to `false` to only show entries that _can’t_ be viewed by the current user. ([#12266](https://github.com/craftcms/cms/pull/12266))
 
 ### Extensibility
+- Console controllers that directly use `craft\console\ControllerTrait` no longer need to call `$this->checkTty()` or `$this->checkRootUser()` themselves; they are now called from `ControllerTrait::init()` and `beforeAction()`.
+- Added `craft\console\ControllerTrait::beforeAction()`.
+- Added `craft\console\ControllerTrait::init()`.
+- Added `craft\console\ControllerTrait::options()`.
+- Added `craft\console\ControllerTrait::runAction()`.
 - Added `craft\elements\conditions\assets\ViewableConditionRule`. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - Added `craft\elements\conditions\entries\ViewableConditionRule`. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - Renamed `craft\elements\conditions\assets\EditableConditionRule` to `SavableConditionRule`, while preserving the original class name with an alias. ([#12266](https://github.com/craftcms/cms/pull/12266))

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -8,7 +8,7 @@
 
 ### Administration
 - Conditional layout components are now identified using a condition icon within field layout designers. ([#12250](https://github.com/craftcms/cms/issues/12250))
-- All CLI commands now support an `--isolate` option, which ensures the command is run in isolation. ([#12337](https://github.com/craftcms/cms/discussions/12337), [#12350](https://github.com/craftcms/cms/pull/12350))
+- All CLI commands now support an `--isolated` option, which ensures the command is run in isolation. ([#12337](https://github.com/craftcms/cms/discussions/12337), [#12350](https://github.com/craftcms/cms/pull/12350))
 
 ### Development
 - Added the `editable` and `savable` asset query params. ([#12266](https://github.com/craftcms/cms/pull/12266))

--- a/src/console/Controller.php
+++ b/src/console/Controller.php
@@ -31,7 +31,11 @@ use yii\helpers\Inflector;
  */
 class Controller extends YiiController
 {
-    use ControllerTrait;
+    use ControllerTrait {
+        ControllerTrait::init as private traitInit;
+        ControllerTrait::options as private traitOptions;
+        ControllerTrait::runAction as private traitRunAction;
+    }
 
     /**
      * @event DefineConsoleActionsEvent The event that is triggered when defining custom actions for this controller.
@@ -127,8 +131,7 @@ class Controller extends YiiController
      */
     public function init(): void
     {
-        parent::init();
-        $this->checkTty();
+        $this->traitInit();
 
         $this->_actions = [];
         foreach ($this->defineActions() as $id => $action) {
@@ -167,19 +170,6 @@ class Controller extends YiiController
     /**
      * @inheritdoc
      */
-    public function beforeAction($action): bool
-    {
-        // Make sure this isn't a root user
-        if (!$this->checkRootUser()) {
-            return false;
-        }
-
-        return parent::beforeAction($action);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function actions(): array
     {
         return ArrayHelper::getColumn($this->_actions, 'action');
@@ -190,7 +180,7 @@ class Controller extends YiiController
      */
     public function options($actionID): array
     {
-        $options = parent::options($actionID);
+        $options = $this->traitOptions($actionID);
 
         if (isset($this->_actions[$actionID]['options'])) {
             $options = array_merge($options, array_keys($this->_actions[$actionID]['options']));
@@ -221,7 +211,7 @@ class Controller extends YiiController
     public function runAction($id, $params = []): int
     {
         $this->_actionId = $id;
-        $result = parent::runAction($id, $params);
+        $result = $this->traitRunAction($id, $params);
         $this->_actionId = null;
         return $result;
     }

--- a/src/console/ControllerTrait.php
+++ b/src/console/ControllerTrait.php
@@ -9,9 +9,13 @@ namespace craft\console;
 
 use Composer\Util\Platform;
 use Composer\Util\Silencer;
+use Craft;
 use craft\base\Model;
 use craft\helpers\App;
 use craft\helpers\Console;
+use yii\base\Action;
+use yii\base\InvalidRouteException;
+use yii\console\Exception;
 
 /**
  * ConsoleControllerTrait implements the common methods and properties for console controllers.
@@ -23,6 +27,104 @@ use craft\helpers\Console;
  */
 trait ControllerTrait
 {
+    /**
+     * Whether the command should ensure it is only being run once at a time.
+     *
+     * If this is passed and the same command is already being run in a separate shell/environment,
+     * the command will abort with an exit code of 1.
+     *
+     * @since 4.4.0
+     */
+    public bool $isolated = false;
+
+    private ?string $isolationMutexName = null;
+
+    /**
+     * Initializes the object.
+     *
+     * @see \yii\base\BaseObject::init()
+     * @since 4.4.0
+     */
+    public function init()
+    {
+        parent::init();
+        $this->checkTty();
+    }
+
+    /**
+     * Returns the names of valid options for the action (id).
+     *
+     * @param string $actionID The action ID of the current request.
+     * @return string[] The names of the options valid for the action.
+     * @see \yii\console\Controller::options()
+     * @since 4.4.0
+     */
+    public function options($actionID): array
+    {
+        $options = parent::options($actionID);
+        $options[] = 'isolated';
+        return $options;
+    }
+
+    /**
+     * Runs an action within this controller with the specified action ID and parameters.
+     *
+     * Runs an action with the specified action ID and parameters.
+     * If the action ID is empty, the method will use [[defaultAction]].
+     * @param string $id The ID of the action to be executed.
+     * @param array $params The parameters (name-value pairs) to be passed to the action.
+     * @return int The status of the action execution. 0 means normal, other values mean abnormal.
+     * @throws InvalidRouteException if the requested action ID cannot be resolved into an action successfully.
+     * @throws Exception if there are unknown options or missing arguments
+     * @see \yii\console\Controller::runAction()
+     * @since 4.4.0
+     */
+    public function runAction($id, $params = [])
+    {
+        try {
+            return parent::runAction($id, $params);
+        } finally {
+            if (isset($this->isolationMutexName)) {
+                Craft::$app->getMutex()->release($this->isolationMutexName);
+            }
+        }
+    }
+
+    /**
+     * This method is invoked right before an action is executed.
+     *
+     * @param Action $action the action to be executed.
+     * @return bool whether the action should continue to run.
+     * @see \yii\base\Controller::beforeAction()
+     * @since 4.4.0
+     */
+    public function beforeAction($action): bool
+    {
+        if (!parent::beforeAction($action)) {
+            return false;
+        }
+
+        // Make sure this isn't a root user
+        if (!$this->checkRootUser()) {
+            return false;
+        }
+
+        if ($this->isolated) {
+            $uniqueId = $action->getUniqueId();
+            $name = "isolated-command:$uniqueId";
+
+            if (!Craft::$app->getMutex()->acquire($name)) {
+                $this->stderr("The $uniqueId command is already running.\n", Console::FG_RED);
+                return false;
+            }
+
+            // Remember the lock name for runAction()
+            $this->isolationMutexName = $name;
+        }
+
+        return true;
+    }
+
     /**
      * Sets [[\yii\console\Controller::$interactive]] to `false` if this isn’t a TTY shell.
      *

--- a/src/console/controllers/FixtureController.php
+++ b/src/console/controllers/FixtureController.php
@@ -21,26 +21,4 @@ use yii\console\controllers\FixtureController as BaseFixtureController;
 class FixtureController extends BaseFixtureController
 {
     use ControllerTrait;
-
-    /**
-     * @inheritdoc
-     */
-    public function init(): void
-    {
-        parent::init();
-        $this->checkTty();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function beforeAction($action): bool
-    {
-        // Make sure this isn't a root user
-        if (!$this->checkRootUser()) {
-            return false;
-        }
-
-        return parent::beforeAction($action);
-    }
 }

--- a/src/console/controllers/MigrateController.php
+++ b/src/console/controllers/MigrateController.php
@@ -49,7 +49,11 @@ use yii\helpers\Console;
  */
 class MigrateController extends BaseMigrateController
 {
-    use ControllerTrait;
+    use ControllerTrait {
+        ControllerTrait::init as private traitInit;
+        ControllerTrait::options as private traitOptions;
+        ControllerTrait::beforeAction as private traitBeforeAction;
+    }
     use BackupTrait;
 
     /**
@@ -122,8 +126,7 @@ class MigrateController extends BaseMigrateController
      */
     public function init(): void
     {
-        parent::init();
-        $this->checkTty();
+        $this->traitInit();
 
         $this->templateFile = Craft::getAlias('@app/updates/migration.php.template');
     }
@@ -142,7 +145,7 @@ class MigrateController extends BaseMigrateController
      */
     public function options($actionID): array
     {
-        $options = parent::options($actionID);
+        $options = $this->traitOptions($actionID);
 
         // Remove options we end up overriding
         ArrayHelper::removeValue($options, 'migrationPath');
@@ -176,11 +179,6 @@ class MigrateController extends BaseMigrateController
      */
     public function beforeAction($action): bool
     {
-        // Make sure this isn't a root user
-        if (!$this->checkRootUser()) {
-            return false;
-        }
-
         if ($action->id !== 'all') {
             if ($this->plugin) {
                 $this->track = "plugin:$this->plugin";
@@ -213,7 +211,7 @@ class MigrateController extends BaseMigrateController
             $projectConfig->regenerateExternalConfig();
         }
 
-        if (!parent::beforeAction($action)) {
+        if (!$this->traitBeforeAction($action)) {
             return false;
         }
 

--- a/src/console/controllers/ServeController.php
+++ b/src/console/controllers/ServeController.php
@@ -27,26 +27,4 @@ class ServeController extends BaseServeController
      * @var string path or [path alias](https://craftcms.com/docs/4.x/config/#aliases) of the directory to serve.
      */
     public $docroot = '@webroot';
-
-    /**
-     * @inheritdoc
-     */
-    public function init(): void
-    {
-        parent::init();
-        $this->checkTty();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function beforeAction($action): bool
-    {
-        // Make sure this isn’t a root user
-        if (!$this->checkRootUser()) {
-            return false;
-        }
-
-        return parent::beforeAction($action);
-    }
 }

--- a/src/queue/Command.php
+++ b/src/queue/Command.php
@@ -7,6 +7,7 @@
 
 namespace craft\queue;
 
+use craft\console\ControllerTrait;
 use craft\helpers\Console;
 use yii\console\ExitCode;
 use yii\db\Exception as YiiDbException;
@@ -20,6 +21,8 @@ use yii\db\Exception as YiiDbException;
  */
 class Command extends \yii\queue\cli\Command
 {
+    use ControllerTrait;
+
     /**
      * @var Queue
      */
@@ -43,18 +46,6 @@ class Command extends \yii\queue\cli\Command
     protected function isWorkerAction($actionID): bool
     {
         return in_array($actionID, ['run', 'listen'], true);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function beforeAction($action): bool
-    {
-        if (!parent::beforeAction($action)) {
-            return false;
-        }
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
### Description

Adds an `--isolated` option to all CLI commands, which will ensure they are run in isolation.

If another request is already running the same command, it will abort with the stderr message `The <command name> command is already running.` and exit code `1`.

(Isolation checking is done via the mutex, which only works when Dev Mode is disabled.)

### Related issues

- #12337