### PR TITLE
Queue job profiling

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '4.5.6.1',
-    'schemaVersion' => '4.5.3.0',
+    'schemaVersion' => '4.6.0.0',
     'minVersionRequired' => '3.7.11',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/controllers/QueueController.php
+++ b/src/controllers/QueueController.php
@@ -9,6 +9,7 @@ namespace craft\controllers;
 
 use Craft;
 use craft\helpers\App;
+use craft\helpers\DateTimeHelper;
 use craft\helpers\Json;
 use craft\queue\QueueInterface;
 use craft\web\Controller;
@@ -174,7 +175,12 @@ class QueueController extends Controller
 
         return $this->asJson([
             'total' => $this->queue->getTotalJobs(),
-            'jobs' => $this->queue->getJobInfo($limit),
+            'jobs' => array_map(function(array $info) {
+                if (isset($info['averageDuration'])) {
+                    $info['averageDurationLabel'] = DateTimeHelper::humanDuration($info['averageDuration']);
+                }
+                return $info;
+            }, $this->queue->getJobInfo($limit)),
         ]);
     }
 

--- a/src/db/Table.php
+++ b/src/db/Table.php
@@ -74,6 +74,8 @@ abstract class Table
     /** @since 3.4.0 */
     public const PROJECTCONFIG = '{{%projectconfig}}';
     public const QUEUE = '{{%queue}}';
+    /** @since 4.6.0 */
+    public const QUEUEPROFILES = '{{%queueprofiles}}';
     public const RELATIONS = '{{%relations}}';
     public const SECTIONS = '{{%sections}}';
     public const SECTIONS_SITES = '{{%sections_sites}}';

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -557,6 +557,12 @@ class Install extends Migration
             'dateFailed' => $this->dateTime(),
             'error' => $this->text(),
         ]);
+        $this->createTable(Table::QUEUEPROFILES, [
+            'key' => $this->string(),
+            'dateExecuted' => $this->dateTime()->notNull(),
+            'duration' => $this->integer()->notNull(),
+            'PRIMARY KEY([[key]], [[dateExecuted]])',
+        ]);
         $this->createTable(Table::RELATIONS, [
             'id' => $this->primaryKey(),
             'fieldId' => $this->integer()->notNull(),

--- a/src/migrations/m231006_071504_job_profiling.php
+++ b/src/migrations/m231006_071504_job_profiling.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m231006_071504_job_profiling migration.
+ */
+class m231006_071504_job_profiling extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->createTable(Table::QUEUEPROFILES, [
+            'key' => $this->string(),
+            'dateExecuted' => $this->dateTime()->notNull(),
+            'duration' => $this->integer()->notNull(),
+            'PRIMARY KEY([[key]], [[dateExecuted]])',
+        ]);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m231006_071504_job_profiling cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/queue/BaseBatchedJob.php
+++ b/src/queue/BaseBatchedJob.php
@@ -9,6 +9,7 @@ namespace craft\queue;
 
 use Craft;
 use craft\base\Batchable;
+use craft\helpers\ArrayHelper;
 use craft\helpers\ConfigHelper;
 use craft\helpers\Queue as QueueHelper;
 use craft\i18n\Translation;
@@ -31,7 +32,7 @@ use craft\i18n\Translation;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.4.0
  */
-abstract class BaseBatchedJob extends BaseJob
+abstract class BaseBatchedJob extends BaseJob implements ProfilableJobInterface
 {
     /**
      * @var int The number of items that should be processed in a single batch
@@ -171,5 +172,15 @@ abstract class BaseBatchedJob extends BaseJob
             'index' => $this->batchIndex + 1,
             'total' => $totalBatches,
         ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getProfileAttributes(): array
+    {
+        $arr = ArrayHelper::toArray($this);
+        unset($arr['batchIndex'], $arr['itemOffset'], $arr['priority'], $arr['ttr']);
+        return $arr;
     }
 }

--- a/src/queue/ProfilableJobInterface.php
+++ b/src/queue/ProfilableJobInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\queue;
+
+/**
+ * ProfilableJobInterface aids in aggregating profile results for queue jobs.
+ *
+ * It should be implemented by jobs which could have wide-varying runtime lengths based on their configuration.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.6.0
+ */
+interface ProfilableJobInterface
+{
+    /**
+     * Returns the job attributes that should be used to semi-uniquely identify this job, based on its configuration,
+     * so that its profile results can be compared with recent similarly-configured jobs.
+     *
+     * @return array
+     */
+    public function getProfileAttributes(): array;
+}

--- a/src/queue/jobs/ResaveElements.php
+++ b/src/queue/jobs/ResaveElements.php
@@ -91,6 +91,7 @@ class ResaveElements extends BaseBatchedJob
      */
     protected function processItem(mixed $item): void
     {
+//        sleep(1);
         // Make sure the element was queried with its content
         /** @var ElementInterface $item */
         if ($item::hasContent() && $item->contentId === null) {


### PR DESCRIPTION
Adds basic profiling for queue jobs using the built-in queue.

Job durations are tracked based on their class, and possibly some common attributes.

Jobs can now implement `ProfilableJobInterface` + `getProfileAttributes()` to provide its common attributes that other jobs should be compared against. `BaseBatchedJob` does this, returning its properties for attributes, sans any properties that definitely won’t impact job duration (`batchIndex`, `itemOffset`, `priority`, and `ttr`).

`craft\queue\Queue` also now has a `getAverageDuration()` method, which takes a job ID, and returns the average of the last (up to) 5 runs of similar jobs.