### PR TITLE
Setup variable agreement

### DIFF
--- a/src/console/controllers/SetupController.php
+++ b/src/console/controllers/SetupController.php
@@ -282,7 +282,7 @@ EOD;
 
         if (!$this->password && $this->interactive) {
             $envPassword = App::env('CRAFT_DB_PASSWORD');
-            if ($envPassword && $this->confirm('Use the password provided by $DB_PASSWORD?', true)) {
+            if ($envPassword && $this->confirm('Use the password provided by $CRAFT_DB_PASSWORD?', true)) {
                 $this->password = $envPassword;
             } else {
                 $this->stdout('Database password: ');


### PR DESCRIPTION
### Description

During setup, I noticed that Craft asked if I wanted to use the password in `$DB_PASSWORD`, but I hadn't defined that environment variable:

```
Which database driver are you using? (mysql or pgsql) [pgsql]
Database server name or IP address: [db]
Database port: [5432]
Database username: [db]
Use the password provided by $DB_PASSWORD? (yes|no) [yes]:no
Database password:
Database name: [db]
Database table prefix:
...
```

Craft _is_ pulling from the expected config override variable (`CRAFT_DB_PASSWORD`), so it's only the messaging that needed correction!