### PR TITLE
Add `uid` handling for Matrix blocks when creating from serialized block data

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1354,6 +1354,11 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
                 $block->enabled = (bool)$blockData['enabled'];
             }
 
+            // Allow setting the UID for the block element
+            if (isset($blockData['uid'])) {
+                $block->uid = $blockData['uid'];
+            }
+
             // Skip disabled blocks on Live Preview requests
             if ($hideDisabledBlocks && !$block->enabled) {
                 continue;


### PR DESCRIPTION
I'm keen to know if you're for or against this alteration. This will allow my plugin to supply a `uid` for a block, which will then be set for the `MatrixBlock` element that's created or updated.

For context, I'm building something that handles migrating content from one install to another. The way to track content for other elements is through their UIDs which are truly unique, unlike IDs. For Matrix blocks, I have the usual serialized data to supply to `element->setFieldValues()`.

```php
[
    'new1' => [
        'type' => 'contentBlock'
        'enabled' => true
        'collapsed' => false
        'uid' => 'd02d03e9-9677-466b-b8ac-0374890ba5a4'
        'fields' => [
            'plainText' => 'someText'
        ]
    ]
]
```

You can see I've added the `uid` there for the `MatrixBlock` in hopes that it would populate the element (it doesn't without this change). With this content populated the block will get created, but a brand new UID would be generated, and this one dicarded. 

If I run this code again (populate the element with `setFieldValues()`), this would create a duplicate block. That's because the only way to control this is through the array index `new1` which would be replaced by the block ID. As you know, the `newX` notation defines new blocks. But, because this content is coming from another install, it's impossible to consolidate that ID, when content is coming from another install.

With this change, blocks can at least have their UID set so it's not reliant on the `new` or ID index. In this way, when the block is created, it's created with the UID we specify, and can be used again to lookup the value. This is not a breaking change at all, so up to you if you want to take on the "extra code".

Hope that makes sense - I know it's probably a little confusing without more context (chat on Discord if you need!)