### PR TITLE
Redirect edit pages to the previous page

### DIFF
--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -356,12 +356,7 @@ class ElementsController extends Controller
         $type = $element::lowerDisplayName();
         $enabledForSite = $element->getEnabledForSite();
         $hasRoute = $element->getRoute() !== null;
-
-        $referrer = Craft::$app->getRequest()->getReferrer();
-        if (!str_contains($referrer, UrlHelper::baseCpUrl())) {
-            $referrer = null;
-        }
-        $redirectUrl = $referrer ?? $element->getPostEditUrl() ?? Craft::$app->getConfig()->getGeneral()->getPostCpLoginRedirect();
+        $redirectUrl = UrlHelper::cpReferralUrl() ?? $element->getPostEditUrl() ?? Craft::$app->getConfig()->getGeneral()->getPostCpLoginRedirect();
 
         // Site statuses
         if ($canEditMultipleSites) {

--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -356,7 +356,12 @@ class ElementsController extends Controller
         $type = $element::lowerDisplayName();
         $enabledForSite = $element->getEnabledForSite();
         $hasRoute = $element->getRoute() !== null;
-        $redirectUrl = $element->getPostEditUrl() ?? Craft::$app->getConfig()->getGeneral()->getPostCpLoginRedirect();
+
+        $referrer = Craft::$app->getRequest()->getReferrer();
+        if (!str_contains($referrer, UrlHelper::baseCpUrl())) {
+            $referrer = null;
+        }
+        $redirectUrl = $referrer ?? $element->getPostEditUrl() ?? Craft::$app->getConfig()->getGeneral()->getPostCpLoginRedirect();
 
         // Site statuses
         if ($canEditMultipleSites) {

--- a/src/controllers/FieldsController.php
+++ b/src/controllers/FieldsController.php
@@ -257,6 +257,8 @@ JS;
         $view->registerAssetBundle(FieldSettingsAsset::class);
         $view->registerJs($js);
 
+        $redirectUrl = UrlHelper::cpReferralUrl() ?? 'settings/fields/' . $groupId;
+
         return $this->renderTemplate('settings/fields/_edit.twig', compact(
             'fieldId',
             'field',
@@ -268,7 +270,8 @@ JS;
             'groupId',
             'groupOptions',
             'crumbs',
-            'title'
+            'title',
+            'redirectUrl'
         ));
     }
 

--- a/src/helpers/UrlHelper.php
+++ b/src/helpers/UrlHelper.php
@@ -569,6 +569,28 @@ class UrlHelper
     }
 
     /**
+     * Returns a CP referral URL.
+     *
+     * @return string|null
+     */
+    public static function cpReferralUrl(): ?string
+    {
+        $referrer = Craft::$app->getRequest()->getReferrer();
+
+        // Make sure it didn't refer itself
+        if ($referrer === Craft::$app->getRequest()->getFullUri()) {
+            return null;
+        }
+
+        // Make sure the CP referred it
+        if (!str_contains($referrer, self::baseCpUrl())) {
+            return null;
+        }
+
+        return $referrer;
+    }
+
+    /**
      * Returns a URL.
      *
      * @param string $path

--- a/src/templates/settings/fields/_edit.twig
+++ b/src/templates/settings/fields/_edit.twig
@@ -22,7 +22,7 @@
 
 {% block content %}
     {{ actionInput('fields/save-field') }}
-    {{ redirectInput('settings/fields/{groupId}') }}
+    {{ redirectInput(redirectUrl) }}
     {% if fieldId is defined and fieldId %}
         {{ hiddenInput('fieldId', fieldId) }}
     {% endif %}


### PR DESCRIPTION
### Description
Updates redirect URLs for elements and fields to return back to the referrer (when available) instead of the `Element::getPostEditUrl()` url. 


### Related issues
#11261, #11246