### PR TITLE
`aria-labelledby` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- The `_includes/forms/checkbox.twig`, `select.twig`, and `text.twig` templates no longer add an `aria-labelledby` attribute to the input if an `aria-label` attribute is also specified.
+- `craft\helpers\Cp::dateTimeFieldHtml()` now returns inputs contained within a fieldset.
+- Fixed a bug where some inputs were getting `aria-labelledby` attributes that referenced a nonexistent label ID.
+
 ## 4.3.7 - 2023-02-03
 
 - Improved the performance of the “Generating pending image transforms” queue job. ([#12274](https://github.com/craftcms/cms/issues/12274))

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -1120,7 +1120,10 @@ class Cp
      */
     public static function dateTimeFieldHtml(array $config): string
     {
-        $config['id'] = $config['id'] ?? 'datetime' . mt_rand();
+        $config += [
+            'id' => 'datetime' . mt_rand(),
+            'fieldset' => true,
+        ];
         return static::fieldHtml('template:_includes/forms/datetime.twig', $config);
     }
 

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -611,9 +611,19 @@ class Cp
         $errors = $config['errors'] ?? null;
         $status = $config['status'] ?? null;
 
+        $fieldset = $config['fieldset'] ?? false;
+        $fieldId = $config['fieldId'] ?? "$id-field";
+        $label = $config['fieldLabel'] ?? $config['label'] ?? null;
+
+        if ($label === '__blank__') {
+            $label = null;
+        }
+
+        $siteId = Craft::$app->getIsMultiSite() && isset($config['siteId']) ? (int)$config['siteId'] : null;
+
         if (str_starts_with($input, 'template:')) {
             // Set labelledBy and describedBy values in case the input template supports it
-            if (!isset($config['labelledBy'])) {
+            if (!isset($config['labelledBy']) && $label) {
                 $config['labelledBy'] = $labelId;
             }
             if (!isset($config['describedBy'])) {
@@ -629,16 +639,6 @@ class Cp
 
             $input = static::renderTemplate(substr($input, 9), $config);
         }
-
-        $fieldset = $config['fieldset'] ?? false;
-        $fieldId = $config['fieldId'] ?? "$id-field";
-        $label = $config['fieldLabel'] ?? $config['label'] ?? null;
-
-        if ($label === '__blank__') {
-            $label = null;
-        }
-
-        $siteId = Craft::$app->getIsMultiSite() && isset($config['siteId']) ? (int)$config['siteId'] : null;
 
         if ($siteId) {
             $site = Craft::$app->getSites()->getSiteById($siteId);
@@ -673,32 +673,37 @@ class Cp
             ])
             : '';
 
-        $labelHtml = $label . (
-            ($required
-                ? Html::tag('span', Craft::t('app', 'Required'), [
-                    'class' => ['visually-hidden'],
-                ]) .
-                Html::tag('span', '', [
-                    'class' => ['required'],
-                    'aria' => [
-                        'hidden' => 'true',
-                    ],
-                ])
-                : '') .
-            ($translatable
-                ? Html::tag('span', '', [
-                    'class' => ['t9n-indicator'],
-                    'title' => $config['translationDescription'] ?? Craft::t('app', 'This field is translatable.'),
-                    'data' => [
-                        'icon' => 'language',
-                    ],
-                    'aria' => [
-                        'label' => $config['translationDescription'] ?? Craft::t('app', 'This field is translatable.'),
-                    ],
-                    'role' => 'img',
-                ])
-                : '')
-            );
+        if ($label) {
+            $labelHtml = $label . (
+                    ($required
+                        ? Html::tag('span', Craft::t('app', 'Required'), [
+                            'class' => ['visually-hidden'],
+                        ]) .
+                        Html::tag('span', '', [
+                            'class' => ['required'],
+                            'aria' => [
+                                'hidden' => 'true',
+                            ],
+                        ])
+                        : '') .
+                    ($translatable
+                        ? Html::tag('span', '', [
+                            'class' => ['t9n-indicator'],
+                            'title' => $config['translationDescription'] ?? Craft::t('app', 'This field is translatable.'),
+                            'data' => [
+                                'icon' => 'language',
+                            ],
+                            'aria' => [
+                                'label' => $config['translationDescription'] ?? Craft::t('app', 'This field is translatable.'),
+                            ],
+                            'role' => 'img',
+                        ])
+                        : '')
+                );
+        } else {
+            $labelHtml = '';
+        }
+
 
         $containerTag = $fieldset ? 'fieldset' : 'div';
 

--- a/src/templates/_includes/forms/checkbox.twig
+++ b/src/templates/_includes/forms/checkbox.twig
@@ -13,7 +13,7 @@
     autofocus: (autofocus ?? false) and not craft.app.request.isMobileBrowser(true),
     disabled: (disabled ?? false) ? true : false,
     aria: {
-        labelledby: labelledBy ?? false,
+        labelledby: (inputAttributes.aria.label ?? false) ? false : (labelledBy ?? false),
         describedby: describedBy ?? false,
     },
     data: {

--- a/src/templates/_includes/forms/select.twig
+++ b/src/templates/_includes/forms/select.twig
@@ -26,7 +26,7 @@
     disabled: disabled ?? false,
     aria: {
         describedby: describedBy ?? false,
-        labelledby: labelledBy ?? false,
+        labelledby: (inputAttributes.aria.label ?? false) ? false : (labelledBy ?? false),
     },
     data: {
         'target-prefix': (toggle ?? false) ? (targetPrefix ?? '') : false,

--- a/src/templates/_includes/forms/text.twig
+++ b/src/templates/_includes/forms/text.twig
@@ -31,7 +31,7 @@
     max: max ?? false,
     dir: orientation,
     aria: {
-        labelledby: labelledBy ?? false,
+        labelledby: (inputAttributes.aria.label ?? false) ? false : (labelledBy ?? false),
         describedby: describedBy ?? false,
     },
 }|merge(inputAttributes ?? [], recursive=true) %}


### PR DESCRIPTION
### Description

- The `_includes/forms/checkbox.twig`, `select.twig`, and `text.twig` templates will no longer output an `aria-labelledby` attribute when `labelledBy` is set, if `inputAttributes.aria.label` is also set.
- `craft\helpers\Cp::fieldHtml()` will no longer define `$config['labelledBy']` if the field doesn’t have a label to begin with.
- `craft\helpers\Cp::dateTimeFieldHtml()` now sets `$config['fieldset'] = true`. 

### Related issues

- Resolves #11961
- DEV-964