### PR TITLE
Add missing `@since` comment

### DIFF
--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -1007,11 +1007,11 @@ class Html extends \yii\helpers\Html
      *
      * @param string|Asset $svg An SVG asset, a file path, or raw SVG markup
      * @param bool|null $sanitize Whether the SVG should be sanitized of potentially
-     * malicious scripts. By default the SVG will only be sanitized if an asset
+     * malicious scripts. By default, the SVG will only be sanitized if an asset
      * or markup is passed in. (File paths are assumed to be safe.)
      * @param bool|null $namespace Whether class names and IDs within the SVG
      * should be namespaced to avoid conflicts with other elements in the DOM.
-     * By default the SVG will only be namespaced if an asset or markup is passed in.
+     * By default, the SVG will only be namespaced if an asset or markup is passed in.
      * @return string
      * @since 4.3.0
      */

--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -1013,6 +1013,7 @@ class Html extends \yii\helpers\Html
      * should be namespaced to avoid conflicts with other elements in the DOM.
      * By default the SVG will only be namespaced if an asset or markup is passed in.
      * @return string
+     * @since 4.3.0
      */
     public static function svg(Asset|string $svg, ?bool $sanitize = null, ?bool $namespace = null): string
     {


### PR DESCRIPTION
Adds a missing `@since` comment to the `Html::svg()` method.

(this tripped me up in https://github.com/putyourlightson/craft-blitz/issues/480)