### PR TITLE
Create storage folder in bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where it was possible to change the status for entries that didn’t show the Status field, via bulk editing. ([#13854](https://github.com/craftcms/cms/issues/13854))
 - Fixed a PHP error that could occur when editing elements via slideouts. ([#13867](https://github.com/craftcms/cms/issues/13867))
+- Fixed an error that could occur if no `storage/` folder existed.
 
 ## 4.5.8 - 2023-10-20
 

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -130,6 +130,7 @@ if (!App::env('CRAFT_LICENSE_KEY') && !App::isEphemeral()) {
     }
 }
 
+$createFolder($storagePath);
 $ensureFolderIsReadable($storagePath, true);
 
 // Create the storage/runtime/ folder if it doesn't already exist


### PR DESCRIPTION
### Description
As of https://github.com/craftcms/cms/pull/10562, we would attempt to create the `$storage` folder if it didn't exist.

[This commit](https://github.com/craftcms/cms/commit/8d0cfc1fe3e51f60ef4ad38bdb466e41054895e1) undid that, in that `$ensureFolderIsReadable` is called on the root `$storage` before it is ever attempted to be create, so the resulting `realpath` will always fail if the `$storage` path doesn't yet exist.