### PR TITLE
Make sure dimensions are normalized

### DIFF
--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -269,6 +269,7 @@ class Raster extends Image
     {
         $upscale = $upscale ?? Craft::$app->getConfig()->getGeneral()->upscaleImages;
 
+        $this->normalizeDimensions($targetWidth, $targetHeight);
         $this->scaleToFit($targetWidth, $targetHeight, $upscale);
         $this->setFill($fill);
 


### PR DESCRIPTION
While messing around, I noticed that the new letterbox transform mode didn't work when one of the dimensions wasn't provided. This updates it to calculate missing dimensions with the `normalizeDimensions` method used by other transform modes.
