### PR TITLE
Use DI for cookie config

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -251,6 +251,8 @@ $config = ArrayHelper::merge(
 /** @var \craft\web\Application|craft\console\Application $app */
 $app = Craft::createObject($config);
 
+Craft::bootstrapContainer();
+
 // If there was a max_input_vars error, kill the request before we start processing it with incomplete data
 if ($lastError && strpos($lastError['message'], 'max_input_vars') !== false) {
     throw new ErrorException($lastError['message']);

--- a/src/Craft.php
+++ b/src/Craft.php
@@ -192,7 +192,7 @@ class Craft extends Yii
     public static function bootstrapContainer(): void
     {
         self::$container->setDefinitions([
-            \yii\web\Cookie::class => \Craft::cookieConfig()
+            \yii\web\Cookie::class => \Craft::cookieConfig(),
         ]);
     }
 

--- a/src/Craft.php
+++ b/src/Craft.php
@@ -173,7 +173,9 @@ class Craft extends Yii
                     $request = static::$app->getRequest();
                 }
 
-                $generalConfig->useSecureCookies = $request->getIsSecureConnection();
+                if (!$request->isConsoleRequest) {
+                    $generalConfig->useSecureCookies = $request->getIsSecureConnection();
+                }
             }
 
             self::$_baseCookieConfig = [
@@ -185,6 +187,13 @@ class Craft extends Yii
         }
 
         return array_merge(self::$_baseCookieConfig, $config);
+    }
+
+    public static function bootstrapContainer(): void
+    {
+        self::$container->setDefinitions([
+            \yii\web\Cookie::class => \Craft::cookieConfig()
+        ]);
     }
 
     /**

--- a/src/test/TestSetup.php
+++ b/src/test/TestSetup.php
@@ -118,10 +118,13 @@ class TestSetup
      */
     public static function warmCraft(): mixed
     {
-        $app = self::createTestCraftObjectConfig();
-        $app['isInstalled'] = false;
+        $app = Craft::createObject([
+            'isInstalled' => false
+        ] + self::createTestCraftObjectConfig());
 
-        return Craft::createObject($app);
+        Craft::bootstrapContainer();
+
+        return $app;
     }
 
     /**

--- a/src/test/TestSetup.php
+++ b/src/test/TestSetup.php
@@ -119,7 +119,7 @@ class TestSetup
     public static function warmCraft(): mixed
     {
         $app = Craft::createObject([
-            'isInstalled' => false
+            'isInstalled' => false,
         ] + self::createTestCraftObjectConfig());
 
         Craft::bootstrapContainer();

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -94,15 +94,17 @@ class User extends \yii\web\User
     public function sendUsernameCookie(UserElement $user): void
     {
         $generalConfig = Craft::$app->getConfig()->getGeneral();
+        $cookie = Craft::createObject([
+            'class' => Cookie::class,
+        ] + $this->usernameCookie);
 
         if ($generalConfig->rememberUsernameDuration !== 0) {
-            $cookie = new Cookie($this->usernameCookie);
             $cookie->value = $user->username;
             $seconds = ConfigHelper::durationInSeconds($generalConfig->rememberUsernameDuration);
             $cookie->expire = time() + $seconds;
             Craft::$app->getResponse()->getCookies()->add($cookie);
         } else {
-            Craft::$app->getResponse()->getCookies()->remove(new Cookie($this->usernameCookie));
+            Craft::$app->getResponse()->getCookies()->remove($cookie);
         }
     }
 

--- a/tests/CraftTest.php
+++ b/tests/CraftTest.php
@@ -7,8 +7,10 @@
 
 namespace crafttests;
 
+use Craft;
 use craft\helpers\App;
 use PHPUnit\Framework\TestCase;
+use yii\web\Cookie;
 
 class CraftTest extends TestCase
 {
@@ -60,5 +62,15 @@ class CraftTest extends TestCase
         $this->assertEquals(false, $env);
         $this->assertIsBool($env);
         putenv('CRAFT_TEST');
+    }
+
+    public function testDependencyInjection(): void
+    {
+        $cookie = Craft::createObject(Cookie::class);
+        $cookieConfig = Craft::cookieConfig();
+
+        foreach ($cookieConfig as $property => $value) {
+            $this->assertEquals($cookie->$property, $value);
+        }
     }
 }


### PR DESCRIPTION
Instead of requiring the passing around of a common cookie config, we should use Yii's DI container to load our cookie config anywhere `\yii\web\Cookie` is instantiated.

Related: https://github.com/craftcms/commerce/pull/3091