### PR TITLE
money filter amend

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -323,13 +323,13 @@ class Extension extends AbstractExtension implements GlobalsInterface
     /**
      * Outputs a value from a Money object.
      *
-     * @param Money|null $money
+     * @param mixed|null $money
      * @param string|null $formatLocale
      * @return string|null
      */
-    public function moneyFilter(?Money $money, ?string $formatLocale = null): ?string
+    public function moneyFilter(mixed $money, ?string $formatLocale = null): ?string
     {
-        if ($money === null) {
+        if (!$money instanceof Money) {
             return null;
         }
 


### PR DESCRIPTION
### Description
Make the `|money` filter fail silently if a value other than Money type is provided.

On the one hand, this would help in cases like the one from the related issue; on the other, it might make it easier not to notice the problem with the field type while developing. Please feel free to reject this PR if you think the benefits of having that filter throw the exception are more significant.

### Related issues
#12539 
