### PR TITLE
Preload Single entry variables

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -54,6 +54,7 @@
 - Added the `editable` and `savable` asset query params. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - Added the `savable` entry query param. ([#12266](https://github.com/craftcms/cms/pull/12266))
 - The `editable` entry query param can now be set to `false` to only show entries that _can’t_ be viewed by the current user. ([#12266](https://github.com/craftcms/cms/pull/12266))
+- Front-end Twig templates now automatically preload any Single section entries that are referenced by their handle within the template. ([#12698](https://github.com/craftcms/cms/pull/12698))
 - Added the `{% dump %}` tag, which dumps variables into a new “Dumps” Debug Toolbar panel. ([#12506](https://github.com/craftcms/cms/pull/12506))
 - Added the `base64_decode` and `base64_encode` Twig filters. ([#12696](https://github.com/craftcms/cms/discussions/12696))
 - The `dump()` Twig function now utilizes `Craft::dump()`, and no longer requires Dev Mode to be active. ([#12486](https://github.com/craftcms/cms/pull/12486), [#12479](https://github.com/craftcms/cms/discussions/12479))
@@ -124,6 +125,7 @@
 - Added `craft\services\Elements::deleteElementsForSite()`.
 - Added `craft\services\Elements::EVENT_AFTER_DELETE_FOR_SITE`. ([#12354](https://github.com/craftcms/cms/issues/12354))
 - Added `craft\services\Elements::EVENT_BEFORE_DELETE_FOR_SITE`. ([#12354](https://github.com/craftcms/cms/issues/12354))
+- Added `craft\services\Entries::getSingleEntriesByHandle()`. ([#12698](https://github.com/craftcms/cms/pull/12698))
 - Added `craft\services\Fields::getFieldsByType()`. ([#12381](https://github.com/craftcms/cms/discussions/12381))
 - Added `craft\services\Path::getImageTransformsPath()`.
 - Added `craft\services\Search::normalizeSearchQuery()`.

--- a/src/helpers/Template.php
+++ b/src/helpers/Template.php
@@ -339,4 +339,18 @@ class Template
         // Template check copied from twig_var_dump()
         return array_filter($context, fn($value) => !$value instanceof TwigTemplate && !$value instanceof TemplateWrapper);
     }
+
+    /**
+     * Preloads Single section entries into the given context.
+     *
+     * @param array $context
+     * @param string[] $handles
+     * @since 4.4.0
+     */
+    public static function preloadSingles(array &$context, array $handles): void
+    {
+        // Filter out any handles that are already defined variables in the context
+        $handles = array_diff($handles, array_keys($context));
+        $context += Craft::$app->getEntries()->getSingleEntriesByHandle($handles);
+    }
 }

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -11,6 +11,8 @@ use Craft;
 use craft\db\Query;
 use craft\db\Table;
 use craft\elements\Entry;
+use craft\helpers\ArrayHelper;
+use craft\models\Section;
 use yii\base\Component;
 
 /**
@@ -23,6 +25,11 @@ use yii\base\Component;
  */
 class Entries extends Component
 {
+    /**
+     * @var array<int,array<string,Entry|false>>
+     */
+    private array $_singleEntries = [];
+
     /**
      * Returns an entry by its ID.
      *
@@ -53,5 +60,69 @@ class Entries extends Component
         }
 
         return Craft::$app->getElements()->getElementById($entryId, Entry::class, $siteId, $criteria);
+    }
+
+    /**
+     * Returns an array of Single section entries which match a given list of section handles.
+     *
+     * @param string[] $handles
+     * @return array<string,Entry>
+     * @since 4.4.0
+     */
+    public function getSingleEntriesByHandle(array $handles): array
+    {
+        $entries = [];
+        $siteId = Craft::$app->getSites()->getCurrentSite()->id;
+        $missingEntries = [];
+
+        if (!isset($this->_singleEntries[$siteId])) {
+            $this->_singleEntries[$siteId] = [];
+        }
+
+        foreach ($handles as $handle) {
+            if (isset($this->_singleEntries[$siteId][$handle])) {
+                if ($this->_singleEntries[$siteId][$handle] !== false) {
+                    $entries[$handle] = $this->_singleEntries[$siteId][$handle];
+                }
+            } else {
+                $missingEntries[] = $handle;
+            }
+        }
+
+        if (!empty($missingEntries)) {
+            /** @var array<string,Section> $singleSections */
+            $singleSections = ArrayHelper::index(
+                Craft::$app->getSections()->getSectionsByType(Section::TYPE_SINGLE),
+                fn(Section $section) => $section->handle,
+            );
+            $fetchSectionIds = [];
+            $fetchSectionHandles = [];
+            foreach ($missingEntries as $handle) {
+                if (isset($singleSections[$handle])) {
+                    $fetchSectionIds[] = $singleSections[$handle]->id;
+                    $fetchSectionHandles[] = $handle;
+                } else {
+                    $this->_singleEntries[$siteId][$handle] = false;
+                }
+            }
+            if (!empty($fetchSectionIds)) {
+                $fetchedEntries = Entry::find()
+                    ->sectionId($fetchSectionIds)
+                    ->siteId($siteId)
+                    ->all();
+                /** @var array<string,Entry> $fetchedEntries */
+                $fetchedEntries = ArrayHelper::index($fetchedEntries, fn(Entry $entry) => $entry->getSection()->handle);
+                foreach ($fetchSectionHandles as $handle) {
+                    if (isset($fetchedEntries[$handle])) {
+                        $this->_singleEntries[$siteId][$handle] = $fetchedEntries[$handle];
+                        $entries[$handle] = $fetchedEntries[$handle];
+                    } else {
+                        $this->_singleEntries[$siteId][$handle] = false;
+                    }
+                }
+            }
+        }
+
+        return $entries;
     }
 }

--- a/src/web/twig/GlobalsExtension.php
+++ b/src/web/twig/GlobalsExtension.php
@@ -8,6 +8,7 @@
 namespace craft\web\twig;
 
 use Craft;
+use craft\web\twig\nodevisitors\SinglePreloader;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 
@@ -29,5 +30,15 @@ class GlobalsExtension extends AbstractExtension implements GlobalsInterface
             $globals[$globalSet->handle] = $globalSet;
         }
         return $globals;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getNodeVisitors()
+    {
+        return [
+            new SinglePreloader(),
+        ];
     }
 }

--- a/src/web/twig/nodes/PreloadSinglesNode.php
+++ b/src/web/twig/nodes/PreloadSinglesNode.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\web\twig\nodes;
+
+use craft\helpers\Template;
+use Twig\Compiler;
+use Twig\Node\Node;
+
+/**
+ * Class PreloadSinglesNode.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.4.0
+ */
+class PreloadSinglesNode extends Node
+{
+    /**
+     * @inheritdoc
+     */
+    public function compile(Compiler $compiler): void
+    {
+        if (!$this->hasAttribute('handles')) {
+            return;
+        }
+
+        $compiler
+            ->write(sprintf(
+                "%s::preloadSingles(\$context, [%s]);\n",
+                Template::class,
+                implode(', ', array_map(fn(string $handle) => "'$handle'", $this->getAttribute('handles'))),
+            ));
+    }
+}

--- a/src/web/twig/nodevisitors/SinglePreloader.php
+++ b/src/web/twig/nodevisitors/SinglePreloader.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\web\twig\nodevisitors;
+
+use craft\web\twig\nodes\PreloadSinglesNode;
+use Twig\Environment;
+use Twig\Node\BodyNode;
+use Twig\Node\Expression\NameExpression;
+use Twig\Node\ModuleNode;
+use Twig\Node\Node;
+use Twig\NodeVisitor\NodeVisitorInterface;
+
+/**
+ * SinglePreloader preloads Single section entries for a template.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.4.0
+ */
+class SinglePreloader implements NodeVisitorInterface
+{
+    /**
+     * @var array<string,bool>
+     */
+    private array $_foundVariables;
+
+    /**
+     * @inheritdoc
+     */
+    public function enterNode(Node $node, Environment $env): Node
+    {
+        if ($node instanceof ModuleNode) {
+            $this->_foundVariables = [];
+        } elseif (get_class($node) === NameExpression::class && $node->hasAttribute('name')) {
+            $this->_foundVariables[$node->getAttribute('name')] = true;
+        }
+        return $node;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function leaveNode(Node $node, Environment $env): ?Node
+    {
+        if (
+            $node instanceof ModuleNode &&
+            !empty($this->_foundVariables) &&
+            $node->hasNode('body')
+        ) {
+            $body = $node->getNode('body');
+            if ($body instanceof BodyNode) {
+                /** @var Node[] $subNodes */
+                $subNodes = iterator_to_array($body);
+                foreach (array_keys($subNodes) as $key) {
+                    $body->removeNode((string)$key);
+                }
+                array_unshift($subNodes, new PreloadSinglesNode(attributes: [
+                    'handles' => array_keys($this->_foundVariables),
+                ]));
+                foreach ($subNodes as $key => $subNode) {
+                    $body->setNode($key, $subNode);
+                }
+            }
+        }
+        return $node;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
Preloads Single entries referenced by front-end templates by their handle.

For example, if you have a Single section with the handle `footer` and somewhere in your template you have:

```twig
{{ footer.copyrightNotice }}
```

then `footer` will be automatically available, even if the template didn’t explicitly fetch it.

Single entries will be queried in batches for each template. So if a template references 3 Single handles that hadn’t been preloaded by prior templates yet, those 3 entries would be fetched together in a single entry query, and memorized in case any future templates reference the same entries later on in the request.