### PR TITLE
Allow registering already-instantiated custom GQL directives.

### DIFF
--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -1403,7 +1403,7 @@ class Gql extends Component
 
         foreach ($event->directives as $directive) {
             /** @var Directive $directive */
-            $directives[] = $directive::create();
+            $directives[] = $directive instanceof Directive ? $directive : $directive::create();
         }
 
         return $directives;


### PR DESCRIPTION
Currently, it's only possible to define custom GQL directives statically, by providing a class name, on which Craft expects to invoke `Directive::create()`. 

But what if we want to _generate_ custom directives _dynamically_?

 - We will need the ability to register already-instantiated `Directive` _instances_ in addition to static class names.
 - And, we will need to move _apply()_ into the instance context, to involve instance-specific behavior, rather than just static logic.