### PR TITLE
Omit db connection errors for console requests

### DIFF
--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -895,10 +895,13 @@ trait ApplicationTrait
         try {
             $this->getDb()->open();
         } catch (DbConnectException|InvalidConfigException $e) {
-            Craft::error('There was a problem connecting to the database: ' . $e->getMessage(), __METHOD__);
-            /** @var ErrorHandler $errorHandler */
-            $errorHandler = $this->getErrorHandler();
-            $errorHandler->logException($e);
+            if ($this instanceof WebApplication) {
+                Craft::error('There was a problem connecting to the database: ' . $e->getMessage(), __METHOD__);
+                /** @var ErrorHandler $errorHandler */
+                $errorHandler = $this->getErrorHandler();
+                $errorHandler->logException($e);
+            }
+
             return false;
         }
 

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -895,6 +895,8 @@ trait ApplicationTrait
         try {
             $this->getDb()->open();
         } catch (DbConnectException|InvalidConfigException $e) {
+
+            // Allow console requests to bypass error
             if ($this instanceof WebApplication) {
                 Craft::error('There was a problem connecting to the database: ' . $e->getMessage(), __METHOD__);
                 /** @var ErrorHandler $errorHandler */

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -896,7 +896,7 @@ trait ApplicationTrait
             $this->getDb()->open();
         } catch (DbConnectException|InvalidConfigException $e) {
 
-            // Allow console requests to bypass error
+            // Only log for web requests
             if ($this instanceof WebApplication) {
                 Craft::error('There was a problem connecting to the database: ' . $e->getMessage(), __METHOD__);
                 /** @var ErrorHandler $errorHandler */


### PR DESCRIPTION
Matches logic from `getIsInstalled`: https://github.com/craftcms/cms/blob/develop/src/base/ApplicationTrait.php#L418-L423, to only log the exception for web.

If you are running a console command, it is possible your db connection isn't valid (`--skip-install-check`) and you don't want a bunch of errors logged to your output.