### PR TITLE
craft_modify_app_config()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `craft\errors\ExitException`.
 - Added `craft\web\View::startMetaTagBuffer()`.
 - Added `craft\web\View::clearMetaTagBuffer()`.
+- Added support for modifying the application config via a global `craft_modify_app_config()` function. ([#13855](https://github.com/craftcms/cms/pull/13855))
 - Fixed a bug where `{% exit %}` tags without a status code weren’t outputting any HTML that had already been output in the template. ([#13848](https://github.com/craftcms/cms/discussions/13848))
 
 ## 4.5.7 - 2023-10-17

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -241,7 +241,7 @@ $config = ArrayHelper::merge(
 );
 
 if (function_exists('craft_modify_app_config')) {
-    craft_modify_app_config($config);
+    craft_modify_app_config($config, $appType);
 }
 
 // Initialize the application

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -240,6 +240,10 @@ $config = ArrayHelper::merge(
     $configService->getConfigFromFile("app.{$appType}")
 );
 
+if (function_exists('craft_modify_app_config')) {
+    craft_modify_app_config($config);
+}
+
 // Initialize the application
 /** @var \craft\web\Application|craft\console\Application $app */
 $app = Craft::createObject($config);


### PR DESCRIPTION
Adds support for a global `craft_modify_app_config()` function. If defined, the application config will be passed to it, and can be modified from there, before being passed to the `Application` constructor.