### PR TITLE
Accounts for non-array fieldId in MatrixBlockQuery

### DIFF
--- a/src/elements/db/MatrixBlockQuery.php
+++ b/src/elements/db/MatrixBlockQuery.php
@@ -676,8 +676,13 @@ class MatrixBlockQuery extends ElementQuery
             }
         } else {
             if ($this->fieldId) {
-                foreach ($this->fieldId as $fieldId) {
-                    $tags[] = "field:$fieldId";
+                if (is_array($this->fieldId)) {
+                    foreach ($this->fieldId as $fieldId) {
+                        $tags[] = "field:$fieldId";
+                    }
+                }
+                else {
+                    $tags[] = "field:{$this->fieldId}";
                 }
             }
             if ($this->primaryOwnerId) {


### PR DESCRIPTION
During a Craft 3.7 -> Craft 4.3 upgrade I ended up with a `$this->fieldId=69` which is not a `foreach`-able array. The fix was to just add the fieldId as a tag directly, but I'm not sure if that affects other parts of the code?

The big question: is this a result of a bad upgrade on my part or an actual bug? The type hints seem to imply that an `int` is a valid value for `->fieldId` but I'm not sure if they're just out of date?