### PR TITLE
Matching parenthesis in craft\console\Controller::do

### DIFF
--- a/src/console/Controller.php
+++ b/src/console/Controller.php
@@ -458,7 +458,7 @@ class Controller extends YiiController
 
         $this->stdout('✓', Console::FG_GREEN, Console::BOLD);
         if ($withDuration) {
-            $this->stdout(sprintf(' (time: %.3fs', microtime(true) - $time), Console::FG_GREY);
+            $this->stdout(sprintf(' (time: %.3fs)', microtime(true) - $time), Console::FG_GREY);
         }
         $this->stdout(PHP_EOL);
     }


### PR DESCRIPTION
Noticed this was missing when doing some debugging output!