### PR TITLE
Stop overriding the pageTrigger for CP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improved the performance of the “Generating pending image transforms” queue job. ([#12274](https://github.com/craftcms/cms/issues/12274))
 - Added more reserved field handles to avoid conflicts with `craft\base\Element` properties. ([#12577](https://github.com/craftcms/cms/issues/12577))
+- Control panel requests no longer override the `pageTrigger` config setting value to `'p'`. ([#12598](https://github.com/craftcms/cms/issues/12598), [#12614](https://github.com/craftcms/cms/pull/12614))
 - Fixed field status badge styling in some contexts. ([#12403](https://github.com/craftcms/cms/issues/12403))
 - Fixed a bug where exporting elements with multiple field layouts as a CSV file using the “Expanded” export type would result in mismatched column values.
 - Fixed a bug where cancelling a conflicting volume folder move would result in the moved folder getting deleted.
@@ -22,6 +23,7 @@
 - Fixed a bug where element indexes could stop showing their loading spinner prematurely if the element listing needed to be reloaded multiple times in rapid succession. ([#12595](https://github.com/craftcms/cms/issues/12595))
 - Fixed a bug where element indexes would show show an expand/collapse toggle for structured elements that only had unsaved draft children, which aren’t actually shown. ([#11253](https://github.com/craftcms/cms/issues/11253))
 - Added `craft\helpers\Db::escapeForLike()`.
+- Added `craft\web\twig\variables\Paginate::$pageTrigger`. ([#12614](https://github.com/craftcms/cms/pull/12614))
 - `craft\services\Assets::getAllDescendantFolders()` now has a `$withParent` argument, which can be passed `false` to omit the parent folder from the results. ([#12536](https://github.com/craftcms/cms/issues/12536))
 - Deprecated `craft\helpers\DateTimeHelper::timeZoneAbbreviation()`.
 - Deprecated `craft\helpers\DateTimeHelper::timeZoneOffset()`.

--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -457,19 +457,22 @@ class TemplateCaches extends Component
             throw new Exception('Not possible to determine the request path for console commands.');
         }
 
-        if (Craft::$app->getRequest()->getIsCpRequest()) {
+        $isCpRequest = $request->getIsCpRequest();
+        if ($isCpRequest) {
             $this->_path = 'cp:';
         } else {
             $this->_path = 'site:';
         }
 
-        $this->_path .= Craft::$app->getRequest()->getPathInfo();
+        $this->_path .= $request->getPathInfo();
         if (Craft::$app->getDb()->getIsMysql()) {
             $this->_path = StringHelper::encodeMb4($this->_path);
         }
 
-        if (($pageNum = Craft::$app->getRequest()->getPageNum()) != 1) {
-            $this->_path .= '/' . Craft::$app->getConfig()->getGeneral()->getPageTrigger() . $pageNum;
+        $pageNum = $request->getPageNum();
+        if ($pageNum !== 1) {
+            $pageTrigger = $isCpRequest ? 'p' : Craft::$app->getConfig()->getGeneral()->getPageTrigger();
+            $this->_path .= sprintf('/%s%s', $pageTrigger, $pageNum);
         }
 
         return $this->_path;

--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -305,14 +305,8 @@ class Request extends \yii\web\Request
             }
         }
 
-        if ($this->_isCpRequest) {
-            // Force 'p' pageTrigger
-            // (all that really matters is that it doesn't have a trailing slash, but whatever.)
-            $this->generalConfig->pageTrigger = 'p';
-        }
-
         // Is this a paginated request?
-        $pageTrigger = $this->generalConfig->getPageTrigger();
+        $pageTrigger = $this->_isCpRequest ? 'p' : $this->generalConfig->getPageTrigger();
 
         // Is this query string-based pagination?
         if (strpos($pageTrigger, '?') === 0) {

--- a/src/web/assets/cp/CpAsset.php
+++ b/src/web/assets/cp/CpAsset.php
@@ -338,7 +338,7 @@ JS;
             'omitScriptNameInUrls' => (bool)$generalConfig->omitScriptNameInUrls,
             'orientation' => $orientation,
             'pageNum' => $request->getPageNum(),
-            'pageTrigger' => $generalConfig->getPageTrigger(),
+            'pageTrigger' => 'p',
             'path' => $request->getPathInfo(),
             'pathParam' => $generalConfig->pathParam,
             'Pro' => Craft::Pro,

--- a/src/web/twig/variables/Paginate.php
+++ b/src/web/twig/variables/Paginate.php
@@ -68,11 +68,31 @@ class Paginate extends BaseObject
     public $totalPages = 0;
 
     /**
+     * @var string
+     * @since 3.7.64
+     */
+    public $pageTrigger;
+
+    /**
      * @var string Base path
      * @see getBasePath()
      * @see setBasePath()
      */
     private $_basePath;
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+
+        if (!isset($this->pageTrigger)) {
+            $this->pageTrigger = Craft::$app->getRequest()->getIsCpRequest()
+                ? 'p'
+                : Craft::$app->getConfig()->getGeneral()->getPageTrigger();
+        }
+    }
 
     /**
      * Returns the base path that should be used for pagination URLs.
@@ -110,8 +130,7 @@ class Paginate extends BaseObject
             return null;
         }
 
-        $pageTrigger = Craft::$app->getConfig()->getGeneral()->getPageTrigger();
-        $useQueryParam = strpos($pageTrigger, '?') === 0;
+        $useQueryParam = strpos($this->pageTrigger, '?') === 0;
 
         $path = $this->getBasePath();
 
@@ -121,7 +140,7 @@ class Paginate extends BaseObject
                 $path .= '/';
             }
 
-            $path .= $pageTrigger . $page;
+            $path .= $this->pageTrigger . $page;
         }
 
         // Build the URL with the same query string as the current request
@@ -129,7 +148,7 @@ class Paginate extends BaseObject
 
         // If using a query param, append or remove it
         if ($useQueryParam) {
-            $param = trim($pageTrigger, '?=');
+            $param = trim($this->pageTrigger, '?=');
             if ($page != 1) {
                 $url = UrlHelper::urlWithParams($url, [$param => $page]);
             } else {


### PR DESCRIPTION
### Description

Moves away from overriding the `pageTrigger` config setting for CP requests.

CP requests continue to paginate using a `p` page trigger, but it’s now hard-coded into the pagination logic, so plugins can still access the original config value if needed.

`craft\web\twig\variables\Paginate` (what the `pageInfo` variable is set to for `{% pagination %}` tags) also now gets a public `$pageTrigger` property, which defaults to `p` or the `pageTrigger` value depending on if it’s a CP request, but it can be overridden if needed.

### Related issues

- #12598