### PR TITLE
Only return true descendants, not the parent.

### DIFF
--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -489,7 +489,7 @@ class Assets extends Component
         $query = $this->_createFolderQuery()
             ->where([
                 'and',
-                ['like', 'path', $parentFolder->path . '%', false],
+                ['like', 'path', $parentFolder->path . '_%', false],
                 ['volumeId' => $parentFolder->volumeId],
                 ['not', ['parentId' => null]],
             ]);

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -489,9 +489,9 @@ class Assets extends Component
         $sql = "
             WITH RECURSIVE descendants AS
             (
-                SELECT vf.* FROM ".Table::VOLUMEFOLDERS." vf WHERE vf.parentId = :parent_id
+                SELECT vf.* FROM " . Table::VOLUMEFOLDERS . " vf WHERE vf.parentId = :parent_id
                 UNION ALL
-                SELECT vf2.* FROM ".Table::VOLUMEFOLDERS." vf2 JOIN descendants 
+                SELECT vf2.* FROM " . Table::VOLUMEFOLDERS . " vf2 JOIN descendants 
                 ON descendants.id = vf2.parentId
             )
             SELECT * FROM descendants
@@ -502,11 +502,11 @@ class Assets extends Component
             $sql .= "ORDER BY :order_by";
             $params[':order_by'] = $orderBy;
         }
-        
+
         $connection = Craft::$app->getDb();
         $command = $connection->createCommand($sql, $params);
-        $results = $command->queryAll();
 
+        $results = $command->queryAll();
         $descendantFolders = [];
 
         foreach ($results as $result) {


### PR DESCRIPTION
Fixes https://github.com/craftcms/cms/issues/12536.

Adding an `_` to the `like` query ensures there's at least one character after the parent folder slash.

MYSQL `_` reference: https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like
Postgres `_` reference: https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE

<img width="1683" alt="Screenshot 2023-01-15 at 9 49 18 pm" src="https://user-images.githubusercontent.com/25124/212536787-30284e7f-fd17-4dd5-981b-6a5e2b990735.png">


