### PR TITLE
Updated docs URLs

### DIFF
--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -321,7 +321,7 @@ interface ElementInterface extends ComponentInterface
     public static function fieldLayouts(string $source): array;
 
     /**
-     * Returns the available [element actions](https://craftcms.com/docs/4.x/extend/element-action-types.html) for a
+     * Returns the available [element actions](https://craftcms.com/docs/4.x/extend/element-actions.html) for a
      * given source.
      *
      * The actions can be represented by their fully qualified class name, a config array with the class name

--- a/src/services/Utilities.php
+++ b/src/services/Utilities.php
@@ -38,7 +38,7 @@ class Utilities extends Component
     /**
      * @event RegisterComponentTypesEvent The event that is triggered when registering utilities.
      *
-     * Utility must implement [[UtilityInterface]]. [[\craft\base\Utility]] provides a base implementation.
+     * Utilities must implement [[UtilityInterface]]. [[\craft\base\Utility]] provides a base implementation.
      *
      * Read more about creating utilities in the [documentation](https://craftcms.com/docs/4.x/extend/utilities.html).
      * ---

--- a/src/services/Utilities.php
+++ b/src/services/Utilities.php
@@ -36,11 +36,11 @@ use yii\base\Component;
 class Utilities extends Component
 {
     /**
-     * @event RegisterComponentTypesEvent The event that is triggered when registering utility types.
+     * @event RegisterComponentTypesEvent The event that is triggered when registering utilities.
      *
-     * Utility types must implement [[UtilityInterface]]. [[\craft\base\Utility]] provides a base implementation.
+     * Utility must implement [[UtilityInterface]]. [[\craft\base\Utility]] provides a base implementation.
      *
-     * See [Utility Types](https://craftcms.com/docs/4.x/extend/utility-types.html) for documentation on creating utility types.
+     * Read more about creating utilities in the [documentation](https://craftcms.com/docs/4.x/extend/utilities.html).
      * ---
      * ```php
      * use craft\events\RegisterComponentTypesEvent;


### PR DESCRIPTION
### Description

I've reorganized and renamed some pages that used `-types` or ` Types` in their URLs and titles (when they ought not have), so these URLs are now obsolete. Redirects were added to Netlify to hold us over.

### Related Issues
- #13162 