### PR TITLE
Fix missing validation errors for meta fields in entry edit pages and slideouts

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1584,6 +1584,8 @@ EOD;
                     'value' => $this->getTypeId(),
                     'options' => $entryTypeOptions,
                     'disabled' => $static,
+                    'attribute' => 'typeId',
+                    'errors' => $this->getErrors('typeId'),
                 ]);
             })();
         }
@@ -1624,6 +1626,7 @@ EOD;
                     'elements' => $parent ? [$parent] : [],
                     'disabled' => $static,
                     'describedBy' => 'parentId-label',
+                    'errors' => $this->getErrors('parentId'),
                 ]);
             })();
         }
@@ -1645,6 +1648,7 @@ EOD;
                         'single' => true,
                         'elements' => $author ? [$author] : null,
                         'disabled' => $static,
+                        'errors' => $this->getErrors('authorId'),
                     ]);
                 })();
             }


### PR DESCRIPTION
### Description

In Craft 3, it was possible to add a validation error for the `typeId` attribute (for example, via a custom validation rule in an `Entry::EVENT_DEFINE_RULES` event handler), and this error would be displayed below the entry type select field in edit pages:

<img width="427" alt="CleanShot 2023-05-01 at 00 11 34@2x" src="https://user-images.githubusercontent.com/298510/235378417-b6d43709-a417-4101-b493-93b6a993b7a3.png">

**In Craft 4.4.8, this error message will no longer appear and the Entry Type field will not be marked as having errors (the only thing that shows is the "Couldn't save entry" error toast).**

This PR fixes this issue, by adding an `'errors'` key to the to the entry type select input's config field array, with a value set to `$this->getErrors('typeId')`.

Additionally, an `'attribute' => 'typeId'` key is added to the entry type select's config array. This is required for slideouts to render the error, since [slideouts use the `data-attribute` for showing errors](https://github.com/craftcms/cms/blob/ea597a0fe33ddd579836b6238626a638dc1f194f/src/web/assets/cp/src/js/CpScreenSlideout.js#L534), which defaults to the field's ID attribute (the Entry Type field has an ID `"entryType"`, not `"typeId"`).

For consistency, this PR also adds the same `'errors'` key to the Parent and Author fields, even if - unlike the Entry Type field - those fields didn't actually support visible validation errors on Craft 3. (For these fields, the IDs and attributes are the same and as such there is no need for an `attribute` key.)

_To give a bit of context and a valid use case_ for this PR: In the past I've often implemented restrictions related to entry types by implementing custom validation rules for the `typeId` attribute. As an example, the below code makes it impossible to create an entry using the entry type "Child" at the root level of a structure:

```php
Event::on(
    Entry::class,
    Entry::EVENT_DEFINE_RULES,
    static function (DefineRulesEvent $event) {
        /** @var Entry $entry */
        $entry = $event->sender;
        $event->rules[] = ['typeId', function () use ($entry) {
            if ($entry->level === 1 && $entry->getType()->handle === 'child') {
                $entry->addError('typeId', Craft::t('site', 'Child entries must have a parent entry. Select a parent entry in the "Parent" field below.'));
            }
        }, 'on' => Entry::SCENARIO_LIVE];
    }
);
```

I was made aware of there not being a visible error message anymore after upgrading a project w/ similar code to Craft 4, so hopefully this PR or a different fix can be merged in. Personally, I feel like being able to surface validation errors like this is a pretty elegant way to implement custom restrictions related to entry types, and I think being able to do the same thing for the Author and Parent fields would be nice.

### Related issues

