### PR TITLE
fix: Fix custom fields have double-encoded values if the content column type is `Schema::TYPE_JSON`

### DIFF
--- a/src/services/Content.php
+++ b/src/services/Content.php
@@ -130,10 +130,10 @@ class Content extends Component
             if (is_array($type)) {
                 foreach (array_keys($type) as $i => $key) {
                     $column = ElementHelper::fieldColumnFromField($field, $i !== 0 ? $key : null);
-                    $values[$column] = Db::prepareValueForDb($value[$key] ?? null);
+                    $values[$column] = Db::prepareValueForDb($value[$key] ?? null, $type[$key]);
                 }
             } else {
-                $column = ElementHelper::fieldColumnFromField($field);
+                $column = ElementHelper::fieldColumnFromField($field, $type);
                 $values[$column] = Db::prepareValueForDb($value);
             }
         }


### PR DESCRIPTION
### Description

Fixes an issue where `Content::saveContent()` doesn't pass in the `$columnType` to `Db::prepareValueForDb()`, which causes content column types of `Schema::TYPE_JSON` to be double-encoded.

### Related issues

Closes: https://github.com/craftcms/cms/issues/13916