### PR TITLE
Console improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 
 - Fixed a bug where entry tab contents could remain visible when switching to other tabs, after changing the entry type.
+- Added `craft\console\Controller::createDirectory()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
+- Added `craft\console\Controller::do()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
+- Added `craft\console\Controller::failure()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
+- Added `craft\console\Controller::note()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
+- Added `craft\console\Controller::success()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
+- Added `craft\console\Controller::tip()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
+- Added `craft\console\Controller::warning()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
+- Added `craft\console\Controller::writeJson()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
+- Added `craft\console\Controller::writeToFile()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
 - Added `craft\helpers\FileHelper::absolutePath()`.
 - Added `craft\helpers\FileHelper::findClosestFile()`.
 - Added `craft\helpers\FileHelper::isWithin()`.

--- a/src/console/MarkdownParser.php
+++ b/src/console/MarkdownParser.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\console;
+
+use yii\console\Markdown;
+use yii\helpers\Console;
+
+/**
+ * Markdown parser
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.3.5
+ */
+class MarkdownParser extends Markdown
+{
+    protected function renderCode($block)
+    {
+        $lines = preg_split('/[\r\n]/', $block['content']);
+        $maxLength = max(array_map(fn(string $line) => strlen($line), $lines));
+        return implode("\n", array_map(fn(string $line) => Console::ansiFormat(str_pad($line, $maxLength), [Console::NEGATIVE]), $lines)) . "\n\n";
+    }
+
+    protected function renderInlineCode($element)
+    {
+        return Console::ansiFormat($element[1], [Console::FG_CYAN]);
+    }
+}

--- a/src/helpers/Console.php
+++ b/src/helpers/Console.php
@@ -8,6 +8,7 @@
 namespace craft\helpers;
 
 use Craft;
+use craft\console\MarkdownParser;
 use yii\base\InvalidConfigException;
 use yii\base\InvalidValueException;
 use yii\console\Controller;
@@ -58,6 +59,15 @@ class Console extends \yii\helpers\Console
     {
         $controller = Craft::$app->controller;
         return $controller instanceof Controller && $controller->isColorEnabled();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function markdownToAnsi($markdown)
+    {
+        $parser = new MarkdownParser();
+        return $parser->parse($markdown);
     }
 
     /**


### PR DESCRIPTION
### Description

Adds new methods to `craft\console\Controller` for outputting nicely-formatted notes, etc:

- `note()`
- `success()`
- `failure()`
- `tip()`
- `warning()`

Example:

```php
$message = <<<EOD
**This is a success message!**
The operation was a complete success!
EOD;

$this->success($message);
```

```sh
✅ This is a success message!
   The operation was a complete success!
```

There’s also a new `do()` method, which takes a callback method, and outputs info before and after the callback is executed:

```php
$this->do('Doing the thing', function() {
    // ...
});
```

```sh
 → Doing the thing … ✓
```

Finally, there’s new file-handling methods (which call `do()` internally):

- `createDirectory()`
- `writeToFile()`
- `writeJson()`