### PR TITLE
twig replace - add support for array of regex in search

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -855,6 +855,38 @@ class Extension extends AbstractExtension implements GlobalsInterface
             return strtr($str, $search);
         }
 
+        // if search is an array, and replace is provided
+        if (is_array($search) && $replace !== null) {
+            // go through each search item
+            foreach ($search as $i => $searchItem) {
+                // if it's a regex, use preg_replace
+                if (preg_match('/^\/.+\/[a-zA-Z]*$/', $searchItem)) {
+                    if (is_array($replace)) {
+                        if (isset($replace[$i])) {
+                            $str = preg_replace($searchItem, $replace[$i], $str);
+                        } else {
+                            $str = preg_replace($searchItem, end($replace), $str);
+                        }
+                    } else {
+                        $str = preg_replace($searchItem, $replace, $str);
+                    }
+                } else {
+                    // otherwise use str_replace
+                    if (is_array($replace)) {
+                        if (isset($replace[$i])) {
+                            $str = str_replace($searchItem, $replace[$i], $str);
+                        } else {
+                            $str = str_replace($searchItem, end($replace), $str);
+                        }
+                    } else {
+                        $str = str_replace($searchItem, $replace, $str);
+                    }
+                }
+            }
+
+            return $str;
+        }
+
         // Is this a regular expression?
         if (preg_match('/^\/.+\/[a-zA-Z]*$/', $search)) {
             return preg_replace($search, $replace, $str);


### PR DESCRIPTION
### Description
Adds support for providing the `$search` parameter as an array containing regular expressions. 

If `$search` and `$replace` are arrays of the same length, a one-to-one replacement will be performed. 
If `$replace` is shorter, its last element will be used for `$search` items that don’t have a corresponding `$replace` item.
If `$replace` is a string, it will be used for all items in the `$search` array.

With this PR, you wouldn’t have to chain regex replacements, so instead of this:
`str|replace('/[^\\w\\s-]/u', '')|replace('/\\s+/u', '-')|replace('/-+/u', '-')`

you could do this:
`str|replace(['/[^\\w\\s-]/u', '/\\s+/u', '/-+/u'], ['', '-', '-'])`

A mixture of regex strings and “regular” strings is allowed in the `$search` array.

### Related issues
#12956
