### PR TITLE
ensure structure elements query factors in siteId

### DIFF
--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -970,6 +970,7 @@ JS, [
                     ->revisions(null)
                     ->provisionalDrafts(null)
                     ->status(null)
+                    ->siteId($this->targetSiteId($element))
                     ->all();
 
                 // Fill in any gaps


### PR DESCRIPTION
### Description
When you had:
- at least 2 sites
- a channel with propagation “let each site choose”, enabled for both sites
- a section with propagation “let each site choose”, enabled for both sites
- an entries field with sources set to your section, maintain hierarchy & manage relations on a per-site basis checked
- that entries field was added to the channel you created
- you created a section entry enabled for the non-primary site only
- you created another section entry enabled for the non-primary site and added it to the primary site added, but it can be disabled
- you created a channel entry and tried to add both section entries - only the second one (one that’s disabled for the primary site) was saved

Ensuring that the query that gets structure elements for `Structures::fillGapsInElements()` uses the element’s target site id fixes this problem.


### Related issues
#13057 
