### PR TITLE
Improve invalid Dropdown value behavior

### DIFF
--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -337,12 +337,25 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
             $selectedValues[] = $val;
         }
 
+        $selectedBlankOption = false;
         $options = [];
         $optionValues = [];
         $optionLabels = [];
         foreach ($this->options() as $option) {
             if (!isset($option['optgroup'])) {
-                $selected = in_array($option['value'], $selectedValues, true);
+                // special case for blank options, when $value is null
+                if ($value === null && $option['value'] === '') {
+                    if (!$selectedBlankOption) {
+                        $selectedValues[] = '';
+                        $selectedBlankOption = true;
+                        $selected = true;
+                    } else {
+                        $selected = false;
+                    }
+                } else {
+                    $selected = in_array($option['value'], $selectedValues, true);
+                }
+
                 $options[] = new OptionData($option['label'], $option['value'], $selected, true);
                 $optionValues[] = (string)$option['value'];
                 $optionLabels[] = (string)$option['label'];

--- a/src/fields/Dropdown.php
+++ b/src/fields/Dropdown.php
@@ -8,6 +8,7 @@
 namespace craft\fields;
 
 use Craft;
+use craft\base\Element;
 use craft\base\ElementInterface;
 use craft\base\SortableFieldInterface;
 use craft\fields\data\SingleOptionFieldData;
@@ -43,6 +44,23 @@ class Dropdown extends BaseOptionsField implements SortableFieldInterface
      */
     protected bool $optgroups = true;
 
+    public function getStatus(ElementInterface $element): ?array
+    {
+        // If the value is invalid and has a default value (which is going to be pulled in via inputHtml()),
+        // preemptively mark the field as modified
+        /** @var SingleOptionFieldData $value */
+        $value = $element->getFieldValue($this->handle);
+
+        if (!$value->valid && $this->defaultValue() !== null) {
+            return [
+                Element::ATTR_STATUS_MODIFIED,
+                Craft::t('app', 'This field has been modified.'),
+            ];
+        }
+
+        return parent::getStatus($element);
+    }
+
     /**
      * @inheritdoc
      */
@@ -57,11 +75,17 @@ class Dropdown extends BaseOptionsField implements SortableFieldInterface
 
         if (!$value->valid) {
             Craft::$app->getView()->setInitialDeltaValue($this->handle, $this->encodeValue($value->value));
-            $value = null;
+            $default = $this->defaultValue();
 
-            // Add a blank option to the beginning if one doesn't already exist
-            if (!$hasBlankOption) {
-                array_unshift($options, ['label' => '', 'value' => '']);
+            if ($default !== null) {
+                $value = $this->normalizeValue($this->defaultValue());
+            } else {
+                $value = null;
+
+                // Add a blank option to the beginning if one doesn't already exist
+                if (!$hasBlankOption) {
+                    array_unshift($options, ['label' => '', 'value' => '']);
+                }
             }
         }
 


### PR DESCRIPTION
### Description

Improves the behavior of Dropdown fields when their value is invalid.

As of 4.4, invalid Dropdown fields which didn’t have a blank option would get a blank option prepended, and that would be selected by default in the UI (see https://github.com/craftcms/cms/discussions/12235#discussioncomment-4059192). This would lead to a validation error on save (because a blank value wasn’t one of the allowed options), forcing the author to make a valid selection.

That confused authors because they were getting validation errors for fields they hadn’t even edited.

With this PR, invalid Dropdown fields which have a default option will now automatically select that instead, and the field will immediately be marked at changed, to indicate that the selected option is not equal to the field’s actual current value, until it’s saved.

<img width="413" alt="A Dropdown field that is marked as changed" src="https://github.com/craftcms/cms/assets/47792/c5d68d52-d4ed-4856-87e5-bd7efaa13620">

### Related issues

- #12262
- #12548
- #13034
- #13133
