### PR TITLE
disallow forwards slashes in slugs

### DIFF
--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -1735,6 +1735,7 @@ return [
     'week' => 'week',
     'weeks' => 'weeks',
     'yesterday' => 'yesterday',
+    '{attribute} cannot contain a forward slash.' => '{attribute} cannot contain a forward slash.',
     '{attribute} cannot contain emoji.' => '{attribute} cannot contain emoji.',
     '{attribute} cannot contain spaces.' => '{attribute} cannot contain spaces.',
     '{attribute} cannot start with the {setting} config setting.' => '{attribute} cannot start with the {setting} config setting.',

--- a/src/validators/SlugValidator.php
+++ b/src/validators/SlugValidator.php
@@ -83,6 +83,11 @@ class SlugValidator extends Validator
                 $this->addError($model, $attribute, Craft::t('yii', '{attribute} cannot be blank.'));
             }
         }
+
+        // Don't allow slugs to contain any forward slashes
+        if (str_contains($slug, '/')) {
+            $this->addError($model, $attribute, Craft::t('app', '{attribute} cannot contain a forward slash.'));
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Disallows forward slash in slugs when saving an element.

I’m torn between this approach and a more drastic version where we check if the `slugWordSeparator` is set to `/` on getting the general config (similar to how we check the `securityKey`). 

On the one hand, the approach in this PR should provide better backward compatibility on the off-chance that someone was using `/` as a slug word separator. It would still allow it in, e.g. autogenerated entry URI format on section creation. 
On the other hand, throwing an exception on getting the general config is a more robust way of seriously disallowing `/`.

@brandonkelly, when you have a second, could you please LMK your thoughts?

### Related issues
#12871 
