### PR TITLE
matrix with inline blocks view - save the title

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1362,6 +1362,10 @@ class Matrix extends Field implements
                 $entry->enabled = (bool)$entryData['enabled'];
             }
 
+            if (isset($entryData['title']) && $entry->getType()->hasTitleField) {
+                $entry->title = $entryData['title'];
+            }
+
             // Allow setting the UID for the entry
             if (isset($entryData['uid'])) {
                 $entry->uid = $entryData['uid'];


### PR DESCRIPTION
### Description
Fixes an issue where when using the matrix field in the inline blocks view, it wasn’t possible to save the title value.


### Related issues
#13766 
