### PR TITLE
Make return value nullable

### DIFF
--- a/src/fields/conditions/OptionsFieldConditionRule.php
+++ b/src/fields/conditions/OptionsFieldConditionRule.php
@@ -35,7 +35,7 @@ class OptionsFieldConditionRule extends BaseMultiSelectConditionRule implements 
     /**
      * @inheritdoc
      */
-    protected function elementQueryParam(): array
+    protected function elementQueryParam(): ?array
     {
         return $this->paramValue();
     }


### PR DESCRIPTION
This PR fixes a bug in which a type error which is thrown if a multi select condition rule is added without any values, as reported in https://github.com/putyourlightson/craft-campaign/issues/367. This is caused by `OptionsFieldConditionRule::elementQueryParam` having a strict return value of `array`, whereas the `paramValue` method has a nullable return value of `?array`.

https://github.com/craftcms/cms/blob/3a5ca05fd07dc8c7ea9938da5a82741ab60b0ac8/src/fields/conditions/OptionsFieldConditionRule.php#L38-L41

The error encountered is as follows.

```
2023-02-21 06:56:47 [web.ERROR] [TypeError] craft\fields\conditions\OptionsFieldConditionRule::elementQueryParam(): Return value must be of type array, null returned {"trace":["#0 /home/www/manufacture.scandella.fr/htdocs/vendor/craftcms/cms/src/fields/conditions/FieldConditionRuleTrait.php(115): craft\\fields\\conditions\\OptionsFieldConditionRule->elementQueryParam()","#1 /home/www/manufacture.scandella.fr/htdocs/vendor/craftcms/cms/src/elements/conditions/ElementCondition.php(181): craft\\fields\\conditions\\OptionsFieldConditionRule->modifyQuery()","#2 /home/www/manufacture.scandella.fr/htdocs/vendor/putyourlightson/craft-campaign/src/services/SegmentsService.php(142): craft\\elements\\conditions\\ElementCondition->modifyQuery()"
```