### PR TITLE
[5.x] Fix an error when querying tags

### DIFF
--- a/src/elements/db/TagQuery.php
+++ b/src/elements/db/TagQuery.php
@@ -38,11 +38,6 @@ use yii\db\Connection;
  */
 class TagQuery extends ElementQuery
 {
-    /**
-     * @inheritdoc
-     */
-    protected array $defaultOrderBy = ['content.title' => SORT_ASC];
-
     // General parameters
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
There's no content table any more, so this orderBy param will fail.