### PR TITLE
Store updated user from register-user event

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1008,6 +1008,8 @@ class UsersController extends Controller
         ]);
         $this->trigger(self::EVENT_REGISTER_USER_ACTIONS, $event);
 
+        $user = $event->user;
+
         $actions = array_filter([
             $event->statusActions,
             $event->miscActions,


### PR DESCRIPTION
### Description
In actionEditUser, the RegisterUserActionsEvent supposedly gives plugins a chance to modify any of the event properties, including the $user object. However, the $user stored in the event is never referenced after the event is triggered. This update stores the $event->user object back to the $user variable

### Related discussions
[#13607](https://github.com/craftcms/cms/discussions/13607)
