### PR TITLE
don't enforce orderBy for eager-loaded categories

### DIFF
--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -130,13 +130,6 @@ class Categories extends BaseRelationField
         return parent::inputHtml($value, $element);
     }
 
-    public function getEagerLoadingMap(array $sourceElements): array|null|false
-    {
-        $map = parent::getEagerLoadingMap($sourceElements);
-        $map['criteria']['orderBy'] = ['structureelements.lft' => SORT_ASC];
-        return $map;
-    }
-
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
### Description
Don’t always add `orderBy` when eager-loading Categories.

Instead, follow the same logic as for Entries - use `orderBy` (to order by structure order) when the field is supposed to maintain the hierarchy.


### Related issues
#13394 
