### PR TITLE
don't preset dirty attrs and fields to empty array

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1238,8 +1238,6 @@ class Elements extends Component
             'revisionId' => null,
             'isProvisionalDraft' => false,
             'updatingFromDerivative' => true,
-            'dirtyAttributes' => [],
-            'dirtyFields' => [],
         ];
 
         foreach ($changedAttributes as $attribute) {


### PR DESCRIPTION
### Description
When updating the canonical element from a given derivative, don’t set the `dirtyAttributes` and `dirtyFields` to an empty array. 

Setting it triggers `setDirtyFields()`, which sets `_allDirty` to `false`, which causes issues when reverting from a revision.


### Related issues
#13626 
