### PR TITLE
DI container for MonologTarget

### DIFF
--- a/src/log/Dispatcher.php
+++ b/src/log/Dispatcher.php
@@ -46,7 +46,7 @@ class Dispatcher extends \yii\log\Dispatcher
     }
 
     /**
-     * @return array<MonologTarget|array>
+     * @return array<MonologTarget>
      */
     public function getTargets(): array
     {
@@ -75,7 +75,7 @@ class Dispatcher extends \yii\log\Dispatcher
                 'level' => App::devMode() ? LogLevel::INFO : LogLevel::WARNING,
             ];
 
-            return [$name => $config];
+            return [$name => Craft::createObject(MonologTarget::class, $config)];
         });
 
         // Queue is enabled via QueueLogBehavior


### PR DESCRIPTION
No need to bother with an array return here, just instantiate with the DI container.
Fixes tests broken here: https://github.com/craftcms/cms/actions/runs/5797710403/job/15714040017