### PR TITLE
don't use default upload location if it's not in sources

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -929,8 +929,13 @@ class Assets extends BaseRelationField
                 return Craft::t('app', 'Asset Location');
             };
         } else {
-            $sourceKey = $this->defaultUploadLocationSource;
-            $subpath = $this->defaultUploadLocationSubpath;
+            if (in_array($this->defaultUploadLocationSource, $this->sources)) {
+                $sourceKey = $this->defaultUploadLocationSource;
+                $subpath = $this->defaultUploadLocationSubpath;
+            } else {
+                $sourceKey = reset($this->sources);
+                $subpath = '';
+            }
             $settingName = function() {
                 return Craft::t('app', 'Default Asset Location');
             };

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -929,7 +929,10 @@ class Assets extends BaseRelationField
                 return Craft::t('app', 'Asset Location');
             };
         } else {
-            if (in_array($this->defaultUploadLocationSource, $this->sources)) {
+            if (
+                $this->sources === '*' ||
+                (is_array($this->sources) && in_array($this->defaultUploadLocationSource, $this->sources))
+            ) {
                 $sourceKey = $this->defaultUploadLocationSource;
                 $subpath = $this->defaultUploadLocationSubpath;
             } else {


### PR DESCRIPTION
### Description
For the Assets field, if the default upload location is set to a volume which is not selected under Sources, set the default upload location to the first selected volume.


### Related issues
#13072 
