### PR TITLE
`exec` command

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -26,6 +26,7 @@
 - The `plugin/install`, `plugin/uninstall`, `plugin/enable`, and `plugin/disabled` commands now support an `--all` option, which applies the action to all applicable Composer-installed plugins. ([#11373](https://github.com/craftcms/cms/discussions/11373), [#12218](https://github.com/craftcms/cms/pull/12218))
 
 ### Development
+- Added the `exec` command, which executes an individual PHP statement and outputs the result. ([#12528](https://github.com/craftcms/cms/pull/12528))
 - Added the `editable` and `savable` asset query params. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - Added the `savable` entry query param. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - The `editable` entry query param can now be set to `false` to only show entries that _can’t_ be viewed by the current user. ([#12266](https://github.com/craftcms/cms/pull/12266))

--- a/src/console/controllers/ExecController.php
+++ b/src/console/controllers/ExecController.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\console\controllers;
+
+use Craft;
+use craft\console\Controller;
+use craft\helpers\Console;
+use ParseError;
+use yii\console\ExitCode;
+
+/**
+ * Executes a PHP statement and outputs the result.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.4.0
+ */
+class ExecController extends Controller
+{
+    /**
+     * @inheritdoc
+     */
+    public $defaultAction = 'exec';
+
+    /**
+     * Executes a PHP statement and outputs the result.
+     *
+     * @param string $command
+     * @return int
+     */
+    public function actionExec(string $command): int
+    {
+        ob_start();
+
+        try {
+            eval("\$result = $command;");
+            $showResult = true;
+        } catch (ParseError) {
+            eval("$command;");
+            $showResult = false;
+        }
+
+        $output = ob_get_clean();
+
+        if ($showResult) {
+            // Dump the result
+            $this->stdout('= ', Console::FG_GREY);
+            /** @var mixed $result */
+            /** @phpstan-ignore-next-line */
+            $dump = Craft::dump($result, return: true);
+            $this->stdout(trim(preg_replace('/^/m', '  ', trim($dump))) . "\n\n");
+        }
+
+        if ($output !== '') {
+            $this->stdout("Output:\n", Console::FG_GREY);
+            $this->stdout("$output\n\n");
+        }
+
+        return ExitCode::OK;
+    }
+}


### PR DESCRIPTION
Adds a new `exec` command, which executes a single PHP statement and outputs the result.

 Examples:

```sh
> php craft exec "'hello world'"
= "hello world"
```

```sh
> php craft exec "echo 'hello world'"
Output:
hello world
```

```sh
> php craft exec "Craft::\$app->version"
= "4.3.6.1"
```

```sh
> php craft exec "craft\elements\Entry::find()->asArray()->one()"
= array:38 [
    "id" => 24
    "canonicalId" => null
    "fieldLayoutId" => 197
    "uid" => "09fec6f1-89bf-425e-9fe6-a2d632bb6cf3"
    "enabled" => 1
    "archived" => 0
    "dateLastMerged" => null
    "dateCreated" => "2014-07-31 22:04:17"
    "dateUpdated" => "2016-06-03 17:43:36"
    "siteSettingsId" => 24
    "slug" => "the-future-of-augmented-reality"
    "siteId" => 1
    "uri" => "news/the-future-of-augmented-reality"
    "enabledForSite" => 1
    "sectionId" => 2
    "typeId" => 2
    "authorId" => 1
    "postDate" => "2016-05-07 00:00:00"
    "expiryDate" => null
    "contentId" => 13
    "title" => "The Future of Augmented Reality"
    "field_address" => null
    "field_backgroundColor" => null
    "field_body" => null
    "field_contactUsLabel" => null
    "field_copyrightNotice" => null
    "field_email" => null
    "field_featuredEntry" => 0
    "field_heading" => "Your iPhone Is No Longer a Way To Hide"
    "field_indexHeading" => null
    "field_linkUrl" => null
    "field_shortDescription" => """
      <p>\r\n
      \tNam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis.\r\n
      </p>
      """
    "field_subheading" => "But is now a way to connect with the world"
    "root" => null
    "lft" => null
    "rgt" => null
    "level" => null
    "structureId" => null
  ]
```