### PR TITLE
Fix `ImageTransformController` type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed a bug where asset thumbnails weren’t respecting the `generateTransformsBeforePageLoad` config setting. ([#12750](https://github.com/craftcms/cms/issues/12750))
 - Fixed a bug where soft hyphens, non-breaking spaces, zero-width characters, invisible times characters, and invisible separators weren’t getting stripped from sanitized asset filenames. ([#12741](https://github.com/craftcms/cms/issues/12741), [#12759](https://github.com/craftcms/cms/pull/12759))
 - Fixed a bug where custom fields’ database columns would get deleted when applying project config changes, if the field type wasn’t present. ([#12760](https://github.com/craftcms/cms/issues/12760))
+- Fixed an error that could occur if a non-numeric value was entered into an image transform’s Width or Height settings. ([#12776](https://github.com/craftcms/cms/pull/12776))
 
 ## 4.3.10 - 2023-02-17
 

--- a/src/controllers/ImageTransformsController.php
+++ b/src/controllers/ImageTransformsController.php
@@ -126,8 +126,8 @@ class ImageTransformsController extends Controller
         $transform->id = $this->request->getBodyParam('transformId');
         $transform->name = $this->request->getBodyParam('name');
         $transform->handle = $this->request->getBodyParam('handle');
-        $transform->width = $this->request->getBodyParam('width') ?: null;
-        $transform->height = $this->request->getBodyParam('height') ?: null;
+        $transform->width = (int)$this->request->getBodyParam('width') ?: null;
+        $transform->height = (int)$this->request->getBodyParam('height') ?: null;
         $transform->mode = $this->request->getBodyParam('mode');
         $transform->position = $this->request->getBodyParam('position');
         $transform->quality = $this->request->getBodyParam('quality') ?: null;


### PR DESCRIPTION
### Description

The `image-transforms/save` action was blowing up when non-numeric values were submitted for `width` and `height`.

There appears to be [precedent](https://github.com/craftcms/cms/blob/aad45b7d4c7005a0ac4809f32e135c6eadec7062/src/controllers/AssetsController.php#L184-L185) for handling this kind of thing with type juggling, but [other](https://github.com/craftcms/cms/blob/aad45b7d4c7005a0ac4809f32e135c6eadec7062/src/controllers/SectionsController.php#L141) controllers may exhibit the same behavior…?

### Related issues

- #12214 
