### PR TITLE
additional logging for image processing

### DIFF
--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -273,7 +273,8 @@ class Image
 
             $image = Craft::$app->getImages()->loadImage($filePath);
             return [$image->getWidth(), $image->getHeight()];
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            Craft::warning($e->getMessage(), __METHOD__);
             return [0, 0];
         }
     }

--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -177,6 +177,12 @@ class Raster extends Image
         try {
             $this->_image = $this->_instance->open($path);
         } catch (Throwable $e) {
+            // Imagick can throw all sorts of errors via the open() method
+            // we should log them to better know what's going on
+            Craft::warning($e->getMessage(), $e->getFile());
+            if (($instanceException = $e->getPrevious()) !== null) {
+                Craft::warning($instanceException->getMessage(), $instanceException->getFile() . ':' . $instanceException->getLine());
+            }
             throw new ImageException(Craft::t('app', 'The file “{name}” does not appear to be an image.', [
                 'name' => basename($path),
             ]), 0, $e);


### PR DESCRIPTION
### Description
Improves logging around raster image processing.

As per our discussion, it’s not the prettiest, but will give us more info on why raster image processing actually failed (without having to make changes to the Imagine).


### Related issues
#13687 
