### PR TITLE
don't drop the field column on pc apply if field is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed a bug where `craft\events\RegisterElementSourcesEvent::$context` wasn’t always set to `modal` when defining the available element sources for an element selection modal.
 - Fixed a styling bug where multi-line checkbox labels within the Customize Sources modal weren’t wrapping properly. ([#12717](https://github.com/craftcms/cms/issues/12717))
 - Fixed a bug where asset thumbnails within collapsed Matrix blocks weren’t loading when the block was expanded. ([#12720](https://github.com/craftcms/cms/issues/12720))
+- Fixed a bug where custom fields’ database columns would get deleted when applying project config changes, if the field type wasn’t present. ([#12760](https://github.com/craftcms/cms/issues/12760))
 - Fixed an XSS vulnerability.
 
 ## 3.7.67 - 2023-02-17

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -1858,7 +1858,8 @@ class Fields extends Component
             // Drop any unneeded columns for this field
             $db->getSchema()->refresh();
 
-            if (!$isNewField) {
+            // don't drop the field content column if the field is missing
+            if (!$isNewField && $class !== 'craft\fields\MissingField') {
                 $this->_dropOldFieldColumns($oldHandle, $oldColumnSuffix, $newColumns);
 
                 if ($data['handle'] !== $oldHandle || ($data['columnSuffix'] ?? null) !== $oldColumnSuffix) {

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -1859,7 +1859,7 @@ class Fields extends Component
             $db->getSchema()->refresh();
 
             // don't drop the field content column if the field is missing
-            if (!$isNewField && $class !== 'craft\fields\MissingField') {
+            if (!$isNewField && $class !== MissingField::class) {
                 $this->_dropOldFieldColumns($oldHandle, $oldColumnSuffix, $newColumns);
 
                 if ($data['handle'] !== $oldHandle || ($data['columnSuffix'] ?? null) !== $oldColumnSuffix) {


### PR DESCRIPTION
### Description
If a field is missing (`craft\fields\MissingField`) when you apply Project Config, retain the content column.


### Related issues
#12760 
