### PR TITLE
adjust when matrix field is reported as translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `craft\helpers\Component::cleanseConfig()`.
 - Fixed a bug where Single entries weren’t getting preloaded for template macros, if the template body wasn‘t rendered. ([#13312](https://github.com/craftcms/cms/issues/13312))
 - Fixed a bug where asset folders could get dynamically created for elements with temporary slugs. ([#13311](https://github.com/craftcms/cms/issues/13311))
+- Fixed a bug where Matrx fields with custom propagation methods were being marked as translatable if the rendered translation key was blank. ([#13329](https://github.com/craftcms/cms/issues/13329)) 
 - Fixed two RCE vulnerabilities.
 
 ## 4.4.14 - 2023-06-13

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -119,7 +119,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
 
     /**
      * @var string Propagation method
-     * @phpstan-var self::PROPAGATION_METHOD_NONE|self::PROPAGATION_METHOD_SITE_GROUP|self::PROPAGATION_METHOD_LANGUAGE|self::PROPAGATION_METHOD_ALL
+     * @phpstan-var self::PROPAGATION_METHOD_NONE|self::PROPAGATION_METHOD_SITE_GROUP|self::PROPAGATION_METHOD_LANGUAGE|self::PROPAGATION_METHOD_ALL|self::PROPAGATION_METHOD_CUSTOM
      *
      * This will be set to one of the following:
      *
@@ -635,7 +635,6 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
      */
     public function getIsTranslatable(?ElementInterface $element = null): bool
     {
-        /** @phpstan-ignore-next-line */
         if ($this->propagationMethod === self::PROPAGATION_METHOD_CUSTOM) {
             $propagationKey = Craft::$app->getView()->renderObjectTemplate($this->propagationKeyFormat, $element);
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -635,6 +635,13 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
      */
     public function getIsTranslatable(?ElementInterface $element = null): bool
     {
+        /** @phpstan-ignore-next-line */
+        if ($this->propagationMethod === self::PROPAGATION_METHOD_CUSTOM) {
+            $propagationKey = Craft::$app->getView()->renderObjectTemplate($this->propagationKeyFormat, $element);
+
+            return $element === null || $propagationKey !== '';
+        }
+
         return $this->propagationMethod !== self::PROPAGATION_METHOD_ALL;
     }
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -636,9 +636,10 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
     public function getIsTranslatable(?ElementInterface $element = null): bool
     {
         if ($this->propagationMethod === self::PROPAGATION_METHOD_CUSTOM) {
-            $propagationKey = Craft::$app->getView()->renderObjectTemplate($this->propagationKeyFormat, $element);
-
-            return $element === null || $propagationKey !== '';
+            return (
+                $element === null ||
+                Craft::$app->getView()->renderObjectTemplate($this->propagationKeyFormat, $element) !== ''
+            );
         }
 
         return $this->propagationMethod !== self::PROPAGATION_METHOD_ALL;


### PR DESCRIPTION
### Description
If the Matrix field’s propagation method is set to `custom` and the propagation key returns an empty string, the field shouldn’t be marked as translatable, just like with `base\Field` and the custom translation method.


### Related issues
#13329 
