### PR TITLE
Add `targetElementRecord` to before/after move element in structure function and events

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -66,6 +66,7 @@ use craft\helpers\UrlHelper;
 use craft\i18n\Formatter;
 use craft\models\FieldLayout;
 use craft\models\Site;
+use craft\records\StructureElement;
 use craft\validators\DateTimeValidator;
 use craft\validators\ElementUriValidator;
 use craft\validators\SiteIdValidator;
@@ -5079,11 +5080,12 @@ JS,
     /**
      * @inheritdoc
      */
-    public function beforeMoveInStructure(int $structureId): bool
+    public function beforeMoveInStructure(int $structureId, StructureElement $targetElementRecord): bool
     {
         // Trigger a 'beforeMoveInStructure' event
         $event = new ElementStructureEvent([
             'structureId' => $structureId,
+            'targetElementRecord' => $targetElementRecord,
         ]);
         $this->trigger(self::EVENT_BEFORE_MOVE_IN_STRUCTURE, $event);
 
@@ -5093,12 +5095,13 @@ JS,
     /**
      * @inheritdoc
      */
-    public function afterMoveInStructure(int $structureId): void
+    public function afterMoveInStructure(int $structureId, StructureElement $targetElementRecord): void
     {
         // Trigger an 'afterMoveInStructure' event
         if ($this->hasEventHandlers(self::EVENT_AFTER_MOVE_IN_STRUCTURE)) {
             $this->trigger(self::EVENT_AFTER_MOVE_IN_STRUCTURE, new ElementStructureEvent([
                 'structureId' => $structureId,
+                'targetElementRecord' => $targetElementRecord,
             ]));
         }
 

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -15,6 +15,7 @@ use craft\elements\User;
 use craft\errors\InvalidFieldException;
 use craft\models\FieldLayout;
 use craft\models\Site;
+use craft\records\StructureElement;
 use Illuminate\Support\Collection;
 use Twig\Markup;
 use yii\web\Response;
@@ -1661,16 +1662,18 @@ interface ElementInterface extends ComponentInterface
      * Performs actions before an element is moved within a structure.
      *
      * @param int $structureId The structure ID
+     * @param StructureElement $targetElementRecord The Structure element record for the item to be moved
      * @return bool Whether the element should be moved within the structure
      */
-    public function beforeMoveInStructure(int $structureId): bool;
+    public function beforeMoveInStructure(int $structureId, StructureElement $targetElementRecord): bool;
 
     /**
      * Performs actions after an element is moved within a structure.
      *
      * @param int $structureId The structure ID
+     * @param StructureElement $targetElementRecord The Structure element record for the item moved
      */
-    public function afterMoveInStructure(int $structureId): void;
+    public function afterMoveInStructure(int $structureId, StructureElement $targetElementRecord): void;
 
     /**
      * Returns the string representation of the element.

--- a/src/events/ElementStructureEvent.php
+++ b/src/events/ElementStructureEvent.php
@@ -7,6 +7,8 @@
 
 namespace craft\events;
 
+use craft\records\StructureElement;
+
 /**
  * ElementStructureEvent class.
  *
@@ -19,4 +21,9 @@ class ElementStructureEvent extends ModelEvent
      * @var int The structure ID
      */
     public int $structureId;
+
+    /**
+     * @var StructureElement The target structure element record
+     */
+    public StructureElement $targetElementRecord;
 }

--- a/src/events/MoveElementEvent.php
+++ b/src/events/MoveElementEvent.php
@@ -7,6 +7,8 @@
 
 namespace craft\events;
 
+use craft\records\StructureElement;
+
 /**
  * Move element event class.
  *
@@ -19,4 +21,9 @@ class MoveElementEvent extends ElementEvent
      * @var int The ID of the structure the element is being moved within.
      */
     public int $structureId;
+
+    /**
+     * @var StructureElement The target structure element record
+     */
+    public StructureElement $targetElementRecord;
 }

--- a/src/services/Structures.php
+++ b/src/services/Structures.php
@@ -510,11 +510,12 @@ class Structures extends Component
             $this->trigger(self::EVENT_BEFORE_MOVE_ELEMENT, new MoveElementEvent([
                 'structureId' => $structureId,
                 'element' => $element,
+                'targetElementRecord' => $targetElementRecord,
             ]));
         }
 
         // Tell the element about it
-        if (!$element->beforeMoveInStructure($structureId)) {
+        if (!$element->beforeMoveInStructure($structureId, $targetElementRecord)) {
             $mutex->release($lockName);
             return false;
         }
@@ -546,7 +547,7 @@ class Structures extends Component
             $element->level = $values['level'];
 
             // Tell the element about it
-            $element->afterMoveInStructure($structureId);
+            $element->afterMoveInStructure($structureId, $targetElementRecord);
 
             $transaction->commit();
         } catch (Throwable $e) {
@@ -560,6 +561,7 @@ class Structures extends Component
             $this->trigger(self::EVENT_AFTER_MOVE_ELEMENT, new MoveElementEvent([
                 'structureId' => $structureId,
                 'element' => $element,
+                'targetElementRecord' => $targetElementRecord,
             ]));
         }
 


### PR DESCRIPTION
I have a use case where my element needs validation rules when moving it within a structure. See https://github.com/verbb/navigation/issues/359 where I want to enforce user-defined rules on how many nodes for a particular level there can be.

Fortunately, I can use the `Element::beforeMoveInStructure()` function (or the `Element::EVENT_BEFORE_MOVE_IN_STRUCTURE` event if I wanted) to trigger validation with `element->validate()`. However, one glaring issue is that I cannot get the to-be-moved element information from the function or event, because it's not passed to it.

For example, if I want validation rules to check if something can be placed at `level` 2 if something is currently at level 1, there's no way for me to know what the new level will be, until after the fact. I only know about the `level` of it currently.

This information can be grabbed from [`$targetElementRecord`](https://github.com/craftcms/cms/blob/75089d5f7a15396f2601ac92f031e4f13d1375e1/src/services/Structures.php#L478).

Happy to revise this, or let me know if I've gone about this the wrong way.