### PR TITLE
Include column type argument when preparing field content to be saved

### DIFF
--- a/src/services/Content.php
+++ b/src/services/Content.php
@@ -130,11 +130,11 @@ class Content extends Component
             if (is_array($type)) {
                 foreach (array_keys($type) as $i => $key) {
                     $column = ElementHelper::fieldColumnFromField($field, $i !== 0 ? $key : null);
-                    $values[$column] = Db::prepareValueForDb($value[$key] ?? null);
+                    $values[$column] = Db::prepareValueForDb($value[$key] ?? null, $type[$key]);
                 }
             } else {
                 $column = ElementHelper::fieldColumnFromField($field);
-                $values[$column] = Db::prepareValueForDb($value);
+                $values[$column] = Db::prepareValueForDb($value, $type);
             }
         }
 


### PR DESCRIPTION
### Description

With a psql database, if a custom field has a `Schema::JSON` field type, Craft inserts/updates the field data as a string instead of valid json. With mysql, this works fine. 

The functionality to prevent any encoding already exists in `prepareValueForDb`, just the type argument was missing in `saveContent`. This PR adds that argument so that data is saved correctly for psql.

### Related issues

N/A