### PR TITLE
load fallback asset icons as inline svgs

### DIFF
--- a/src/helpers/Assets.php
+++ b/src/helpers/Assets.php
@@ -905,7 +905,44 @@ class Assets
             return $path;
         }
 
+        $svg = self::_prepFileIconSvg($extension);
+
+        FileHelper::writeToFile($path, $svg);
+        return $path;
+    }
+
+    /**
+     * Returns SVG markup for an asset icon for a given extension
+     *
+     * @param string $extension
+     * @return string
+     * @since 4.5.0
+     */
+    public static function iconHtml(string $extension): string
+    {
+        if (!preg_match('/^\w+$/', $extension)) {
+            throw new InvalidArgumentException("$extension isn’t a valid file extension.");
+        }
+
+        return self::_prepFileIconSvg($extension, true);
+    }
+
+    /**
+     * Get file icon svg and add the extension text to it
+     *
+     * @param string $extension
+     * @param bool $removeXml
+     * @return string
+     * @since 4.5.0
+     */
+    private static function _prepFileIconSvg(string $extension, bool $removeXml = false): string
+    {
         $svg = file_get_contents(Craft::getAlias('@appicons/file.svg'));
+
+        if ($removeXml) {
+            // remove <?xml from the svg
+            $svg = preg_replace('/^<\?xml.*\?>\n?/', '', $svg);
+        }
 
         $extLength = strlen($extension);
         if ($extLength <= 3) {
@@ -922,7 +959,6 @@ class Assets
         $textNode = "<text x=\"50\" y=\"73\" text-anchor=\"middle\" font-family=\"sans-serif\" fill=\"#9aa5b1\" font-size=\"$textSize\">" . strtoupper($extension) . '</text>';
         $svg = str_replace('<!-- EXT -->', $textNode, $svg);
 
-        FileHelper::writeToFile($path, $svg);
-        return $path;
+        return $svg;
     }
 }

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -414,27 +414,44 @@ class Cp
         }
 
         if ($thumbUrl !== null) {
-            $imageSize2x = $thumbSizePx * 2;
-            $thumbUrl2x = $element->getThumbUrl($imageSize2x);
+            // $element->getThumbUrl can return an SVG markup now (for icons)
+            // we need to check if $thumbUrl starts with <svg
+            // if it does - use it
+            if (preg_match('/^<svg/', $thumbUrl) === 1) {
+                $imgHtml = Html::tag('div', $thumbUrl, [
+                    'class' => array_filter([
+                        'elementthumb',
+                        $element->getHasCheckeredThumb() ? 'checkered' : null,
+                        $size === self::ELEMENT_SIZE_SMALL && $element->getHasRoundedThumb() ? 'rounded' : null,
+                    ]),
+                    'data' => [
+                        'alt' => $element->getThumbAlt(),
+                    ],
+                ]);
+            } else {
+                // otherwise do what we always had
+                $imageSize2x = $thumbSizePx * 2;
+                $thumbUrl2x = $element->getThumbUrl($imageSize2x);
 
-            $srcsets = [
-                "$thumbUrl {$thumbSizePx}w",
-                "$thumbUrl2x {$imageSize2x}w",
-            ];
-            $sizesHtml = "{$thumbSizePx}px";
-            $srcsetHtml = implode(', ', $srcsets);
-            $imgHtml = Html::tag('div', '', [
-                'class' => array_filter([
-                    'elementthumb',
-                    $element->getHasCheckeredThumb() ? 'checkered' : null,
-                    $size === self::ELEMENT_SIZE_SMALL && $element->getHasRoundedThumb() ? 'rounded' : null,
-                ]),
-                'data' => [
-                    'sizes' => $sizesHtml,
-                    'srcset' => $srcsetHtml,
-                    'alt' => $element->getThumbAlt(),
-                ],
-            ]);
+                $srcsets = [
+                    "$thumbUrl {$thumbSizePx}w",
+                    "$thumbUrl2x {$imageSize2x}w",
+                ];
+                $sizesHtml = "{$thumbSizePx}px";
+                $srcsetHtml = implode(', ', $srcsets);
+                $imgHtml = Html::tag('div', '', [
+                    'class' => array_filter([
+                        'elementthumb',
+                        $element->getHasCheckeredThumb() ? 'checkered' : null,
+                        $size === self::ELEMENT_SIZE_SMALL && $element->getHasRoundedThumb() ? 'rounded' : null,
+                    ]),
+                    'data' => [
+                        'sizes' => $sizesHtml,
+                        'srcset' => $srcsetHtml,
+                        'alt' => $element->getThumbAlt(),
+                    ],
+                ]);
+            }
         } else {
             $imgHtml = '';
         }

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -645,7 +645,8 @@ class Assets extends Component
         // If it’s not an image, return a generic file extension icon
         $extension = $asset->getExtension();
         if (!Image::canManipulateAsImage($extension)) {
-            return AssetsHelper::iconUrl($extension);
+            // return an SVG markup for this icon
+            return AssetsHelper::iconHtml($extension);
         }
 
         $transform = new ImageTransform([


### PR DESCRIPTION
### Description
Load fallback asset icons as inline SVGs.

@timkelty LMK if I have missed the point here!


### Related issues
[#242](https://github.com/craftcms/cloud/issues/242)
