### PR TITLE
Fixed test suite type compatibility

### DIFF
--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -140,7 +140,7 @@ class Craft extends Yii2
     /**
      * @inheritdoc
      */
-    public function _afterSuite()
+    public function _afterSuite(): void
     {
         parent::_afterSuite();
 


### PR DESCRIPTION
Fixes

```
Fatal error: Declaration of craft\test\Craft::_afterSuite() must be compatible with Codeception\Module\Yii2::_afterSuite(): void in /app/user/vendor/craftcms/cms/src/test/Craft.php on line 143
```

### Description



### Related issues

