### PR TITLE
Add support for certificates in mysqldump

### DIFF
--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -395,13 +395,13 @@ SQL;
         }
         
         // Certificates
-        if(isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_CA])) {
+        if (isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_CA])) {
             $contents .= PHP_EOL . 'ssl_ca=' . $this->db->attributes[\PDO::MYSQL_ATTR_SSL_CA];
         }
-        if(isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_CERT])) {
+        if (isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_CERT])) {
             $contents .= PHP_EOL . 'ssl_cert=' . $this->db->attributes[\PDO::MYSQL_ATTR_SSL_CERT];
         }
-        if(isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_KEY])) {
+        if (isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_KEY])) {
             $contents .= PHP_EOL . 'ssl_key=' . $this->db->attributes[\PDO::MYSQL_ATTR_SSL_KEY];
         }
         

--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -393,7 +393,18 @@ SQL;
             $contents .= PHP_EOL . 'host=' . ($parsed['host'] ?? '') .
                 PHP_EOL . 'port=' . ($parsed['port'] ?? '');
         }
-
+        
+        // Certificates
+        if(isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_CA])) {
+            $contents .= PHP_EOL . 'ssl_ca=' . $this->db->attributes[\PDO::MYSQL_ATTR_SSL_CA];
+        }
+        if(isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_CERT])) {
+            $contents .= PHP_EOL . 'ssl_cert=' . $this->db->attributes[\PDO::MYSQL_ATTR_SSL_CERT];
+        }
+        if(isset($this->db->attributes[\PDO::MYSQL_ATTR_SSL_KEY])) {
+            $contents .= PHP_EOL . 'ssl_key=' . $this->db->attributes[\PDO::MYSQL_ATTR_SSL_KEY];
+        }
+        
         FileHelper::writeToFile($this->tempMyCnfPath, '');
         // Avoid a “world-writable config file 'my.cnf' is ignored” warning
         chmod($this->tempMyCnfPath, 0600);


### PR DESCRIPTION
### Description

As it is right now, craft does not support setting the ssl attributes in the configuration it uses for mysqldump. Add support for this instead of having to use the really cumbersome method of overriding the backup command setting.

### Related issues
#10351
#11753
