### PR TITLE
`dumper` app component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - The `entrify/categories` and `entrify/global-set` commands now update user permissions for the new sections. ([#12849](https://github.com/craftcms/cms/discussions/12849))
+- Variable dumps now use a light theme for web requests by default. ([#12857](https://github.com/craftcms/cms/pull/12857))
+- Added the `dumper` application component and `craft\base\ApplicationTrait::getDumper()`. ([#12869](https://github.com/craftcms/cms/pull/12869))
 - Fixed a bug where multi-value field inputs would be considered modified even if they weren’t, if the field type’s `isValueEmpty()` method returned `true`. ([#12858](https://github.com/craftcms/cms/issues/12858))
 
 ## 4.4.1 - 2023-03-09

--- a/src/Craft.php
+++ b/src/Craft.php
@@ -16,13 +16,9 @@ use craft\helpers\FileHelper;
 use craft\helpers\StringHelper;
 use GuzzleHttp\Client;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
-use Symfony\Component\VarDumper\Dumper\CliDumper;
-use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use yii\base\ExitException;
-use yii\console\Controller;
 use yii\db\Expression;
 use yii\helpers\VarDumper;
-use yii\web\Application as WebApplication;
 use yii\web\Request;
 use function GuzzleHttp\default_user_agent;
 
@@ -123,15 +119,8 @@ class Craft extends Yii
             return $return ? ob_get_clean() : null;
         }
 
-        if (Craft::$app instanceof WebApplication) {
-            $dumper = new HtmlDumper();
-            $dumper->setTheme('light');
-        } else {
-            $dumper = new CliDumper();
-            $dumper->setColors(Craft::$app->controller instanceof Controller && Craft::$app->controller->isColorEnabled());
-        }
-
-        return $dumper->dump((new VarCloner())->cloneVar($var)->withMaxDepth($depth), $return ? true : null);
+        $data = (new VarCloner())->cloneVar($var)->withMaxDepth($depth);
+        return Craft::$app->getDumper()->dump($data, $return ? true : null);
     }
 
     /**

--- a/src/Craft.php
+++ b/src/Craft.php
@@ -125,6 +125,7 @@ class Craft extends Yii
 
         if (Craft::$app instanceof WebApplication) {
             $dumper = new HtmlDumper();
+            $dumper->setTheme('light');
         } else {
             $dumper = new CliDumper();
             $dumper->setColors(Craft::$app->controller instanceof Controller && Craft::$app->controller->isColorEnabled());

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -102,6 +102,10 @@ use craft\web\Request as WebRequest;
 use craft\web\User as UserSession;
 use craft\web\View;
 use Illuminate\Support\Collection;
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\AbstractDumper;
+use Symfony\Component\VarDumper\VarDumper;
 use Yii;
 use yii\base\Application;
 use yii\base\ErrorHandler;
@@ -1042,6 +1046,18 @@ trait ApplicationTrait
     }
 
     /**
+     * Returns the variable dumper.
+     *
+     * @return AbstractDumper
+     * @since 4.4.2
+     */
+    public function getDumper(): AbstractDumper
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->get('dumper');
+    }
+
+    /**
      * Returns the element indexes service.
      *
      * @return ElementSources The element indexes service
@@ -1496,6 +1512,13 @@ trait ApplicationTrait
         if ($this instanceof WebApplication && $request->getIsCpRequest()) {
             $this->getResponse()->setNoCacheHeaders();
         }
+
+        // Register the variable dumper
+        VarDumper::setHandler(function($var) {
+            $cloner = new VarCloner();
+            $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+            $this->getDumper()->dump($cloner->cloneVar($var));
+        });
     }
 
     /**

--- a/src/config/app.console.php
+++ b/src/config/app.console.php
@@ -1,6 +1,8 @@
 <?php
 
 use craft\console\Application;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use yii\console\Controller;
 
 return [
     'class' => Application::class,
@@ -8,6 +10,11 @@ return [
         'queue',
     ],
     'components' => [
+        'dumper' => function() {
+            $dumper = new CliDumper();
+            $dumper->setColors(Craft::$app->controller instanceof Controller && Craft::$app->controller->isColorEnabled());
+            return $dumper;
+        },
         'errorHandler' => [
             'class' => craft\console\ErrorHandler::class,
         ],

--- a/src/config/app.web.php
+++ b/src/config/app.web.php
@@ -1,11 +1,18 @@
 <?php
 
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+
 return [
     'class' => craft\web\Application::class,
     'components' => [
         'assetManager' => function() {
             $config = craft\helpers\App::assetManagerConfig();
             return Craft::createObject($config);
+        },
+        'dumper' => function() {
+            $dumper = new HtmlDumper();
+            $dumper->setTheme('light');
+            return $dumper;
         },
         'request' => function() {
             $config = craft\helpers\App::webRequestConfig();


### PR DESCRIPTION
### Description

Adds a new `dumper` application component, which returns either `HtmlDumper` or `CliDumper` depending on the request type. `HtmlDumper` is configured to use the `light` theme by default, and `CliDumper` is explicitly set to use/not use colors depending on `Controller::isColorEnabled()`.

Additionally, we are now registering a dump handler on `VarDumper`, so generic calls to `VarDumper::dump()` (such as from `Collection::dump()`) will also get routed through Craft’s `dumper`, so the output will be consistent.

### Related issues

- #12857