### PR TITLE
Add Development mode to the System report

### DIFF
--- a/src/utilities/SystemReport.php
+++ b/src/utilities/SystemReport.php
@@ -100,6 +100,7 @@ class SystemReport extends Utility
     private static function _appInfo(): array
     {
         $info = [
+            'Development mode' => Craft::t('app', Craft::$app->config->general->devMode ? 'Yes' : 'No'),
             'PHP version' => App::phpVersion(),
             'OS version' => PHP_OS . ' ' . php_uname('r'),
             'Database driver & version' => self::_dbDriver(),


### PR DESCRIPTION
It would be terrible to run in development mode on a production server, this makes it clear whether the configuration is correct.
