### PR TITLE
Removes `is defined` checks in Image Transform settings template

### DIFF
--- a/src/templates/settings/assets/transforms/_settings.twig
+++ b/src/templates/settings/assets/transforms/_settings.twig
@@ -22,8 +22,8 @@
             label: "Name"|t('app'),
             id: 'name',
             name: 'name',
-            value: (transform is defined ? transform.name : null),
-            errors: (transform is defined ? transform.getErrors('name') : null),
+            value: transform.name,
+            errors: transform.getErrors('name'),
             autofocus: true,
             required: true,
         }) }}
@@ -35,30 +35,30 @@
             class: 'code',
             autocorrect: false,
             autocapitalize: false,
-            value: (transform is defined ? transform.handle : null),
-            errors: (transform is defined ? transform.getErrors('handle') : null),
+            value: transform.handle,
+            errors: transform.getErrors('handle'),
             required: true,
         }) }}
 
         {% set modeInput %}
             <div id="mode">
                 <label id="mode-crop">
-                    <input type="radio" name="mode" value="crop"{% if transform is not defined or transform.mode == 'crop' %} checked{% endif %}>
+                    <input type="radio" name="mode" value="crop"{% if transform.mode == 'crop' %} checked{% endif %}>
                     {{ "Crop"|t('app') }}
                 </label>
 
                 <label id="mode-fit">
-                    <input type="radio" name="mode" value="fit"{% if transform is defined and transform.mode == 'fit' %} checked{% endif %}>
+                    <input type="radio" name="mode" value="fit"{% if transform.mode == 'fit' %} checked{% endif %}>
                     {{ "Fit"|t('app') }}
                 </label>
 
                 <label id="mode-letterbox">
-                    <input type="radio" name="mode" value="letterbox"{% if transform is defined and transform.mode == 'letterbox' %} checked{% endif %}>
+                    <input type="radio" name="mode" value="letterbox"{% if transform.mode == 'letterbox' %} checked{% endif %}>
                     {{ "Letterbox"|t('app') }}
                 </label>
 
                 <label id="mode-stretch">
-                    <input type="radio" name="mode" value="stretch"{% if transform is defined and transform.mode == 'stretch' %} checked{% endif %}>
+                    <input type="radio" name="mode" value="stretch"{% if transform.mode == 'stretch' %} checked{% endif %}>
                     {{ "Stretch"|t('app') }}
                 </label>
             </div>
@@ -68,16 +68,16 @@
             label: "Mode"|t('app')
         }, modeInput) }}
 
-        <div id="fill-color" class="field {% if transform is defined and transform.mode != 'letterbox' or transform.fill is null %}hidden{% endif %}">
+        <div id="fill-color" class="field {% if transform.mode != 'letterbox' or transform.fill is null %}hidden{% endif %}">
             {{ forms.colorField({
                 label: 'Fill Color',
                 name: 'fill',
-                value: (transform is defined and transform.mode == 'letterbox' and transform.fill != 'transparent' ? transform.fill : null),
-                errors: (transform is defined ? transform.getErrors('fill') : null)
+                value: transform.mode == 'letterbox' and transform.fill != 'transparent' ? transform.fill,
+                errors: transform.getErrors('fill'),
             }) }}
         </div>
 
-        <div id="letterbox-position-container"{% if transform is defined and transform.mode != 'letterbox' %} class="hidden"{% endif %}>
+        <div id="letterbox-position-container"{% if transform.mode != 'letterbox' %} class="hidden"{% endif %}>
             {{ forms.selectField({
                 label: "Image Position"|t('app'),
                 id: 'position',
@@ -93,11 +93,11 @@
                     'bottom-center': "Bottom-Center"|t('app'),
                     'bottom-right': "Bottom-Right"|t('app')
                 },
-                value: (transform is defined and transform.mode != 'letterbox' ? transform.position : 'center-center')
+                value: transform.mode != 'letterbox' ? transform.position : 'center-center'
             }) }}
         </div>
 
