### PR TITLE
add sites.id as additional ordering parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed an error that occurred when cropping an image that was missing its dimension info. ([#13884](https://github.com/craftcms/cms/issues/13884))])
 - Fixed an error that occurred if a filesystem didn’t have any settings. ([#13883](https://github.com/craftcms/cms/pull/13883))
 - Fixed a bug where related element validation wansn’t ensuring that related elements were loaded in the same site as the source element when possible. ([#13907](https://github.com/craftcms/cms/issues/13907))
+- Fixed a bug where sites weren’t always getting queried in the same order, if multiple sites’ `sortOrder` values were the same. ([#13896](https://github.com/craftcms/cms/issues/13896))
 
 ## 4.5.9 - 2023-10-23
 

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -1164,7 +1164,7 @@ class Sites extends Component
             ->innerJoin(['sg' => Table::SITEGROUPS], '[[sg.id]] = [[s.groupId]]')
             ->where(['s.dateDeleted' => null])
             ->andWhere(['sg.dateDeleted' => null])
-            ->orderBy(['sg.name' => SORT_ASC, 's.sortOrder' => SORT_ASC])
+            ->orderBy(['sg.name' => SORT_ASC, 's.sortOrder' => SORT_ASC, 's.id' => SORT_ASC])
             ->all();
 
         // Check for results because during installation, the transaction hasn't been committed yet.


### PR DESCRIPTION
### Description
This PR adds `sites.id` as an additional ordering parameter to the `_loadAllSites()` method.

At the moment, when loading all sites, they’re ordered by `sortOrder` within their Sites Group. This can create unexpected behaviour on the off-chance that the `sortOrder` got “wonky”, and there are duplicate `sortOrder` values for multiple sitest in the same group. Adding `sites.id` to `orderBy`, ensures that the order will be consistent even if it can't be determined by only `sortOrder` within the group.


### Related issues
#13896 
