### PR TITLE
don't propagate matrix blocks to unsupported sites

### DIFF
--- a/src/services/Matrix.php
+++ b/src/services/Matrix.php
@@ -762,7 +762,7 @@ class Matrix extends Component
                 // If propagateAll isn't set, only deal with sites that the element was just propagated to for the first time
                 if (!$owner->propagateAll) {
                     $preexistingOtherSiteIds = array_diff($otherSiteIds, $owner->newSiteIds);
-                    $otherSiteIds = array_intersect($otherSiteIds, $owner->newSiteIds);
+                    $otherSiteIds = array_intersect($otherSiteIds, $owner->newSiteIds, $fieldSiteIds);
                 } else {
                     $preexistingOtherSiteIds = [];
                 }


### PR DESCRIPTION
### Description
When adding the owner element to a new site, don’t propagate matrix blocks to that new site if the field’s propagation method disallows it.

With the following setup:
- (at least) 2 sites
- matrix field with propagation: none (“Only save blocks to the site they were created in”)
- section enabled for both sites with the above matrix field and propagation: custom (“Let each entry choose which sites it should be saved to”)

Create an entry on `site 1`, add at least one block to the matrix field and save.
Add the entry to `site 2` and, without saving (while still editing a provisional draft), switch to the entry for `site 2`.
You shouldn’t see the matrix blocks from `site 1` once you switch to `site 2`.


### Related issues
https://app.frontapp.com/open/msg_ukaoki1?key=U6zkE_S6_ApMXn3ntPMwUxSLe0sUPsmY
