### PR TITLE
Improved asset indexing error msg for empty FS root folder

### DIFF
--- a/src/controllers/AssetIndexesController.php
+++ b/src/controllers/AssetIndexesController.php
@@ -65,7 +65,7 @@ class AssetIndexesController extends Controller
 
         if ($indexingSession->totalEntries === 0) {
             $data['stop'] = $indexingSession->id;
-            $error = Craft::t('app', 'Nothing to index.');
+            $error = Craft::t('app', 'The filesystem doesn\'t contain any files.');
             Craft::$app->getAssetIndexer()->stopIndexingSession($indexingSession);
         }
 

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -1432,6 +1432,7 @@ return [
     'The file failed to upload to the server properly.' => 'The file failed to upload to the server properly.',
     'The file “{name}” does not appear to be an image.' => 'The file “{name}” does not appear to be an image.',
     'The file “{path}” does not appear to be an image.' => 'The file “{path}” does not appear to be an image.',
+    'The filesystem doesn\'t contain any files.' => 'The filesystem doesn\'t contain any files.',
     'The following <a href="{url}">aliases</a> are defined:' => 'The following <a href="{url}">aliases</a> are defined:',
     'The following items were not indexed.' => 'The following items were not indexed.',
     'The following {items} could not be found. Should they be deleted from the index?' => 'The following {items} could not be found. Should they be deleted from the index?',


### PR DESCRIPTION
### Description
Changed the error message wording for when you're trying to index assets, and there's absolutely nothing in the FS root folder.


### Related issues
#12585 
