### PR TITLE
strip soft hyphens and others from filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed a bug where localized relations could be moved to a newly-added site rather than copied, when applying project config changes. ([#12702](https://github.com/craftcms/cms/issues/12702))
 - Fixed a bug where element indexes’ “View” buttons could be inconsistently positioned in the toolbar.
 - Fixed a bug where element selector modal footers could hide the modal contents. ([#12708](https://github.com/craftcms/cms/issues/12708))
+- Fixed a bug where soft hyphens, non-breaking spaces, zero-width characters, invisible times characters, and invisible separators weren’t getting stripped from sanitized asset filenames. ([#12759](https://github.com/craftcms/cms/pull/12759))
 
 ## 4.3.10 - 2023-02-17
 

--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -248,6 +248,11 @@ class FileHelper extends \yii\helpers\FileHelper
         // Replace any control characters in the name with a space.
         $filename = preg_replace("/\\x{00a0}/iu", ' ', $filename);
 
+        // https://github.com/craftcms/cms/issues/12741
+        // Remove soft hyphens (00ad), no break (0083), zero width non-joiner (200c),
+        // zero width joiner (200d), invisible times (2062), invisible comma (2063) in the name
+        $filename = preg_replace('/\\x{00ad}|\\x{0083}|\\x{200c}|\\x{200d}|\\x{2062}|\\x{2063}/iu', '', $filename);
+
         // Strip any characters not allowed.
         $filename = str_replace($disallowedChars, '', strip_tags($filename));
 


### PR DESCRIPTION
### Description
Remove additional unicode special characters: soft hyphens (00ad), no break (0083), zero-width non-joiner (200c),
zero width joiner (200d), invisible times (2062), and invisible comma (2063) from the filename before uploading.


### Related issues
#12741 
