### PR TITLE
More explicit size ordering

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -402,7 +402,11 @@ class Asset extends Element
         return [
             'title' => Craft::t('app', 'Title'),
             'filename' => Craft::t('app', 'Filename'),
-            'size' => Craft::t('app', 'File Size'),
+            'size' => [
+                'label' => Craft::t('app', 'File Size'),
+                'orderBy' => 'assets.size',
+                'defaultDir' => 'desc',
+            ],
             [
                 'label' => Craft::t('app', 'File Modification Date'),
                 'orderBy' => 'dateModified',


### PR DESCRIPTION
### Description
Explicitly orders by `asset.size` just in case users have a field with a handle of `size`. Reserved handles don't help us here because the `columnMap` used by `orderBy` uses all columns on the `content` table, so any entry type with a `fieldHandle` of `size` will cause issues. 

### Related issues
Fixes #12652 

