### PR TITLE
related elements validation message adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where Dropdown fields weren’t visible when viewing revisions and other static forms. ([#13753](https://github.com/craftcms/cms/issues/13753), [craftcms/commerce#3270](https://github.com/craftcms/commerce/issues/3270))
 - Fixed a bug where the `defaultDirMode` config setting wasn’t being respected when the `storage/runtime/` and `storage/logs/` folders were created. ([#13756](https://github.com/craftcms/cms/issues/13756))
 - Fixed a bug where the “Save and continue editing” action wasn’t working on Edit User pages if they contained a Money field. ([#13760](https://github.com/craftcms/cms/issues/13760))
+- Fixed a bug where relational fields’ validation messages weren’t using the actual field name. ([#13807](https://github.com/craftcms/cms/issues/13807))
 - Fixed RCE vulnerabilities.
 
 ## 4.5.6.1 - 2023-09-27

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -506,7 +506,7 @@ JS, [
             $elementType = static::elementType();
             $element->addError($this->handle, Craft::t('app', 'Validation errors found in {attribute} {type}; please fix them.', [
                 'type' => $errorCount === 1 ? $elementType::lowerDisplayName() : $elementType::pluralLowerDisplayName(),
-                'attribute' => $this->getAttributeLabel($this->handle),
+                'attribute' => Craft::t('site', $this->name),
             ]));
         }
     }


### PR DESCRIPTION
### Description
Use field name, not labelled handle, when constructing the related elements validation message and provide the ability for the site translation to be used for it. Using the field’s name also means that it’s emphasised in the error summary.


### Related issues
#13807 
