### PR TITLE
added creatorId to createDraft mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improved performance when loading users with eager-loaded `addresses`. ([#13400](https://github.com/craftcms/cms/issues/13400))
+- `createDraft` GraphQL mutations now support a `creatorId` argument. ([#13401](https://github.com/craftcms/cms/issues/13401))
 - Added `craft\elements\Address::setOwner()`.
 - `craft\base\ElementInterface::eagerLoadingMap()` can now include a `createElement` key in the returned array, which defines a target element factory function.
 - Fixed a bug where entry titles could overflow within Entries fields with “Maintain hierarchy” enabled. ([#13382](https://github.com/craftcms/cms/issues/13382))

--- a/src/gql/mutations/Entry.php
+++ b/src/gql/mutations/Entry.php
@@ -107,6 +107,11 @@ class Entry extends Mutation
                             'type' => Type::boolean(),
                             'description' => 'Whether the draft should be a provisional draft.',
                         ],
+                        'creatorId' => [
+                            'name' => 'creatorId',
+                            'type' => Type::int(),
+                            'description' => 'The id of the creator of the draft.',
+                        ],
                     ],
                     'resolve' => [$resolver, 'createDraft'],
                     'description' => 'Create a draft for an entry and return the draft ID.',

--- a/src/gql/resolvers/mutations/Entry.php
+++ b/src/gql/resolvers/mutations/Entry.php
@@ -146,7 +146,7 @@ class Entry extends ElementMutationResolver
         $draftName = $arguments['name'] ?? '';
         $draftNotes = $arguments['notes'] ?? '';
         $provisional = $arguments['provisional'] ?? false;
-        $creatorId = $arguments['creatorId'];
+        $creatorId = $arguments['creatorId'] ?? null;
 
         /** @var EntryElement|DraftBehavior $draft */
         $draft = Craft::$app->getDrafts()->createDraft($entry, $creatorId ?? $entry->getAuthorId(), $draftName, $draftNotes, [], $provisional);

--- a/src/gql/resolvers/mutations/Entry.php
+++ b/src/gql/resolvers/mutations/Entry.php
@@ -146,9 +146,10 @@ class Entry extends ElementMutationResolver
         $draftName = $arguments['name'] ?? '';
         $draftNotes = $arguments['notes'] ?? '';
         $provisional = $arguments['provisional'] ?? false;
+        $creatorId = $arguments['creatorId'];
 
         /** @var EntryElement|DraftBehavior $draft */
-        $draft = Craft::$app->getDrafts()->createDraft($entry, $entry->getAuthorId(), $draftName, $draftNotes, [], $provisional);
+        $draft = Craft::$app->getDrafts()->createDraft($entry, $creatorId ?? $entry->getAuthorId(), $draftName, $draftNotes, [], $provisional);
 
         return $draft->draftId;
     }


### PR DESCRIPTION
### Description
Adds `creatorId` to `createDraft` mutation.


### Related issues
#13401 
