### PR TITLE
store generated license keys in .env only if .env exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where clicking on the scrollbar of a disclosure menu would close it. ([#12681](https://github.com/craftcms/cms/issues/12681))
+- Fixed an error that could occur when loading the Plugin Store, if there wasn’t a `.env` file. ([#12687](https://github.com/craftcms/cms/issues/12687))
 
 ## 3.7.66 - 2023-02-14
 

--- a/src/services/Plugins.php
+++ b/src/services/Plugins.php
@@ -1173,7 +1173,12 @@ class Plugins extends Component
 
         // If the license key is set to an empty environment variable, set the environment variable's value
         $oldLicenseKey = $this->getStoredPluginInfo($handle)['licenseKey'] ?? null;
-        if (preg_match('/^\$(\w+)$/', $oldLicenseKey, $matches) && App::env($matches[1]) === '') {
+        // https://github.com/craftcms/cms/issues/12687 - check if the .env file exists first
+        if (
+            preg_match('/^\$(\w+)$/', $oldLicenseKey, $matches) &&
+            App::env($matches[1]) === '' &&
+            file_exists(Craft::$app->getConfig()->getDotEnvPath())
+        ) {
             Craft::$app->getConfig()->setDotEnvVar($matches[1], $normalizedLicenseKey);
         } else {
             // Set the plugin's license key in the project config


### PR DESCRIPTION
### Description
In August 2022, a change was made to make sure that if a plugin’s license key is set to an empty environment variable, its trial license key will be stored in `.env` rather than the project config.

This PR adjusts this behaviour to only store the trial license key in the `.env` file if such a file exists. Otherwise, use the “old” approach of storing it in the project config.


### Related issues
#12687
#11830