### PR TITLE
element route() - get correct siteId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed a bug where the `transformGifs` and `transformSvgs` config settings weren’t always being respected when using `@transform` GraphQL directives. ([#13808](https://github.com/craftcms/cms/issues/13808))
 - Fixed a bug where Composer operations were sorting `require` packages differently than how Composer does it natively, when `config.sort-packages` was set to `true`. ([#13806](https://github.com/craftcms/cms/issues/13806))
 - Fixed a MySQL error that could occur when creating a Plain Text field with a high charcter limit. ([#13781](https://github.com/craftcms/cms/pull/13781))
+- Fixed a bug where entries weren’t always being treated as live for View and Preview buttons, when editing a non-primary site. ([#13746](https://github.com/craftcms/cms/issues/13746))
 - Fixed RCE vulnerabilities.
 
 ## 4.5.6.1 - 2023-09-27

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -435,7 +435,7 @@ class Category extends Element
     protected function route(): array|string|null
     {
         // Make sure the category group is set to have URLs for this site
-        $siteId = Craft::$app->getSites()->getCurrentSite()->id;
+        $siteId = Craft::$app->request->getIsCpRequest() ? $this->siteId : Craft::$app->getSites()->getCurrentSite()->id;
         $categoryGroupSiteSettings = $this->getGroup()->getSiteSettings();
 
         if (!isset($categoryGroupSiteSettings[$siteId]) || !$categoryGroupSiteSettings[$siteId]->hasUrls) {

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -435,16 +435,15 @@ class Category extends Element
     protected function route(): array|string|null
     {
         // Make sure the category group is set to have URLs for this site
-        $siteId = Craft::$app->request->getIsCpRequest() ? Cp::requestedSite()?->id : Craft::$app->getSites()->getCurrentSite()->id;
-        $categoryGroupSiteSettings = $this->getGroup()->getSiteSettings();
+        $categoryGroupSiteSettings = $this->getGroup()->getSiteSettings()[$this->siteId] ?? null;
 
-        if (!isset($categoryGroupSiteSettings[$siteId]) || !$categoryGroupSiteSettings[$siteId]->hasUrls) {
+        if (!$categoryGroupSiteSettings?->hasUrls) {
             return null;
         }
 
         return [
             'templates/render', [
-                'template' => (string)$categoryGroupSiteSettings[$siteId]->template,
+                'template' => (string)$categoryGroupSiteSettings->template,
                 'variables' => [
                     'category' => $this,
                 ],

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -435,7 +435,7 @@ class Category extends Element
     protected function route(): array|string|null
     {
         // Make sure the category group is set to have URLs for this site
-        $siteId = Craft::$app->request->getIsCpRequest() ? $this->siteId : Craft::$app->getSites()->getCurrentSite()->id;
+        $siteId = Craft::$app->request->getIsCpRequest() ? Cp::requestedSite()?->id : Craft::$app->getSites()->getCurrentSite()->id;
         $categoryGroupSiteSettings = $this->getGroup()->getSiteSettings();
 
         if (!isset($categoryGroupSiteSettings[$siteId]) || !$categoryGroupSiteSettings[$siteId]->hasUrls) {

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -967,7 +967,7 @@ class Entry extends Element implements ExpirableElementInterface
         }
 
         // Make sure the section is set to have URLs for this site
-        $siteId = Craft::$app->getSites()->getCurrentSite()->id;
+        $siteId = Craft::$app->request->getIsCpRequest() ? $this->siteId : Craft::$app->getSites()->getCurrentSite()->id;
         $sectionSiteSettings = $this->getSection()->getSiteSettings();
 
         if (!isset($sectionSiteSettings[$siteId]) || !$sectionSiteSettings[$siteId]->hasUrls) {

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -967,16 +967,15 @@ class Entry extends Element implements ExpirableElementInterface
         }
 
         // Make sure the section is set to have URLs for this site
-        $siteId = Craft::$app->request->getIsCpRequest() ? Cp::requestedSite()?->id : Craft::$app->getSites()->getCurrentSite()->id;
-        $sectionSiteSettings = $this->getSection()->getSiteSettings();
+        $sectionSiteSettings = $this->getSection()->getSiteSettings()[$this->siteId] ?? null;
 
-        if (!isset($sectionSiteSettings[$siteId]) || !$sectionSiteSettings[$siteId]->hasUrls) {
+        if (!$sectionSiteSettings?->hasUrls) {
             return null;
         }
 
         return [
             'templates/render', [
-                'template' => (string)$sectionSiteSettings[$siteId]->template,
+                'template' => (string)$sectionSiteSettings->template,
                 'variables' => [
                     'entry' => $this,
                 ],

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -967,7 +967,7 @@ class Entry extends Element implements ExpirableElementInterface
         }
 
         // Make sure the section is set to have URLs for this site
-        $siteId = Craft::$app->request->getIsCpRequest() ? $this->siteId : Craft::$app->getSites()->getCurrentSite()->id;
+        $siteId = Craft::$app->request->getIsCpRequest() ? Cp::requestedSite()?->id : Craft::$app->getSites()->getCurrentSite()->id;
         $sectionSiteSettings = $this->getSection()->getSiteSettings();
 
         if (!isset($sectionSiteSettings[$siteId]) || !$sectionSiteSettings[$siteId]->hasUrls) {


### PR DESCRIPTION
### Description
When determining the element’s route and we’re in the control panel, get the `siteId` based on the element’s siteId, not the current site.

It was causing an issue for Entries, but adjusted for Categories for consistency and because it just feels like the right approach.


### Related issues
#13746 
