### PR TITLE
Fix namespacing of pseudo-classes

### DIFF
--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -836,7 +836,7 @@ class Html extends \yii\helpers\Html
                         return $match[0];
                     }, $match[2]);
                 if ($withClasses) {
-                    $html = preg_replace("/(?<![\\w'\"])\\.([\\w\\-]+)(?=[,\\s\\{])/", ".$namespace-$1", $match[2]);
+                    $html = preg_replace("/(?<![\\w'\"])\\.([\\w\\-]+)(?=[,:\\s\\{])/", ".$namespace-$1", $match[2]);
                 }
                 return $match[1] . $html . $match[3];
             }, $html);


### PR DESCRIPTION
This (tiny) PR fixes the namespacing of pseudo-classes within `<style>` tags by adding a `:` to the list of possible characters that can follow a class name. 

Before:

```php
// Outputs `<style>.ns-a, .b:hover</style>`
Html::namespaceHtml('<style>.a, .b:hover</style>', 'ns', true))
```

After:

```php
// Outputs `<style>.ns-a, .ns-b:hover</style>`
Html::namespaceHtml('<style>.a, .b:hover</style>', 'ns', true))
```

Discovered and reported via Discord by @maxstrebel. 