### PR TITLE
changedfields table - support for multi-instance fields

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '5.0.0-alpha',
-    'schemaVersion' => '5.0.0.8',
+    'schemaVersion' => '5.0.0.9',
     'minVersionRequired' => '4.4.0',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -256,7 +256,7 @@ class Install extends Migration
             'dateUpdated' => $this->dateTime()->notNull(),
             'propagated' => $this->boolean()->notNull(),
             'userId' => $this->integer(),
-            'PRIMARY KEY([[elementId]], [[siteId]], [[fieldId]])',
+            'PRIMARY KEY([[elementId]], [[siteId]], [[fieldId]], [[layoutElementUid]])',
         ]);
         $this->createTable(Table::CRAFTIDTOKENS, [
             'id' => $this->primaryKey(),

--- a/src/migrations/m231013_185640_changedfields_amend_primary_key.php
+++ b/src/migrations/m231013_185640_changedfields_amend_primary_key.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m231013_185640_changedfields_amend_primary_key migration.
+ */
+class m231013_185640_changedfields_amend_primary_key extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->dropPrimaryKey('elementId', Table::CHANGEDFIELDS);
+        $this->addPrimaryKey('layoutUid', Table::CHANGEDFIELDS, ['elementId', 'siteId', 'fieldId', 'layoutElementUid']);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m231013_185640_changedfields_amend_primary_key cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
### Description
With the multi-instance fields, the `changedfields` primary key can’t be limited to `elementId`, `siteId`, `fieldId`. 
This PR adds a migration that extends the PK to contain `elementId`, `siteId`, `fieldId` and `layoutElementUid`. 


### Related issues
N/A
