### PR TITLE
matrix blocks propagation when owner added for new site

### DIFF
--- a/src/services/Matrix.php
+++ b/src/services/Matrix.php
@@ -711,7 +711,13 @@ class Matrix extends Component
                 $sortOrder++;
                 if (
                     // skip blocks that are primarily owned by a different element
-                    ($saveAll && (!$block->primaryOwnerId || $block->primaryOwnerId === $owner->id)) ||
+                    ($saveAll &&
+                        (
+                            !$block->primaryOwnerId ||
+                            (!$owner->getIsDraft() && $block->primaryOwnerId === $owner->id) ||
+                            ($owner->getIsDraft() && $block->primaryOwnerId === $owner->getCanonicalId())
+                        )
+                    ) ||
                     !$block->id ||
                     $block->dirty
                 ) {

--- a/src/services/Matrix.php
+++ b/src/services/Matrix.php
@@ -710,8 +710,8 @@ class Matrix extends Component
             foreach ($blocks as $block) {
                 $sortOrder++;
                 if (
-                    // skip blocks that are primarily owned by a different element
-                    ($saveAll && (!$block->primaryOwnerId || $block->primaryOwnerId === $owner->id)) ||
+                    // skip blocks that are primarily owned by a different element, unless we're adding owner to new site(s)
+                    ($saveAll && (!$block->primaryOwnerId || $block->primaryOwnerId === $owner->id || !empty($owner->newSiteIds))) ||
                     !$block->id ||
                     $block->dirty
                 ) {

--- a/src/services/Matrix.php
+++ b/src/services/Matrix.php
@@ -710,8 +710,8 @@ class Matrix extends Component
             foreach ($blocks as $block) {
                 $sortOrder++;
                 if (
-                    // skip blocks that are primarily owned by a different element, unless we're adding owner to new site(s)
-                    ($saveAll && (!$block->primaryOwnerId || $block->primaryOwnerId === $owner->id || !empty($owner->newSiteIds))) ||
+                    // skip blocks that are primarily owned by a different element
+                    ($saveAll && (!$block->primaryOwnerId || $block->primaryOwnerId === $owner->id)) ||
                     !$block->id ||
                     $block->dirty
                 ) {


### PR DESCRIPTION
### Description
Following a fix for #13155, matrix blocks were not getting propagated when the owner element was enabled for a new site.

Please note: I can’t actually replicate 13155 to test if this still works as expected. I believe it does, but I couldn’t fully test it.


### Related issues
#13181 
