### PR TITLE
send utilities/upgrade requests to system report

### DIFF
--- a/src/config/cproutes/common.php
+++ b/src/config/cproutes/common.php
@@ -74,6 +74,7 @@ return [
     'settings/tags/<tagGroupId:\d+>' => 'tags/edit-tag-group',
     'settings/users' => ['template' => 'settings/users/fields'],
     'utilities' => 'utilities',
+    'utilities/upgrade' => 'utilities', // to be removed when we're ready to show Upgrade to Craft 5 Utility
     'utilities/<id:[\w\-]+><extra:(\/.*)?>' => 'utilities/show-utility',
     'plugin-store' => 'plugin-store',
     'plugin-store/callback' => 'plugin-store/callback',


### PR DESCRIPTION
### Description
After Upgrading to Craft 4, the `utilities/upgrade` link will redirect to Utilities > System Report.


### Related issues
#13282 
