### PR TITLE
make startImageEditing more forgiving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a bug where disclosure menus could be positioned off-screen on mobile.
 - Fixed a bug where element edit pages could show a context menu when it wasn’t necessary.
 - Fixed a bug where the “Delete entry for this site” action wasn’t deleting the canonical entry for the selected site, when editing a provisional draft.
+- Fixed an error that occurred when cropping an image that was missing its dimension info. ([#13884](https://github.com/craftcms/cms/issues/13884))])
 
 ## 4.5.9 - 2023-10-23
 

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -664,8 +664,14 @@ class ImageTransformer extends Component implements ImageTransformerInterface, E
     {
         $imageCopy = $asset->getCopyOfFile();
 
-        /** @var Raster $image */
-        $image = Craft::$app->getImages()->loadImage($imageCopy, true, max($asset->height, $asset->width));
+        if (FileHelper::isSvg($imageCopy)) {
+            $size = max($asset->width, $asset->height) ?? 1000;
+            /** @var Raster $image */
+            $image = Craft::$app->getImages()->loadImage($imageCopy, true, $size);
+        } else {
+            /** @var Raster $image */
+            $image = Craft::$app->getImages()->loadImage($imageCopy);
+        }
 
         // TODO Is this hacky? It seems hacky.
         // We're rasterizing SVG, we have to make sure that the filename change does not get lost


### PR DESCRIPTION
### Description
When asset width and height are set to `null` in the database, and you want to edit (e.g. crop) such image, you’ll get `craft\services\Images::loadImage(): Argument https://github.com/craftcms/cms/issues/3 ($svgSize) must be of type int, null given, called in /imagetransforms/ImageTransformer.php on line 668` error.

In this context, we actually only use the stored dimensions if we’re about to process an SVG, so I’ve applied a similar logic here as we do in `ImageTransforms::generateTransform()`, where we try to get the max dimension, and if it’s `null` then we assume the default of 1000.


### Related issues
#13884 
