### PR TITLE
hide field handle for entryType

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1655,8 +1655,14 @@ EOD;
                     'value' => $this->getTypeId(),
                     'options' => $entryTypeOptions,
                     'disabled' => $static,
-                    'attribute' => 'typeId',
                     'errors' => $this->getErrors('typeId'),
+                    // we can't simply use 'attribute' as that will make the field handle show
+                    // see https://github.com/craftcms/cms/issues/13627 for more detail
+                    'fieldAttributes' => [
+                        'data' => [
+                            'attribute' => 'typeId',
+                        ],
+                    ],
                 ]);
             })();
         }


### PR DESCRIPTION
### Description
PR https://github.com/craftcms/cms/pull/13138 added missing validation messages to the meta fields. In the process, it was necessary to add the `attribute` param to the Entry Type select field to trigger the containing `div` to have the `data-attribute="typeId"` attribute, which is needed for the validation errors to show in a slideout.

Adding `attribute`, however, makes the field handle show for the Entry Type field when the user has “Show field handles in edit forms” enabled, and this wasn’t the case before (nor should it be).

This PR removes the `attribute` from the Entry Type select field and replaces it with `fieldAttributes[data][attribute]`, which will give the field container the correct attribute for the error messages to show in a slideout, without making the field handle show.


### Related issues
#13627 
