### PR TITLE
set to `:empty:` for relation fields

### DIFF
--- a/src/queue/jobs/ResaveElements.php
+++ b/src/queue/jobs/ResaveElements.php
@@ -102,7 +102,7 @@ class ResaveElements extends BaseBatchedJob
         $item->resaving = true;
 
         if (isset($this->set) && (!$this->ifEmpty || ElementHelper::isAttributeEmpty($item, $this->set))) {
-            $to = ResaveController::normalizeTo($this->to);
+            $to = ResaveController::normalizeTo($this->to, $this->set);
             $item->{$this->set} = $to($item);
         }
 


### PR DESCRIPTION
### Description
When setting a relation field to `:empty:` via the resave command, the normalised `$to` value needs to return an empty string (not `null`). Otherwise, the updated (empty) value won’t be set.


### Related issues
#13951 
