### PR TITLE
Set a default element type property for all element condition builders

### DIFF
--- a/src/elements/conditions/ElementCondition.php
+++ b/src/elements/conditions/ElementCondition.php
@@ -55,7 +55,10 @@ class ElementCondition extends BaseCondition implements ElementConditionInterfac
      */
     public function __construct(?string $elementType = null, array $config = [])
     {
-        $this->elementType = $elementType;
+        if ($elementType !== null) {
+            $this->elementType = $elementType;
+        }
+
         parent::__construct($config);
     }
 

--- a/src/elements/conditions/addresses/AddressCondition.php
+++ b/src/elements/conditions/addresses/AddressCondition.php
@@ -2,6 +2,7 @@
 
 namespace craft\elements\conditions\addresses;
 
+use craft\elements\Address;
 use craft\elements\conditions\ElementCondition;
 
 /**
@@ -12,6 +13,11 @@ use craft\elements\conditions\ElementCondition;
  */
 class AddressCondition extends ElementCondition
 {
+    /**
+     * @inheritdoc
+     */
+    public ?string $elementType = Address::class;
+
     /**
      * @inheritdoc
      */

--- a/src/elements/conditions/assets/AssetCondition.php
+++ b/src/elements/conditions/assets/AssetCondition.php
@@ -2,6 +2,7 @@
 
 namespace craft\elements\conditions\assets;
 
+use craft\elements\Asset;
 use craft\elements\conditions\ElementCondition;
 
 /**
@@ -12,6 +13,11 @@ use craft\elements\conditions\ElementCondition;
  */
 class AssetCondition extends ElementCondition
 {
+    /**
+     * @inheritdoc
+     */
+    public ?string $elementType = Asset::class;
+
     /**
      * @inheritdoc
      */

--- a/src/elements/conditions/categories/CategoryCondition.php
+++ b/src/elements/conditions/categories/CategoryCondition.php
@@ -2,6 +2,7 @@
 
 namespace craft\elements\conditions\categories;
 
+use craft\elements\Category;
 use craft\elements\conditions\ElementCondition;
 use craft\elements\conditions\LevelConditionRule;
 
@@ -13,6 +14,11 @@ use craft\elements\conditions\LevelConditionRule;
  */
 class CategoryCondition extends ElementCondition
 {
+    /**
+     * @inheritdoc
+     */
+    public ?string $elementType = Category::class;
+
     /**
      * @inheritdoc
      */

--- a/src/elements/conditions/entries/EntryCondition.php
+++ b/src/elements/conditions/entries/EntryCondition.php
@@ -4,6 +4,7 @@ namespace craft\elements\conditions\entries;
 
 use craft\elements\conditions\ElementCondition;
 use craft\elements\conditions\LevelConditionRule;
+use craft\elements\Entry;
 
 /**
  * Entry query condition.
@@ -13,6 +14,11 @@ use craft\elements\conditions\LevelConditionRule;
  */
 class EntryCondition extends ElementCondition
 {
+    /**
+     * @inheritdoc
+     */
+    public ?string $elementType = Entry::class;
+
     /**
      * @inheritdoc
      */

--- a/src/elements/conditions/tags/TagCondition.php
+++ b/src/elements/conditions/tags/TagCondition.php
@@ -3,6 +3,7 @@
 namespace craft\elements\conditions\tags;
 
 use craft\elements\conditions\ElementCondition;
+use craft\elements\Tag;
 
 /**
  * Tag query condition.
@@ -12,6 +13,11 @@ use craft\elements\conditions\ElementCondition;
  */
 class TagCondition extends ElementCondition
 {
+    /**
+     * @inheritdoc
+     */
+    public ?string $elementType = Tag::class;
+
     /**
      * @inheritdoc
      */

--- a/src/elements/conditions/users/UserCondition.php
+++ b/src/elements/conditions/users/UserCondition.php
@@ -4,6 +4,7 @@ namespace craft\elements\conditions\users;
 
 use Craft;
 use craft\elements\conditions\ElementCondition;
+use craft\elements\User;
 
 /**
  * User query condition.
@@ -13,6 +14,11 @@ use craft\elements\conditions\ElementCondition;
  */
 class UserCondition extends ElementCondition
 {
+    /**
+     * @inheritdoc
+     */
+    public ?string $elementType = User::class;
+
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
### Description

This PR adds a default $elementType value to each element condition builder. This is useful, as passing it into the constructor is no longer required.

### Related PR

https://github.com/craftcms/cms/pull/12601
