### PR TITLE
Fix BaseDateRangeConditionRule not handling negative intervals correctly.

### DIFF
--- a/src/helpers/DateTimeHelper.php
+++ b/src/helpers/DateTimeHelper.php
@@ -654,7 +654,8 @@ class DateTimeHelper
         if (is_numeric($value)) {
             // Use DateTime::diff() so the years/months/days/hours/minutes values are all populated correctly
             $now = static::now(new DateTimeZone('UTC'));
-            $then = (clone $now)->modify("+$value seconds");
+            $operator = $value < 0 ? '-' : '+';
+            $then = (clone $now)->modify("$operator$value seconds");
             return $now->diff($then);
         }
 

--- a/tests/unit/helpers/DateTimeHelperTest.php
+++ b/tests/unit/helpers/DateTimeHelperTest.php
@@ -682,7 +682,7 @@ class DateTimeHelperTest extends TestCase
     {
         return [
             [10, 10],
-            [-10, -10]
+            [-10, -10],
         ];
     }
 

--- a/tests/unit/helpers/DateTimeHelperTest.php
+++ b/tests/unit/helpers/DateTimeHelperTest.php
@@ -682,6 +682,7 @@ class DateTimeHelperTest extends TestCase
     {
         return [
             [10, 10],
+            [-10, -10]
         ];
     }
 


### PR DESCRIPTION
### Description
This fixes a bug in the `DateTimeHelper::toDateInterval` method, where if passed a negative value, returns a positive interval. This caused an issue in `DateRange::dateIntervalByTimePeriod`, and subsequently the `BaseDateRangeConditionRule`. 

I noticed this when trying to filter elements on the element index page by date period (e.g. After 1 day ago).

I went ahead and added a check for negative numbers in `DateTimeHelper::toDateInterval` and updated the `DateTimeHelperTest` to make sure it works. `DateCreatedConditionRuleTest` also passes now thanks to this fix.

Ran these tests using PHP version 8.2.4.