### PR TITLE
GraphQL improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -45,6 +45,7 @@
 - Added `craft\base\FsTrait::$showHasUrlSetting`. ([#13224](https://github.com/craftcms/cms/pull/13224))
 - Added `craft\base\FsTrait::$showUrlSetting`. ([#13224](https://github.com/craftcms/cms/pull/13224))
 - Added `craft\controllers\AssetsControllerTrait`.
+- Added `craft\gql\GqlEntityRegistry::getOrCreate()`. ([#13354](https://github.com/craftcms/cms/pull/13354))
 - Added `craft\helpers\Assets::iconSvg()`.
 - Added `craft\helpers\StringHelper::escapeShortcodes()`. ([#12935](https://github.com/craftcms/cms/issues/12935))
 - Added `craft\helpers\StringHelper::unescapeShortcodes()`. ([#12935](https://github.com/craftcms/cms/issues/12935))
@@ -72,6 +73,7 @@
 - When `content` table columns are resized, if any existing values are too long, all column data is now backed up into a new table, and the overflowing values are set to `null`. ([#13025](https://github.com/craftcms/cms/pull/13025))
 - When `content` table columns are renamed, if an existing column with the same name already exists, the original column data is now backed up into a new table and then deleted from the `content` table. ([#13025](https://github.com/craftcms/cms/pull/13025))
 - Plain Text and Table fields no longer convert emoji to shortcodes on PostgreSQL.
+- Improved GraphQL performance. ([#13354](https://github.com/craftcms/cms/pull/13354))
 - Fixed a bug where Plain Text and Table fields were converting posted shortcode-looking strings to emoji. ([#12935](https://github.com/craftcms/cms/issues/12935))
 - Fixed a bug where `craft\elements\Asset::getUrl()` was returning invalid URLs for GIF and SVG assets within filesystems without base URLs, if the `transformGifs` or `transformSvgs` config settings were disabled. ([#13306](https://github.com/craftcms/cms/issues/13306)) 
 - Updated Selectize to 0.15.2. ([#13273](https://github.com/craftcms/cms/discussions/13273))

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -575,7 +575,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, GqlInlineFragm
                 'type' => $block->getType()->handle,
                 'enabled' => $block->enabled,
                 'collapsed' => $block->collapsed,
-                'fields' => $block->getSerializedFieldValues(),
+                'fields' => fn() => $block->getSerializedFieldValues(),
             ];
         }
 

--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -575,13 +575,9 @@ class Table extends Field
             return Type::listOf($argumentType);
         }
 
-        $contentFields = TableRow::prepareRowFieldDefinition($this->columns, false);
-
         $argumentType = GqlEntityRegistry::createEntity($typeName, new InputObjectType([
             'name' => $typeName,
-            'fields' => function() use ($contentFields) {
-                return $contentFields;
-            },
+            'fields' => fn() => TableRow::prepareRowFieldDefinition($this->columns, false),
         ]));
 
         return Type::listOf($argumentType);

--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -571,16 +571,10 @@ class Table extends Field
     {
         $typeName = $this->handle . '_TableRowInput';
 
-        if ($argumentType = GqlEntityRegistry::getEntity($typeName)) {
-            return Type::listOf($argumentType);
-        }
-
-        $argumentType = GqlEntityRegistry::createEntity($typeName, new InputObjectType([
+        return Type::listOf(GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
             'fields' => fn() => TableRow::prepareRowFieldDefinition($this->columns, false),
-        ]));
-
-        return Type::listOf($argumentType);
+        ])));
     }
 
     /**

--- a/src/gql/base/GqlTypeTrait.php
+++ b/src/gql/base/GqlTypeTrait.php
@@ -27,7 +27,7 @@ trait GqlTypeTrait
      */
     public static function getType(?array $fields = null): Type
     {
-        return GqlEntityRegistry::getEntity(static::class) ?: GqlEntityRegistry::createEntity(static::class, new GqlObjectType([
+        return GqlEntityRegistry::getOrCreate(static::class, fn() => new GqlObjectType([
             /** @phpstan-ignore-next-line */
             'name' => static::getName(),
             'fields' => $fields ?: (static::class . '::getFieldDefinitions'),

--- a/src/gql/directives/FormatDateTime.php
+++ b/src/gql/directives/FormatDateTime.php
@@ -35,12 +35,10 @@ class FormatDateTime extends Directive
      */
     public static function create(): GqlDirective
     {
-        if ($type = GqlEntityRegistry::getEntity(self::name())) {
-            return $type;
-        }
+        $typeName = static::name();
 
-        return GqlEntityRegistry::createEntity(static::name(), new self([
-            'name' => static::name(),
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new self([
+            'name' => $typeName,
             'locations' => [
                 DirectiveLocation::FIELD,
             ],

--- a/src/gql/directives/Markdown.php
+++ b/src/gql/directives/Markdown.php
@@ -32,12 +32,10 @@ class Markdown extends Directive
      */
     public static function create(): GqlDirective
     {
-        if ($type = GqlEntityRegistry::getEntity(self::name())) {
-            return $type;
-        }
+        $typeName = static::name();
 
-        return GqlEntityRegistry::createEntity(static::name(), new self([
-            'name' => static::name(),
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new self([
+            'name' => $typeName,
             'locations' => [
                 DirectiveLocation::FIELD,
             ],

--- a/src/gql/directives/Money.php
+++ b/src/gql/directives/Money.php
@@ -42,12 +42,10 @@ class Money extends Directive
      */
     public static function create(): GqlDirective
     {
-        if ($type = GqlEntityRegistry::getEntity(self::name())) {
-            return $type;
-        }
+        $typeName = static::name();
 
-        return GqlEntityRegistry::createEntity(static::name(), new self([
-            'name' => static::name(),
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new self([
+            'name' => $typeName,
             'locations' => [
                 DirectiveLocation::FIELD,
             ],

--- a/src/gql/directives/ParseRefs.php
+++ b/src/gql/directives/ParseRefs.php
@@ -27,12 +27,10 @@ class ParseRefs extends Directive
      */
     public static function create(): GqlDirective
     {
-        if ($type = GqlEntityRegistry::getEntity(self::name())) {
-            return $type;
-        }
+        $typeName = static::name();
 
-        return GqlEntityRegistry::createEntity(static::name(), new self([
-            'name' => static::name(),
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new self([
+            'name' => $typeName,
             'locations' => [
                 DirectiveLocation::FIELD,
             ],

--- a/src/gql/directives/Transform.php
+++ b/src/gql/directives/Transform.php
@@ -43,12 +43,10 @@ class Transform extends Directive
      */
     public static function create(): GqlDirective
     {
-        if ($type = GqlEntityRegistry::getEntity(self::name())) {
-            return $type;
-        }
+        $typeName = static::name();
 
-        return GqlEntityRegistry::createEntity(static::name(), new self([
-            'name' => static::name(),
+        return GqlEntityRegistry::getOrCreate(static::name(), fn() => new self([
+            'name' => $typeName,
             'locations' => [
                 DirectiveLocation::FIELD,
             ],

--- a/src/gql/types/DateTime.php
+++ b/src/gql/types/DateTime.php
@@ -39,7 +39,7 @@ class DateTime extends ScalarType implements SingularTypeInterface
      */
     public static function getType(): DateTime
     {
-        return GqlEntityRegistry::getEntity(self::getName()) ?: GqlEntityRegistry::createEntity(self::getName(), new self());
+        return GqlEntityRegistry::getOrCreate(self::getName(), fn() => new self());
     }
 
     /**

--- a/src/gql/types/Money.php
+++ b/src/gql/types/Money.php
@@ -42,7 +42,7 @@ class Money extends ScalarType implements SingularTypeInterface
      */
     public static function getType(): Money
     {
-        return GqlEntityRegistry::getEntity(static::getName()) ?: GqlEntityRegistry::createEntity(self::getName(), new self());
+        return GqlEntityRegistry::getOrCreate(static::getName(), fn() => new self());
     }
 
     /**

--- a/src/gql/types/Number.php
+++ b/src/gql/types/Number.php
@@ -41,7 +41,7 @@ class Number extends ScalarType implements SingularTypeInterface
      */
     public static function getType(): Number
     {
-        return GqlEntityRegistry::getEntity(static::getName()) ?: GqlEntityRegistry::createEntity(self::getName(), new self());
+        return GqlEntityRegistry::getOrCreate(static::getName(), fn() => new self());
     }
 
     /**

--- a/src/gql/types/QueryArgument.php
+++ b/src/gql/types/QueryArgument.php
@@ -45,7 +45,7 @@ class QueryArgument extends ScalarType implements SingularTypeInterface
      */
     public static function getType(): QueryArgument
     {
-        return GqlEntityRegistry::getEntity(self::getName()) ?: GqlEntityRegistry::createEntity(self::getName(), new self());
+        return GqlEntityRegistry::getOrCreate(self::getName(), fn() => new self());
     }
 
     /**

--- a/src/gql/types/generators/AddressType.php
+++ b/src/gql/types/generators/AddressType.php
@@ -43,7 +43,7 @@ class AddressType extends Generator implements GeneratorInterface, SingleGenerat
     {
         $typeName = AddressElement::gqlTypeNameByContext(null);
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Address([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new Address([
             'name' => $typeName,
             'fields' => function() use ($context, $typeName) {
                 // Users don't have different types, so the context for a user will be the same every time.

--- a/src/gql/types/generators/AddressType.php
+++ b/src/gql/types/generators/AddressType.php
@@ -41,16 +41,15 @@ class AddressType extends Generator implements GeneratorInterface, SingleGenerat
      */
     public static function generateType(mixed $context): ObjectType
     {
-        // Users don't have different types, so the context for a user will be the same every time.
-        $context = $context ?: Craft::$app->getFields()->getLayoutByType(AddressElement::class);
-
         $typeName = AddressElement::gqlTypeNameByContext(null);
-        $contentFieldGqlTypes = self::getContentFields($context);
-        $addressFields = array_merge(AddressInterface::getFieldDefinitions(), $contentFieldGqlTypes);
 
         return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Address([
             'name' => $typeName,
-            'fields' => function() use ($addressFields, $typeName) {
+            'fields' => function() use ($context, $typeName) {
+                // Users don't have different types, so the context for a user will be the same every time.
+                $context ??= Craft::$app->getFields()->getLayoutByType(AddressElement::class);
+                $contentFieldGqlTypes = self::getContentFields($context);
+                $addressFields = array_merge(AddressInterface::getFieldDefinitions(), $contentFieldGqlTypes);
                 return Craft::$app->getGql()->prepareFieldDefinitions($addressFields, $typeName);
             },
         ]));

--- a/src/gql/types/generators/AssetType.php
+++ b/src/gql/types/generators/AssetType.php
@@ -56,13 +56,12 @@ class AssetType extends Generator implements GeneratorInterface, SingleGenerator
     public static function generateType(mixed $context): ObjectType
     {
         $typeName = AssetElement::gqlTypeNameByContext($context);
-        $contentFieldGqlTypes = self::getContentFields($context);
-
-        $assetFields = array_merge(AssetInterface::getFieldDefinitions(), $contentFieldGqlTypes);
 
         return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Asset([
             'name' => $typeName,
-            'fields' => function() use ($assetFields, $typeName) {
+            'fields' => function() use ($context, $typeName) {
+                $contentFieldGqlTypes = self::getContentFields($context);
+                $assetFields = array_merge(AssetInterface::getFieldDefinitions(), $contentFieldGqlTypes);
                 return Craft::$app->getGql()->prepareFieldDefinitions($assetFields, $typeName);
             },
         ]));

--- a/src/gql/types/generators/AssetType.php
+++ b/src/gql/types/generators/AssetType.php
@@ -57,7 +57,7 @@ class AssetType extends Generator implements GeneratorInterface, SingleGenerator
     {
         $typeName = AssetElement::gqlTypeNameByContext($context);
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Asset([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new Asset([
             'name' => $typeName,
             'fields' => function() use ($context, $typeName) {
                 $contentFieldGqlTypes = self::getContentFields($context);

--- a/src/gql/types/generators/CategoryType.php
+++ b/src/gql/types/generators/CategoryType.php
@@ -56,7 +56,7 @@ class CategoryType extends Generator implements GeneratorInterface, SingleGenera
     {
         $typeName = CategoryElement::gqlTypeNameByContext($context);
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Category([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new Category([
             'name' => $typeName,
             'fields' => function() use ($context, $typeName) {
                 $contentFieldGqlTypes = self::getContentFields($context);

--- a/src/gql/types/generators/CategoryType.php
+++ b/src/gql/types/generators/CategoryType.php
@@ -55,13 +55,12 @@ class CategoryType extends Generator implements GeneratorInterface, SingleGenera
     public static function generateType(mixed $context): ObjectType
     {
         $typeName = CategoryElement::gqlTypeNameByContext($context);
-        $contentFieldGqlTypes = self::getContentFields($context);
-
-        $categoryGroupFields = array_merge(CategoryInterface::getFieldDefinitions(), $contentFieldGqlTypes);
 
         return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Category([
             'name' => $typeName,
-            'fields' => function() use ($categoryGroupFields, $typeName) {
+            'fields' => function() use ($context, $typeName) {
+                $contentFieldGqlTypes = self::getContentFields($context);
+                $categoryGroupFields = array_merge(CategoryInterface::getFieldDefinitions(), $contentFieldGqlTypes);
                 return Craft::$app->getGql()->prepareFieldDefinitions($categoryGroupFields, $typeName);
             },
         ]));

--- a/src/gql/types/generators/ElementType.php
+++ b/src/gql/types/generators/ElementType.php
@@ -40,11 +40,11 @@ class ElementType implements GeneratorInterface, SingleGeneratorInterface
     public static function generateType(mixed $context): ObjectType
     {
         $typeName = BaseElement::gqlTypeNameByContext(null);
-        $elementFields = ElementInterface::getFieldDefinitions();
 
         return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Element([
             'name' => $typeName,
-            'fields' => function() use ($elementFields, $typeName) {
+            'fields' => function() use ($typeName) {
+                $elementFields = ElementInterface::getFieldDefinitions();
                 return Craft::$app->getGql()->prepareFieldDefinitions($elementFields, $typeName);
             },
         ]));

--- a/src/gql/types/generators/ElementType.php
+++ b/src/gql/types/generators/ElementType.php
@@ -41,7 +41,7 @@ class ElementType implements GeneratorInterface, SingleGeneratorInterface
     {
         $typeName = BaseElement::gqlTypeNameByContext(null);
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Element([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new Element([
             'name' => $typeName,
             'fields' => function() use ($typeName) {
                 $elementFields = ElementInterface::getFieldDefinitions();

--- a/src/gql/types/generators/EntryType.php
+++ b/src/gql/types/generators/EntryType.php
@@ -51,11 +51,7 @@ class EntryType extends Generator implements GeneratorInterface, SingleGenerator
     {
         $typeName = EntryElement::gqlTypeNameByContext($context);
 
-        if ($createdType = GqlEntityRegistry::getEntity($typeName)) {
-            return $createdType;
-        }
-
-        return GqlEntityRegistry::createEntity($typeName, new Entry([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new Entry([
             'name' => $typeName,
             'fields' => function() use ($context, $typeName) {
                 $contentFieldGqlTypes = self::getContentFields($context);

--- a/src/gql/types/generators/EntryType.php
+++ b/src/gql/types/generators/EntryType.php
@@ -55,12 +55,11 @@ class EntryType extends Generator implements GeneratorInterface, SingleGenerator
             return $createdType;
         }
 
-        $contentFieldGqlTypes = self::getContentFields($context);
-        $entryTypeFields = array_merge(EntryInterface::getFieldDefinitions(), $contentFieldGqlTypes);
-
         return GqlEntityRegistry::createEntity($typeName, new Entry([
             'name' => $typeName,
-            'fields' => function() use ($entryTypeFields, $typeName) {
+            'fields' => function() use ($context, $typeName) {
+                $contentFieldGqlTypes = self::getContentFields($context);
+                $entryTypeFields = array_merge(EntryInterface::getFieldDefinitions(), $contentFieldGqlTypes);
                 return Craft::$app->getGql()->prepareFieldDefinitions($entryTypeFields, $typeName);
             },
         ]));

--- a/src/gql/types/generators/GlobalSetType.php
+++ b/src/gql/types/generators/GlobalSetType.php
@@ -65,7 +65,7 @@ class GlobalSetType extends Generator implements GeneratorInterface, SingleGener
     {
         $typeName = self::getName($context);
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new GlobalSet([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new GlobalSet([
             'name' => $typeName,
             'fields' => function() use ($context, $typeName) {
                 $contentFieldGqlTypes = self::getContentFields($context);

--- a/src/gql/types/generators/GlobalSetType.php
+++ b/src/gql/types/generators/GlobalSetType.php
@@ -65,13 +65,11 @@ class GlobalSetType extends Generator implements GeneratorInterface, SingleGener
     {
         $typeName = self::getName($context);
 
-        $contentFieldGqlTypes = self::getContentFields($context);
-
-        $globalSetFields = array_merge(GlobalSetInterface::getFieldDefinitions(), $contentFieldGqlTypes);
-
         return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new GlobalSet([
             'name' => $typeName,
-            'fields' => function() use ($globalSetFields, $typeName) {
+            'fields' => function() use ($context, $typeName) {
+                $contentFieldGqlTypes = self::getContentFields($context);
+                $globalSetFields = array_merge(GlobalSetInterface::getFieldDefinitions(), $contentFieldGqlTypes);
                 return Craft::$app->getGql()->prepareFieldDefinitions($globalSetFields, $typeName);
             },
         ]));

--- a/src/gql/types/generators/MatrixBlockType.php
+++ b/src/gql/types/generators/MatrixBlockType.php
@@ -57,23 +57,15 @@ class MatrixBlockType extends Generator implements GeneratorInterface, SingleGen
         $typeName = MatrixBlockElement::gqlTypeNameByContext($context);
 
         if (!($entity = GqlEntityRegistry::getEntity($typeName))) {
-            $contentFieldGqlTypes = self::getContentFields($context);
-            $blockTypeFields = array_merge(MatrixBlockInterface::getFieldDefinitions(), $contentFieldGqlTypes);
-
-            // Generate a type for each block type
-            $entity = GqlEntityRegistry::getEntity($typeName);
-
-            if (!$entity) {
-                $entity = new MatrixBlock([
-                    'name' => $typeName,
-                    'fields' => function() use ($blockTypeFields, $typeName) {
-                        return Craft::$app->getGql()->prepareFieldDefinitions($blockTypeFields, $typeName);
-                    },
-                ]);
-
-                // It's possible that creating the matrix block triggered creating all matrix block types, so check again.
-                $entity = GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, $entity);
-            }
+            $entity = new MatrixBlock([
+                'name' => $typeName,
+                'fields' => function() use ($context, $typeName) {
+                    $contentFieldGqlTypes = self::getContentFields($context);
+                    $blockTypeFields = array_merge(MatrixBlockInterface::getFieldDefinitions(), $contentFieldGqlTypes);
+                    return Craft::$app->getGql()->prepareFieldDefinitions($blockTypeFields, $typeName);
+                },
+            ]);
+            GqlEntityRegistry::createEntity($typeName, $entity);
         }
 
         return $entity;

--- a/src/gql/types/generators/MatrixBlockType.php
+++ b/src/gql/types/generators/MatrixBlockType.php
@@ -56,18 +56,13 @@ class MatrixBlockType extends Generator implements GeneratorInterface, SingleGen
     {
         $typeName = MatrixBlockElement::gqlTypeNameByContext($context);
 
-        if (!($entity = GqlEntityRegistry::getEntity($typeName))) {
-            $entity = new MatrixBlock([
-                'name' => $typeName,
-                'fields' => function() use ($context, $typeName) {
-                    $contentFieldGqlTypes = self::getContentFields($context);
-                    $blockTypeFields = array_merge(MatrixBlockInterface::getFieldDefinitions(), $contentFieldGqlTypes);
-                    return Craft::$app->getGql()->prepareFieldDefinitions($blockTypeFields, $typeName);
-                },
-            ]);
-            GqlEntityRegistry::createEntity($typeName, $entity);
-        }
-
-        return $entity;
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new MatrixBlock([
+            'name' => $typeName,
+            'fields' => function() use ($context, $typeName) {
+                $contentFieldGqlTypes = self::getContentFields($context);
+                $blockTypeFields = array_merge(MatrixBlockInterface::getFieldDefinitions(), $contentFieldGqlTypes);
+                return Craft::$app->getGql()->prepareFieldDefinitions($blockTypeFields, $typeName);
+            },
+        ]));
     }
 }

--- a/src/gql/types/generators/TableRowType.php
+++ b/src/gql/types/generators/TableRowType.php
@@ -47,7 +47,7 @@ class TableRowType implements GeneratorInterface, SingleGeneratorInterface
     {
         $typeName = self::getName($context);
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new TableRow([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new TableRow([
             'name' => $typeName,
             'fields' => function() use ($context, $typeName) {
                 /** @var TableField $context */

--- a/src/gql/types/generators/TableRowType.php
+++ b/src/gql/types/generators/TableRowType.php
@@ -45,13 +45,13 @@ class TableRowType implements GeneratorInterface, SingleGeneratorInterface
      */
     public static function generateType(mixed $context): ObjectType
     {
-        /** @var TableField $context */
         $typeName = self::getName($context);
-        $contentFields = TableRow::prepareRowFieldDefinition($context->columns);
 
         return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new TableRow([
             'name' => $typeName,
-            'fields' => function() use ($contentFields, $typeName) {
+            'fields' => function() use ($context, $typeName) {
+                /** @var TableField $context */
+                $contentFields = TableRow::prepareRowFieldDefinition($context->columns);
                 return Craft::$app->getGql()->prepareFieldDefinitions($contentFields, $typeName);
             },
         ]));

--- a/src/gql/types/generators/TagType.php
+++ b/src/gql/types/generators/TagType.php
@@ -55,12 +55,12 @@ class TagType extends Generator implements GeneratorInterface, SingleGeneratorIn
     public static function generateType(mixed $context): ObjectType
     {
         $typeName = TagElement::gqlTypeNameByContext($context);
-        $contentFieldGqlTypes = self::getContentFields($context);
-        $tagGroupFields = array_merge(TagInterface::getFieldDefinitions(), $contentFieldGqlTypes);
 
         return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Tag([
             'name' => $typeName,
-            'fields' => function() use ($tagGroupFields, $typeName) {
+            'fields' => function() use ($context, $typeName) {
+                $contentFieldGqlTypes = self::getContentFields($context);
+                $tagGroupFields = array_merge(TagInterface::getFieldDefinitions(), $contentFieldGqlTypes);
                 return Craft::$app->getGql()->prepareFieldDefinitions($tagGroupFields, $typeName);
             },
         ]));

--- a/src/gql/types/generators/TagType.php
+++ b/src/gql/types/generators/TagType.php
@@ -56,7 +56,7 @@ class TagType extends Generator implements GeneratorInterface, SingleGeneratorIn
     {
         $typeName = TagElement::gqlTypeNameByContext($context);
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new Tag([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new Tag([
             'name' => $typeName,
             'fields' => function() use ($context, $typeName) {
                 $contentFieldGqlTypes = self::getContentFields($context);

--- a/src/gql/types/generators/UserType.php
+++ b/src/gql/types/generators/UserType.php
@@ -42,7 +42,7 @@ class UserType extends Generator implements GeneratorInterface, SingleGeneratorI
     {
         $typeName = UserElement::gqlTypeNameByContext(null);
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new User([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new User([
             'name' => $typeName,
             'fields' => function() use ($context, $typeName) {
                 // Users don't have different types, so the context for a user will be the same every time.

--- a/src/gql/types/generators/UserType.php
+++ b/src/gql/types/generators/UserType.php
@@ -40,16 +40,15 @@ class UserType extends Generator implements GeneratorInterface, SingleGeneratorI
      */
     public static function generateType(mixed $context): ObjectType
     {
-        // Users don't have different types, so the context for a user will be the same every time.
-        $context = $context ?: Craft::$app->getFields()->getLayoutByType(UserElement::class);
-
         $typeName = UserElement::gqlTypeNameByContext(null);
-        $contentFieldGqlTypes = self::getContentFields($context);
-        $userFields = array_merge(UserInterface::getFieldDefinitions(), $contentFieldGqlTypes);
 
         return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new User([
             'name' => $typeName,
-            'fields' => function() use ($userFields, $typeName) {
+            'fields' => function() use ($context, $typeName) {
+                // Users don't have different types, so the context for a user will be the same every time.
+                $context ??= Craft::$app->getFields()->getLayoutByType(UserElement::class);
+                $contentFieldGqlTypes = self::getContentFields($context);
+                $userFields = array_merge(UserInterface::getFieldDefinitions(), $contentFieldGqlTypes);
                 return Craft::$app->getGql()->prepareFieldDefinitions($userFields, $typeName);
             },
         ]));

--- a/src/gql/types/input/File.php
+++ b/src/gql/types/input/File.php
@@ -26,7 +26,7 @@ class File extends InputObjectType
     {
         $typeName = 'FileInput';
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new InputObjectType([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
             'fields' => [
                 'fileData' => [

--- a/src/gql/types/input/Matrix.php
+++ b/src/gql/types/input/Matrix.php
@@ -33,17 +33,13 @@ class Matrix extends InputObjectType
     {
         $typeName = $context->handle . '_MatrixInput';
 
-        if ($inputType = GqlEntityRegistry::getEntity($typeName)) {
-            return $inputType;
-        }
-
-        return GqlEntityRegistry::createEntity($typeName, new InputObjectType([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
             'fields' => function() use ($context) {
                 // All the different field block types now get wrapped in a container input.
                 // If two different block types are passed, the selected block type to parse is undefined.
                 $blockTypeContainerName = $context->handle . '_MatrixBlockContainerInput';
-                $blockContainerInputType = GqlEntityRegistry::createEntity($blockTypeContainerName, new InputObjectType([
+                $blockContainerInputType = GqlEntityRegistry::getOrCreate($blockTypeContainerName, fn() => new InputObjectType([
                     'name' => $blockTypeContainerName,
                     'fields' => function() use ($context) {
                         $blockInputTypes = [];
@@ -52,7 +48,7 @@ class Matrix extends InputObjectType
                             $blockTypeGqlName = $context->handle . '_' . $blockType->handle . '_MatrixBlockInput';
                             $blockInputTypes[$blockType->handle] = [
                                 'name' => $blockType->handle,
-                                'type' => GqlEntityRegistry::createEntity($blockTypeGqlName, new InputObjectType([
+                                'type' => GqlEntityRegistry::getOrCreate($blockTypeGqlName, fn() => new InputObjectType([
                                     'name' => $blockTypeGqlName,
                                     'fields' => function() use ($blockType) {
                                         $blockTypeFields = [

--- a/src/gql/types/input/criteria/Asset.php
+++ b/src/gql/types/input/criteria/Asset.php
@@ -26,7 +26,7 @@ class Asset extends InputObjectType
     {
         $typeName = 'AssetCriteriaInput';
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new InputObjectType([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
             'fields' => function() {
                 return AssetArguments::getArguments();

--- a/src/gql/types/input/criteria/Category.php
+++ b/src/gql/types/input/criteria/Category.php
@@ -26,7 +26,7 @@ class Category extends InputObjectType
     {
         $typeName = 'CategoryCriteriaInput';
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new InputObjectType([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
             'fields' => function() {
                 return CategoryArguments::getArguments();

--- a/src/gql/types/input/criteria/Entry.php
+++ b/src/gql/types/input/criteria/Entry.php
@@ -26,7 +26,7 @@ class Entry extends InputObjectType
     {
         $typeName = 'EntryCriteriaInput';
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new InputObjectType([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
             'fields' => function() {
                 return EntryArguments::getArguments();

--- a/src/gql/types/input/criteria/Tag.php
+++ b/src/gql/types/input/criteria/Tag.php
@@ -26,7 +26,7 @@ class Tag extends InputObjectType
     {
         $typeName = 'TagCriteriaInput';
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new InputObjectType([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
             'fields' => function() {
                 return TagArguments::getArguments();

--- a/src/gql/types/input/criteria/User.php
+++ b/src/gql/types/input/criteria/User.php
@@ -26,7 +26,7 @@ class User extends InputObjectType
     {
         $typeName = 'UserCriteriaInput';
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new InputObjectType([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
             'fields' => function() {
                 return UserArguments::getArguments();

--- a/src/helpers/Gql.php
+++ b/src/helpers/Gql.php
@@ -292,13 +292,9 @@ class Gql
      */
     public static function getUnionType(string $typeName, array $includedTypes, ?callable $resolveFunction = null): mixed
     {
-        if (!$resolveFunction) {
-            $resolveFunction = function(ElementInterface $value) {
-                return $value->getGqlTypeName();
-            };
-        }
+        $resolveFunction ??= fn(ElementInterface $value) => $value->getGqlTypeName();
 
-        return GqlEntityRegistry::getEntity($typeName) ?: GqlEntityRegistry::createEntity($typeName, new UnionType([
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new UnionType([
             'name' => $typeName,
             'types' => $includedTypes,
             'resolveType' => $resolveFunction,

--- a/src/test/mockclasses/gql/MockType.php
+++ b/src/test/mockclasses/gql/MockType.php
@@ -22,7 +22,7 @@ class MockType extends ScalarType
      */
     public static function getType(): MockType
     {
-        return GqlEntityRegistry::getEntity(self::getName()) ?: GqlEntityRegistry::createEntity(self::getName(), new self());
+        return GqlEntityRegistry::getOrCreate(self::getName(), fn() => new self());
     }
 
     /**

--- a/tests/unit/gql/DirectiveTest.php
+++ b/tests/unit/gql/DirectiveTest.php
@@ -197,8 +197,7 @@ class DirectiveTest extends TestCase
             ]),
         ]));
 
-        if (!GqlEntityRegistry::getEntity($directiveName)) {
-            GqlEntityRegistry::createEntity($directiveName, $className::create());
-        }
+        /** @var string|Directive $className */
+        GqlEntityRegistry::getOrCreate($directiveName, fn() => $className::create());
     }
 }

--- a/tests/unit/gql/InterfaceAndGeneratorTest.php
+++ b/tests/unit/gql/InterfaceAndGeneratorTest.php
@@ -13,7 +13,6 @@ use craft\elements\Asset as AssetElement;
 use craft\elements\Category as CategoryElement;
 use craft\elements\Entry as EntryElement;
 use craft\elements\GlobalSet as GlobalSetElement;
-use craft\elements\MatrixBlock as MatrixBlockElement;
 use craft\elements\Tag as TagElement;
 use craft\elements\User as UserElement;
 use craft\errors\GqlException;
@@ -28,7 +27,6 @@ use craft\gql\interfaces\elements\Asset as AssetInterface;
 use craft\gql\interfaces\elements\Category as CategoryInterface;
 use craft\gql\interfaces\elements\Entry as EntryInterface;
 use craft\gql\interfaces\elements\GlobalSet as GlobalSetInterface;
-use craft\gql\interfaces\elements\MatrixBlock as MatrixBlockInterface;
 use craft\gql\interfaces\elements\Tag as TagInterface;
 use craft\gql\interfaces\elements\User as UserInterface;
 use craft\gql\TypeLoader;
@@ -219,7 +217,6 @@ class InterfaceAndGeneratorTest extends TestCase
             [GlobalSetInterface::class, [$this, 'mockGlobalSets'], [GlobalSetElement::class, 'gqlTypeNameByContext']],
             [CategoryInterface::class, [$this, 'mockCategoryGroups'], [CategoryElement::class, 'gqlTypeNameByContext']],
             [TagInterface::class, [$this, 'mockTagGroups'], [TagElement::class, 'gqlTypeNameByContext']],
-            [MatrixBlockInterface::class, [$this, 'mockMatrixBlocks'], [MatrixBlockElement::class, 'gqlTypeNameByContext']],
             [
                 UserInterface::class, function() {
                     return ['User'];

--- a/tests/unit/gql/mutations/InputTypeTest.php
+++ b/tests/unit/gql/mutations/InputTypeTest.php
@@ -8,19 +8,14 @@
 namespace crafttests\unit\gql\mutations;
 
 use craft\base\Field;
-use craft\fieldlayoutelements\CustomField;
 use craft\fields\Checkboxes;
 use craft\fields\Dropdown;
 use craft\fields\Matrix as MatrixField;
 use craft\fields\MultiSelect;
-use craft\fields\PlainText;
 use craft\fields\RadioButtons;
 use craft\gql\GqlEntityRegistry;
 use craft\gql\types\input\File;
 use craft\gql\types\input\Matrix;
-use craft\models\FieldLayout;
-use craft\models\FieldLayoutTab;
-use craft\models\MatrixBlockType;
 use craft\test\TestCase;
 use GraphQL\Type\Definition\InputType;
 use GraphQL\Type\Definition\ListOfType;
@@ -60,23 +55,20 @@ class InputTypeTest extends TestCase
     }
 
     /**
-     * @dataProvider testMatrixInputDataProvider
-     * @param MatrixField $matrixField
-     * @param MatrixBlockType[] $blockTypes
+     *
      */
-    public function testMatrixInput(MatrixField $matrixField, array $blockTypes): void
+    public function testMatrixInput(): void
     {
+        $matrixField = new MatrixField([
+            'handle' => 'matrixField',
+        ]);
+
         // Trigger addition to the registry
         Matrix::getType($matrixField);
 
         $fieldTypeName = $matrixField->handle . '_MatrixInput';
         self::assertNotFalse(GqlEntityRegistry::getEntity($fieldTypeName));
-        self::assertNotFalse(GqlEntityRegistry::getEntity($matrixField->handle . '_MatrixBlockContainerInput'));
         self::assertNotEmpty(GqlEntityRegistry::getEntity($fieldTypeName)->getFields());
-
-        foreach ($blockTypes as $blockType) {
-            self::assertNotFalse(GqlEntityRegistry::getEntity($matrixField->handle . '_' . $blockType->handle . '_MatrixBlockInput'));
-        }
     }
 
     /**
@@ -89,45 +81,6 @@ class InputTypeTest extends TestCase
     public function testMatrixInputValueNormalization(array $input, array $normalized): void
     {
         self::assertEquals($normalized, Matrix::normalizeValue($input));
-    }
-
-    public function testMatrixInputDataProvider(): array
-    {
-        $data = [];
-
-        $matrixField = new MatrixField([
-            'handle' => 'matrixField',
-        ]);
-
-        $blockTypes = [];
-
-        for ($j = 0; $j < 3; $j++) {
-            $blockType = new MatrixBlockType([
-                'handle' => 'blockType' . ($j + 1),
-            ]);
-
-            $layoutElements = [];
-
-            for ($k = 0; $k < 3; $k++) {
-                $layoutElements[] = new CustomField(new PlainText([
-                    'handle' => "nestedField$k",
-                ]));
-            }
-
-            $fieldLayout = new FieldLayout();
-            $tab = new FieldLayoutTab();
-            $fieldLayout->setTabs([$tab]);
-            $tab->setElements($layoutElements);
-            $blockType->setFieldLayout($fieldLayout);
-
-            $blockTypes[] = $blockType;
-        }
-
-        $matrixField->setBlockTypes($blockTypes);
-
-        $data[] = [$matrixField, $blockTypes];
-
-        return $data;
     }
 
     public function matrixInputValueNormalizerDataProvider(): array


### PR DESCRIPTION
Moves all dynamic `fields` definition code fully into the callback function, improving performance and reducing the likelihood of an infinite recursion bug.

Also introduces `GqlEntityRegistry::getOrCreate()`, which provides a slightly nicer way to return an entity or create one if it doesn’t exist yet.
