### PR TITLE
edit user set fail flash adjustment

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -794,7 +794,12 @@ class UsersController extends Controller
     public function actionEditUser(mixed $userId = null, ?User $user = null, ?array $errors = null): Response
     {
         if (!empty($errors)) {
-            $this->setFailFlash(implode(', ', reset($errors)));
+            $firstError = reset($errors);
+            if (is_array($firstError)) {
+                $this->setFailFlash(implode(', ', $firstError));
+            } else {
+                $this->setFailFlash($firstError);
+            }
         }
 
         // Determine which user account we're editing


### PR DESCRIPTION
### Description
If `$errors` passed to `actionEditUser` is a one-dimensional array, calling implode on `reset($errors)` will throw an exception. This PR checks if the result of `reset($errors)` is an array or not and set the fail flash accordingly.


### Related issues

