### PR TITLE
`setup/cloud` command

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -31,6 +31,7 @@
 ### Administration
 - Added the “Slug Translation Method” setting to entry types. ([#8962](https://github.com/craftcms/cms/discussions/8962), [#13291](https://github.com/craftcms/cms/pull/13291))
 - Added the “Show the Status field” setting to entry types. ([#12837](https://github.com/craftcms/cms/discussions/12837), [#13265](https://github.com/craftcms/cms/pull/13265))
+- Added the `setup/cloud` command, which prepares a Craft install to be deployed to Craft Cloud.
 - Added the `setup/message-tables` command, which can be run to set the project up for database-stored static translations via [DbMessageSource](https://www.yiiframework.com/doc/api/2.0/yii-i18n-dbmessagesource). ([#13542](https://github.com/craftcms/cms/pull/13542))
 - Entry types created via the `entrify/global-set` command now have “Show the Status field” disabled by default. ([#12837](https://github.com/craftcms/cms/discussions/12837))
 - Added the `defaultCountryCode` config setting. ([#13478](https://github.com/craftcms/cms/discussions/13478))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased (4.5)
 
+- Added the `setup/cloud` command.
 - Admin table properties are now reactive. ([#13558](https://github.com/craftcms/cms/pull/13558), [#13520](https://github.com/craftcms/cms/discussions/13520))
 - Elements are no longer cross-site-validated when saved from a slideout.
 - Fixed a bug where element edit pages were displaying sidebar content incorrectly if there weren’t any normal form fields. ([#13567](https://github.com/craftcms/cms/issues/13567))

--- a/src/services/Composer.php
+++ b/src/services/Composer.php
@@ -201,11 +201,13 @@ class Composer extends Component
         $process->setTimeout(null);
 
         try {
-            $process->mustRun();
-        } catch (ProcessFailedException $e) {
-            $io->write($process->getOutput());
-            $io->writeError($process->getErrorOutput());
-            throw $e;
+            $process->mustRun(function($type, $buffer) use ($io): void {
+                if ($type === Process::ERR) {
+                    $io->writeErrorRaw($buffer, false);
+                } else {
+                    $io->writeRaw($buffer, false);
+                }
+            });
         } finally {
             unlink($pharPath);
         }


### PR DESCRIPTION
Adds a `setup/cloud` command which:

1. Installs the `craftcms/cloud` extension as a dependency
2. Runs the `cloud/setup` command provided by the `craftcms/cloud` extension