### PR TITLE
4.x Docs URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "issues": "https://github.com/craftcms/cms/issues?state=open",
     "forum": "https://craftcms.stackexchange.com/",
     "source": "https://github.com/craftcms/cms",
-    "docs": "https://docs.craftcms.com/v3/",
+    "docs": "https://craftcms.com/docs/4.x/",
     "rss": "https://github.com/craftcms/cms/releases.atom"
   },
   "require": {


### PR DESCRIPTION
Uses the 4.x documentation URL, which should update the corresponding link on [Packagist](https://packagist.org/packages/craftcms/cms), as well as the Composer CLI output:

```txt
composer info craftcms/cms

name     : craftcms/cms
descrip. : Craft CMS
keywords : cms, craftcms, yii2
versions : * 4.4.5
type     : library
license  : proprietary
homepage : https://craftcms.com
source   : [git] https://github.com/craftcms/cms.git 4adcbee22dc3c8b4ea08678df724628bca4e8fc1
dist     : [zip] https://api.github.com/repos/craftcms/cms/zipball/4adcbee22dc3c8b4ea08678df724628bca4e8fc1 4adcbee22dc3c8b4ea08678df724628bca4e8fc1
path     : /var/www/html/vendor/craftcms/cms
names    : craftcms/cms, bower-asset/inputmask, bower-asset/jquery, bower-asset/punycode, bower-asset/yii2-pjax, yii2tech/ar-softdelete

support
docs : https://docs.craftcms.com/v3/
email : support@craftcms.com
forum : https://craftcms.stackexchange.com/
issues : https://github.com/craftcms/cms/issues?state=open
rss : https://github.com/craftcms/cms/releases.atom
source : https://github.com/craftcms/cms
```