### PR TITLE
Bugfix/12795 cp screen response sidebar

### DIFF
--- a/src/web/CpScreenResponseBehavior.php
+++ b/src/web/CpScreenResponseBehavior.php
@@ -176,6 +176,13 @@ class CpScreenResponseBehavior extends Behavior
     public $sidebar = null;
 
     /**
+     * @var string|callable|null The details HTML.
+     * @see details()
+     * @see detailsTemplate()
+     */
+    public $details = null;
+
+    /**
      * @var string|callable|null The content notice HTML.
      * @see notice()
      * @see noticeTemplate()
@@ -565,6 +572,32 @@ class CpScreenResponseBehavior extends Behavior
     public function sidebarTemplate(string $template, array $variables = []): Response
     {
         return $this->sidebar(
+            fn() => Craft::$app->getView()->renderTemplate($template, $variables, View::TEMPLATE_MODE_CP)
+        );
+    }
+
+    /**
+     * Sets the details HTML.
+     *
+     * @param callable|string|null $value
+     * @return Response
+     */
+    public function details(callable|string|null $value): Response
+    {
+        $this->details = $value;
+        return $this->owner;
+    }
+
+    /**
+     * Sets a template that should be used to render the details HTML.
+     *
+     * @param string $template
+     * @param array $variables
+     * @return Response
+     */
+    public function detailsTemplate(string $template, array $variables = []): Response
+    {
+        return $this->details(
             fn() => Craft::$app->getView()->renderTemplate($template, $variables, View::TEMPLATE_MODE_CP)
         );
     }

--- a/src/web/CpScreenResponseFormatter.php
+++ b/src/web/CpScreenResponseFormatter.php
@@ -158,7 +158,7 @@ class CpScreenResponseFormatter extends Component implements ResponseFormatterIn
                 'saveShortcutRedirect' => $behavior->saveShortcutRedirectUrl,
                 'contentNotice' => $notice,
                 'content' => $content,
-                'details' => $sidebar,
+                'sidebar' => $sidebar,
             ],
             'templateMode' => View::TEMPLATE_MODE_CP,
         ]);

--- a/src/web/CpScreenResponseFormatter.php
+++ b/src/web/CpScreenResponseFormatter.php
@@ -120,6 +120,7 @@ class CpScreenResponseFormatter extends Component implements ResponseFormatterIn
         $notice = is_callable($behavior->notice) ? call_user_func($behavior->notice) : $behavior->notice;
         $content = is_callable($behavior->content) ? call_user_func($behavior->content) : ($behavior->content ?? '');
         $sidebar = is_callable($behavior->sidebar) ? call_user_func($behavior->sidebar) : $behavior->sidebar;
+        $details = is_callable($behavior->details) ? call_user_func($behavior->details) : $behavior->details;
 
         if ($behavior->action) {
             $content .= Html::actionInput($behavior->action, [
@@ -159,6 +160,7 @@ class CpScreenResponseFormatter extends Component implements ResponseFormatterIn
                 'contentNotice' => $notice,
                 'content' => $content,
                 'sidebar' => $sidebar,
+                'details' => $details,
             ],
             'templateMode' => View::TEMPLATE_MODE_CP,
         ]);


### PR DESCRIPTION
### Description
When adding a sidebar via `$this->asCpScreen()`, it was injected into the `details-container` and not `sidebar-container`.

This PR ensures sidebar content is injected as an actual sidebar via the `CpScreenResponseFormatter` and adds `details` param, `details()` and `detailsTemplate()` methods to the `CpScreenResponseBehavior` which are then injected into the `details-container` via the formatter.



### Related issues
#12795 
