### PR TITLE
Keep existing video asset dimensions (if set) for newly uploaded assets

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -3148,6 +3148,9 @@ JS;
 
             if ($this->kind === self::KIND_IMAGE) {
                 [$this->_width, $this->_height] = Image::imageSize($tempPath);
+            } elseif ($this->kind === self::KIND_VIDEO) {
+                $this->_width = $this->_width ?? null;
+                $this->_height = $this->_height ?? null;
             } else {
                 $this->_width = null;
                 $this->_height = null;


### PR DESCRIPTION
### Description

After issue #9038 a [change was made](https://github.com/craftcms/cms/commit/738906772dcac69efcb3f95843dea49d08aea5b0) to allow for outputting video asset dimensions if they exist, instead of returning `[null, null]` for all video assets (the previous behavior):

```
if (!in_array($this->kind, [self::KIND_IMAGE, self::KIND_VIDEO], true)) {
   return [null, null];
}
```

I've written a plugin that sets an uploaded video asset's dimensions.

Unfortunately those values are currently being [overwritten](https://github.com/craftcms/cms/blob/2071a07d13b7c5bb79854ea2b7032264bdf9fecc/src/elements/Asset.php#L3152C15-L3153) by the Asset element's `_relocateFile()` function:

```
if ($this->kind === self::KIND_IMAGE) {
   [$this->_width, $this->_height] = Image::imageSize($tempPath);
} else {
   $this->_width = null;
   $this->_height = null;
}
```

This PR expands on the [original change](https://github.com/craftcms/cms/commit/738906772dcac69efcb3f95843dea49d08aea5b0) and fixes the issue by checking if video assets (and only video assets) have existing values for `$this->_width` and `$this->_height` and, if that is the case, keeps those. Otherwise, they will be set to `null` like before, avoiding any side effects. 

### Related issues
#9038 
