### PR TITLE
[4.x] Update `Asset::getMimeType()` to respect transforms

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1724,7 +1724,7 @@ JS;
         $transform = $transform ?? $this->_transform;
         $transform = ImageTransforms::normalizeTransform($transform);
 
-        if (!$transform || !$transform->format) {
+        if (!Image::canManipulateAsImage($this->getExtension()) || !$transform || !$transform->format) {
             // todo: maybe we should be passing this off to volume fs
             // so Local filesystems can call FileHelper::getMimeType() (uses magic file instead of ext)
             return FileHelper::getMimeTypeByExtension($this->_filename);

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1715,13 +1715,23 @@ JS;
     /**
      * Returns the file’s MIME type, if it can be determined.
      *
+     * @param mixed|null $transform A transform handle or configuration that should be applied to the mime type
      * @return string|null
+     * @throws ImageTransformException if $transform is an invalid transform handle
      */
-    public function getMimeType(): ?string
+    public function getMimeType(mixed $transform = null): ?string
     {
-        // todo: maybe we should be passing this off to volume fs
-        // so Local filesystems can call FileHelper::getMimeType() (uses magic file instead of ext)
-        return FileHelper::getMimeTypeByExtension($this->_filename);
+        $transform = $transform ?? $this->_transform;
+        $transform = ImageTransforms::normalizeTransform($transform);
+
+        if (!$transform || !$transform->format) {
+            // todo: maybe we should be passing this off to volume fs
+            // so Local filesystems can call FileHelper::getMimeType() (uses magic file instead of ext)
+            return FileHelper::getMimeTypeByExtension($this->_filename);
+        }
+
+        // Prepend with '.' to let pathinfo() work
+        return FileHelper::getMimeTypeByExtension('.' . $transform->format);
     }
 
     /**


### PR DESCRIPTION
### Description
`Asset::getMimeType()` will now return the mime type of the transform rather than the image when a transform is set. 


### Related issues
#12269
