### PR TITLE
Directly delete entries/categories alongside section/group

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -148,6 +148,7 @@
 - Improved queue performance. ([#12274](https://github.com/craftcms/cms/issues/12274), [#12340](https://github.com/craftcms/cms/pull/12340))
 - “Applying new propagation method to elements”, “Propagating [element type]”, and “Resaving [element type]” queue jobs are now splt up into batches of up to 100 items. ([#12638](https://github.com/craftcms/cms/pull/12638))
 - Assets’ alternative text values are now included as search keywords.
+- Entry type, section, and category group deletion no longer involves looping through all affected entries/categories and deleting each one individually via `craft\services\Elements::deleteElement()`. ([#12665](https://github.com/craftcms/cms/pull/12665))
 - Updated LitEmoji to v4. ([#12226](https://github.com/craftcms/cms/discussions/12226))
 - Fixed a database deadlock error that could occur when updating a relation or structure position for an element that was simultaneously being saved. ([#9905](https://github.com/craftcms/cms/issues/9905))
 - Fixed a bug where element query `select()` and `orderBy()` params could resolve element extension table column names to custom field columns, if a custom field had a conflicting handle. ([#12652](https://github.com/craftcms/cms/issues/12652))

--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -37,6 +37,7 @@ use craft\queue\jobs\ResaveElements;
 use craft\records\EntryType as EntryTypeRecord;
 use craft\records\Section as SectionRecord;
 use craft\records\Section_SiteSettings as Section_SiteSettingsRecord;
+use DateTime;
 use Throwable;
 use yii\base\Component;
 use yii\base\Exception;
@@ -864,16 +865,35 @@ class Sections extends Component
         try {
             // All entries *should* be deleted by now via their entry types, but loop through all the sites in case
             // there are any lingering entries from unsupported sites
-            $entryQuery = Entry::find()
-                ->sectionId($sectionRecord->id)
-                ->status(null);
-            $elementsService = Craft::$app->getElements();
-            foreach (Craft::$app->getSites()->getAllSiteIds() as $siteId) {
-                foreach (Db::each($entryQuery->siteId($siteId)) as $entry) {
-                    /** @var Entry $entry */
-                    $elementsService->deleteElement($entry);
-                }
+            $elementsTable = Table::ELEMENTS;
+            $entriesTable = Table::ENTRIES;
+            $now = Db::prepareDateForDb(new DateTime());
+            $db = Craft::$app->getDb();
+
+            if ($db->getIsMysql()) {
+                $sql = <<<SQL
+UPDATE $elementsTable [[elements]], $entriesTable [[sections]] 
+SET [[elements.dateDeleted]] = '$now'
+WHERE [[sections.sectionId]] = $section->id AND
+  [[sections.id]] = [[elements.id]] AND
+  [[elements.canonicalId]] IS NULL AND
+  [[elements.revisionId]] IS NULL AND
+  [[elements.dateDeleted]] IS NULL
+SQL;
+            } else {
+                $sql = <<<SQL
+UPDATE $elementsTable
+SET [[elements.dateDeleted]] = '$now'
+FROM $entriesTable
+WHERE [[sections.sectionId]] = $section->id AND
+  [[sections.id]] = [[elements.id]] AND
+  [[elements.canonicalId]] IS NULL AND
+  [[elements.revisionId]] IS NULL AND
+  [[elements.dateDeleted]] IS NULL
+SQL;
             }
+
+            $db->createCommand($sql)->execute();
 
             // Delete the structure
             if ($sectionRecord->structureId) {
@@ -1334,22 +1354,38 @@ class Sections extends Component
         $transaction = Craft::$app->getDb()->beginTransaction();
 
         try {
-            // Delete the entries, including unpublished drafts
-            // (loop through all the sites in case there are any lingering entries from unsupported sites
-            $entryQuery = Entry::find()
-                ->typeId($entryTypeRecord->id)
-                ->status(null)
-                ->drafts(null)
-                ->draftOf(false);
+            // Delete the entries
+            $elementsTable = Table::ELEMENTS;
+            $entriesTable = Table::ENTRIES;
+            $now = Db::prepareDateForDb(new DateTime());
+            $db = Craft::$app->getDb();
 
-            $elementsService = Craft::$app->getElements();
-            foreach (Craft::$app->getSites()->getAllSiteIds() as $siteId) {
-                foreach (Db::each($entryQuery->siteId($siteId)) as $entry) {
-                    /** @var Entry $entry */
-                    $entry->deletedWithEntryType = true;
-                    $elementsService->deleteElement($entry);
-                }
+            if ($db->getIsMysql()) {
+                $sql = <<<SQL
+UPDATE $elementsTable [[elements]], $entriesTable [[entries]] 
+SET [[elements.dateDeleted]] = '$now',
+  [[entries.deletedWithEntryType]] = 1
+WHERE [[entries.typeId]] = $entryType->id AND
+  [[entries.id]] = [[elements.id]] AND
+  [[elements.canonicalId]] IS NULL AND
+  [[elements.revisionId]] IS NULL AND
+  [[elements.dateDeleted]] IS NULL
+SQL;
+            } else {
+                $sql = <<<SQL
+UPDATE $elementsTable
+SET [[elements.dateDeleted]] = '$now',
+  [[entries.deletedWithEntryType]] = TRUE
+FROM $entriesTable
+WHERE [[entries.typeId]] = $entryType->id AND
+  [[entries.id]] = [[elements.id]] AND
+  [[elements.canonicalId]] IS NULL AND
+  [[elements.revisionId]] IS NULL AND
+  [[elements.dateDeleted]] IS NULL
+SQL;
             }
+
+            $db->createCommand($sql)->execute();
 
             // Delete the field layout
             if ($entryTypeRecord->fieldLayoutId) {


### PR DESCRIPTION
Improves the performance of entry type, section, and category group deletion, by no longer looping through all affected entries/categories and soft-deleting each one individually via `craft\services\Elements::deleteElement()`.

Instead, affected entries/categories are soft-deleted all at once via a single `update` SQL query.

There are a couple side effects of this change:

- `Elements::EVENT_BEFORE_DELETE_ELEMENT` and `EVENT_AFTER_DELETE_ELEMENT` are no longer triggered for each entry/category, but that’s probably fine in these cases, as the individual elements aren’t relevant to the project anymore. (The entry type/section/category group deletion events still get triggered.)
- Bulk-soft-deleted elements are no longer getting removed from their associated structures in these cases. This should be completely moot in the case of section and category group deletion, since the entire structures are also soft-deleted. Which leaves entry types, where gaps will appear within the structure data once the entries have been hard-deleted. That won’t break anything though, and is easily repairable via the [`utils/repair/section-structure`](https://craftcms.com/docs/4.x/console-commands.html#utils-repair-section-structure) command.