### PR TITLE
prepare arguments for prev/next "fields"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 3.x
 
+## Unreleased
+
+- Fixed an error that occurred when passing arguments to an element’s `prev` and `next` fields via GraphQL. ([#13334](https://github.com/craftcms/cms/issues/13334))
+
 ## 3.8.14 - 2023-06-13
 
 - The `_includes/forms/date` and `_includes/forms/time` templates now accept a `timeZone` variable.

--- a/src/gql/types/elements/Element.php
+++ b/src/gql/types/elements/Element.php
@@ -9,6 +9,7 @@ namespace craft\gql\types\elements;
 
 use craft\base\ElementInterface as BaseElementInterface;
 use craft\behaviors\RevisionBehavior;
+use craft\gql\ArgumentManager;
 use craft\gql\base\ObjectType;
 use craft\gql\interfaces\Element as ElementInterface;
 use craft\services\Gql;
@@ -49,6 +50,10 @@ class Element extends ObjectType
         }
 
         if (in_array($fieldName, ['prev', 'next'])) {
+            // we need to prepare arguments for prev/next - otherwise registered argument handlers won't kick in for them
+            /** @var ArgumentManager $argumentManager */
+            $argumentManager = empty($context['argumentManager']) ? \Craft::createObject(['class' => ArgumentManager::class]) : $context['argumentManager'];
+            $arguments = $argumentManager->prepareArguments($arguments);
             return $source->{'get' . ucfirst($fieldName)}(empty($arguments) ? false : $arguments);
         }
 

--- a/src/gql/types/elements/Element.php
+++ b/src/gql/types/elements/Element.php
@@ -7,6 +7,7 @@
 
 namespace craft\gql\types\elements;
 
+use Craft;
 use craft\base\ElementInterface as BaseElementInterface;
 use craft\behaviors\RevisionBehavior;
 use craft\gql\ArgumentManager;
@@ -52,7 +53,7 @@ class Element extends ObjectType
         if (in_array($fieldName, ['prev', 'next'])) {
             // we need to prepare arguments for prev/next - otherwise registered argument handlers won't kick in for them
             /** @var ArgumentManager $argumentManager */
-            $argumentManager = empty($context['argumentManager']) ? \Craft::createObject(['class' => ArgumentManager::class]) : $context['argumentManager'];
+            $argumentManager = $context['argumentManager'] ?? Craft::createObject(['class' => ArgumentManager::class]);
             $arguments = $argumentManager->prepareArguments($arguments);
             return $source->{'get' . ucfirst($fieldName)}(empty($arguments) ? false : $arguments);
         }


### PR DESCRIPTION
### Description
Registered argument handlers were not being used for `prev` and `next` “fields”, causing `relatedToCategories`, `relatedToEntries` etc., to throw an error as there are no such properties in the `ElementQuery`.


### Related issues
#13334 
