### PR TITLE
change fallback hint to empty string

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1123,7 +1123,7 @@ class UsersController extends Controller
                 'value' => $locale->id,
                 'data' => [
                     'data' => [
-                        'hint' => $locale->getLanguageID() !== $languageId ? $locale->getDisplayName() : false,
+                        'hint' => $locale->getLanguageID() !== $languageId ? $locale->getDisplayName() : '',
                         'hintLang' => $locale->id,
                     ],
                 ],


### PR DESCRIPTION
### Description
Fixes an issue where, for all languages in the dropdowns on the user profile page (preferences tab), the literal ’false’ hint was displayed if the language matched the control panel language. In cases like that, no hint should be shown.


### Related issues
#13837 
