### PR TITLE
additional safeguards for matrix field and cached results

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -799,7 +799,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
             }
         }
 
-        if (!$allBlocksValidate) {
+        if (!$allBlocksValidate && $value instanceof MatrixBlockQuery) {
             // Just in case the blocks weren't already cached
             $value->setCachedResult($blocks);
         }
@@ -1074,8 +1074,8 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
             $value = $element->getFieldValue($this->handle);
             if ($value instanceof MatrixBlockQuery) {
                 $this->_populateQuery($value, $element);
+                $value->clearCachedResult();
             }
-            $value->clearCachedResult();
         }
 
         parent::afterElementPropagate($element, $isNew);


### PR DESCRIPTION
### Description
When trying to set/clear cached results for a matrix field, make sure we’re working with a query and not a collection.


### Related issues
#12815 
