### PR TITLE
first save user groups then permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improved `craft\helpers\FileHelper::getExtensionByMimeType()` for some ambiguous, web-friendly MIME types.
 - Removed the OAuth 2.0 Client library, as it’s no longer used in core.
+- Fixed a bug where activation emails sent to newly-created users could link to the front-end site, if they were granted control panel access via a user group. ([#13204](https://github.com/craftcms/cms/issues/13204))
 
 ## 3.8.11 - 2023-05-15
 

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1348,8 +1348,8 @@ JS;
                 }
 
                 // Assign user groups and permissions if the current user is allowed to do that
-                $this->_saveUserPermissions($user, $currentUser);
                 $this->_saveUserGroups($user, $currentUser);
+                $this->_saveUserPermissions($user, $currentUser);
 
                 // Fire an 'afterAssignGroupsAndPermissions' event
                 if ($this->hasEventHandlers(self::EVENT_AFTER_ASSIGN_GROUPS_AND_PERMISSIONS)) {


### PR DESCRIPTION
### Description
If you:
- have `setPasswordPath` in your `config/general.php`
- start creating a new user, assign them to a group that has control panel access, and check the “Send activation email now”, 

After saving the user, the link in the email will contain the `setPasswordPath` URL, not the control panel set password URL.

Changing the order so that saving user groups happens before saving user permissions fixes this issue because then, when it comes to saving permissions, the group(s) are already set, and group-level permissions are taken into consideration.

I couldn’t replicate this on Craft 3, but I think it makes sense to keep it consistent across 3 and 4. (I can replicate it on Craft 4.)

### Related issues
#13204 
