### PR TITLE
don't skip custom field validation if field was passed in without 'field:' prefix

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2393,7 +2393,11 @@ abstract class Element extends Component implements ElementInterface
                 $field = $layoutElement->getField();
                 $attribute = "field:$field->handle";
 
-                if (isset($this->_attributeNames) && !isset($this->_attributeNames[$attribute])) {
+                // https://github.com/craftcms/commerce/issues/3109
+                if (isset($this->_attributeNames) &&
+                    !isset($this->_attributeNames[$attribute]) &&
+                    !isset($this->_attributeNames[$field->handle])
+                ) {
                     continue;
                 }
 


### PR DESCRIPTION
### Description
Don’t skip custom field validation if the fields were passed without the `field:` prefix. (Introduced in [this commit](https://github.com/craftcms/cms/commit/081660a4792262054f32b663465d914ea3037147)).

Alternatively, I can submit a PR for Commerce to prefix custom field attributes with `field:`, which will also work but just for the Commerce plugin.


### Related issues
[#3109](https://github.com/craftcms/commerce/issues/3109)
#12884 
