### PR TITLE
ensure localized uris when propagating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed a bug where the “Save and continue editing” action wasn’t working on Edit User pages if they contained a Money field. ([#13760](https://github.com/craftcms/cms/issues/13760))
 - Fixed a bug where relational fields’ validation messages weren’t using the actual field name. ([#13807](https://github.com/craftcms/cms/issues/13807))
 - Fixed a bug where element editor slideouts were appearing behind element selector modals within Live Preview. ([#13798](https://github.com/craftcms/cms/issues/13798))
+- Fixed a bug where element URIs weren’t getting updated for propagated sites automatically. ([#13812](https://github.com/craftcms/cms/issues/13812))
 - Fixed RCE vulnerabilities.
 
 ## 4.5.6.1 - 2023-09-27

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3621,10 +3621,13 @@ class Elements extends Component
 
         // Ensure the uri is properly localized
         // see https://github.com/craftcms/cms/issues/13812 for more details
-        if ($element::hasUris() &&
-            ($isNewSiteForElement ||
-            in_array('uri', $siteElement->getDirtyAttributes()) ||
-            $siteElement->resaving)
+        if (
+            $element::hasUris() &&
+            (
+                $isNewSiteForElement ||
+                in_array('uri', $siteElement->getDirtyAttributes()) ||
+                $siteElement->resaving
+            )
         ) {
             // Set a unique URI on the site clone
             try {

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3587,6 +3587,7 @@ class Elements extends Component
             $siteElement->siteId = $oldSiteElement->siteId;
             $siteElement->contentId = $oldSiteElement->contentId;
             $siteElement->setEnabledForSite($oldSiteElement->getEnabledForSite());
+            $siteElement->uri = $oldSiteElement->uri;
         } else {
             $siteElement->enabled = $element->enabled;
             $siteElement->resaving = $element->resaving;
@@ -3618,7 +3619,22 @@ class Elements extends Component
             $siteElement->slug = $element->slug;
         }
 
-        // Copy the dirty attributes (except title and slug, which may be translatable)
+        // Ensure the uri is properly localized
+        // see https://github.com/craftcms/cms/issues/13812 for more details
+        if ($element::hasUris() &&
+            ($isNewSiteForElement ||
+            in_array('uri', $siteElement->getDirtyAttributes()) ||
+            $siteElement->resaving)
+        ) {
+            // Set a unique URI on the site clone
+            try {
+                ElementHelper::setUniqueUri($siteElement);
+            } catch (OperationAbortedException) {
+                // carry on
+            }
+        }
+
+        // Copy the dirty attributes (except title, slug and uri, which may be translatable)
         $siteElement->setDirtyAttributes(array_filter($element->getDirtyAttributes(), function(string $attribute): bool {
             return $attribute !== 'title' && $attribute !== 'slug';
         }));

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3625,8 +3625,8 @@ class Elements extends Component
             $element::hasUris() &&
             (
                 $isNewSiteForElement ||
-                in_array('uri', $siteElement->getDirtyAttributes()) ||
-                $siteElement->resaving
+                in_array('uri', $element->getDirtyAttributes()) ||
+                $element->resaving
             )
         ) {
             // Set a unique URI on the site clone


### PR DESCRIPTION
### Description
When propagating elements to other sites, ensure that the dynamic URI respects the site the element is for. 

For example:
- you have 2 sites, 
- you have 2 sections which are enabled for both sites and propagating to both of them
- lets say `section1` has the URI format set to `{slug}`
- lets say `section2` has an Entry URI format set to: `{{ craft.entries.section('section1').type('blog').siteId(siteId).one().uri }}/{slug}`
- you add an entry to `section1` with a slug of `foo` for site A and a slug of `bar` for site B
- you then add an entry to `section2`; let's say the slug is `test`

The expected result is for the uri of the entry in `section2` to be `foo/test` for site A and `bar/test` for site B.


### Related issues
#13812 
