### PR TITLE
Field column size improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -21,3 +21,6 @@
 ### System
 - All generated URL param characters are now properly encoded. ([#12796](https://github.com/craftcms/cms/issues/12796))
 - `migrate` commands besides `migrate/create` no longer create the migration directory if it doesn’t exist yet. ([#12732](https://github.com/craftcms/cms/pull/12732))
+- Dropdown and Radio Buttons fields now use smart `content` table column lengths, based on their longest option value’s length. ([#13025](https://github.com/craftcms/cms/pull/13025), [#12954](https://github.com/craftcms/cms/issues/12954))
+- When `content` table columns are resized, if any existing values are too long, all column data is now backed up into a new table, and the overflowing values are set to `null`. ([#13025](https://github.com/craftcms/cms/pull/13025))
+- When `content` table columns are renamed, if an existing column with the same name already exists, the original column data is now backed up into a new table and then deleted from the `content` table. ([#13025](https://github.com/craftcms/cms/pull/13025))

--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -179,7 +179,8 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
             return Db::getTextualColumnTypeByContentLength($length + 1);
         }
 
-        return Schema::TYPE_STRING;
+        $maxLength = max([1, ...array_map(fn(array $option) => strlen($option['value']), $this->options())]);
+        return $maxLength === 1 ? Schema::TYPE_CHAR : sprintf('%s(%s)', Schema::TYPE_STRING, $maxLength);
     }
 
     /**

--- a/src/fields/Color.php
+++ b/src/fields/Color.php
@@ -51,7 +51,7 @@ class Color extends Field implements PreviewableFieldInterface
      */
     public function getContentColumnType(): string
     {
-        return Schema::TYPE_STRING . '(7)';
+        return sprintf('%s(7)', Schema::TYPE_CHAR);
     }
 
     /** @inheritdoc */

--- a/src/fields/Url.php
+++ b/src/fields/Url.php
@@ -112,7 +112,7 @@ class Url extends Field implements PreviewableFieldInterface
      */
     public function getContentColumnType(): string
     {
-        return Schema::TYPE_STRING . "($this->maxLength)";
+        return sprintf('%s(%s)', Schema::TYPE_STRING, $this->maxLength);
     }
 
     /**

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -67,6 +67,8 @@ use yii\base\Component;
 use yii\base\Exception;
 use yii\base\InvalidArgumentException;
 use yii\db\Exception as DbException;
+use yii\db\Expression;
+use yii\db\Schema;
 use yii\db\Transaction;
 use yii\web\BadRequestHttpException;
 
@@ -1760,10 +1762,18 @@ class Fields extends Component
      * @param string|null $oldName
      * @param string $newName
      * @param string $type
+     * @param bool $handleOverflowData
      * @since 3.7.39
      */
-    protected function updateColumn(Connection $db, Transaction &$transaction, string $table, ?string $oldName, string $newName, string $type): void
-    {
+    protected function updateColumn(
+        Connection $db,
+        Transaction &$transaction,
+        string $table,
+        ?string $oldName,
+        string $newName,
+        string $type,
+        bool $handleOverflowData = true,
+    ): void {
         // Clear the schema cache
         $db->getSchema()->refresh();
 
@@ -1776,11 +1786,36 @@ class Fields extends Component
                 $db->createCommand()
                     ->alterColumn($table, $oldName, $type)
                     ->execute();
-            } catch (DbException) {
-                // Just rename the old column and pretend it didn’t exist
+            } catch (DbException $e) {
+                // Restart the transaction
                 $transaction->rollBack();
                 $transaction = $db->beginTransaction();
-                $this->_preserveColumn($db, $table, $oldName);
+
+                // 22001 == the existing data is too long (applies to both MySQL and PostgreSQL)
+                if ($handleOverflowData && $e->getCode() == '22001') {
+                    $maxLength = Db::getTextualColumnStorageCapacity($type);
+                    if ($maxLength) {
+                        // Backup the current column data
+                        $this->_backupFieldColumn($db, $table, $oldName);
+
+                        // Empty the overflowing values and try again
+                        try {
+                            Db::update(
+                                $table,
+                                [$oldName => null],
+                                ['>', new Expression("LENGTH([[$oldName]])"), $maxLength],
+                            );
+                        } catch (DbException $truncateException) {
+                        }
+                        if (!isset($truncateException)) {
+                            $this->updateColumn($db, $transaction, $table, $oldName, $newName, $type, false);
+                            return;
+                        }
+                    }
+                }
+
+                // Backup the column data and drop it
+                $this->_backupFieldColumn($db, $table, $oldName, true);
                 $existingColumn = false;
             }
         }
@@ -1790,8 +1825,8 @@ class Fields extends Component
             if ($oldName !== $newName) {
                 // Does the new column already exist?
                 if ($db->columnExists($table, $newName)) {
-                    // Rename it so we don't lose any data
-                    $this->_preserveColumn($db, $table, $newName);
+                    // Backup the old column data and drop it
+                    $this->_backupFieldColumn($db, $table, $newName, true);
                 }
 
                 // Rename the column
@@ -1802,8 +1837,8 @@ class Fields extends Component
         } else {
             // Does the new column already exist?
             if ($db->columnExists($table, $newName)) {
-                // Rename it so we don't lose any data
-                $this->_preserveColumn($db, $table, $newName);
+                // Backup the old column data and drop it
+                $this->_backupFieldColumn($db, $table, $newName, true);
             }
 
             // Add the new column
@@ -1814,23 +1849,62 @@ class Fields extends Component
     }
 
     /**
-     * Renames a content table column so its data is preserved.
+     * Backs up a table column’s content so its data is preserved.
      *
      * @param Connection $db
      * @param string $table
      * @param string $column
+     * @param bool $dropColumn
      */
-    private function _preserveColumn(Connection $db, string $table, string $column): void
+    private function _backupFieldColumn(Connection $db, string $table, string $column, bool $dropColumn = false): void
     {
-        $n = 0;
+        // Make sure there are any non-null values worth backing up
+        $hasValues = (new Query())
+            ->from($table)
+            ->where(['not', [$column => null]])
+            ->exists($db);
+
+        if (!$hasValues) {
+            return;
+        }
+
+        // Find a unique backup table name
+        $shortTableName = Db::rawTableShortName($table);
+        $timestamp = time();
+        $n = 1;
         do {
+            $suffix = $n === 1 ? '' : "_$n";
+            $bakTable = "{{%{$shortTableName}_{$column}_bak_$timestamp$suffix}}";
             $n++;
-            $newName = $column . '_old' . ($n > 1 ? $n : '');
-        } while ($db->columnExists($table, $newName));
+        } while ($db->tableExists($bakTable));
+
+        $schema = $db->getSchema();
+        $columnSchema = $schema->getTableSchema($table)->getColumn($column);
 
         $db->createCommand()
-            ->renameColumn($table, $column, $newName)
+            ->createTable($bakTable, [
+                'id' => $schema->createColumnSchemaBuilder(Schema::TYPE_PK),
+                'elementId' => $schema->createColumnSchemaBuilder(Schema::TYPE_INTEGER)->notNull(),
+                'siteId' => $schema->createColumnSchemaBuilder(Schema::TYPE_INTEGER)->notNull(),
+                $column => $schema->createColumnSchemaBuilder($columnSchema->type, $columnSchema->size),
+            ])
             ->execute();
+
+        $db->getSchema()->refreshTableSchema($bakTable);
+
+        // Copy the non-null values
+        $db->createCommand(<<<SQL
+INSERT INTO $bakTable ([[id]], [[elementId]], [[siteId]], [[$column]])
+SELECT [[id]], [[elementId]], [[siteId]], [[$column]]
+FROM $table
+WHERE [[$column]] IS NOT NULL
+SQL)->execute();
+
+        if ($dropColumn) {
+            $db->createCommand()
+                ->dropColumn($table, $column)
+                ->execute();
+        }
     }
 
     /**

--- a/tests/unit/helpers/dbhelper/DbHelperTest.php
+++ b/tests/unit/helpers/dbhelper/DbHelperTest.php
@@ -762,7 +762,9 @@ class DbHelperTest extends TestCase
     {
         return [
             [1, Schema::TYPE_CHAR],
+            [5, sprintf('%s(5)', Schema::TYPE_CHAR)],
             [255, Schema::TYPE_STRING],
+            [50, sprintf('%s(50)', Schema::TYPE_STRING)],
             [false, Schema::TYPE_MONEY],
             [false, Schema::TYPE_BOOLEAN],
         ];


### PR DESCRIPTION
### Description

Makes the following improvements for custom field `content` table columns:

- When adding or renaming a column, if a column with the same name already exists, a new table will be created (`content_<columnName>_bak_<timestamp>` to store the existing column’s non-null values, along with the rows’ `id`, `elementId`, and `siteId` values, and then the original column will be deleted from the `content` table. (Previously, the column was just renamed to `<columnName>_old`, adding to the table’s row size.)
- When changing a custom field’s column type, if a SQL error occurs due to the existing data being too long, the existing column data will be backed up in a new table, and then any existing values that would overflow the new column size will be set to `null`, then the `alter table` command will be attempted once again. (Previously, the column was just renamed to `<columnName>_old` and a new column was created, effectively wiping out the field’s existing values until manually reconstructed.)
- Dropdown and Radio Buttons fields now use smart column lengths, based on their longest option value’s length. (Note this doesn’t come into effect until the fields are re-saved.)

#### Example

If you have a Dropdown field with `yes`, `no`, and `maybe` options, its column type will be `varchar(5)` (instead of `varchar(255)` as before).

If its `maybe` option is removed later on, its column type will be changed to `varchar(3)`. If any entries exist that had `maybe` selected, a new `content_<columnName>_bak_<timestamp>` table will be created, which will contain _all_ of the non-null Dropdown field values, and all `maybe` options will be set to `null`.

### Related issues

- #2009
- #4308
- #7221
- #7750
- #12954