### PR TITLE
made sure path is casted to string before escaping

### DIFF
--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -490,7 +490,7 @@ class Assets extends Component
         $query = $this->_createFolderQuery()
             ->where([
                 'and',
-                ['like', 'path', Db::escapeForLike($parentFolder->path) . '%', false],
+                ['like', 'path', Db::escapeForLike((string)$parentFolder->path) . '%', false],
                 ['volumeId' => $parentFolder->volumeId],
                 ['not', ['parentId' => null]],
             ]);


### PR DESCRIPTION
### Description
In `services\Assets->getAllDescendantFolders()`, make sure that the `$parentFolder->path` is cast to a string before passing it on to `Db::escapeForLike`. This should only matter when `$parentFolder->path` is `null`.


### Related issues
[#1231](https://github.com/craftcms/feed-me/issues/1231)
