### PR TITLE
Track if we're in the process of dropping provisional draft

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -3390,7 +3390,7 @@ abstract class Element extends Component implements ElementInterface
             ->structureId($this->structureId)
             ->siteId(['not', $this->siteId])
             ->drafts($this->getIsDraft())
-            ->provisionalDrafts($this->isProvisionalDraft)
+            ->provisionalDrafts($this->droppingProvisionalDraft ? null : $this->isProvisionalDraft)
             ->revisions($this->getIsRevision());
     }
 

--- a/src/base/ElementTrait.php
+++ b/src/base/ElementTrait.php
@@ -46,6 +46,12 @@ trait ElementTrait
     public bool $isProvisionalDraft = false;
 
     /**
+     * @var bool Whether we're in the process of dropping a provisional draft.
+     * @since 4.4.17
+     */
+    public bool $droppingProvisionalDraft = false;
+
+    /**
      * @var string|null The element’s UID
      */
     public ?string $uid = null;

--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -1182,6 +1182,7 @@ JS, [
 
             if ($this->_dropProvisional) {
                 $element->isProvisionalDraft = false;
+                $element->droppingProvisionalDraft = true;
             }
 
             $element->setScenario(Element::SCENARIO_ESSENTIALS);


### PR DESCRIPTION
### Description
The issue was introduced in `4.4.12` via https://github.com/craftcms/cms/commit/9cd0a532c0fb387b69f0945c8b143e6b7ead58ba.

I added new `droppingProvisionalDraft` property for elements to track whether we’re in the process of dropping a provisional draft so that `Element::getLocalized()` can build a query based on that.

### Related issues
#13451 
