### PR TITLE
different handling of Date and Time for tables

### DIFF
--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -136,7 +136,7 @@ class Table extends Field
                 if (in_array($col['type'], ['date', 'time'], true)) {
                     foreach ($config['defaults'] as &$row) {
                         if (isset($row[$colId])) {
-                            $row[$colId] = DateTimeHelper::toIso8601($row[$colId]) ?: null;
+                            $row[$colId] = DateTimeHelper::toDateTime($row[$colId]) ?: null;
                         }
                     }
                 }

--- a/src/helpers/ProjectConfig.php
+++ b/src/helpers/ProjectConfig.php
@@ -271,6 +271,10 @@ class ProjectConfig
             $value = (array)$value;
         }
 
+        if ($value instanceof \DateTime) {
+            $value = DateTimeHelper::toIso8601($value);
+        }
+
         if (!empty($value) && !is_scalar($value) && !is_array($value)) {
             Craft::info('Unexpected data encountered in config data - ' . print_r($value, true));
             throw new InvalidConfigException('Unexpected data encountered in config data');


### PR DESCRIPTION
### Description
Fixes a problem where after changes from https://github.com/craftcms/cms/commit/e1714a84ec8a3db3c1a158e21bf749c4ba2816aa, default date and time fields in a table field could no longer be displayed when trying to edit the field, throwing `datefmt_create: No such time zone: '+01:00': U_ILLEGAL_ARGUMENT_ERROR`

The `IntlDateFormatter` doesn’t seem to like the `timezone_type=1` (e.g. `+01.00`).


### Related issues
#13270 
