### PR TITLE
Escape :empty:/:notempty:

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -63,6 +63,7 @@
 - `Craft::dump()`, `Craft::dd()`, the `dump()` Twig function, and the `{% dd %}` Twig tag now use Symfony’s VarDumper. ([#12479](https://github.com/craftcms/cms/discussions/12479))
 - `Craft::dump()` now has a `$return` argument, which will cause the resulting dump to be returned as a string rather than output, if `true`.
 - `craft\elements\Asset::getMimeType()` now has a `$transform` argument, and assets’ `mimeType` GraphQL fields now support a `@transform` directive. ([#12269](https://github.com/craftcms/cms/discussions/12269), [#12397](https://github.com/craftcms/cms/pull/12397), [#12522](https://github.com/craftcms/cms/pull/12522))
+- `craft\helpers\Db::escapeParam()` now escapes `:empty:` and `:notempty:` strings. ([#12691](https://github.com/craftcms/cms/discussions/12691))
 
 ### Extensibility
 - Added the `elements/revisions` action. ([#12211](https://github.com/craftcms/cms/pull/12211))

--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -445,14 +445,18 @@ class Db
     }
 
     /**
-     * Escapes commas and asterisks in a string so they are not treated as special characters in
-     * [[Db::parseParam()]].
+     * Escapes commas, asterisks, and colons in a string, so they are not treated as special characters in
+     * [[parseParam()]].
      *
      * @param string $value The param value.
      * @return string The escaped param value.
      */
     public static function escapeParam(string $value): string
     {
+        if (in_array(strtolower($value), [':empty:', 'not :empty:', ':notempty:'])) {
+            return "\\$value";
+        }
+
         $value = preg_replace('/(?<!\\\)[,*]/', '\\\$0', $value);
 
         // If the value starts with an operator, escape that too.
@@ -467,7 +471,29 @@ class Db
     }
 
     /**
-     * Escapes commas in a string so the value doesn’t get interpreted as an array by [[Db::parseParam()]].
+     * Unescapes commas, asterisks, and colons added to a string via [[escapeParam()]].
+     *
+     * @param string $value The param value.
+     * @return string The escaped param value.
+     * @since 4.4.0
+     */
+    public static function unescapeParam(string $value): string
+    {
+        $value = preg_replace('/\\\([,*:])/', '$1', $value);
+
+        // If the value starts with an escaped operator, unescape that too.
+        foreach (self::$_operators as $operator) {
+            if (stripos($value, "\\$operator") === 0) {
+                $value = ltrim($value, '\\');
+                break;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Escapes commas in a string so the value doesn’t get interpreted as an array by [[parseParam()]].
      *
      * @param string $value The param value.
      * @return string The escaped param value.
@@ -612,8 +638,12 @@ class Db
                     $like = false;
                 }
 
-                // Unescape any asterisks
-                $val = str_replace('\*', '*', $val);
+                // Unescape any asterisks and :empty:/:notempty:
+                if (in_array(strtolower($val), ['\\:empty:', '\\:notempty:', '\\not :empty:'])) {
+                    $val = ltrim($val, '\\');
+                } else {
+                    $val = str_replace('\*', '*', $val);
+                }
 
                 if ($like) {
                     if ($caseInsensitive) {

--- a/tests/unit/helpers/dbhelper/DbHelperTest.php
+++ b/tests/unit/helpers/dbhelper/DbHelperTest.php
@@ -548,6 +548,14 @@ class DbHelperTest extends TestCase
             ['\,', ','],
             ['\,\*', ',*'],
             ['\,\*', '\,\*'],
+            ['\>10', '>10'],
+            ['\not :empty:', 'not :empty:'],
+            ['\:notempty:', ':notempty:'],
+            ['\:empty:', ':empty:'],
+            ['\NOT :EMPTY:', 'NOT :EMPTY:'],
+            ['\:NOTEMPTY:', ':NOTEMPTY:'],
+            ['\:EMPTY:', ':EMPTY:'],
+            [':foo:', ':foo:'],
         ];
     }
 


### PR DESCRIPTION
### Description

Updates `craft\helpers\Db::escapeParam()` to start escaping `:empty:` and `:notempty:` values, and `Db::parseParam()` to respect those escaped values.

### Related issues

- #12691