### PR TITLE
create/save and add another shouldn't be available for singles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where Quick Post widget settings weren’t filtering custom field options for the selected entry type.
 - Fixed a bug where Matrix blocks could get detached from entries when sections were enabled for a new site. ([#13155](https://github.com/craftcms/cms/issues/13155))
 - Fixed an error that could occur when entrifying a global set without a field layout. ([#13156](https://github.com/craftcms/cms/issues/13156))
+- Fixed a bug where Single entries’ edit pages could have “Save and add another” actions. ([#13157](https://github.com/craftcms/cms/issues/13157))
 
 ## 4.4.9 - 2023-05-02
 

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1317,7 +1317,10 @@ class Entry extends Element implements ExpirableElementInterface
         $section = $this->getSection();
 
         if (!$this->id) {
-            return $user->can("createEntries:$section->uid");
+            return (
+                $section->type !== Section::TYPE_SINGLE &&
+                $user->can("createEntries:$section->uid")
+            );
         }
 
         if ($this->getIsDraft()) {


### PR DESCRIPTION
### Description
“Create/Save and add another” alternative action should not be available for singles.

(Craft 3 is not affected by this.)


### Related issues
#13157 
