### PR TITLE
respect query limit for assets index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where Assets fields weren’t respecting their View Mode setting when viewing entry revisions. ([#12948](https://github.com/craftcms/cms/issues/12948))
 - Fixed a bug where some relational fields were showing duplicate selected relations. ([#12949](https://github.com/craftcms/cms/issues/12949))
+- Fixed a bug where asset pagination was broken when there was more than 100 subfolders. ([#12969](https://github.com/craftcms/cms/issues/12969))
 
 ## 3.8.5 - 2023-03-21
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -633,11 +633,19 @@ class Asset extends Element
             }
         }
 
-        if (!self::isFolderIndex()) {
-            $assets = array_merge($assets, $elementQuery->all());
+        // if it's a 'foldersOnly' request - just return folders
+        if (self::isFolderIndex()) {
+            return $assets;
         }
 
-        return $assets;
+        // if we have enough folders to hit the query limit - return them
+        // there's no room for any assets
+        if (count($assets) === $elementQuery->limit) {
+            return $assets;
+        }
+
+        // otherwise will up the rest of the limit with assets
+        return array_merge($assets, $elementQuery->all());
     }
 
     /**

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -633,18 +633,16 @@ class Asset extends Element
             }
         }
 
-        // if it's a 'foldersOnly' request - just return folders
-        if (self::isFolderIndex()) {
+        // if it's a 'foldersOnly' request, or we have enough folders to hit the query limit,
+        // return the folders directly
+        if (
+            self::isFolderIndex() ||
+            count($assets) == $elementQuery->limit
+        ) {
             return $assets;
         }
 
-        // if we have enough folders to hit the query limit - return them
-        // there's no room for any assets
-        if (count($assets) === $elementQuery->limit) {
-            return $assets;
-        }
-
-        // otherwise will up the rest of the limit with assets
+        // otherwise merge in the resulting assets
         return array_merge($assets, $elementQuery->all());
     }
 


### PR DESCRIPTION
### Description
While investigating this ticket, I discovered 2 issues:
1. In the index context (e.g. Assets index page): if there are more than 100 folders and more than 100 assets, pagination appears to work, but in fact, it’s a bit broken. 
- I have a volume with 2 subfolders and 2 assets in the root - all works fine.
- One of the subfolders has 121 subfolders and 116 assets. That’s 237 “rows” in total.
  - *Page 1*: displays the first 100 folders and the first 100 assets. In addition, the counter at the bottom says 1-100 of 237. We do technically show 100 assets, but overall we show 200 “rows”.
  - *Page 2*: displays the remaining 21 folders and the first 79 assets. The counter says 101-200 of 237, but we only really show 79 assets, and they’re not actually starting from position 101; they start from scratch;
  - *Page 3*: displays 37 assets (116 - 79 from page 2 = 37). The counter says 201-237 of 237. The number is correct, but not the “positions”.
2. In the modal context (e.g. assets field), if there are more than 100 folders and assets, lazy loading is broken because of this check: https://github.com/craftcms/cms/blob/develop/src/web/assets/cp/src/js/BaseElementIndexView.js#L41-L43. `$elements.length` exceeds `this.settings.batchSize` which causes lazy loading never to be triggered. 

I considered pagination in the module, but that would mean the assets modal works differently from any other modal.

I considered lazy loading, where the “second” page loads another set of folders and assets, but that means some folders are stuck between assets, making things harder to find.

Finally, I set on the approach where we respect the query limit and potentially only show folders on the “first” page(s) before lazy loading adds another batch.


### Related issues
#12969 
