### PR TITLE
Update version to 4.3.7.1

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -3,7 +3,7 @@
 return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
-    'version' => '4.3.7',
+    'version' => '4.3.7.1',
     'schemaVersion' => '4.0.0.9',
     'minVersionRequired' => '3.7.11',
     'basePath' => dirname(__DIR__), // Defines the @app alias


### PR DESCRIPTION
@brandonkelly the version number `4.3.7` has not been updated to match the recently tagged `4.3.7.1`:
https://github.com/craftcms/cms/releases/tag/4.3.7.1