### PR TITLE
asset indexing by "all" to account for EVENT_LIST_VOLUMES

### DIFF
--- a/src/templates/_components/utilities/AssetIndexes.twig
+++ b/src/templates/_components/utilities/AssetIndexes.twig
@@ -82,7 +82,13 @@
         const data = {
             'cacheImages': !!$('input[name=cacheImages]').val(),
             'listEmptyFolders': !!$('input[name=listEmptyFolders]').val(),
-            'volumes': $(ev.target).find('.checkbox-select input:checked:enabled').map(function(){return $(this).val();}).get()
+            // get all selected volume ids; don't rely on '*' because of the new EVENT_LIST_VOLUMES event
+            'volumes': $(ev.target).find('.checkbox-select input:checked').map(function(){
+                let val = $(this).val();
+                if (val !== '*') {
+                    return val;
+                }
+            }).get()
         };
 
         $submitButton.addClass('disabled').after('<div class="spinner"></div>');


### PR DESCRIPTION
### Description
When using Utilities > Asset Indexes and choosing to index by “All”, get all listed volume ids instead of relying on `*` being passed to account for volumes that could have been excluded by the new `EVENT_LIST_VOLUMES` event.


### Related issues
#12749 
