### PR TITLE
ensure unique tab ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where element edit pages weren’t displaying layout tabs that didn’t have a unique name. ([#12928](https://github.com/craftcms/cms/issues/12928))
+
 ## 4.4.4 - 2023-03-20
 
 - Input autofocussing has been reintroduced throughout the control panel. ([#12921](https://github.com/craftcms/cms/discussions/12921))

--- a/src/models/FieldLayoutTab.php
+++ b/src/models/FieldLayoutTab.php
@@ -315,8 +315,11 @@ class FieldLayoutTab extends FieldLayoutComponent
             $asciiName = sprintf('tab-%s', md5($this->name));
         }
 
+        // ensure unique tab id even if there are multiple tabs with the same name
+        $tabOrder = StringHelper::pad((string)$this->sortOrder, 2, '0', 'left');
+
         // Use two dashes here in case a tab name starts with “Tab”
-        return "tab--$asciiName";
+        return "tab$tabOrder--$asciiName";
     }
 
     /**


### PR DESCRIPTION
### Description
Craft 4 allows you to have multiple tabs with the same name (in Craft 3, they were merged into one). I assume this is because of the conditions where you could have 2 tabs with the same name showing under different circumstances.

However, when no conditions are defined for the tabs, and you have at least 2 with the same name, only the first one will show when editing an element due to having the same ID. 

This PR ensures tab ID is always unique, even if the name is not, by adding sort order (padded with zero), so what used to be `tab--content` now becomes, e.g. `tab02--content`.


### Related issues
#12928 
