### PR TITLE
Docblocks for project-config console controllers

### DIFF
--- a/src/console/controllers/ProjectConfigController.php
+++ b/src/console/controllers/ProjectConfigController.php
@@ -125,9 +125,9 @@ class ProjectConfigController extends Controller
      * ```
      * php craft project-config/get system.edition
      * ```
-     * 
+     *
      * The “path” syntax used here may be composed of directory and filenames (within your `config/project` folder), YAML object keys (including UUIDs for many Craft resources), and integers (referencing numerically-indexed arrays), joined by a dot (`.`): `path.to.nested.array.0.property`.
-     * 
+     *
      * @param string $path The config item path
      * @return int
      * @since 4.1.0
@@ -148,15 +148,15 @@ class ProjectConfigController extends Controller
      * ```
      * php craft project-config/set some.nested.key
      * ```
-     * 
+     *
      * See [get](#project-config-get) for the accepted key formats.
-     * 
+     *
      * ::: danger
      * This should only be used when the equivalent change is not possible through the control panel or other Craft APIs. By directly modifying project config values, you are bypassing all validation and can easily destabilize configuration.
      * :::
-     * 
+     *
      * Values are updated in the database *and* in your local YAML files, but the root `dateModified` project config property is only touched when using the [`--update-timestamp` flag](#project-config-set-options). If you do not update the timestamp along with the value, the change may not be detected or applied in other environments!
-     * 
+     *
      * @param string $path The config item path
      * @param string $value The config item value as a valid YAML string
      * @return int
@@ -205,13 +205,13 @@ class ProjectConfigController extends Controller
      * ```
      * php craft project-config/remove some.nested.key
      * ```
-     * 
+     *
      * ::: danger
      * This should only be used when the equivalent change is not possible through the control panel or other Craft APIs. By directly modifying project config values, you are bypassing all validation and can easily destabilize configuration.
      * :::
-     * 
+     *
      * As with [set](#project-config-set), removing values only updates the root `dateModified` key when using the [`--update-timestamp` flag](#project-config-set-options). If you do not include this flag, you must run `project-config/touch` before changes will be detected or applied in other environments!
-     * 
+     *
      * @param string $path The config item path
      * @return int
      * @since 4.1.0

--- a/src/console/controllers/ProjectConfigController.php
+++ b/src/console/controllers/ProjectConfigController.php
@@ -125,7 +125,9 @@ class ProjectConfigController extends Controller
      * ```
      * php craft project-config/get system.edition
      * ```
-     *
+     * 
+     * The “path” syntax used here may be composed of directory and filenames (within your `config/project` folder), YAML object keys (including UUIDs for many Craft resources), and integers (referencing numerically-indexed arrays), joined by a dot (`.`): `path.to.nested.array.0.property`.
+     * 
      * @param string $path The config item path
      * @return int
      * @since 4.1.0
@@ -144,9 +146,17 @@ class ProjectConfigController extends Controller
      *
      * Example:
      * ```
-     * php craft project-config/set system.edition pro
+     * php craft project-config/set some.nested.key
      * ```
-     *
+     * 
+     * See [get](#project-config-get) for the accepted key formats.
+     * 
+     * ::: danger
+     * This should only be used when the equivalent change is not possible through the control panel or other Craft APIs. By directly modifying project config values, you are bypassing all validation and can easily destabilize configuration.
+     * :::
+     * 
+     * Values are updated in the database *and* in your local YAML files, but the root `dateModified` project config property is only touched when using the [`--update-timestamp` flag](#project-config-set-options). If you do not update the timestamp along with the value, the change may not be detected or applied in other environments!
+     * 
      * @param string $path The config item path
      * @param string $value The config item value as a valid YAML string
      * @return int
@@ -193,9 +203,15 @@ class ProjectConfigController extends Controller
      *
      * Example:
      * ```
-     * php craft project-config/set system.edition pro
+     * php craft project-config/remove some.nested.key
      * ```
-     *
+     * 
+     * ::: danger
+     * This should only be used when the equivalent change is not possible through the control panel or other Craft APIs. By directly modifying project config values, you are bypassing all validation and can easily destabilize configuration.
+     * :::
+     * 
+     * As with [set](#project-config-set), removing values only updates the root `dateModified` key when using the [`--update-timestamp` flag](#project-config-set-options). If you do not include this flag, you must run `project-config/touch` before changes will be detected or applied in other environments!
+     * 
      * @param string $path The config item path
      * @return int
      * @since 4.1.0


### PR DESCRIPTION
Corrects the example command for `get`, and elaborates on the usage (and dangers) of the `get`, `set`, and `remove` actions.