### PR TITLE
respect $createDynamicFolders

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -899,7 +899,7 @@ class Assets extends BaseRelationField
 
         // Ensure that the folder exists
         if (!$folder) {
-            if (!$isDynamic && !$createDynamicFolders) {
+            if (!$createDynamicFolders) {
                 throw new InvalidSubpathException($subpath);
             }
 


### PR DESCRIPTION
### Description
In 4.3, if you had an assets field with a default upload location of `{slug}`, the folder was only created on direct upload. If, by that time, the slug field was filled out (populated), then it was used; otherwise, a temporary slug was used (e.g. `temp_oxdlfzeechncdnjpultcbvhsjsbudjfxfueb`).

In 4.4, the folder was created (just in the database) on rendering the entry form and called by a temporary slug. That folder then persisted even after one based on the slug was created.

I went back to the original condition that fully respects `$createDynamicFolders` regardless of whether the folder is dynamic or not.

### Related issues
#13311 
