### PR TITLE
transformed image dimensions - don't use nulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added `craft\helpers\Component::cleanseConfig()`.
 - Fixed a bug where Single entries weren’t getting preloaded for template macros, if the template body wasn‘t rendered. ([#13312](https://github.com/craftcms/cms/issues/13312))
 - Fixed a bug where asset folders could get dynamically created for elements with temporary slugs. ([#13311](https://github.com/craftcms/cms/issues/13311))
-- Fixed a bug where Matrx fields with custom propagation methods were being marked as translatable if the rendered translation key was blank. ([#13329](https://github.com/craftcms/cms/issues/13329)) 
+- Fixed a bug where Matrx fields with custom propagation methods were being marked as translatable if the rendered translation key was blank. ([#13329](https://github.com/craftcms/cms/issues/13329))
 - Fixed two RCE vulnerabilities.
 
 ## 4.4.14 - 2023-06-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug where Single entries weren’t getting preloaded for template macros, if the template body wasn‘t rendered. ([#13312](https://github.com/craftcms/cms/issues/13312))
 - Fixed a bug where asset folders could get dynamically created for elements with temporary slugs. ([#13311](https://github.com/craftcms/cms/issues/13311))
 - Fixed a bug where Matrx fields with custom propagation methods were being marked as translatable if the rendered translation key was blank. ([#13329](https://github.com/craftcms/cms/issues/13329))
+- Fixed a bug where transformed images’ `width` or `height` properties could be `null` if the transform didn’t specify both dimensions. ([#13335](https://github.com/craftcms/cms/issues/13335))
 - Fixed two RCE vulnerabilities.
 
 ## 4.4.14 - 2023-06-13

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -113,8 +113,9 @@ class Image
         }
 
         // Since we don't want to upscale, make sure the calculated ratios aren't bigger than the actual image size.
-        $newWidth = min($sourceWidth, $transformWidth, (int)round($sourceHeight * $transformRatio));
-        $newHeight = min($sourceHeight, $transformHeight, (int)round($sourceWidth / $transformRatio));
+        // transformWidth and transformHeight can be null, so check for that and if they are, use the calculatedMissingDimensions
+        $newWidth = min($sourceWidth, $transformWidth ?? $width, (int)round($sourceHeight * $transformRatio));
+        $newHeight = min($sourceHeight, $transformHeight ?? $height, (int)round($sourceWidth / $transformRatio));
 
         return [$newWidth, $newHeight];
     }


### PR DESCRIPTION
### Description
When calculating transformed image dimensions, `$transformWidth` and `$transformHeight` could be `null`. If `null` is passed to a `min()` function, it’s what will be returned. 
This PR checks if `$transformWidth` or `$transformHeight` is `null`; if they are, use the calculated missing dimension value instead.


### Related issues
#13335 
