### PR TITLE
(fix) Prevent crash when the Fs has no settings

### DIFF
--- a/src/services/Fs.php
+++ b/src/services/Fs.php
@@ -119,7 +119,9 @@ class Fs extends Component
             $configs = Craft::$app->getProjectConfig()->get(ProjectConfig::PATH_FS) ?? [];
             $filesystems = array_map(function(string $handle, array $config) {
                 $config['handle'] = $handle;
-                $config['settings'] = ProjectConfigHelper::unpackAssociativeArrays($config['settings']);
+                $config['settings'] = !isset($config['settings'])
+                    ? []
+                    : ProjectConfigHelper::unpackAssociativeArrays($config['settings']);
                 return $this->createFilesystem($config);
             }, array_keys($configs), $configs);
             $this->_filesystems = new MemoizableArray($filesystems);


### PR DESCRIPTION
This fix is required for Fs that do not have any settings. Without it, the filesystem page crashes with an undefined "settings" key error message.

Please tell me if I did something wrong. If not, this fix is required.

