### PR TITLE
Bugfix/13854 set status bulk action

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -4944,7 +4944,7 @@ JS,
      * @return bool
      * @since 4.5.0
      */
-    protected function showStatusField(): bool
+    public function showStatusField(): bool
     {
         return true;
     }

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -4944,7 +4944,7 @@ JS,
      * @return bool
      * @since 4.5.0
      */
-    public function showStatusField(): bool
+    protected function showStatusField(): bool
     {
         return true;
     }

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -4950,6 +4950,20 @@ JS,
     }
 
     /**
+     * Public method that returns whether status field should be shown for given element.
+     * It's a temporary solution, to be removed in v5 when Element::showStatusField() can be set to be public.
+     * (introduced to deal with #13854)
+     *
+     * @return bool
+     * @since 4.5.9
+     * @deprecated @4.5.9
+     */
+    public function getShowStatusField(): bool
+    {
+        return $this->showStatusField();
+    }
+
+    /**
      * Returns the status field HTML for the sidebar.
      *
      * @return string

--- a/src/elements/actions/SetStatus.php
+++ b/src/elements/actions/SetStatus.php
@@ -92,7 +92,7 @@ JS, [static::class]);
                 case self::ENABLED:
                     // Skip if we're not supposed to allow changing status
                     /** @var Element $element */
-                    if (!$element->showStatusField()) {
+                    if (!$element->getShowStatusField()) {
                         continue 2;
                     }
 
@@ -109,7 +109,7 @@ JS, [static::class]);
                 case self::DISABLED:
                     // Skip if we're not supposed to allow changing status
                     /** @var Element $element */
-                    if (!$element->showStatusField()) {
+                    if (!$element->getShowStatusField()) {
                         continue 2;
                     }
 

--- a/src/elements/actions/SetStatus.php
+++ b/src/elements/actions/SetStatus.php
@@ -90,6 +90,12 @@ JS, [static::class]);
         foreach ($elements as $element) {
             switch ($this->status) {
                 case self::ENABLED:
+                    // Skip if we're not supposed to allow changing status
+                    /** @var Element $element */
+                    if (!$element->showStatusField()) {
+                        continue 2;
+                    }
+
                     // Skip if there's nothing to change
                     if ($element->enabled && $element->getEnabledForSite()) {
                         continue 2;
@@ -101,6 +107,12 @@ JS, [static::class]);
                     break;
 
                 case self::DISABLED:
+                    // Skip if we're not supposed to allow changing status
+                    /** @var Element $element */
+                    if (!$element->showStatusField()) {
+                        continue 2;
+                    }
+
                     // Is this a multi-site element?
                     if ($isLocalized && count($element->getSupportedSites()) !== 1) {
                         // Skip if there's nothing to change


### PR DESCRIPTION
### Description
Don’t change the element’s status via bulk action if its type’s `showStatusField` is `false`.


### Related issues
#13854 
