### PR TITLE
keep notice param type like it was before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where it was possible to change the status for entries that didn’t show the Status field, via bulk editing. ([#13854](https://github.com/craftcms/cms/issues/13854))
+- Fixed a PHP error that could occur when editing elements via slideouts. ([#13867](https://github.com/craftcms/cms/issues/13867))
 
 ## 4.5.8 - 2023-10-20
 

--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -378,9 +378,9 @@ class ElementsController extends Controller
         $security = Craft::$app->getSecurity();
         $notice = null;
         if ($element->isProvisionalDraft) {
-            $notice = $this->_draftNotice();
+            $notice = fn() => $this->_draftNotice();
         } elseif ($element->getIsRevision()) {
-            $notice = $this->_revisionNotice($element::lowerDisplayName());
+            $notice = fn() => $this->_revisionNotice($element::lowerDisplayName());
         }
 
         $response = $this->asCpScreen()
@@ -406,7 +406,7 @@ class ElementsController extends Controller
                 $isUnpublishedDraft,
                 $isDraft
             ))
-            ->notice(fn() => $notice)
+            ->notice($notice)
             ->errorSummary(fn() => $this->_errorSummary($element))
             ->prepareScreen(
                 fn(Response $response, string $containerId) => $this->_prepareEditor(

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -1660,13 +1660,13 @@ JS;
             // If no namespace was passed in, just return the callable response directly.
             // No need to namespace it via the currently-set namespace in this case; if there is one, it should get applied later on.
             if ($namespace === null) {
-                return $html();
+                return (string)$html();
             }
 
             $oldNamespace = $this->getNamespace();
             $this->setNamespace($this->namespaceInputName($namespace));
             try {
-                $response = $this->namespaceInputs($html(), $namespace, $otherAttributes, $withClasses);
+                $response = $this->namespaceInputs((string)$html(), $namespace, $otherAttributes, $withClasses);
             } finally {
                 $this->setNamespace($oldNamespace);
             }


### PR DESCRIPTION
### Description
Keep the type of the `$notice` param passed to the `CpScreenResponseBehavior::notice()` method like it was before introducing a `_revisionNotice()`.


### Related issues
#13867 
