### PR TITLE
ApplicationTrait::onInit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where entry tab contents could remain visible when switching to other tabs, after changing the entry type.
+- Added `craft\base\ApplicationTrait::onInit()`. ([#12439](https://github.com/craftcms/cms/pull/12439))
 - Added `craft\console\Controller::createDirectory()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
 - Added `craft\console\Controller::do()`. ([#12438](https://github.com/craftcms/cms/pull/12438))
 - Added `craft\console\Controller::failure()`. ([#12438](https://github.com/craftcms/cms/pull/12438))

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -422,6 +422,23 @@ trait ApplicationTrait
     }
 
     /**
+     * Invokes a callback method when Craft is fully initialized.
+     *
+     * @param callable $callback
+     * @since 4.3.5
+     */
+    public function onInit(callable $callback): void
+    {
+        if ($this->_isInitialized) {
+            $callback();
+        } else {
+            $this->on(WebApplication::EVENT_INIT, function() use ($callback) {
+                $callback();
+            });
+        }
+    }
+
+    /**
      * Returns whether this Craft install has multiple sites.
      *
      * @param bool $refresh Whether to ignore the cached result and check again


### PR DESCRIPTION
### Description

Adds a new `onInit()` method to `craft\base\ApplicationTrait`, which can be used to simplify initialization code for plugins and modules.

It accepts a callback function that contains code that shouldn’t be executed until the app (including all installed plugins) is fully initialized, such as rendering a Twig template, executing an element query, etc.

If Craft is already initialized, the callback function will be called immediately. Otherwise it will be called on `EVENT_INIT`.

```php
class Plugin extends \craft\base\Plugin
{
    public function init(): void
    {
        // Defer most setup tasks until Craft is fully initialized
        Craft::$app->onInit(function() {
            // ...
        });
    }

    // ...
}
```

### Related issues

- #9671