### PR TITLE
Bugfix/12364 unpermitted volumes

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -688,6 +688,12 @@ class Assets extends BaseRelationField
         if (!$this->showUnpermittedVolumes && !empty($sources)) {
             $userService = Craft::$app->getUser();
             return ArrayHelper::where($sources, function(string $source) use ($assetsService, $userService) {
+                // Enforce showUnpermittedVolumes setting on volumes listed in sources
+                if (str_starts_with($source, 'volume:')) {
+                    $volume = Craft::$app->getVolumes()->getVolumeByUid(explode(':', $source)[1]);
+                    return $volume && ($userService->checkPermission("viewAssets:$volume->uid"));
+                }
+
                 // If it’s not a volume folder, let it through
                 if (!str_starts_with($source, 'folder:')) {
                     return true;

--- a/src/templates/_components/fieldtypes/Assets/input.twig
+++ b/src/templates/_components/fieldtypes/Assets/input.twig
@@ -38,6 +38,8 @@
                     describedby: describedBy ?? false,
                 },
             }) }}
+        {% else %}
+            <p class="error">{{ 'You don’t have access to the sources available for this field.'|t('app') }}</p>
         {% endif %}
         <div class="spinner hidden"></div>
     </div>

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -1766,6 +1766,7 @@ return [
     'You cannot access the control panel while the system is offline with that account.' => 'You cannot access the control panel while the system is offline with that account.',
     'You cannot access the control panel with that account.' => 'You cannot access the control panel with that account.',
     'You cannot access the site while the system is offline with that account.' => 'You cannot access the site while the system is offline with that account.',
+    'You don’t have access to the sources available for this field.' => 'You don’t have access to the sources available for this field.',
     'You don’t have any active drafts.' => 'You don’t have any active drafts.',
     'You don’t have any widgets yet.' => 'You don’t have any widgets yet.',
     'You don’t have the proper credentials to access this page.' => 'You don’t have the proper credentials to access this page.',


### PR DESCRIPTION
### Description
Ensure "Show unpermitted volumes" setting is enforced when unchecked too. 

If Assets field sources are set to volumes for which user doesn't have permissions, make sure a message shows instead of just not showing any buttons at all.


### Related issues
#12364 
