### PR TITLE
adjust offset for getting marker's content

### DIFF
--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -768,7 +768,7 @@ class Html extends \yii\helpers\Html
                 break;
             }
             $marker = sprintf('{marker:%s}', StringHelper::randomString());
-            $markers[$marker] = substr($html, $openMatch[0][1], $closeMatch[0][1] - $innerOffset);
+            $markers[$marker] = substr($html, $innerOffset, $closeMatch[0][1] - $innerOffset);
             $html = substr($html, 0, $innerOffset) . $marker . substr($html, $closeMatch[0][1]);
             $offset = $innerOffset + strlen($marker) + strlen($closeMatch[0][0]);
         }


### PR DESCRIPTION
### Description
Adjusted offset for getting marker’s content. `$openMatch[0][1]` was getting the start of the `<textarea>`. `$innerOffset` gets the start of the content inside that `<textarea>`.


### Related issues
#13085
