### PR TITLE
Fluent/Static Config Fixes

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -228,9 +228,9 @@ class GeneralConfig extends BaseConfig
      *
      * ```php Static Config
      * // Nothing bug GIFs!
-     * 'allowedFileExtensions' => [
+     * ->allowedFileExtensions([
      *     'gif',
-     * ],
+     * ])
      * ```
      *
      * @see extraAllowedFileExtensions
@@ -393,7 +393,7 @@ class GeneralConfig extends BaseConfig
      *
      * ::: code
      * ```php Static Config
-     * 'autosaveDrafts' => false,
+     * ->autosaveDrafts(false)
      * ```
      * ```shell Environment Override
      * CRAFT_AUTOSAVE_DRAFTS=false
@@ -827,7 +827,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // One week
-     * 'defaultTokenDuration' => 604800,
+     * ->defaultTokenDuration(604800)
      * ```
      * ```shell Environment Override
      * # One week
@@ -1232,7 +1232,7 @@ class GeneralConfig extends BaseConfig
      *
      * ::: code
      * ```php Static Config
-     * 'extraLastNamePrefixes' => ['Dal', 'Van Der'],
+     * ->extraLastNamePrefixes(['Dal', 'Van Der'])
      * ```
      * ```shell Environment Override
      * CRAFT_EXTRA_LAST_NAME_PREFIXES="Dal,Van Der"
@@ -1249,7 +1249,7 @@ class GeneralConfig extends BaseConfig
      *
      * ::: code
      * ```php Static Config
-     * 'extraNameSalutations' => ['Lady', 'Sire'],
+     * ->extraNameSalutations(['Lady', 'Sire'])
      * ```
      * ```shell Environment Override
      * CRAFT_EXTRA_NAME_SALUTATIONS=Lady,Sire
@@ -1266,7 +1266,7 @@ class GeneralConfig extends BaseConfig
      *
      * ::: code
      * ```php Static Config
-     * 'extraNameSuffixes' => ['CCNA', 'OBE'],
+     * ->extraNameSuffixes(['CCNA', 'OBE'])
      * ```
      * ```shell Environment Override
      * CRAFT_EXTRA_NAME_SUFFIXES=CCNA,OBE
@@ -1471,7 +1471,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 1 day
-     * 'invalidLoginWindowDuration' => 86400,
+     * ->invalidLoginWindowDuration(86400)
      * ```
      * ```shell Environment Override
      * # 1 day
@@ -1493,7 +1493,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 1 day
-     * 'invalidUserTokenPath' => 'nope',
+     * ->invalidUserTokenPath('nope')
      * ```
      * ```shell Environment Override
      * # 1 day
@@ -2177,7 +2177,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 2 weeks
-     * 'purgePendingUsersDuration' => 1209600,
+     * ->purgePendingUsersDuration(1209600)
      * ```
      * ```shell Environment Override
      * # 2 weeks
@@ -2199,7 +2199,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 1 week
-     * 'purgeStaleUserSessionDuration' => 604800,
+     * ->purgeStaleUserSessionDuration(604800)
      * ```
      * ```shell Environment Override
      * # 1 week
@@ -3011,7 +3011,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 3 hours
-     * 'userSessionDuration' => 10800,
+     * ->userSessionDuration(10800)
      * ```
      * ```shell Environment Override
      * # 3 hours
@@ -3053,7 +3053,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 1 hour
-     * 'verificationCodeDuration' => 3600,
+     * ->verificationCodeDuration(3600)
      * ```
      * ```shell Environment Override
      * # 1 hour

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1752,7 +1752,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 25MB
-     * ->maxUploadFileSize(26214400),
+     * ->maxUploadFileSize(26214400)
      * ```
      * ```shell Environment Override
      * # 25MB

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -2128,7 +2128,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 1 hour
-     * 'previewTokenDuration' => 3600,
+     * ->previewTokenDuration(3600)
      * ```
      * ```shell Environment Override
      * # 1 hour

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1752,7 +1752,7 @@ class GeneralConfig extends BaseConfig
      * ::: code
      * ```php Static Config
      * // 25MB
-     * 'maxUploadFileSize' => 26214400,
+     * ->maxUploadFileSize(26214400),
      * ```
      * ```shell Environment Override
      * # 25MB


### PR DESCRIPTION
### Description

@olivierbon [noticed that a setting or two](https://github.com/craftcms/docs/pull/513) still used the "static" syntax, and issued a docs PR to correct—but it'll have to be handled in `cms` to prevent the changes getting squashed on the next build.

This only affects docblocks; no actual code updates.

### Related issues

- https://github.com/craftcms/docs/pull/513