### PR TITLE
Allow suppression of web alias warning

### DIFF
--- a/src/templates/_includes/forms.twig
+++ b/src/templates/_includes/forms.twig
@@ -331,7 +331,7 @@
                     text: 'Learn more'|t('app'),
                 }),
             }) %}
-        {% elseif config.warning is not defined and (value == '@web' or value[0:5] == '@web/') and craft.app.request.isWebAliasSetDynamically %}
+        {% elseif config.warning is not defined and (value == '@web' or value[0:5] == '@web/') and craft.app.request.isWebAliasSetDynamically and not getenv('CRAFT_ALLOW_DYNAMIC_WEB_ALIAS') %}
             {% set config = config|merge({
                 warning: 'The `@web` alias is not recommended if it is determined automatically.'|t('app')
             }) %}


### PR DESCRIPTION
Checks a `CRAFT_ALLOW_DYNAMIC_WEB_ALIAS` env/constant to optionally suppress the dynamic `@web` warning.
For use in an environment where `@web` is known to be trusted.