### PR TITLE
Response::$defaultFormatters

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -101,6 +101,7 @@
 - Added `craft\web\CpScreenResponseBehavior::$errorSummary`, `errorSummary()`, and `errorSummaryTemplate()`. ([#12125](https://github.com/craftcms/cms/pull/12125))
 - Added `craft\web\CpScreenResponseBehavior::$pageSidebar`, `pageSidebar()`, and `pageSidebarTemplate()`. ([#13019](https://github.com/craftcms/cms/pull/13019), [#12795](https://github.com/craftcms/cms/issues/12795))
 - Added `craft\web\CpScreenResponseBehavior::$slideoutBodyClass`.
+- Added `craft\web\Response::$defaultFormatters`. ([#13541](https://github.com/craftcms/cms/pull/13541))
 - `craft\helpers\Cp::selectizeFieldHtml()`, `selectizeHtml()`, and `_includes/forms/selectize.twig` now support a `multi` param. ([#13176](https://github.com/craftcms/cms/pull/13176))
 - `craft\helpers\Typecast::properties()` now supports backed enum values. ([#13371](https://github.com/craftcms/cms/pull/13371))
 - `craft\services\Assets::getRootFolderByVolumeId()` now ensures the root folder actually exists, and caches its results internally, improving performance. ([#13297](https://github.com/craftcms/cms/issues/13297))

--- a/src/web/Response.php
+++ b/src/web/Response.php
@@ -8,6 +8,7 @@
 namespace craft\web;
 
 use Craft;
+use craft\helpers\ArrayHelper;
 use craft\helpers\UrlHelper;
 use Throwable;
 use yii\base\Application as BaseApplication;
@@ -27,6 +28,38 @@ class Response extends \yii\web\Response
      * @since 3.4.0
      */
     public const FORMAT_CSV = 'csv';
+
+    /**
+     * Default response formatter configurations.
+     *
+     * This could be set from `config/app.web.php` to append additional default response formatters, or modify existing ones.
+     *
+     * ```php
+     * use craft\helpers\App;
+     * use craft\helpers\ArrayHelper;
+     * use craft\web\Response;
+     *
+     * return [
+     *     'components' => [
+     *         'response' => fn() => Craft::createObject(ArrayHelper::merge(
+     *             App::webResponseConfig(),
+     *             [
+     *                 'defaultFormatters' => [
+     *                     Response::FORMAT_CSV => [
+     *                         'delimiter' => chr(9),
+     *                     ],
+     *                 ],
+     *             ]
+     *         )),
+     *     ],
+     * ];
+     * ```
+     *
+     * @see defaultFormatters()
+     * @since 4.5.0
+     */
+    public array $defaultFormatters = [];
+
 
     /**
      * @var bool whether the response has been prepared.
@@ -294,11 +327,15 @@ class Response extends \yii\web\Response
      */
     protected function defaultFormatters(): array
     {
-        $formatters = parent::defaultFormatters();
-        $formatters[self::FORMAT_CSV] = [
-            'class' => CsvResponseFormatter::class,
-        ];
-        return $formatters;
+        return ArrayHelper::merge(
+            parent::defaultFormatters(),
+            [
+                self::FORMAT_CSV => [
+                    'class' => CsvResponseFormatter::class,
+                ],
+            ],
+            $this->defaultFormatters,
+        );
     }
 
     /**


### PR DESCRIPTION
### Description

Adds the ability to modify the default response formatter configurations via `config/app.web.php`. For example, `CsvResponseFormatter::$delimiter` could be changed to `chr(9)` (a tab character) like so:

```php
use craft\helpers\App;
use craft\helpers\ArrayHelper;
use craft\web\Response;

return [
    'components' => [
        'response' => fn() => Craft::createObject(ArrayHelper::merge(
            App::webResponseConfig(),
            [
                'defaultFormatters' => [
                    Response::FORMAT_CSV => [
                        'delimiter' => chr(9),
                    ],
                ],
            ]
        )),
    ],
];
```
