### PR TITLE
Feature/dev 1101 set new global variables from twig

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -13,6 +13,7 @@
 ### Administration
 
 ### Development
+- Added a new `_globals` global Twig variable for front-end templates, which can be used to store custom values in a global scope. ([#13050](https://github.com/craftcms/cms/pull/13050), [#12951](https://github.com/craftcms/cms/discussions/12951))
 - The `|replace` Twig filter now supports passing in a hash with regular expression keys. ([#12956](https://github.com/craftcms/cms/issues/12956))
 - Elements now include custom field values when being iterated over, and when being merged. ([#13009](https://github.com/craftcms/cms/issues/13009))
 

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -1495,6 +1495,19 @@ trait ApplicationTrait
         ColumnSchemaBuilder::$typeCategoryMap[Schema::TYPE_LONGTEXT] = ColumnSchemaBuilder::CATEGORY_STRING;
         ColumnSchemaBuilder::$typeCategoryMap[Schema::TYPE_ENUM] = ColumnSchemaBuilder::CATEGORY_STRING;
 
+        // Register Collection::set() as an alias of put() - with support for bulk-setting values
+        Collection::macro('set', function(mixed $values) {
+            /** @var Collection $this */
+            if (is_array($values)) {
+                foreach ($values as $key => $value) {
+                    $this->put($key, $value);
+                }
+            } else {
+                $this->put(...func_get_args());
+            }
+            return $this;
+        });
+
         // Register Collection::one() as an alias of first(), for consistency with yii\db\Query.
         Collection::macro('one', function() {
             /** @var Collection $this */

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -21,6 +21,7 @@ use craft\helpers\StringHelper;
 use craft\web\twig\CpExtension;
 use craft\web\twig\Environment;
 use craft\web\twig\Extension;
+use craft\web\twig\FeExtension;
 use craft\web\twig\GlobalsExtension;
 use craft\web\twig\SinglePreloaderExtension;
 use craft\web\twig\TemplateLoader;
@@ -359,6 +360,7 @@ class View extends \yii\web\View
         if ($this->_templateMode === self::TEMPLATE_MODE_CP) {
             $twig->addExtension(new CpExtension());
         } elseif (Craft::$app->getIsInstalled()) {
+            $twig->addExtension(new FeExtension());
             $twig->addExtension(new GlobalsExtension());
 
             if (Craft::$app->getConfig()->getGeneral()->preloadSingles) {

--- a/src/web/twig/FeExtension.php
+++ b/src/web/twig/FeExtension.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\web\twig;
+
+use Illuminate\Support\Collection;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
+/**
+ * Front-end Twig extension
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.5.0
+ */
+class FeExtension extends AbstractExtension implements GlobalsInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function getGlobals(): array
+    {
+        return [
+            '_globals' => Collection::make(),
+        ];
+    }
+}


### PR DESCRIPTION
### Description

Adds a new `_globals` global Twig variable for front-end templates, set to an empty collection. All templates have access to it, and can set/retrieve values on it, providing a way for templates to store custom values in a global scope.

A new `set()` macro has also been added to collections, which can work as an alias of `Collection::put()` (key + value arguments), and it also accepts an array of key/value pairs.

```twig
{# setting values: #}
{% do _globals.set('foo', 'bar') %}
{% do _globals.set({
  foo: 'bar',
  baz: 'qux',
}) %}

{# getting values: #}
{{ _globals.foo }}
{{ _globals.get('foo') }}
{% dump_globals.all() %}
```

### Related issues

- #12951