### PR TITLE
pageSidebar support for CP screens

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -13,6 +13,7 @@
 - The `|replace` Twig filter now supports passing in a hash with regular expression keys. ([#12956](https://github.com/craftcms/cms/issues/12956))
 
 ### Extensibility
+- Added `craft\web\CpScreenResponseBehavior::$pageSidebar`, `pageSidebar()`, and `pageSidebarTemplate()`. ([#13019](https://github.com/craftcms/cms/pull/13019), [#12795](https://github.com/craftcms/cms/issues/12795))
 - `craft\validators\UniqueValidator` now supports setting an additional filter via the `filter` property. ([#12941](https://github.com/craftcms/cms/pull/12941))
 - Deprecated `craft\helpers\UrlHelper::buildQuery()`. `http_build_query()` should be used instead.
 

--- a/src/web/CpScreenResponseBehavior.php
+++ b/src/web/CpScreenResponseBehavior.php
@@ -169,11 +169,19 @@ class CpScreenResponseBehavior extends Behavior
     public $content = null;
 
     /**
-     * @var string|callable|null The sidebar HTML.
+     * @var string|callable|null The right-hand sidebar HTML.
      * @see sidebar()
      * @see sidebarTemplate()
      */
     public $sidebar = null;
+
+    /**
+     * @var string|callable|null The left-hand page sidebar HTML (only used by full-page screens).
+     * @see pageSidebar()
+     * @see pageSidebarTemplate()
+     * @since 4.5.0
+     */
+    public $pageSidebar = null;
 
     /**
      * @var string|callable|null The content notice HTML.
@@ -544,7 +552,7 @@ class CpScreenResponseBehavior extends Behavior
     }
 
     /**
-     * Sets the sidebar HTML.
+     * Sets the right-hand sidebar HTML.
      *
      * @param callable|string|null $value
      * @return Response
@@ -556,7 +564,7 @@ class CpScreenResponseBehavior extends Behavior
     }
 
     /**
-     * Sets a template that should be used to render the sidebar HTML.
+     * Sets a template that should be used to render the right-hand sidebar HTML.
      *
      * @param string $template
      * @param array $variables
@@ -565,6 +573,34 @@ class CpScreenResponseBehavior extends Behavior
     public function sidebarTemplate(string $template, array $variables = []): Response
     {
         return $this->sidebar(
+            fn() => Craft::$app->getView()->renderTemplate($template, $variables, View::TEMPLATE_MODE_CP)
+        );
+    }
+
+    /**
+     * Sets the left-hand page sidebar HTML (only used by full-page screens).
+     *
+     * @param callable|string|null $value
+     * @return Response
+     * @since 4.5.0
+     */
+    public function pageSidebar(callable|string|null $value): Response
+    {
+        $this->pageSidebar = $value;
+        return $this->owner;
+    }
+
+    /**
+     * Sets a template that should be used to render the left-hand page sidebar HTML (only used by full-page screens).
+     *
+     * @param string $template
+     * @param array $variables
+     * @return Response
+     * @since 4.5.0
+     */
+    public function pageSidebarTemplate(string $template, array $variables = []): Response
+    {
+        return $this->pageSidebar(
             fn() => Craft::$app->getView()->renderTemplate($template, $variables, View::TEMPLATE_MODE_CP)
         );
     }

--- a/src/web/CpScreenResponseFormatter.php
+++ b/src/web/CpScreenResponseFormatter.php
@@ -120,6 +120,7 @@ class CpScreenResponseFormatter extends Component implements ResponseFormatterIn
         $notice = is_callable($behavior->notice) ? call_user_func($behavior->notice) : $behavior->notice;
         $content = is_callable($behavior->content) ? call_user_func($behavior->content) : ($behavior->content ?? '');
         $sidebar = is_callable($behavior->sidebar) ? call_user_func($behavior->sidebar) : $behavior->sidebar;
+        $pageSidebar = is_callable($behavior->pageSidebar) ? call_user_func($behavior->pageSidebar) : $behavior->pageSidebar;
 
         if ($behavior->action) {
             $content .= Html::actionInput($behavior->action, [
@@ -159,6 +160,7 @@ class CpScreenResponseFormatter extends Component implements ResponseFormatterIn
                 'contentNotice' => $notice,
                 'content' => $content,
                 'details' => $sidebar,
+                'sidebar' => $pageSidebar,
             ],
             'templateMode' => View::TEMPLATE_MODE_CP,
         ]);


### PR DESCRIPTION
### Description

Adds `$pageSidebar`, `pageSidebar()`, and `pageSidebarTemplate()` to `craft\web\CpScreenResponseBehavior`, making it possible for control panel screens to define left-hand page sidebars. (Available for full-page screens only.)

### Related issues

- #12795