### PR TITLE
don't encode quotes before passing to markdown

### DIFF
--- a/src/fieldlayoutelements/Tip.php
+++ b/src/fieldlayoutelements/Tip.php
@@ -101,7 +101,7 @@ class Tip extends BaseUiElement
             $classes[] = 'dismissible';
         }
 
-        $tip = Markdown::process(Html::encode(Craft::t('site', $this->tip)));
+        $tip = Markdown::process(Html::encodeNoQuotes(Craft::t('site', $this->tip), false));
         $closeBtn = $this->dismissible
             ? Html::button('', [
                 'class' => 'tip-dismiss-btn',

--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -969,6 +969,19 @@ class Html extends \yii\helpers\Html
     }
 
     /**
+     * Variation of \yii\helpers\Html::encode where the quotes are not encoded.
+     *
+     * @param string $content the content to be encoded
+     * @param bool $doubleEncode whether to encode HTML entities in `$content`. If false, HTML entities in `$content` will not be further encoded.
+     * @return string
+     * @since 4.5.12
+     */
+    public static function encodeNoQuotes(string $content, bool $doubleEncode = true): string
+    {
+        return htmlspecialchars($content, ENT_NOQUOTES | ENT_SUBSTITUTE, Craft::$app ? Craft::$app->charset : 'UTF-8', $doubleEncode);
+    }
+
+    /**
      * Encodes invalid (unclosed) HTML tags so they appear as plain text.
      *
      * @param string $html


### PR DESCRIPTION
### Description
Don’t encode single and double quotes in a string that’s passed to Markdown for further processing.

Before:
<img width="875" alt="Screenshot 2023-11-23 at 13 33 17" src="https://github.com/craftcms/cms/assets/4500340/a0c38c4c-0269-4e74-9cc1-9007cf16d7e5">


After:
<img width="965" alt="Screenshot 2023-11-23 at 13 33 05" src="https://github.com/craftcms/cms/assets/4500340/75a48ff7-4b60-49a5-abaf-5182f7df5c39">


### Related issues
#13959 
