### PR TITLE
Update `getCurrentRevision()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 3.x
 
+## Unreleased
+
+- Fixed a bug where entries that aren’t propagated to the primary site weren’t showing revision notes. ([#12641](https://github.com/craftcms/cms/issues/12641))
+
 ## 3.7.65.2 - 2023-02-08
 
 - Fixed a PHP error that could occur if relational fields were getting eager-loaded for elements that the fields didn’t belong to. ([#12648](https://github.com/craftcms/cms/issues/12648))

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -3758,6 +3758,7 @@ abstract class Element extends Component implements ElementInterface
         if ($this->_currentRevision === null) {
             $canonical = $this->getCanonical(true);
             $this->_currentRevision = static::find()
+                ->siteId($canonical->siteId)
                 ->revisionOf($canonical->id)
                 ->dateCreated($canonical->dateUpdated)
                 ->anyStatus()


### PR DESCRIPTION
Make sure we're loading the current revision from the same site as the canonical entry.

@olivierbon gets all the dev points on this one.

Fixes #12641
