### PR TITLE
adjust craft_log_php_errors conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where element edit pages weren’t displaying layout tabs that didn’t have a unique name. ([#12928](https://github.com/craftcms/cms/issues/12928))
+- Fixed a bug where the `CRAFT_LOG_PHP_ERRORS` constant/environment variable wasn’t being respected when set to `false`. ([#12862](https://github.com/craftcms/cms/issues/12862))
 
 ## 4.4.4 - 2023-03-20
 

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -145,7 +145,7 @@ if (!App::isStreamLog()) {
 }
 
 // Log errors to storage/logs/phperrors.log or php://stderr
-if (App::parseBooleanEnv('$CRAFT_LOG_PHP_ERRORS') === null || App::parseBooleanEnv('$CRAFT_LOG_PHP_ERRORS') === true) {
+if (App::parseBooleanEnv('$CRAFT_LOG_PHP_ERRORS') !== false) {
     ini_set('log_errors', '1');
 
     if (App::isStreamLog()) {

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -145,7 +145,7 @@ if (!App::isStreamLog()) {
 }
 
 // Log errors to storage/logs/phperrors.log or php://stderr
-if (!App::parseBooleanEnv('$CRAFT_LOG_PHP_ERRORS')) {
+if (App::parseBooleanEnv('$CRAFT_LOG_PHP_ERRORS') === null || App::parseBooleanEnv('$CRAFT_LOG_PHP_ERRORS') === true) {
     ini_set('log_errors', '1');
 
     if (App::isStreamLog()) {


### PR DESCRIPTION
### Description
Amended condition that checks the value of `CRAFT_LOG_PHP_ERRORS` constant so that when it’s set to `false`, Craft doesn’t log PHP errors in its logs.

(Works as expected in Craft 3.)


### Related issues
#12862 
