### PR TITLE
Strip elisions from search keywords

### DIFF
--- a/src/helpers/Search.php
+++ b/src/helpers/Search.php
@@ -72,7 +72,7 @@ class Search
     }
 
     /**
-     * Returns an array of [elisions](https://en.wikipedia.org/wiki/Elision) that will be stripped from search keywords.
+     * Returns an array of elisions to remove from search keywords.
      *
      * @return array
      */

--- a/src/helpers/Search.php
+++ b/src/helpers/Search.php
@@ -51,6 +51,9 @@ class Search
         if ($processCharMap) {
             $str = strtr($str, StringHelper::asciiCharMap(true, $language ?? Craft::$app->language));
 
+            $elisions = self::_getElisions();
+            $str = str_replace($elisions, '', $str);
+
             // Remove punctuation and diacritics
             $punctuation = self::_getPunctuation();
             $str = str_replace(array_keys($punctuation), $punctuation, $str);
@@ -66,6 +69,36 @@ class Search
 
         // Strip out new lines and superfluous spaces
         return trim(preg_replace(['/[\n\r]+/u', '/\s{2,}/u'], ' ', $str));
+    }
+
+    /**
+     * Returns an array of [elisions](https://en.wikipedia.org/wiki/Elision) that will be stripped from search keywords.
+     *
+     * @return array
+     */
+    private static function _getElisions(): array
+    {
+        static $elisions = [];
+
+        if (empty($elisions)) {
+            $elisions = [
+                "l'",
+                "m'",
+                "t'",
+                "qu'",
+                "n'",
+                "s'",
+                "j'",
+                "d'",
+                "c'",
+                "jusqu'",
+                "quoiqu'",
+                "lorsqu'",
+                "puisqu'",
+            ];
+        }
+
+        return $elisions;
     }
 
     /**


### PR DESCRIPTION
### Description
I learned some things today. The first of which, is that when you smash together some sounds, it's called an [elision](https://en.wikipedia.org/wiki/Elision). They're not very common in English, but they're pretty common in French (they also happen in Catalon, Irish and Italian). 

Elisions should be stripped out of search keywords because they change the word and make it harder to find what you're looking for. This fixes that by creating an array of elisions that should be stripped from search terms. I only added the common list in French at the moment, primarily because [that's what Elastic search does by default](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-elision-tokenfilter.html), but we may want to expand this in the future. 

### Related issues
Fixes #12467
