### PR TITLE
Feature/dev 1159 improve structure events

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -55,6 +55,9 @@
 - Added `craft\controllers\AssetsControllerTrait`.
 - Added `craft\elements\db\ElementQuery::EVENT_BEFORE_POPULATE_ELEMENT`.
 - Added `craft\events\DefineAddressSubdivisionsEvent`. ([#13361](https://github.com/craftcms/cms/pull/13361))
+- Added `craft\events\MoveElementEvent::$action`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Added `craft\events\MoveElementEvent::$targetElementId`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Added `craft\events\MoveElementEvent::getTargetElement()`. ([#13429](https://github.com/craftcms/cms/pull/13429))
 - Added `craft\gql\GqlEntityRegistry::getOrCreate()`. ([#13354](https://github.com/craftcms/cms/pull/13354))
 - Added `craft\helpers\Assets::iconSvg()`.
 - Added `craft\helpers\StringHelper::escapeShortcodes()`. ([#12935](https://github.com/craftcms/cms/issues/12935))
@@ -63,14 +66,26 @@
 - Added `craft\services\Addresses::$formatter`, which can be used to override the default address formatter. ([#13242](https://github.com/craftcms/cms/pull/13242), [#12615](https://github.com/craftcms/cms/discussions/12615))
 - Added `craft\services\Addresses::EVENT_DEFINE_ADDRESS_SUBDIVISIONS`. ([#13361](https://github.com/craftcms/cms/pull/13361))
 - Added `craft\services\Addresses::defineAddressSubdivisions()`. ([#13361](https://github.com/craftcms/cms/pull/13361))
+- Added `craft\services\Structures::ACTION_APPEND`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Added `craft\services\Structures::ACTION_PLACE_AFTER`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Added `craft\services\Structures::ACTION_PLACE_BEFORE`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Added `craft\services\Structures::ACTION_PREPEND`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Added `craft\services\Structures::EVENT_AFTER_INSERT_ELEMENT`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Added `craft\services\Structures::EVENT_BEFORE_INSERT_ELEMENT`. ([#13429](https://github.com/craftcms/cms/pull/13429))
 - Added `craft\web\CpScreenResponseBehavior::$pageSidebar`, `pageSidebar()`, and `pageSidebarTemplate()`. ([#13019](https://github.com/craftcms/cms/pull/13019), [#12795](https://github.com/craftcms/cms/issues/12795))
 - Added `craft\web\CpScreenResponseBehavior::$slideoutBodyClass`.
 - `craft\helpers\Cp::selectizeFieldHtml()`, `selectizeHtml()`, and `_includes/forms/selectize.twig` now support a `multi` param. ([#13176](https://github.com/craftcms/cms/pull/13176))
 - `craft\helpers\Typecast::properties()` now supports backed enum values. ([#13371](https://github.com/craftcms/cms/pull/13371))
 - `craft\services\Assets::getRootFolderByVolumeId()` now ensures the root folder actually exists, and caches its results internally, improving performance. ([#13297](https://github.com/craftcms/cms/issues/13297))
 - `craft\services\Assets::getThumbUrl()` now has an `$iconFallback` argument, which can be set to `false` to prevent a file icon URL from being returned as a fallback for assets that don’t have image thumbnails.
+- `craft\services\Structures::EVENT_BEFORE_MOVE_ELEMENT` is now cancellable. ([#13429](https://github.com/craftcms/cms/pull/13429))
 - `craft\validators\UniqueValidator` now supports setting an additional filter via the `filter` property. ([#12941](https://github.com/craftcms/cms/pull/12941))
 - `craft\web\UrlManager` no longer triggers its `EVENT_REGISTER_CP_URL_RULES` and `EVENT_REGISTER_SITE_URL_RULES` events until the request is ready to be routed, making it safe to call `UrlManager::addRules()` from plugin/module constructors. ([#13109](https://github.com/craftcms/cms/issues/13109))
+- Deprecated `craft\base\Element::EVENT_AFTER_MOVE_IN_STRUCTURE`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Deprecated `craft\base\Element::EVENT_BEFORE_MOVE_IN_STRUCTURE`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Deprecated `craft\base\Element::afterMoveInStructure()`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Deprecated `craft\base\Element::beforeMoveInStructure()`. ([#13429](https://github.com/craftcms/cms/pull/13429))
+- Deprecated `craft\events\ElementStructureEvent`. ([#13429](https://github.com/craftcms/cms/pull/13429))
 - Deprecated `craft\helpers\ArrayHelper::firstKey()`. `array_key_first()` should be used instead.
 - Deprecated `craft\helpers\Assets::iconPath()`. `craft\helpers\Assets::iconSvg()` or `craft\elements\Asset::getThumbHtml()` should be used instead.
 - Deprecated `craft\helpers\Assets::iconUrl()`.

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -729,11 +729,18 @@ abstract class Element extends Component implements ElementInterface
      * @event ElementStructureEvent The event that is triggered before the element is moved in a structure.
      *
      * You may set [[\yii\base\ModelEvent::$isValid]] to `false` to prevent the element from getting moved.
+     *
+     * @deprecated in 4.5.0. [[\craft\services\Structures::EVENT_BEFORE_INSERT_ELEMENT]] or
+     * [[\craft\services\Structures::EVENT_BEFORE_MOVE_ELEMENT|EVENT_BEFORE_MOVE_ELEMENT]]
+     * should be used instead.
      */
     public const EVENT_BEFORE_MOVE_IN_STRUCTURE = 'beforeMoveInStructure';
 
     /**
      * @event ElementStructureEvent The event that is triggered after the element is moved in a structure.
+     * @deprecated in 4.5.0. [[\craft\services\Structures::EVENT_AFTER_INSERT_ELEMENT]] or
+     * [[\craft\services\Structures::EVENT_AFTER_MOVE_ELEMENT|EVENT_AFTER_MOVE_ELEMENT]]
+     * should be used instead.
      */
     public const EVENT_AFTER_MOVE_IN_STRUCTURE = 'afterMoveInStructure';
 

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -1702,6 +1702,9 @@ interface ElementInterface extends ComponentInterface
      *
      * @param int $structureId The structure ID
      * @return bool Whether the element should be moved within the structure
+     * @deprecated in 4.5.0. [[\craft\services\Structures::EVENT_BEFORE_INSERT_ELEMENT]] or
+     * [[\craft\services\Structures::EVENT_BEFORE_MOVE_ELEMENT|EVENT_BEFORE_MOVE_ELEMENT]]
+     * should be used instead.
      */
     public function beforeMoveInStructure(int $structureId): bool;
 
@@ -1709,6 +1712,9 @@ interface ElementInterface extends ComponentInterface
      * Performs actions after an element is moved within a structure.
      *
      * @param int $structureId The structure ID
+     * @deprecated in 4.5.0. [[\craft\services\Structures::EVENT_AFTER_INSERT_ELEMENT]] or
+     * [[\craft\services\Structures::EVENT_AFTER_MOVE_ELEMENT|EVENT_AFTER_MOVE_ELEMENT]]
+     * should be used instead.
      */
     public function afterMoveInStructure(int $structureId): void;
 

--- a/src/events/ElementStructureEvent.php
+++ b/src/events/ElementStructureEvent.php
@@ -12,6 +12,10 @@ namespace craft\events;
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
+ * @deprecated in 4.5.0. [[\craft\services\Structures::EVENT_BEFORE_INSERT_ELEMENT]],
+ * [[\craft\services\Structures::EVENT_AFTER_INSERT_ELEMENT|EVENT_AFTER_INSERT_ELEMENT]],
+ * [[\craft\services\Structures::EVENT_BEFORE_MOVE_ELEMENT|EVENT_BEFORE_MOVE_ELEMENT]] and
+ * [[\craft\services\Structures::EVENT_AFTER_MOVE_ELEMENT|EVENT_AFTER_MOVE_ELEMENT]] should be used instead.
  */
 class ElementStructureEvent extends ModelEvent
 {

--- a/src/events/MoveElementEvent.php
+++ b/src/events/MoveElementEvent.php
@@ -34,8 +34,8 @@ class MoveElementEvent extends ElementEvent
 
     /**
      * @var string The type of structure action being performed (one of [[Structures::ACTION_PREPEND]],
-     * [[Structures::ACTION_APPEND]], [[Structures::ACTION_INSERT_BEFORE]], or
-     * [[Structures::ACTION_INSERT_AFTER]]).
+     * [[Structures::ACTION_APPEND|ACTION_APPEND]], [[Structures::ACTION_PLACE_BEFORE|ACTION_PLACE_BEFORE]],
+     * or [[Structures::ACTION_PLACE_AFTER|ACTION_PLACE_AFTER]]).
      * @phpstan-var Structures::ACTION_*
      * @since 4.5.0
      */

--- a/src/events/MoveElementEvent.php
+++ b/src/events/MoveElementEvent.php
@@ -7,9 +7,14 @@
 
 namespace craft\events;
 
+use craft\base\ElementInterface;
+use craft\services\Structures;
+use yii\base\InvalidConfigException;
+
 /**
  * Move element event class.
  *
+ * @property-read ?ElementInterface $targetElement
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
@@ -19,4 +24,58 @@ class MoveElementEvent extends ElementEvent
      * @var int The ID of the structure the element is being moved within.
      */
     public int $structureId;
+
+    /**
+     * @var int|null The ID of the element that [[element]] is being moved in reference to, or `null` if
+     * [[element]] is being appended/prepended to the root of the structure.
+     * @since 4.5.0
+     */
+    public ?int $targetElementId;
+
+    /**
+     * @var string The type of structure action being performed (one of [[Structures::ACTION_PREPEND]],
+     * [[Structures::ACTION_APPEND]], [[Structures::ACTION_INSERT_BEFORE]], or
+     * [[Structures::ACTION_INSERT_AFTER]]).
+     * @phpstan-var Structures::ACTION_*
+     * @since 4.5.0
+     */
+    public string $action;
+
+    private ElementInterface $_targetElement;
+
+    /**
+     * Returns the element that [[element]] is being moved in reference to, or `null` if [[element]] is being
+     * appended/prepended to the root of the structure.
+     *
+     * @return ElementInterface|null
+     * @since 4.5.0
+     */
+    public function getTargetElement(): ?ElementInterface
+    {
+        if (!isset($this->targetElementId)) {
+            return null;
+        }
+
+        if (!isset($this->_targetElement)) {
+            $targetElement = $this->element::find()
+                ->id($this->targetElementId)
+                ->site('*')
+                ->preferSites([$this->element->siteId])
+                ->status(null)
+                ->status(null)
+                ->drafts(null)
+                ->provisionalDrafts(null)
+                ->revisions(null)
+                ->structureId($this->structureId)
+                ->one();
+
+            if (!$targetElement) {
+                throw new InvalidConfigException("Invalid target element ID: $this->targetElementId");
+            }
+
+            $this->_targetElement = $targetElement;
+        }
+
+        return $this->_targetElement;
+    }
 }

--- a/src/services/Structures.php
+++ b/src/services/Structures.php
@@ -72,9 +72,9 @@ class Structures extends Component
     /** @since 4.5.0 */
     public const ACTION_APPEND = 'append';
     /** @since 4.5.0 */
-    public const ACTION_INSERT_BEFORE = 'insertBefore';
+    public const ACTION_PLACE_BEFORE = 'placeBefore';
     /** @since 4.5.0 */
-    public const ACTION_INSERT_AFTER = 'insertAfter';
+    public const ACTION_PLACE_AFTER = 'placeAfter';
 
     /**
      * @var int The timeout to pass to [[\yii\mutex\Mutex::acquire()]] when acquiring a lock on the structure.
@@ -388,7 +388,7 @@ class Structures extends Component
             throw new Exception('There was a problem getting the next element.');
         }
 
-        return $this->_doIt($structureId, $element, $nextElementRecord, self::ACTION_INSERT_BEFORE, $mode);
+        return $this->_doIt($structureId, $element, $nextElementRecord, self::ACTION_PLACE_BEFORE, $mode);
     }
 
     /**
@@ -409,7 +409,7 @@ class Structures extends Component
             throw new Exception('There was a problem getting the previous element.');
         }
 
-        return $this->_doIt($structureId, $element, $prevElementRecord, self::ACTION_INSERT_AFTER, $mode);
+        return $this->_doIt($structureId, $element, $prevElementRecord, self::ACTION_PLACE_AFTER, $mode);
     }
 
     /**
@@ -555,11 +555,11 @@ class Structures extends Component
             return false;
         }
 
-        // prepend => prependTo(), append => appendTo()
         $method = match ($action) {
             self::ACTION_PREPEND => 'prependTo',
             self::ACTION_APPEND => 'appendTo',
-            default => $action,
+            self::ACTION_PLACE_BEFORE => 'insertBefore',
+            self::ACTION_PLACE_AFTER => 'insertAfter',
         };
 
         $transaction = Craft::$app->getDb()->beginTransaction();


### PR DESCRIPTION
### Description

- Adds new `EVENT_BEFORE_INSERT_ELEMENT` and `EVENT_AFTER_INSERT_ELEMENT` events to `craft\services\Structures`
- Adds `craft\events\MoveElementEvent::$targetElementId` and `getTargetElement()`, for getting the target element that the action is being performed in reference to, if any. (These will be `null` if `$element` is being prepended/appended to the root of the structure.)
- Adds `craft\events\MoveElementEvent::$action`, which will be set to `craft\services\Structures::ACTION_PREPEND`, `ACTION_APPEND`, `ACTION_PLACE_BEFORE`, or `ACTION_PLACE_AFTER`.
- `craft\events\Structures::EVENT_BEFORE_MOVE_ELEMENT` is now cancellable, so setting `$isValid` to `false` will prevent the element from getting moved.
- Deprecates `craft\base\Element::beforeMoveInStructure()` and `afterMoveInStructure()`, as well as the `EVENT_BEFORE_MOVE_IN_STRUCTURE` and `EVENT_AFTER_MOVE_IN_STRUCTURE` events they trigger, as they were named consistently with `craft\services\Structures::EVENT_BEFORE_MOVE_ELEMENT` and `EVENT_AFTER_MOVE_ELEMENT`, however they didn’t behave the same (they were also triggered for insert operations, whereas the service events were only for actual moves).

### Related issues

- #13409