### PR TITLE
fallback on using getimagesize to get image dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Top-level disabled related/nested elements are now included in “Extended” element exports. ([#13496](https://github.com/craftcms/cms/issues/13496))
 - Addresses’ owner elements are now automatically set on them during initialization, if they were queried with the `owner` address query param.
 - Entry Title fields are no longer shown when “Show the Title field” is disabled and there’s a validation error on the `title` attribute. ([#13876](https://github.com/craftcms/cms/issues/13876))
+- Improved the reliability of image dimension detection. ([#13886](https://github.com/craftcms/cms/pull/13886))
 - Added `craft\web\AssetManager::$cacheSourcePaths`.
 - Fixed a bug where disclosure menus could be positioned off-screen on mobile.
 - Fixed a bug where element edit pages could show a context menu when it wasn’t necessary.

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2872,6 +2872,23 @@ JS;
                 Image::cleanImageByPath($this->tempFilePath);
             }
 
+            // if we're creating or replacing and image, get the width or height via getimagesize
+            // in case loadImage is not able to get them properly (e.g. imagick runs out of memory)
+            $fallbackWidth = null;
+            $fallbackHeight = null;
+            if (
+                in_array($this->getScenario(), [self::SCENARIO_REPLACE, self::SCENARIO_CREATE], true) &&
+                Assets::getFileKindByExtension($this->tempFilePath) === static::KIND_IMAGE
+            ) {
+                $imageSize = getimagesize($this->tempFilePath);
+                if (isset($imageSize[0])) {
+                    $fallbackWidth = (int)$imageSize[0];
+                }
+                if (isset($imageSize[1])) {
+                    $fallbackHeight = (int)$imageSize[1];
+                }
+            }
+
             // Relocate the file?
             if (isset($this->newLocation) || isset($this->tempFilePath)) {
                 $this->_relocateFile();
@@ -2896,8 +2913,8 @@ JS;
             $record->kind = $this->kind;
             $record->alt = $this->alt;
             $record->size = (int)$this->size ?: null;
-            $record->width = (int)$this->_width ?: null;
-            $record->height = (int)$this->_height ?: null;
+            $record->width = (int)$this->_width ?: $fallbackWidth;
+            $record->height = (int)$this->_height ?: $fallbackHeight;
             $record->dateModified = Db::prepareDateForDb($this->dateModified);
 
             if ($this->getHasFocalPoint()) {


### PR DESCRIPTION
### Description
When creating or replacing an image asset, use `getimagesize` to grab the fallback width and height for the image and use those values if we’re not able to obtain them via `Image::imageSize()` (which relies on `Raster->loadImage()`). This can happen if, e.g. ImageMagick runs out of memory.


### Related issues
#13687 
