### PR TITLE
Add `string` @var type to `orderBy`

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -354,6 +354,7 @@ class ElementQuery extends Query implements ElementQueryInterface
 
     /**
      * @inheritdoc
+     * @var array|string|null
      * @used-by orderBy()
      * @used-by addOrderBy()
      */


### PR DESCRIPTION
This PR adds a `string` @var type to the `ElementQuery::orderBy` PHPDoc to keep PHPStan happy, since its parent specifies `array|null`.
https://github.com/yiisoft/yii2/blob/f388ca71b08b89e940f1ffbe4afa19ae9d5e115f/framework/db/QueryTrait.php#L39-L47

```php
if (empty($elementQuery->orderBy) || !is_array($elementQuery->orderBy)) {
    return false;
}
```

<img width="945" alt="Screenshot 2023-02-21 at 19 24 32" src="https://user-images.githubusercontent.com/57572400/220674582-430f2458-e8eb-40ca-b1b2-6cfa8aa5dd83.png">
