### PR TITLE
Description for $propagateTo, use FG_RED on error

### DIFF
--- a/src/console/controllers/ResaveController.php
+++ b/src/console/controllers/ResaveController.php
@@ -124,7 +124,7 @@ class ResaveController extends Controller
     public ?string $site = null;
 
     /**
-     * @var string|int[]|null The site handle to propagate entries to.
+     * @var string|int[]|null The comma separated site handles to propagate entries to.
      *
      * When this is set, the entry will *only* be saved for this site.
      *
@@ -279,7 +279,7 @@ class ResaveController extends Controller
             foreach ($siteHandles as $siteHandle) {
                 $site = $sitesService->getSiteByHandle($siteHandle, true);
                 if (!$site) {
-                    $this->stderr("Invalid site handle: $siteHandle");
+                    $this->stderr("Invalid site handle: $siteHandle" . PHP_EOL, Console::FG_RED);
                     return false;
                 }
                 $this->propagateTo[] = $site->id;

--- a/src/console/controllers/ResaveController.php
+++ b/src/console/controllers/ResaveController.php
@@ -124,7 +124,7 @@ class ResaveController extends Controller
     public ?string $site = null;
 
     /**
-     * @var string|int[]|null The comma separated site handles to propagate entries to.
+     * @var string|int[]|null Comma-separated site handles to propagate entries to.
      *
      * When this is set, the entry will *only* be saved for this site.
      *


### PR DESCRIPTION
### Description
This PR describes the $propagateTo option and also modifies the 'Invalid site handle:' error color in red to be consistent with other console errors.

Also when wrong site handle error is passed, after the 'Invalid site handle:' error, there is an exception `Exception 'TypeError' with message 'craft\console\Controller::runAction(): Return value must be of type int, null returned` which i don't know if this exception needs a fix or this is expected behavior. 

Thanks!





