### PR TITLE
Bump dep to support automatic version upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "ext-pdo": "*",
     "ext-zip": "*",
     "commerceguys/addressing": "^1.2",
-    "composer/composer": "2.2.19",
+    "composer/composer": "^2.2.19",
     "craftcms/plugin-installer": "~1.6.0",
     "craftcms/server-check": "~2.1.2",
     "creocoder/yii2-nested-sets": "~0.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db570d1d17f4ec1b4c17cba6640cf8c5",
+    "content-hash": "7dc1c416e88a95b2a78a1830ac68a038",
     "packages": [
         {
             "name": "cebe/markdown",
@@ -212,16 +212,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.2.19",
+            "version": "2.2.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "30ff21a9af9a10845436abaeeb0bb7276e996d24"
+                "reference": "978198befc71de0b18fc1fc5a472c03b184b504a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/30ff21a9af9a10845436abaeeb0bb7276e996d24",
-                "reference": "30ff21a9af9a10845436abaeeb0bb7276e996d24",
+                "url": "https://api.github.com/repos/composer/composer/zipball/978198befc71de0b18fc1fc5a472c03b184b504a",
+                "reference": "978198befc71de0b18fc1fc5a472c03b184b504a",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.2.19"
+                "source": "https://github.com/composer/composer/tree/2.2.21"
             },
             "funding": [
                 {
@@ -307,7 +307,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-04T13:54:48+00:00"
+            "time": "2023-02-15T12:07:40+00:00"
         },
         {
             "name": "composer/metadata-minifier",


### PR DESCRIPTION
### Description
Any chance we can get `composer/composer` updated to a more recent version? I'm trying to require `pestphp/pest:^2.0` to support 2.x which needs `symfony/console ^6.0.0`. Unfortunately you're currently pinned to 2.2.19 which only goes up `^5.0`, per https://packagist.org/packages/composer/composer#2.2.19

### Related issues
- https://github.com/craftcms/cms/pull/12288
- https://github.com/craftcms/cms/pull/11013