### PR TITLE
PC - removing nested field names from meta > __names__

### DIFF
--- a/src/events/ConfigEvent.php
+++ b/src/events/ConfigEvent.php
@@ -38,4 +38,11 @@ class ConfigEvent extends Event
      * or one of its shortcut methods.
      */
     public ?array $tokenMatches = null;
+
+    /**
+     * @var array The list of removed nested fields. Used to remove meta names of deleted nested fields,
+     * like fields in a matrix block.
+     * @see https://github.com/craftcms/cms/issues/13456
+     */
+    public array $removedNestedFields = [];
 }

--- a/src/models/ProjectConfigData.php
+++ b/src/models/ProjectConfigData.php
@@ -83,6 +83,12 @@ class ProjectConfigData extends ReadOnlyProjectConfigData
             }
         }
 
+        if (!empty($event->removedNestedFields)) {
+            foreach ($event->removedNestedFields as $item) {
+                $this->removeContainedProjectConfigNames($item, []);
+            }
+        }
+
         // Mark this path, and any parent paths, as parsed
         $tok = strtok($path, '.');
         $thisPath = '';

--- a/src/models/ProjectConfigData.php
+++ b/src/models/ProjectConfigData.php
@@ -177,7 +177,7 @@ class ProjectConfigData extends ReadOnlyProjectConfigData
         foreach ($data as $key => $value) {
             // Traverse further
             if (is_array($value)) {
-                $this->setContainedProjectConfigNames($key, $value);
+                $this->removeContainedProjectConfigNames($key, $value);
             }
         }
     }

--- a/src/services/Matrix.php
+++ b/src/services/Matrix.php
@@ -304,6 +304,7 @@ class Matrix extends Component
                 foreach ($oldFields as $fieldUid => $fieldData) {
                     if (!array_key_exists($fieldUid, $newFields)) {
                         $fieldsService->applyFieldDelete($fieldUid);
+                        $event->removedNestedFields[] = $fieldUid;
                     }
                 }
 


### PR DESCRIPTION
### Description
When deleting a matrix field, ensure that the nested fields are removed from the `project.yaml` -> `meta` -> `__names__`.

When deleting a nested field from a matrix block, remove that field from the `project.yaml` -> `meta` -> `__names__` too.


### Related issues
#13456 
