### PR TITLE
account for wildcards when checking accepts header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `craft\web\Request::accepts()` now supports wildcard (e.g. `application/*`). ([#13759](https://github.com/craftcms/cms/issues/13759))
 - Fixed a bug where relational fields’ element selector modals weren’t always getting set to the correct site per the field’s “Relate entries from a specific site?” setting. ([#13750](https://github.com/craftcms/cms/issues/13750))
 - Fixed a bug where Dropdown fields weren’t visible when viewing revisions and other static forms. ([#13753](https://github.com/craftcms/cms/issues/13753), [craftcms/commerce#3270](https://github.com/craftcms/commerce/issues/3270))
 - Fixed a bug where the `defaultDirMode` config setting wasn’t being respected when the `storage/runtime/` and `storage/logs/` folders were created. ([#13756](https://github.com/craftcms/cms/issues/13756))

--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -1288,17 +1288,12 @@ class Request extends \yii\web\Request
     {
         $acceptableContentTypes = $this->getAcceptableContentTypes();
 
-        // if we have "*/*" listed in the acceptable content types, just return true
-        if (array_key_exists('*/*', $acceptableContentTypes)) {
-            return true;
-        }
-
         // then check if the actual key exists
         if (array_key_exists($contentType, $acceptableContentTypes)) {
             return true;
         }
 
-        // finally, check for cases where acceptable content type contains mimeType/*
+        // check for cases where acceptable content type contains mimeType/*
         foreach ($acceptableContentTypes as $mime => $params) {
             $mimeParts = explode('/', $mime);
             if ($mimeParts[1] === '*' && str_starts_with($contentType, $mimeParts[0] . '/')) {

--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -1294,9 +1294,8 @@ class Request extends \yii\web\Request
         }
 
         // check for cases where acceptable content type contains mimeType/*
-        foreach ($acceptableContentTypes as $mime => $params) {
-            $mimeParts = explode('/', $mime);
-            if ($mimeParts[1] === '*' && str_starts_with($contentType, $mimeParts[0] . '/')) {
+        foreach (array_keys($acceptableContentTypes) as $mime) {
+            if (str_ends_with($mime, '/*') && str_starts_with($contentType, substr($mime, 0, -1))) {
                 return true;
             }
         }

--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -1286,7 +1286,27 @@ class Request extends \yii\web\Request
      */
     public function accepts(string $contentType): bool
     {
-        return array_key_exists($contentType, $this->getAcceptableContentTypes());
+        $acceptableContentTypes = $this->getAcceptableContentTypes();
+
+        // if we have "*/*" listed in the acceptable content types, just return true
+        if (array_key_exists('*/*', $acceptableContentTypes)) {
+            return true;
+        }
+
+        // then check if the actual key exists
+        if (array_key_exists($contentType, $acceptableContentTypes)) {
+            return true;
+        }
+
+        // finally, check for cases where acceptable content type contains mimeType/*
+        foreach ($acceptableContentTypes as $mime => $params) {
+            $mimeParts = explode('/', $mime);
+            if ($mimeParts[1] === '*' && str_starts_with($contentType, $mimeParts[0] . '/')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/unit/web/RequestTest.php
+++ b/tests/unit/web/RequestTest.php
@@ -387,6 +387,17 @@ class RequestTest extends TestCase
     }
 
     /**
+     * @dataProvider acceptsDataProvider
+     */
+    public function testAccepts(bool $expected, string $contentType, array $accepts): void
+    {
+        $request = $this->make(Request::class, [
+            'getAcceptableContentTypes' => array_flip($accepts),
+        ]);
+        self::assertEquals($expected, $request->accepts($contentType));
+    }
+
+    /**
      * https://deviceatlas.com/blog/list-of-user-agent-strings
      *
      * @return array
@@ -486,6 +497,20 @@ class RequestTest extends TestCase
             ['login'],
             ['logout'],
             ['update'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function acceptsDataProvider(): array
+    {
+        return [
+            [false, 'application/json', ['text/html']],
+            [true, 'application/json', ['application/json']],
+            [true, 'application/json', ['application/*']],
+            [true, 'text/*', ['text/*']],
+            [false, 'text/*', ['text/html']],
         ];
     }
 


### PR DESCRIPTION
### Description
When using `craft\web\Request->accepts()`, we should account for subtype wildcards in accepted content types.

With changes in this PR:
- if `getAcceptableContentTypes()` contains `"application/*"` and you’re checking `accepts('application/json')`, the results should be `true`
- if `getAcceptableContentTypes()` contains `"application/json"` and you’re checking `accepts('application/*')`, the results should be `false`
- if `getAcceptableContentTypes()` contains `"application/json"` and you’re checking `accepts('application/json')`, the results should be `true`


### Related issues
#13759 
