### PR TITLE
additional check for layout without elements

### DIFF
--- a/src/models/FieldLayout.php
+++ b/src/models/FieldLayout.php
@@ -319,23 +319,25 @@ class FieldLayout extends Model
 
             // Ensure there aren't any layout element UUID conflicts
             $layoutElements = $tab->getElements();
-            $filteredLayoutElements = array_filter($layoutElements, function(FieldLayoutElement $layoutElement) use (&$elementUids) {
-                if (!isset($layoutElement->uid)) {
+            if (!empty($layoutElements)) {
+                $filteredLayoutElements = array_filter($layoutElements, function(FieldLayoutElement $layoutElement) use (&$elementUids) {
+                    if (!isset($layoutElement->uid)) {
+                        return true;
+                    }
+                    if (isset($elementUids[$layoutElement->uid])) {
+                        return false;
+                    }
+                    $elementUids[$layoutElement->uid] = true;
                     return true;
-                }
-                if (isset($elementUids[$layoutElement->uid])) {
-                    return false;
-                }
-                $elementUids[$layoutElement->uid] = true;
-                return true;
-            });
+                });
 
-            if (empty($filteredLayoutElements)) {
-                continue;
-            }
+                if (empty($filteredLayoutElements)) {
+                    continue;
+                }
 
-            if (count($filteredLayoutElements) !== count($layoutElements)) {
-                $tab->setElements($filteredLayoutElements);
+                if (count($filteredLayoutElements) !== count($layoutElements)) {
+                    $tab->setElements($filteredLayoutElements);
+                }
             }
 
             $tab->sortOrder = ++$index;


### PR DESCRIPTION
### Description
Additional check so that we only check for layout element UUID conflicts if there are elements in the layout. In other words - don’t check empty layouts, as that causes issues. For example, when you add a new block to a matrix field and try to add a field to that block - the field won’t be saved. This also caused the unit `FieldLayoutTest` to fail.


### Related issues
#12459
