### PR TITLE
let StringHelper::toAscii use language detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "mikehaertl/php-shellcommand": "^1.6.3",
     "moneyphp/money": "^4.0",
     "monolog/monolog": "^2.3",
+    "patrickschur/language-detection": "^5.2",
     "pixelandtonic/imagine": "~1.3.3.1",
     "samdark/yii2-psr-log-target": "^1.1",
     "seld/cli-prompt": "^1.0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9c2bb7c8eecd9be2d7ad11bd30e76e8",
+    "content-hash": "c1f2e4d8807fc1c6177086ba035734f7",
     "packages": [
         {
             "name": "cebe/markdown",
@@ -2294,6 +2294,57 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "patrickschur/language-detection",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/patrickschur/language-detection.git",
+                "reference": "4849c2e8618cce09dbe15d5b534b51137bd6d477"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/patrickschur/language-detection/zipball/4849c2e8618cce09dbe15d5b534b51137bd6d477",
+                "reference": "4849c2e8618cce09dbe15d5b534b51137bd6d477",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LanguageDetection\\": "src/LanguageDetection"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Patrick Schur",
+                    "email": "patrick_schur@outlook.de"
+                }
+            ],
+            "description": "A language detection library for PHP. Detects the language from a given text string.",
+            "homepage": "https://github.com/patrickschur/language-detection",
+            "keywords": [
+                "detect",
+                "detection",
+                "language"
+            ],
+            "support": {
+                "issues": "https://github.com/patrickschur/language-detection/issues",
+                "source": "https://github.com/patrickschur/language-detection/tree/v5.2.0"
+            },
+            "time": "2022-03-01T22:22:41+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -10,6 +10,7 @@ namespace craft\helpers;
 use Craft;
 use HTMLPurifier_Config;
 use IteratorAggregate;
+use LanguageDetection\Language;
 use Normalizer;
 use Stringy\Stringy as BaseStringy;
 use voku\helper\ASCII;
@@ -1577,7 +1578,17 @@ class StringHelper extends \yii\helpers\StringHelper
         /** @var ASCII::*_LANGUAGE_CODE $language */
         $language = $language ?? Craft::$app->language;
 
-        return (string)BaseStringy::create($str)->toAscii($language);
+        // keep the "old" toAscii behaviour if it produces a result
+        $asciiString = (string)BaseStringy::create($str)->toAscii($language);
+
+        // but if we were not able to get the ascii version of the string
+        // let's try to detect the language of the provided $str
+        if (empty($asciiString)) {
+            $ld = new Language();
+            $language = $ld->detect($str);
+            $asciiString = (string)BaseStringy::create($str)->toAscii($language);
+        }
+        return $asciiString;
     }
 
     /**

--- a/src/models/FieldLayoutTab.php
+++ b/src/models/FieldLayoutTab.php
@@ -309,7 +309,7 @@ class FieldLayoutTab extends FieldLayoutComponent
     public function getHtmlId(): string
     {
         // Use two dashes here in case a tab name starts with “Tab”
-        return 'tab--' . StringHelper::toKebabCase(StringHelper::toAscii($this->name, 'en'));
+        return 'tab--' . StringHelper::toKebabCase(StringHelper::toAscii($this->name));
     }
 
     /**


### PR DESCRIPTION
### Description
Field layout tabs don’t show when the tab name is in a language that doesn’t easily convert to ASCII. This affects languages like Mandarin, Hebrew, Korean, Japanese and potentially others.

This PR adds language detection via [patrickschur/language-detection](https://github.com/patrickschur/language-detection) to the `StringHelper::toAscii` (only) if the current approach returns an empty string.


### Related issues
#12602 
