### PR TITLE
GC for orphaned site entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improved performance when loading users with eager-loaded `addresses`. ([#13400](https://github.com/craftcms/cms/issues/13400))
 - `createDraft` GraphQL mutations now support a `creatorId` argument. ([#13401](https://github.com/craftcms/cms/issues/13401))
+- Garbage collection now deletes entries for sites that aren’t supported by their section. ([#13383](https://github.com/craftcms/cms/issues/13383))
 - Added `craft\elements\Address::setOwner()`.
 - `craft\base\ElementInterface::eagerLoadingMap()` can now include a `createElement` key in the returned array, which defines a target element factory function.
 - Fixed a bug where entry titles could overflow within Entries fields with “Maintain hierarchy” enabled. ([#13382](https://github.com/craftcms/cms/issues/13382))


### PR DESCRIPTION
### Description
If you entrify categories/tags/global sets, change the settings of the section used in entrification to, e.g. turn it off for one of the sites, deploy, apply the project config changes and then run the entrification command, the entrified entries will still exist for the site the section was turned off for. 

This PR adds a new method to the Garbage Collection that deletes entries for a site not enabled for a section.


### Related issues
#13383 
