### PR TITLE
Feature/parent selection criteria event

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -29,6 +29,7 @@
 - Added `craft\console\ControllerTrait::runAction()`.
 - Added `craft\elements\conditions\assets\ViewableConditionRule`. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - Added `craft\elements\conditions\entries\ViewableConditionRule`. ([#12266](https://github.com/craftcms/cms/pull/12266))
+- Added `craft\elemens\Entry::EVENT_DEFINE_PARENT_SELECTION_CRITERIA`. ([#12475](https://github.com/craftcms/cms/discussions/12475))
 - Added `craft\events\DefineInputOptionsEvent`. ([#12351](https://github.com/craftcms/cms/pull/12351))
 - Added `craft\events\UserPhotoEvent`. ([#12360](https://github.com/craftcms/cms/pull/12360))
 - Added `craft\fields\BaseOptionsField::EVENT_DEFINE_OPTIONS`. ([#12351](https://github.com/craftcms/cms/pull/12351))

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -32,6 +32,7 @@ use craft\elements\db\ElementQueryInterface;
 use craft\elements\db\EntryQuery;
 use craft\errors\UnsupportedSiteException;
 use craft\events\DefineEntryTypesEvent;
+use craft\events\ElementCriteriaEvent;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
 use craft\helpers\DateTimeHelper;
@@ -80,6 +81,13 @@ class Entry extends Element implements ExpirableElementInterface
      * @since 3.6.0
      */
     public const EVENT_DEFINE_ENTRY_TYPES = 'defineEntryTypes';
+
+    /**
+     * @event ElementCriteriaEvent The event that is triggered when defining the parent selection criteria.
+     * @see _parentOptionCriteria()
+     * @since 4.4.0
+     */
+    public const EVENT_DEFINE_PARENT_SELECTION_CRITERIA = 'defineParentSelectionCriteria';
 
     /**
      * @inheritdoc
@@ -1760,6 +1768,15 @@ EOD;
             }
 
             $parentOptionCriteria['level'] = sprintf('<=%s', $section->maxLevels - $depth);
+        }
+
+        if ($this->hasEventHandlers(self::EVENT_DEFINE_PARENT_SELECTION_CRITERIA)) {
+            // Fire a defineParentSelectionCriteria event
+            $event = new ElementCriteriaEvent([
+                'criteria' => $parentOptionCriteria,
+            ]);
+            $this->trigger(self::EVENT_DEFINE_PARENT_SELECTION_CRITERIA, $event);
+            return $event->criteria;
         }
 
         return $parentOptionCriteria;


### PR DESCRIPTION
### Description

Adds a new `EVENT_DEFINE_PARENT_SELECTION_CRITERIA` event to `craft\elements\Entry`, making it possible for modules/plugins to modify which entries are selectable within the **Parent** setting.

### Related issues

- Resolves #12475