### PR TITLE
Private plugin support

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -17,6 +17,7 @@
 - `craft\elements\Asset::getMimeType()` now has a `$transform` argument, and assets’ `mimeType` GraphQL fields now support a `@transform` directive. ([#12269](https://github.com/craftcms/cms/discussions/12269), [#12397](https://github.com/craftcms/cms/pull/12397), [#12522](https://github.com/craftcms/cms/pull/12522))
 
 ### Extensibility
+- Added support for private plugins. ([#12716](https://github.com/craftcms/cms/pull/12716), [#8908](https://github.com/craftcms/cms/discussions/8908))
 - Element source definitions can now include a `defaultSourcePath` key.
 - Added `craft\base\Element::indexElements()`.
 - Added `craft\base\ElementInterface::findSource()`.

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "ext-zip": "*",
     "composer/composer": "2.2.19",
     "craftcms/oauth2-craftid": "~1.0.0",
-    "craftcms/plugin-installer": "~1.5.6",
+    "craftcms/plugin-installer": "~1.6.0",
     "craftcms/server-check": "~1.2.0",
     "creocoder/yii2-nested-sets": "~0.9.0",
     "elvanto/litemoji": "^3.0.1",

--- a/src/helpers/Api.php
+++ b/src/helpers/Api.php
@@ -70,7 +70,7 @@ abstract class Api
         $pluginLicenses = [];
         $pluginsService = Craft::$app->getPlugins();
         foreach ($pluginsService->getAllPluginInfo() as $pluginHandle => $pluginInfo) {
-            if ($pluginInfo['isInstalled']) {
+            if ($pluginInfo['isInstalled'] && !$pluginInfo['private']) {
                 $headers['X-Craft-System'] .= ",plugin-{$pluginHandle}:{$pluginInfo['version']};{$pluginInfo['edition']}";
                 try {
                     $licenseKey = $pluginsService->getPluginLicenseKey($pluginHandle);
@@ -174,7 +174,7 @@ abstract class Api
         $pluginLicenseStatuses = [];
         $pluginLicenseEditions = [];
         foreach ($pluginsService->getAllPluginInfo() as $pluginHandle => $pluginInfo) {
-            if ($pluginInfo['isInstalled']) {
+            if ($pluginInfo['isInstalled'] && !$pluginInfo['private']) {
                 $pluginLicenseStatuses[$pluginHandle] = LicenseKeyStatus::Unknown;
             }
         }

--- a/src/services/Plugins.php
+++ b/src/services/Plugins.php
@@ -1009,6 +1009,7 @@ class Plugins extends Component
 
         $info['isInstalled'] = $installed = $pluginInfo !== null;
         $info['isEnabled'] = $plugin !== null;
+        $info['private'] = StringHelper::startsWith($handle, '_');
         $info['moduleId'] = $handle;
         $info['edition'] = $edition;
         $info['hasMultipleEditions'] = count($editions) > 1;


### PR DESCRIPTION
### Description

Adds support for “private plugins”, which are completely normal plugins in every way, _except_ that they don’t get included in license validation.

Private plugins identify themselves by beginning their handle with an underscore (e.g. `_foo-bar`).

### Related issues

- #8908