-        <div id="position-container"{% if transform is defined and transform.mode in ['stretch', 'letterbox'] %} class="hidden"{% endif %}>
+        <div id="position-container"{% if transform.mode in ['stretch', 'letterbox'] %} class="hidden"{% endif %}>
             {{ forms.selectField({
                 label: "Default Focal Point"|t('app'),
                 id: 'position',
@@ -113,7 +113,7 @@
                     'bottom-center': "Bottom-Center"|t('app'),
                     'bottom-right': "Bottom-Right"|t('app')
                 },
-                value: (transform is defined and transform.mode in ['crop', 'fit'] ? transform.position : 'center-center')
+                value: transform.mode in ['crop', 'fit'] ? transform.position : 'center-center'
             }) }}
         </div>
 
@@ -122,8 +122,8 @@
             id: "width",
             name: "width",
             size: 5,
-            value: (transform is defined ? transform.width : null),
-            errors: (transform is defined ? transform.getErrors('width') : null),
+            value: transform.width,
+            errors: transform.getErrors('width'),
         }) }}
 
         {{ forms.textField({
@@ -131,8 +131,8 @@
             id: "height",
             name: "height",
             size: 5,
-            value: (transform is defined ? transform.height : null),
-            errors: (transform is defined ? transform.getErrors('height') : null),
+            value: transform.height,
+            errors: transform.getErrors('height'),
         }) }}
 
         {{ forms.lightswitchField({
@@ -140,12 +140,12 @@
             id: 'upscale',
             name: 'upscale',
             on: transform.upscale ?? craft.app.config.general.upscaleImages,
-            errors: (transform is defined ? transform.getErrors('upscale') : null)
+            errors: transform.getErrors('upscale'),
         }) }}
 
         {% embed '_includes/forms/field.twig' with {
             label: 'Quality'|t('app'),
-            errors: (transform is defined ? transform.getErrors('quality') : null),
+            errors: transform.getErrors('quality'),
         } %}
             {% block input %}
                 {% import '_includes/forms.twig' as forms %}
@@ -190,8 +190,8 @@
                 {label: 'Plane'|t('app'), value: 'plane'},
                 {label: 'Partition'|t('app'), value: 'partition'},
             ],
-            value: (transform is defined ? transform.interlace : 'none'),
-            errors: (transform is defined ? transform.getErrors('interlace') : null),
+            value: transform.interlace ?? 'none',
+            errors: transform.getErrors('interlace'),
         }) }}
 
         {% set formatOptions = [
@@ -201,11 +201,11 @@
             {label: 'gif', value: 'gif'},
         ] %}
 
-        {% if (transform is defined and transform.format == 'webp') or craft.app.images.supportsWebP %}
+        {% if transform.format == 'webp' or craft.app.images.supportsWebP %}
             {% set formatOptions = formatOptions|merge([{label: 'webp', value: 'webp'}]) %}
         {% endif %}
 
-        {% if (transform is defined and transform.format == 'avif') or craft.app.images.supportsAvif %}
+        {% if transform.format == 'avif' or craft.app.images.supportsAvif %}
             {% set formatOptions = formatOptions|merge([{label: 'avif', value: 'avif'}]) %}
         {% endif %}
 
@@ -214,8 +214,8 @@
             id: "format",
             name: "format",
             instructions: "The image format that transformed images should use."|t('app'),
-            value: (transform is defined ? transform.format : null),
-            errors: (transform is defined ? transform.getErrors('format') : null),
+            value: transform.format,
+            errors: transform.getErrors('format'),
             options: formatOptions,
         }) }}
 
@@ -224,7 +224,7 @@
 
 
 {% js %}
-    {% if transform is not defined or not transform.handle %}new Craft.HandleGenerator('#name', '#handle');{% endif %}
+    {% if not transform.handle %}new Craft.HandleGenerator('#name', '#handle');{% endif %}
 
     $('#mode input').change(function() {
         const value = $(this).val();


### PR DESCRIPTION
### Description

These checks are unnecessary, as [we always pass a `craft\models\ImageTransform` to the template](https://github.com/craftcms/cms/blob/4.4/src/controllers/ImageTransformsController.php#L65-L75).

Cases where sensible defaults are applied (i.e. `upscale` defaulting to a General Config option) were preserved!

### Related issues

#12214