### PR TITLE
Allow `_fields()` to include non-layout fields

### DIFF
--- a/src/Craft.php
+++ b/src/Craft.php
@@ -348,10 +348,17 @@ EOD;
      */
     private static function _fields(): array
     {
-        return array_merge(...array_map(
+        // Fetch all the fields for every layout, which includes every instance of a field
+        $fieldInstances = array_merge(...array_map(
             fn(FieldLayout $fieldLayout) => $fieldLayout->getCustomFields(),
             Craft::$app->getFields()->getAllLayouts(),
         ));
+
+        // Then, also fetch every top-level field, just in case - to handle any fields not in a layout
+        $fields = Craft::$app->getFields()->getAllFields(false);
+
+        // Return everything unique
+        return array_values(array_unique(array_merge(...[$fieldInstances, $fields])));
     }
 
     /**


### PR DESCRIPTION
There's been a change in behaviour for the custom field behaviour for elements. Previously, in Craft 4, all fields in the field table would be used to generate the behaviour file. Now, due to field instances being a thing, you need to loop through each field layout, and use the handles of _those_ instances.

This poses an issue for Formie, and it's likely very unique to us an our situation. For some background, Formie uses field layouts for its forms, but requires it's own structure. Craft's field layouts use Tabs > Fields, where Formie uses Pages > Rows > Fields. While we'd **love** to use Craft's field layouts (and we did for Formie v1/2 but it was a mess), having this custom structure isn't really possible to store against a field layout. So, we store the field layout information in our own table, and spin up a FieldLayout-compatible model, sprinkled with our own stuff for Formie's needs.

But, where this trips up is that because we're not saving a field layout to the `fieldlayouts` table, Formie's fields won't be included in this generation. This is despite Formie fields being present in the `fields` database table, with their own context.

This fix incorporates all custom fields, and all field instances, returning the unique fields.

As an aside, a larger "fix" for this would be to allow Formie to implement a layer of structure between the field layout and Formie, so we could use things natively, instead of rolling our own field layout mechanism. Brandon mentioned a 
 `FieldCompilationInterface` or something similar, which `FieldLayout` implements, but leaving room for other things that have fields but not field layouts.