### PR TITLE
potential fix for constraint "plugins_licenseKeyStatus_check" error

### DIFF
--- a/src/migrations/m230226_013114_drop_plugin_license_columns.php
+++ b/src/migrations/m230226_013114_drop_plugin_license_columns.php
@@ -19,7 +19,7 @@ class m230226_013114_drop_plugin_license_columns extends Migration
     {
         if ($this->db->columnExists(Table::PLUGINS, 'licenseKeyStatus')) {
             if ($this->db->getIsPgsql()) {
-                $this->execute(sprintf('alter table %s drop constraint %s', Table::PLUGINS, '{{%plugins_licenseKeyStatus_check}}'));
+                $this->execute(sprintf('alter table %s drop constraint if exists %s', Table::PLUGINS, '{{%plugins_licenseKeyStatus_check}}'));
             }
             $this->dropColumn(Table::PLUGINS, 'licenseKeyStatus');
         }


### PR DESCRIPTION
### Description
Potential fix for `constraint “plugins_licenseKeyStatus_check” of relation “plugins” does not exist` error thrown when trying to apply `m230226_013114_drop_plugin_license_columns` migration.

I was not able to replicate the issue, but I was able to successfully run both the previous and this version of the migration on Postgres 11


### Related issues
#13186 
