### PR TITLE
Twig variable dump improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -20,6 +20,8 @@
 - Added the `editable` and `savable` asset query params. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - Added the `savable` entry query param. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - The `editable` entry query param can now be set to `false` to only show entries that _can’t_ be viewed by the current user. ([#12266](https://github.com/craftcms/cms/pull/12266))
+- The `dump()` Twig function now utilizes `Craft::dump()`, and no longer requires Dev Mode to be active. ([#12486](https://github.com/craftcms/cms/pull/12486), [#12479](https://github.com/craftcms/cms/discussions/12479))
+- The `{% dd %}` Twig tag can now output the entire `context` array, if no variable is passed to it. ([#12486](https://github.com/craftcms/cms/pull/12486))
 
 ### Extensibility
 - Console controllers that directly use `craft\console\ControllerTrait` no longer need to call `$this->checkTty()` or `$this->checkRootUser()` themselves; they are now called from `ControllerTrait::init()` and `beforeAction()`.

--- a/src/helpers/Template.php
+++ b/src/helpers/Template.php
@@ -18,6 +18,7 @@ use Twig\Error\RuntimeError;
 use Twig\Markup;
 use Twig\Source;
 use Twig\Template as TwigTemplate;
+use Twig\TemplateWrapper;
 use yii\base\BaseObject;
 use yii\base\InvalidConfigException;
 use yii\base\UnknownMethodException;
@@ -322,5 +323,20 @@ class Template
         }
 
         return [$templatePath, $templateLine];
+    }
+
+    /**
+     * Filters the template from a context array.
+     *
+     * Used by the `dump()` function and `dd` tags.
+     *
+     * @param array $context
+     * @return array
+     * @since 4.4.0
+     */
+    public static function contextWithoutTemplate(array $context): array
+    {
+        // Template check copied from twig_var_dump()
+        return array_filter($context, fn($value) => !$value instanceof TwigTemplate && !$value instanceof TemplateWrapper);
     }
 }

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -28,7 +28,6 @@ use Twig\Error\LoaderError as TwigLoaderError;
 use Twig\Error\RuntimeError as TwigRuntimeError;
 use Twig\Error\SyntaxError as TwigSyntaxError;
 use Twig\Extension\CoreExtension;
-use Twig\Extension\DebugExtension;
 use Twig\Extension\ExtensionInterface;
 use Twig\Extension\StringLoaderExtension;
 use Twig\Template as TwigTemplate;
@@ -355,10 +354,6 @@ class View extends \yii\web\View
             $twig->addExtension(new CpExtension());
         } elseif (Craft::$app->getIsInstalled()) {
             $twig->addExtension(new GlobalsExtension());
-        }
-
-        if (App::devMode()) {
-            $twig->addExtension(new DebugExtension());
         }
 
         // Add plugin-supplied extensions

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1251,6 +1251,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFunction('create', [Craft::class, 'createObject']),
             new TwigFunction('dataUrl', [$this, 'dataUrlFunction']),
             new TwigFunction('date', [$this, 'dateFunction'], ['needs_environment' => true]),
+            new TwigFunction('dump', [$this, 'dumpFunction'], ['is_safe' => ['html'], 'needs_context' => true, 'is_variadic' => true]),
             new TwigFunction('expression', [$this, 'expressionFunction']),
             new TwigFunction('floor', 'floor'),
             new TwigFunction('getenv', [App::class, 'env']),
@@ -1355,6 +1356,31 @@ class Extension extends AbstractExtension implements GlobalsInterface
         }
 
         return twig_date_converter($env, $date, $timezone);
+    }
+
+    /**
+     * Displays a variable(s).
+     *
+     * @param array $context
+     * @param ...$vars
+     * @return string
+     * @since 4.4.0
+     */
+    public function dumpFunction(array $context, ...$vars): string
+    {
+        if (!$vars) {
+            $vars = [TemplateHelper::contextWithoutTemplate($context)];
+        }
+
+        $output = '';
+
+        foreach ($vars as $var) {
+            ob_start();
+            Craft::dump($var);
+            $output .= str_replace('<code>', '<code style="display:block;">', ob_get_clean());
+        }
+
+        return $output;
     }
 
     /**

--- a/src/web/twig/nodes/DdNode.php
+++ b/src/web/twig/nodes/DdNode.php
@@ -8,6 +8,7 @@
 namespace craft\web\twig\nodes;
 
 use Craft;
+use craft\helpers\Template;
 use Twig\Compiler;
 use Twig\Node\Node;
 
@@ -27,8 +28,14 @@ class DdNode extends Node
         $compiler->addDebugInfo($this);
 
         $compiler
-            ->write(Craft::class . '::dd(')
-            ->subcompile($this->getNode('var'))
-            ->raw(");\n");
+            ->write(Craft::class . '::dd(');
+
+        if ($this->hasNode('var')) {
+            $compiler->subcompile($this->getNode('var'));
+        } else {
+            $compiler->raw(sprintf('%s::contextWithoutTemplate($context)', Template::class));
+        }
+
+        $compiler->raw(");\n");
     }
 }

--- a/src/web/twig/tokenparsers/DdTokenParser.php
+++ b/src/web/twig/tokenparsers/DdTokenParser.php
@@ -28,9 +28,11 @@ class DdTokenParser extends AbstractTokenParser
         $parser = $this->parser;
         $stream = $parser->getStream();
 
-        $nodes = [
-            'var' => $parser->getExpressionParser()->parseExpression(),
-        ];
+        $nodes = [];
+
+        if (!$stream->test(Token::BLOCK_END_TYPE)) {
+            $nodes['var'] = $parser->getExpressionParser()->parseExpression();
+        }
 
         $stream->expect(Token::BLOCK_END_TYPE);
 


### PR DESCRIPTION
### Description

Adds a new `dump()` function, which outputs a variable(s) via `Craft::dump()`. It replaces the `dump()` function provided by Twig’s `Debug` extension, and doesn’t require Dev Mode to be active. To maintain consistency with the original, the new one supports outputting multiple variables at once by passing them as separate arguments, and will default to outputting the entire `context` array if no arguments are provided.

```twig
{{ dump(foo, bar, baz) }}
{{ dump() }} → context array
```

The `{% dd %}` tag has also been updated to no longer require a variable, in which case the entire `context` array will be output.

```twig
{% dd foo %}
{% dd %} → context array
```

Passing multiple values to `{% dd %}` is **not** supported, as the application will exit before we could loop around to the second. If you want to do that, you’d have to pass them as a hash:

```twig
{% dd {foo: foo, bar: bar} %}
```

### Related issues

- #12479