### PR TITLE
added non-json response to actionSendActivationEmail

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1713,9 +1713,17 @@ JS,
             );
         }
 
-        return $emailSent ?
-            $this->asSuccess(Craft::t('app', 'Activation email sent.')) :
-            $this->asFailure(Craft::t('app', 'Couldn’t send activation email. Check your email settings.'));
+        if ($this->request->getAcceptsJson()) {
+            return $emailSent ?
+                $this->asSuccess(Craft::t('app', 'Activation email sent.')) :
+                $this->asFailure(Craft::t('app', 'Couldn’t send activation email. Check your email settings.'));
+        }
+
+        $emailSent ?
+            $this->setSuccessFlash(Craft::t('app', 'Activation email sent.')) :
+            $this->setFailFlash(Craft::t('app', 'Couldn’t send activation email. Check your email settings.'));
+
+        return $this->redirectToPostedUrl($user);
     }
 
     /**


### PR DESCRIPTION
### Description

> If for whatever reason activation emails won't send successfully (e.g. a misconfigured Email setting), any selected checkboxes on the Permissions tab are cleared, which can cause issues if the user is then saved without reloading the page or reselecting the desired permissions.

Return `asSuccess`/`asFailure` if the request accepts json; otherwise, redirect back to prevent the above from happening.

### Related issues
#13061 
