### PR TITLE
Updates "Addresses" label on account page to be a fieldset legend

### DIFF
--- a/src/fieldlayoutelements/users/AddressesField.php
+++ b/src/fieldlayoutelements/users/AddressesField.php
@@ -66,6 +66,14 @@ class AddressesField extends BaseNativeField
     /**
      * @inheritdoc
      */
+    public function useFieldset(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function inputHtml(?ElementInterface $element = null, bool $static = false): ?string
     {
         if (!$element instanceof User) {

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -1311,6 +1311,7 @@ JS, [
             Html::beginTag('button', [
                 'type' => 'button',
                 'class' => ['btn', 'dashed', 'add', 'icon', 'address-cards__add-btn'],
+                'aria-label' => Craft::t('app', 'Add an address'),
             ]) .
             Html::tag('div', '', [
                 'class' => ['spinner', 'spinner-absolute'],


### PR DESCRIPTION
### Description
Also sets `aria-label` to ensure the accessible name starts with the visible label


### Related issues

