### PR TITLE
Change `HtmlDumper` to use light theme

### DIFF
--- a/src/Craft.php
+++ b/src/Craft.php
@@ -125,6 +125,7 @@ class Craft extends Yii
 
         if (Craft::$app instanceof WebApplication) {
             $dumper = new HtmlDumper();
+            $dumper->setTheme('light');
         } else {
             $dumper = new CliDumper();
             $dumper->setColors(Craft::$app->controller instanceof Controller && Craft::$app->controller->isColorEnabled());


### PR DESCRIPTION
This might be a contentious change, but in Craft 4.4 logging was changed to use [Symfony VarDumper](https://symfony.com/doc/current/components/var_dumper.html) which is a neat choice. I'm not a massive fan of things being collapsed by default, but control+click expands all.

See https://github.com/craftcms/cms/discussions/12479

Personally, I find the dark colours **very** jarring on a blank white screen. Even if the OS is set to use dark mode, the browser screen will always be white, because this is a "dump-and-die" call. Changing this renders things a little lighter:

<img width="726" alt="image" src="https://user-images.githubusercontent.com/1221575/224177343-b36749db-e9d2-4b2a-a567-7873bb25efc8.png">

Side note: I'm also happy to develop a "craftcms" theme to reflect how it was (larger font, colours), but it requires creating a new `HtmlDumper` class to extend things, and I honestly wasn't sure where that should sit in the codebase.

If you're down for that, let me know where to put it and can alter that. Or, you might be happy with how it is.