### PR TITLE
Bugfix/13553 autosuggest click part2

### DIFF
--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -775,7 +775,7 @@ class Cp
                     'data' => [
                         'attribute' => $attribute,
                     ],
-                    'tabindex' => $config['tabindex'] ?? -1,
+                    'tabindex' => -1,
                 ],
                 $config['fieldAttributes'] ?? []
             )) .
@@ -1248,8 +1248,6 @@ class Cp
                 $config['warning'] = Craft::t('app', 'The `@web` alias is not recommended if it is determined automatically.');
             }
         }
-
-        $config['tabindex'] = false;
 
         return static::fieldHtml('template:_includes/forms/autosuggest.twig', $config);
     }

--- a/src/templates/_includes/forms.twig
+++ b/src/templates/_includes/forms.twig
@@ -316,7 +316,6 @@
 {% macro autosuggestField(config) %}
     {% set config = config|merge({
         id: config.id ?? "autosuggest#{random()}",
-        tabindex: false,
     }) %}
 
     {# Suggest an environment variable / alias? #}

--- a/src/templates/_includes/forms/autosuggest.twig
+++ b/src/templates/_includes/forms/autosuggest.twig
@@ -30,6 +30,8 @@
         @focus="updateFilteredOptions"
         @blur="onBlur"
         @input="onInputChange"
+        @opened="onOpened"
+        @closed="onClosed"
         v-model="inputProps.initialValue"
     >
         <template slot-scope="{suggestion}">
@@ -78,6 +80,22 @@ new Vue({
         onInputChange(q) {
             this.query = (q || '').toLowerCase();
             this.updateFilteredOptions();
+        },
+        onOpened() {
+            let $element = $(this.$el);
+
+            // hacky but works
+            let $tabindexParent = $element.parents('[tabindex="-1"]');
+            if ($tabindexParent.length > 0) {
+                this.$refs.tabindexParent = $tabindexParent;
+                $tabindexParent.removeAttr('tabindex');
+            }
+        },
+        onClosed() {
+            if (this.$refs.tabindexParent !== undefined) {
+                this.$refs.tabindexParent.attr('tabindex', '-1');
+                this.$refs.tabindexParent = null;
+            }
         },
         updateFilteredOptions() {
             if (this.query === '') {

--- a/src/templates/_includes/forms/autosuggest.twig
+++ b/src/templates/_includes/forms/autosuggest.twig
@@ -84,7 +84,11 @@ new Vue({
         onOpened() {
             let $element = $(this.$el);
 
-            // hacky but works
+            // clicking on autosuggestion value won't work if the element's parent has any sort of tabindex set
+            // (it's not vue-autosuggest issue as on its own it works fine with tabindex)
+            // so we have to temporary remove that tabindex when opening the suggestions list
+            // and then add it back in when closing the list
+            // see https://github.com/craftcms/cms/issues/13553 for more details
             let $tabindexParent = $element.parents('[tabindex="-1"]');
             if ($tabindexParent.length > 0) {
                 this.$refs.tabindexParent = $tabindexParent;


### PR DESCRIPTION
### Description
Different approach to fixing vue-autosuggest click issues.

It’s not the vue-autosuggest issue, as when isolated, it works fine with the `tabindex` attribute.

Also, it was present before v4.5, but it was very difficult to trigger this problem (only triggerable in a slideout under certain conditions).

### Related issues
#13553 