### PR TITLE
eager loading map - bail if sourceElements is empty

### DIFF
--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -670,6 +670,10 @@ JS;
      */
     public function getEagerLoadingMap(array $sourceElements)
     {
+        if (empty($sourceElements)) {
+            return null;
+        }
+
         $sourceSiteId = $sourceElements[0]->siteId;
 
         // Get the source element IDs


### PR DESCRIPTION
### Description
Don’t attempt to get an eager loading map if the $sourceElements array is empty.


### Related issues
#12648 
