### PR TITLE
Bulk element operation tracking + event

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -61,6 +61,7 @@
 - Entry type names and handles must now be unique globally, rather than just within a single section. Existing entry type names and handles will be renamed automatically where needed, to ensure uniqueness.
 - Assets, categories, entries, and tags now support eager-loading paths prefixed with a field layout provider’s handle (e.g. `myEntryType:myField`).
 - Element queries now have an `eagerly` param, which can be used to lazily eager-load the resulting elements for all peer elements, when `all()`, `collect()`, `one()`, `nth()`, or `count()` is called.
+- Element queries now have an `inBulkOp` param, which limits the results to elements which were involved in a bulk operation. ([#14032](https://github.com/craftcms/cms/pull/14032))
 - Address queries now have `addressLine1`, `addressLine2`, `administrativeArea`, `countryCode`, `dependentLocality`, `firstName`, `fullName`, `lastName`, `locality`, `organizationTaxId`, `organization`, `postalCode`, and `sortingCode` params.
 - Entry queries now have `field`, `fieldId`, `primaryOwner`, `primaryOwnerId`, `owner`, `ownerId`, `allowOwnerDrafts`, and `allowOwnerRevisions` params.
 - Entries’ GraphQL type names are now formatted as `<entryTypeHandle>_Entry`, and are no longer prefixed with their section’s handle. (That goes for Matrix-nested entries as well.)
@@ -171,6 +172,7 @@
 - Added `craft\enums\PropagationMethod`.
 - Added `craft\enums\TimePeriod`.
 - Added `craft\events\BulkElementsEvent`.
+- Added `craft\events\BulkOpEvent`. ([#14032](https://github.com/craftcms/cms/pull/14032))
 - Added `craft\events\DefineEntryTypesForFieldEvent`.
 - Added `craft\events\DefineFieldHtmlEvent::$inline`.
 - Added `craft\fieldlayoutelements\BaseField::$includeInCards`.
@@ -226,6 +228,11 @@
 - Added `craft\models\Section::getCpEditUrl()`.
 - Added `craft\models\Volume::getSubpath()`.
 - Added `craft\models\Volume::setSubpath()`.
+- Added `craft\queue\BaseBatchedElementJob`. ([#14032](https://github.com/craftcms/cms/pull/14032))
+- Added `craft\queue\BaseBatchedJob::after()`.
+- Added `craft\queue\BaseBatchedJob::afterBatch()`.
+- Added `craft\queue\BaseBatchedJob::before()`.
+- Added `craft\queue\BaseBatchedJob::beforeBatch()`.
 - Added `craft\services\Auth`.
 - Added `craft\services\Entries::refreshEntryTypes()`.
 - Added `craft\services\Fields::$fieldContext`, which replaces `craft\services\Content::$fieldContext`.

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '5.0.0-alpha',
-    'schemaVersion' => '5.0.0.10',
+    'schemaVersion' => '5.0.0.11',
     'minVersionRequired' => '4.4.0',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/db/Table.php
+++ b/src/db/Table.php
@@ -44,6 +44,8 @@ abstract class Table
     public const DRAFTS = '{{%drafts}}';
     /** @since 4.5.0 */
     public const ELEMENTACTIVITY = '{{%elementactivity}}';
+    /** @since 5.0.0 */
+    public const ELEMENTBULKOPS = '{{%elementbulkops}}';
     public const ELEMENTS = '{{%elements}}';
     /** @since 5.0.0 */
     public const ELEMENTS_OWNERS = '{{%elements_owners}}';

--- a/src/db/Table.php
+++ b/src/db/Table.php
@@ -44,9 +44,9 @@ abstract class Table
     public const DRAFTS = '{{%drafts}}';
     /** @since 4.5.0 */
     public const ELEMENTACTIVITY = '{{%elementactivity}}';
-    /** @since 5.0.0 */
-    public const ELEMENTBULKOPS = '{{%elementbulkops}}';
     public const ELEMENTS = '{{%elements}}';
+    /** @since 5.0.0 */
+    public const ELEMENTS_BULKOPS = '{{%elements_bulkops}}';
     /** @since 5.0.0 */
     public const ELEMENTS_OWNERS = '{{%elements_owners}}';
     public const ELEMENTS_SITES = '{{%elements_sites}}';

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -350,6 +350,7 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @var string|null The bulk element operation key that the resulting elements were involved in.
      *
      * @used-by ElementQuery::inBulkOp()
+     * @since 5.0.0
      */
     public ?string $inBulkOp = null;
 
@@ -2871,8 +2872,8 @@ class ElementQuery extends Query implements ElementQueryInterface
     {
         if ($this->inBulkOp) {
             $this->subQuery
-                ->innerJoin(['elementbulkops' => Table::ELEMENTBULKOPS], '[[elementbulkops.elementId]] = [[elements.id]]')
-                ->andWhere(['elementbulkops.key' => $this->inBulkOp]);
+                ->innerJoin(['elements_bulkops' => Table::ELEMENTS_BULKOPS], '[[elements_bulkops.elementId]] = [[elements.id]]')
+                ->andWhere(['elements_bulkops.key' => $this->inBulkOp]);
         }
     }
 

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -101,6 +101,9 @@ class ElementQuery extends Query implements ElementQueryInterface
      */
     public const EVENT_AFTER_POPULATE_ELEMENTS = 'afterPopulateElements';
 
+    // Base config attributes
+    // -------------------------------------------------------------------------
+
     /**
      * @var string The name of the [[ElementInterface]] class.
      * @phpstan-var class-string<ElementInterface>
@@ -342,6 +345,13 @@ class ElementQuery extends Query implements ElementQueryInterface
      * @used-by ElementQuery::search()
      */
     public mixed $search = null;
+
+    /**
+     * @var string|null The bulk element operation key that the resulting elements were involved in.
+     *
+     * @used-by ElementQuery::inBulkOp()
+     */
+    public ?string $inBulkOp = null;
 
     /**
      * @var mixed The reference code(s) used to identify the element(s).
@@ -1077,6 +1087,16 @@ class ElementQuery extends Query implements ElementQueryInterface
 
     /**
      * @inheritdoc
+     * @uses $inBulkOp
+     */
+    public function inBulkOp(?string $value): static
+    {
+        $this->inBulkOp = $value;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
      * @uses $ref
      */
     public function ref($value): static
@@ -1531,6 +1551,7 @@ class ElementQuery extends Query implements ElementQueryInterface
         $this->_applyStructureParams($class);
         $this->_applyRevisionParams();
         $this->_applySearchParam($db);
+        $this->_applyInBulkOpParam();
         $this->_applyOrderByParams($db);
         $this->_applySelectParam();
         $this->_applyJoinParams();
@@ -2840,6 +2861,18 @@ class ElementQuery extends Query implements ElementQueryInterface
             $this->_searchResults = $searchResults;
 
             $this->subQuery->andWhere(['elements.id' => array_keys($searchResults)]);
+        }
+    }
+
+    /**
+     * Applies the 'inBulkOp' param to the query being prepared.
+     */
+    private function _applyInBulkOpParam(): void
+    {
+        if ($this->inBulkOp) {
+            $this->subQuery
+                ->innerJoin(['elementbulkops' => Table::ELEMENTBULKOPS], '[[elementbulkops.elementId]] = [[elements.id]]')
+                ->andWhere(['elementbulkops.key' => $this->inBulkOp]);
         }
     }
 

--- a/src/elements/db/ElementQueryInterface.php
+++ b/src/elements/db/ElementQueryInterface.php
@@ -1004,6 +1004,7 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
      *
      * @param string|null $value The property value
      * @return static self reference
+     * @since 5.0.0
      */
     public function inBulkOp(?string $value): static;
 

--- a/src/elements/db/ElementQueryInterface.php
+++ b/src/elements/db/ElementQueryInterface.php
@@ -1000,6 +1000,14 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
     public function search(mixed $value): static;
 
     /**
+     * Narrows the query results to only {elements} that were involved in a bulk element operation.
+     *
+     * @param string|null $value The property value
+     * @return static self reference
+     */
+    public function inBulkOp(?string $value): static;
+
+    /**
      * Narrows the query results based on a reference string.
      *
      * @param mixed $value The property value

--- a/src/events/BulkElementOpEvent.php
+++ b/src/events/BulkElementOpEvent.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+/**
+ * Bulk element operation event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.0.0
+ */
+class BulkElementOpEvent extends ElementQueryEvent
+{
+    /**
+     * @var string The bulk operation key.
+     */
+    public string $key;
+}

--- a/src/events/BulkOpEvent.php
+++ b/src/events/BulkOpEvent.php
@@ -8,12 +8,12 @@
 namespace craft\events;
 
 /**
- * Bulk element operation event class.
+ * Bulk operation event class.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 5.0.0
  */
-class BulkElementOpEvent extends ElementQueryEvent
+class BulkOpEvent extends ElementQueryEvent
 {
     /**
      * @var string The bulk operation key.

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -307,6 +307,12 @@ class Install extends Migration
             'timestamp' => $this->dateTime(),
             'PRIMARY KEY([[elementId]], [[userId]], [[type]])',
         ]);
+        $this->createTable(Table::ELEMENTBULKOPS, [
+            'elementId' => $this->integer(),
+            'key' => $this->char(10)->notNull(),
+            'timestamp' => $this->dateTime()->notNull(),
+            'PRIMARY KEY([[elementId]], [[key]])',
+        ]);
         $this->createTable(Table::ELEMENTS, [
             'id' => $this->primaryKey(),
             'canonicalId' => $this->integer(),
@@ -803,6 +809,7 @@ class Install extends Migration
         $this->createIndex(null, Table::DRAFTS, ['creatorId', 'provisional'], false);
         $this->createIndex(null, Table::DRAFTS, ['saved'], false);
         $this->createIndex(null, Table::ELEMENTACTIVITY, ['elementId', 'timestamp', 'userId'], false);
+        $this->createIndex(null, Table::ELEMENTBULKOPS, ['timestamp'], false);
         $this->createIndex(null, Table::ELEMENTS, ['dateDeleted'], false);
         $this->createIndex(null, Table::ELEMENTS, ['fieldLayoutId'], false);
         $this->createIndex(null, Table::ELEMENTS, ['type'], false);
@@ -982,6 +989,7 @@ class Install extends Migration
         $this->addForeignKey(null, Table::ELEMENTACTIVITY, ['userId'], Table::USERS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTACTIVITY, ['siteId'], Table::SITES, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTACTIVITY, ['draftId'], Table::DRAFTS, ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, Table::ELEMENTBULKOPS, ['elementId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTS, ['canonicalId'], Table::ELEMENTS, ['id'], 'SET NULL');
         $this->addForeignKey(null, Table::ELEMENTS, ['draftId'], Table::DRAFTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTS, ['revisionId'], Table::REVISIONS, ['id'], 'CASCADE', null);

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -307,12 +307,6 @@ class Install extends Migration
             'timestamp' => $this->dateTime(),
             'PRIMARY KEY([[elementId]], [[userId]], [[type]])',
         ]);
-        $this->createTable(Table::ELEMENTBULKOPS, [
-            'elementId' => $this->integer(),
-            'key' => $this->char(10)->notNull(),
-            'timestamp' => $this->dateTime()->notNull(),
-            'PRIMARY KEY([[elementId]], [[key]])',
-        ]);
         $this->createTable(Table::ELEMENTS, [
             'id' => $this->primaryKey(),
             'canonicalId' => $this->integer(),
@@ -328,6 +322,12 @@ class Install extends Migration
             'dateDeleted' => $this->dateTime()->null(),
             'deletedWithOwner' => $this->boolean()->null(),
             'uid' => $this->uid(),
+        ]);
+        $this->createTable(Table::ELEMENTS_BULKOPS, [
+            'elementId' => $this->integer(),
+            'key' => $this->char(10)->notNull(),
+            'timestamp' => $this->dateTime()->notNull(),
+            'PRIMARY KEY([[elementId]], [[key]])',
         ]);
         $this->createTable(Table::ELEMENTS_OWNERS, [
             'elementId' => $this->integer()->notNull(),
@@ -809,7 +809,6 @@ class Install extends Migration
         $this->createIndex(null, Table::DRAFTS, ['creatorId', 'provisional'], false);
         $this->createIndex(null, Table::DRAFTS, ['saved'], false);
         $this->createIndex(null, Table::ELEMENTACTIVITY, ['elementId', 'timestamp', 'userId'], false);
-        $this->createIndex(null, Table::ELEMENTBULKOPS, ['timestamp'], false);
         $this->createIndex(null, Table::ELEMENTS, ['dateDeleted'], false);
         $this->createIndex(null, Table::ELEMENTS, ['fieldLayoutId'], false);
         $this->createIndex(null, Table::ELEMENTS, ['type'], false);
@@ -818,6 +817,7 @@ class Install extends Migration
         $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateCreated'], false);
         $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateDeleted', 'draftId', 'revisionId', 'canonicalId'], false);
         $this->createIndex(null, Table::ELEMENTS, ['archived', 'dateDeleted', 'draftId', 'revisionId', 'canonicalId', 'enabled'], false);
+        $this->createIndex(null, Table::ELEMENTS_BULKOPS, ['timestamp'], false);
         $this->createIndex(null, Table::ELEMENTS_SITES, ['elementId', 'siteId'], true);
         $this->createIndex(null, Table::ELEMENTS_SITES, ['siteId'], false);
         $this->createIndex(null, Table::ELEMENTS_SITES, ['title', 'siteId'], false);
@@ -989,11 +989,11 @@ class Install extends Migration
         $this->addForeignKey(null, Table::ELEMENTACTIVITY, ['userId'], Table::USERS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTACTIVITY, ['siteId'], Table::SITES, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTACTIVITY, ['draftId'], Table::DRAFTS, ['id'], 'CASCADE', null);
-        $this->addForeignKey(null, Table::ELEMENTBULKOPS, ['elementId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTS, ['canonicalId'], Table::ELEMENTS, ['id'], 'SET NULL');
         $this->addForeignKey(null, Table::ELEMENTS, ['draftId'], Table::DRAFTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTS, ['revisionId'], Table::REVISIONS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTS, ['fieldLayoutId'], Table::FIELDLAYOUTS, ['id'], 'SET NULL', null);
+        $this->addForeignKey(null, Table::ELEMENTS_BULKOPS, ['elementId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTS_OWNERS, ['elementId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTS_OWNERS, ['ownerId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
         $this->addForeignKey(null, Table::ELEMENTS_SITES, ['elementId'], Table::ELEMENTS, ['id'], 'CASCADE', null);

--- a/src/migrations/m231213_030600_element_bulk_ops.php
+++ b/src/migrations/m231213_030600_element_bulk_ops.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m231213_030600_element_bulk_ops migration.
+ */
+class m231213_030600_element_bulk_ops extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->createTable(Table::ELEMENTBULKOPS, [
+            'elementId' => $this->integer(),
+            'key' => $this->char(10)->notNull(),
+            'timestamp' => $this->dateTime()->notNull(),
+            'PRIMARY KEY([[elementId]], [[key]])',
+        ]);
+        $this->addForeignKey(null, Table::ELEMENTBULKOPS, ['elementId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
+        $this->createIndex(null, Table::ELEMENTBULKOPS, ['timestamp'], false);
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m231213_030600_element_bulk_ops cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/migrations/m231213_030600_element_bulk_ops.php
+++ b/src/migrations/m231213_030600_element_bulk_ops.php
@@ -15,14 +15,14 @@ class m231213_030600_element_bulk_ops extends Migration
      */
     public function safeUp(): bool
     {
-        $this->createTable(Table::ELEMENTBULKOPS, [
+        $this->createTable(Table::ELEMENTS_BULKOPS, [
             'elementId' => $this->integer(),
             'key' => $this->char(10)->notNull(),
             'timestamp' => $this->dateTime()->notNull(),
             'PRIMARY KEY([[elementId]], [[key]])',
         ]);
-        $this->addForeignKey(null, Table::ELEMENTBULKOPS, ['elementId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
-        $this->createIndex(null, Table::ELEMENTBULKOPS, ['timestamp'], false);
+        $this->addForeignKey(null, Table::ELEMENTS_BULKOPS, ['elementId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
+        $this->createIndex(null, Table::ELEMENTS_BULKOPS, ['timestamp'], false);
         return true;
     }
 

--- a/src/queue/BaseBatchedElementJob.php
+++ b/src/queue/BaseBatchedElementJob.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\queue;
+
+use Craft;
+
+/**
+ * BaseBatchedElementJob is the base class for large jobs that may need to spawn
+ * additional jobs to complete the workload, which perform actions on elements.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.0.0
+ */
+abstract class BaseBatchedElementJob extends BaseBatchedJob
+{
+    /** @internal */
+    public string $bulkOpKey;
+
+    /**
+     * @inheritdoc
+     */
+    protected function before(): void
+    {
+        $this->bulkOpKey = Craft::$app->getElements()->beginBulkOp();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function beforeBatch(): void
+    {
+        Craft::$app->getElements()->resumeBulkOp($this->bulkOpKey);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function after(): void
+    {
+        Craft::$app->getElements()->endBulkOp($this->bulkOpKey);
+    }
+}

--- a/src/queue/jobs/ApplyNewPropagationMethod.php
+++ b/src/queue/jobs/ApplyNewPropagationMethod.php
@@ -18,7 +18,7 @@ use craft\helpers\ArrayHelper;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
 use craft\i18n\Translation;
-use craft\queue\BaseBatchedJob;
+use craft\queue\BaseBatchedElementJob;
 use craft\services\Structures;
 use Throwable;
 
@@ -30,7 +30,7 @@ use Throwable;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.4.8
  */
-class ApplyNewPropagationMethod extends BaseBatchedJob
+class ApplyNewPropagationMethod extends BaseBatchedElementJob
 {
     /**
      * @var string The element type to use

--- a/src/queue/jobs/PropagateElements.php
+++ b/src/queue/jobs/PropagateElements.php
@@ -14,7 +14,7 @@ use craft\base\ElementInterface;
 use craft\db\QueryBatcher;
 use craft\helpers\ElementHelper;
 use craft\i18n\Translation;
-use craft\queue\BaseBatchedJob;
+use craft\queue\BaseBatchedElementJob;
 
 /**
  * PropagateElements job
@@ -22,7 +22,7 @@ use craft\queue\BaseBatchedJob;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.13
  */
-class PropagateElements extends BaseBatchedJob
+class PropagateElements extends BaseBatchedElementJob
 {
     /**
      * @var string The element type that should be propagated

--- a/src/queue/jobs/ResaveElements.php
+++ b/src/queue/jobs/ResaveElements.php
@@ -15,7 +15,7 @@ use craft\console\controllers\ResaveController;
 use craft\db\QueryBatcher;
 use craft\helpers\ElementHelper;
 use craft\i18n\Translation;
-use craft\queue\BaseBatchedJob;
+use craft\queue\BaseBatchedElementJob;
 use Throwable;
 
 /**
@@ -24,7 +24,7 @@ use Throwable;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
-class ResaveElements extends BaseBatchedJob
+class ResaveElements extends BaseBatchedElementJob
 {
     /**
      * @var string The element type that should be resaved

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1107,7 +1107,7 @@ class Elements extends Component
             ]));
         }
 
-        Db::delete(Table::ELEMENTBULKOPS, ['key' => $key]);
+        Db::delete(Table::ELEMENTS_BULKOPS, ['key' => $key]);
     }
 
     /**
@@ -1125,7 +1125,7 @@ class Elements extends Component
         $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
 
         foreach (array_keys($this->bulkKeys) as $key) {
-            Db::upsert(Table::ELEMENTBULKOPS, [
+            Db::upsert(Table::ELEMENTS_BULKOPS, [
                 'elementId' => $element->id,
                 'key' => $key,
                 'timestamp' => $timestamp,

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -37,7 +37,7 @@ use craft\errors\OperationAbortedException;
 use craft\errors\SiteNotFoundException;
 use craft\errors\UnsupportedSiteException;
 use craft\events\AuthorizationCheckEvent;
-use craft\events\BulkElementOpEvent;
+use craft\events\BulkOpEvent;
 use craft\events\DeleteElementEvent;
 use craft\events\EagerLoadElementsEvent;
 use craft\events\ElementEvent;
@@ -116,7 +116,7 @@ class Elements extends Component
     public const EVENT_BEFORE_EAGER_LOAD_ELEMENTS = 'beforeEagerLoadElements';
 
     /**
-     * @event Event The event that is triggered before a bulk element operation has started.
+     * @event BulkOpEvent The event that is triggered before a bulk element operation has started.
      *
      * Note that this won’t necessarily fire from the same request as [[EVENT_AFTER_BULK_OP]].
      *
@@ -125,7 +125,7 @@ class Elements extends Component
     public const EVENT_BEFORE_BULK_OP = 'beforeBulkOp';
 
     /**
-     * @event Event The event that is triggered after a bulk element operation is completed.
+     * @event BulkOpEvent The event that is triggered after a bulk element operation is completed.
      *
      * Note that this won’t necessarily fire from the same request as [[EVENT_BEFORE_BULK_OP]].
      *
@@ -1071,7 +1071,7 @@ class Elements extends Component
         $key = StringHelper::randomString(10);
 
         if ($this->hasEventHandlers(self::EVENT_BEFORE_BULK_OP)) {
-            $this->trigger(self::EVENT_BEFORE_BULK_OP, new BulkElementOpEvent([
+            $this->trigger(self::EVENT_BEFORE_BULK_OP, new BulkOpEvent([
                 'key' => $key,
             ]));
         }
@@ -1102,7 +1102,7 @@ class Elements extends Component
         unset($this->bulkKeys[$key]);
 
         if ($this->hasEventHandlers(self::EVENT_AFTER_BULK_OP)) {
-            $this->trigger(self::EVENT_AFTER_BULK_OP, new BulkElementOpEvent([
+            $this->trigger(self::EVENT_AFTER_BULK_OP, new BulkOpEvent([
                 'key' => $key,
             ]));
         }

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -37,6 +37,7 @@ use craft\errors\OperationAbortedException;
 use craft\errors\SiteNotFoundException;
 use craft\errors\UnsupportedSiteException;
 use craft\events\AuthorizationCheckEvent;
+use craft\events\BulkElementOpEvent;
 use craft\events\DeleteElementEvent;
 use craft\events\EagerLoadElementsEvent;
 use craft\events\ElementEvent;
@@ -113,6 +114,12 @@ class Elements extends Component
      * @since 3.5.0
      */
     public const EVENT_BEFORE_EAGER_LOAD_ELEMENTS = 'beforeEagerLoadElements';
+
+    /**
+     * @event Event The event that is triggered after a bulk element operation is completed.
+     * @since 5.0.0
+     */
+    public const EVENT_AFTER_BULK_OP = 'afterBulkOp';
 
     /**
      * @event MergeElementsEvent The event that is triggered after two elements are merged together.
@@ -1036,6 +1043,92 @@ class Elements extends Component
             ->column();
     }
 
+    // Bulk ops
+    // -------------------------------------------------------------------------
+
+    private array $bulkKeys = [];
+
+    /**
+     * Begins tracking element saves and deletes as part of a bulk operation, identified by a unique key.
+     *
+     * @return string The bulk operation key
+     * @since 5.0.0
+     */
+    public function beginBulkOp(): string
+    {
+        $key = StringHelper::randomString(10);
+        $this->resumeBulkOp($key);
+        return $key;
+    }
+
+    /**
+     * Resumes tracking element saves and deletes as part of a bulk operation.
+     *
+     * @param string $key The bulk operation key returned by [[beginBulkOp()]].
+     * @since 5.0.0
+     */
+    public function resumeBulkOp(string $key): void
+    {
+        $this->bulkKeys[$key] = true;
+    }
+
+    /**
+     * Finishes tracking element saves and deletes as part of a bulk operation.
+     *
+     * @param string $key The bulk operation key returned by [[beginBulkOp()]].
+     * @since 5.0.0
+     */
+    public function endBulkOp(string $key): void
+    {
+        unset($this->bulkKeys[$key]);
+
+        if ($this->hasEventHandlers(self::EVENT_AFTER_BULK_OP)) {
+            $this->trigger(self::EVENT_AFTER_BULK_OP, new BulkElementOpEvent([
+                'key' => $key,
+            ]));
+        }
+
+        Db::delete(Table::ELEMENTBULKOPS, ['key' => $key]);
+    }
+
+    /**
+     * Tracks an element as being affected by any active bulk operations.
+     *
+     * @param ElementInterface $element
+     * @since 5.0.0
+     */
+    public function trackElementInBulkOps(ElementInterface $element): void
+    {
+        if (empty($this->bulkKeys)) {
+            return;
+        }
+
+        $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
+
+        foreach (array_keys($this->bulkKeys) as $key) {
+            Db::upsert(Table::ELEMENTBULKOPS, [
+                'elementId' => $element->id,
+                'key' => $key,
+                'timestamp' => $timestamp,
+            ]);
+        }
+    }
+
+    private function ensureBulkOp(callable $callback): void
+    {
+        if (empty($this->bulkKeys)) {
+            $bulkKey = $this->beginBulkOp();
+        }
+
+        try {
+            $callback();
+        } finally {
+            if (isset($bulkKey)) {
+                $this->endBulkOp($bulkKey);
+            }
+        }
+    }
+
     // Saving Elements
     // -------------------------------------------------------------------------
 
@@ -1169,38 +1262,40 @@ class Elements extends Component
             ]));
         }
 
-        Craft::$app->getDb()->transaction(function() use ($element, $supportedSites) {
-            // Start with the other sites (if any), so we don't update dateLastMerged until the end
-            $otherSiteIds = ArrayHelper::withoutValue(array_keys($supportedSites), $element->siteId);
-            if (!empty($otherSiteIds)) {
-                $siteElements = $this->_localizedElementQuery($element)
-                    ->siteId($otherSiteIds)
-                    ->status(null)
-                    ->all();
-            } else {
-                $siteElements = [];
-            }
+        $this->ensureBulkOp(function() use ($element, $supportedSites) {
+            Craft::$app->getDb()->transaction(function() use ($element, $supportedSites) {
+                // Start with the other sites (if any), so we don't update dateLastMerged until the end
+                $otherSiteIds = ArrayHelper::withoutValue(array_keys($supportedSites), $element->siteId);
+                if (!empty($otherSiteIds)) {
+                    $siteElements = $this->_localizedElementQuery($element)
+                        ->siteId($otherSiteIds)
+                        ->status(null)
+                        ->all();
+                } else {
+                    $siteElements = [];
+                }
 
-            foreach ($siteElements as $siteElement) {
-                $siteElement->mergeCanonicalChanges();
-                $siteElement->mergingCanonicalChanges = true;
-                $this->_saveElementInternal($siteElement, false, false, null, $supportedSites);
-            }
+                foreach ($siteElements as $siteElement) {
+                    $siteElement->mergeCanonicalChanges();
+                    $siteElement->mergingCanonicalChanges = true;
+                    $this->_saveElementInternal($siteElement, false, false, null, $supportedSites);
+                }
 
-            // Now the $element’s site
-            $element->mergeCanonicalChanges();
-            $duplicateOf = $element->duplicateOf;
-            $element->duplicateOf = null;
-            $element->dateLastMerged = DateTimeHelper::now();
-            $element->mergingCanonicalChanges = true;
-            $this->_saveElementInternal($element, false, false, null, $supportedSites);
-            $element->duplicateOf = $duplicateOf;
+                // Now the $element’s site
+                $element->mergeCanonicalChanges();
+                $duplicateOf = $element->duplicateOf;
+                $element->duplicateOf = null;
+                $element->dateLastMerged = DateTimeHelper::now();
+                $element->mergingCanonicalChanges = true;
+                $this->_saveElementInternal($element, false, false, null, $supportedSites);
+                $element->duplicateOf = $duplicateOf;
 
-            // It's now fully merged and propagated
-            $element->afterPropagate(false);
+                // It's now fully merged and propagated
+                $element->afterPropagate(false);
+            });
+
+            $element->mergingCanonicalChanges = false;
         });
-
-        $element->mergingCanonicalChanges = false;
 
         // Fire an 'afterMergeCanonical' event
         if ($this->hasEventHandlers(self::EVENT_AFTER_MERGE_CANONICAL_CHANGES)) {
@@ -1257,8 +1352,6 @@ class Elements extends Component
             ->from([Table::CHANGEDFIELDS])
             ->where(['elementId' => $element->id])
             ->all();
-
-        $fieldsService = Craft::$app->getFields();
 
         $newAttributes += [
             'id' => $canonical->id,
@@ -1356,64 +1449,66 @@ class Elements extends Component
             ]));
         }
 
-        $position = 0;
+        $this->ensureBulkOp(function() use ($query, $skipRevisions, $touch, $updateSearchIndex, $continueOnError) {
+            $position = 0;
 
-        try {
-            foreach (Db::each($query) as $element) {
-                /** @var ElementInterface $element */
-                $position++;
+            try {
+                foreach (Db::each($query) as $element) {
+                    /** @var ElementInterface $element */
+                    $position++;
 
-                $element->setScenario(Element::SCENARIO_ESSENTIALS);
-                $element->resaving = true;
+                    $element->setScenario(Element::SCENARIO_ESSENTIALS);
+                    $element->resaving = true;
 
-                $e = null;
-                try {
-                    // Fire a 'beforeResaveElement' event
-                    if ($this->hasEventHandlers(self::EVENT_BEFORE_RESAVE_ELEMENT)) {
-                        $this->trigger(self::EVENT_BEFORE_RESAVE_ELEMENT, new MultiElementActionEvent([
+                    $e = null;
+                    try {
+                        // Fire a 'beforeResaveElement' event
+                        if ($this->hasEventHandlers(self::EVENT_BEFORE_RESAVE_ELEMENT)) {
+                            $this->trigger(self::EVENT_BEFORE_RESAVE_ELEMENT, new MultiElementActionEvent([
+                                'query' => $query,
+                                'element' => $element,
+                                'position' => $position,
+                            ]));
+                        }
+
+                        // Make sure this isn't a revision
+                        if ($skipRevisions) {
+                            try {
+                                if (ElementHelper::isRevision($element)) {
+                                    throw new InvalidElementException($element, "Skipped resaving {$element->getUiLabel()} ($element->id) because it's a revision.");
+                                }
+                            } catch (Throwable $rootException) {
+                                throw new InvalidElementException($element, "Skipped resaving {$element->getUiLabel()} ($element->id) due to an error obtaining its root element: " . $rootException->getMessage());
+                            }
+                        }
+                    } catch (InvalidElementException $e) {
+                    }
+
+                    if ($e === null) {
+                        try {
+                            $this->_saveElementInternal($element, true, true, $updateSearchIndex, forceTouch: $touch);
+                        } catch (Throwable $e) {
+                            if (!$continueOnError) {
+                                throw $e;
+                            }
+                            Craft::$app->getErrorHandler()->logException($e);
+                        }
+                    }
+
+                    // Fire an 'afterResaveElement' event
+                    if ($this->hasEventHandlers(self::EVENT_AFTER_RESAVE_ELEMENT)) {
+                        $this->trigger(self::EVENT_AFTER_RESAVE_ELEMENT, new MultiElementActionEvent([
                             'query' => $query,
                             'element' => $element,
                             'position' => $position,
+                            'exception' => $e,
                         ]));
                     }
-
-                    // Make sure this isn't a revision
-                    if ($skipRevisions) {
-                        try {
-                            if (ElementHelper::isRevision($element)) {
-                                throw new InvalidElementException($element, "Skipped resaving {$element->getUiLabel()} ($element->id) because it's a revision.");
-                            }
-                        } catch (Throwable $rootException) {
-                            throw new InvalidElementException($element, "Skipped resaving {$element->getUiLabel()} ($element->id) due to an error obtaining its root element: " . $rootException->getMessage());
-                        }
-                    }
-                } catch (InvalidElementException $e) {
                 }
-
-                if ($e === null) {
-                    try {
-                        $this->_saveElementInternal($element, true, true, $updateSearchIndex, forceTouch: $touch);
-                    } catch (Throwable $e) {
-                        if (!$continueOnError) {
-                            throw $e;
-                        }
-                        Craft::$app->getErrorHandler()->logException($e);
-                    }
-                }
-
-                // Fire an 'afterResaveElement' event
-                if ($this->hasEventHandlers(self::EVENT_AFTER_RESAVE_ELEMENT)) {
-                    $this->trigger(self::EVENT_AFTER_RESAVE_ELEMENT, new MultiElementActionEvent([
-                        'query' => $query,
-                        'element' => $element,
-                        'position' => $position,
-                        'exception' => $e,
-                    ]));
-                }
+            } catch (QueryAbortedException) {
+                // Fail silently
             }
-        } catch (QueryAbortedException) {
-            // Fail silently
-        }
+        });
 
         // Fire an 'afterResaveElements' event
         if ($this->hasEventHandlers(self::EVENT_AFTER_RESAVE_ELEMENTS)) {
@@ -1450,70 +1545,75 @@ class Elements extends Component
             }, (array)$siteIds);
         }
 
-        $position = 0;
+        $this->ensureBulkOp(function() use ($query, $siteIds, $continueOnError) {
+            $position = 0;
 
-        try {
-            foreach (Db::each($query) as $element) {
-                /** @var ElementInterface $element */
-                $position++;
+            try {
+                foreach (Db::each($query) as $element) {
+                    /** @var ElementInterface $element */
+                    $position++;
 
-                // Fire a 'beforePropagateElement' event
-                if ($this->hasEventHandlers(self::EVENT_BEFORE_PROPAGATE_ELEMENT)) {
-                    $this->trigger(self::EVENT_BEFORE_PROPAGATE_ELEMENT, new MultiElementActionEvent([
-                        'query' => $query,
-                        'element' => $element,
-                        'position' => $position,
-                    ]));
-                }
+                    // Fire a 'beforePropagateElement' event
+                    if ($this->hasEventHandlers(self::EVENT_BEFORE_PROPAGATE_ELEMENT)) {
+                        $this->trigger(self::EVENT_BEFORE_PROPAGATE_ELEMENT, new MultiElementActionEvent([
+                            'query' => $query,
+                            'element' => $element,
+                            'position' => $position,
+                        ]));
+                    }
 
-                $element->setScenario(Element::SCENARIO_ESSENTIALS);
-                $supportedSites = ArrayHelper::index(ElementHelper::supportedSitesForElement($element), 'siteId');
-                $supportedSiteIds = array_keys($supportedSites);
-                $elementSiteIds = $siteIds !== null ? array_intersect($siteIds, $supportedSiteIds) : $supportedSiteIds;
-                /** @var string|ElementInterface $elementType */
-                $elementType = get_class($element);
+                    $element->setScenario(Element::SCENARIO_ESSENTIALS);
+                    $supportedSites = ArrayHelper::index(ElementHelper::supportedSitesForElement($element), 'siteId');
+                    $supportedSiteIds = array_keys($supportedSites);
+                    $elementSiteIds = $siteIds !== null ? array_intersect($siteIds, $supportedSiteIds) : $supportedSiteIds;
+                    /** @var string|ElementInterface $elementType */
+                    $elementType = get_class($element);
 
-                $e = null;
-                try {
-                    $element->newSiteIds = [];
+                    $e = null;
+                    try {
+                        $element->newSiteIds = [];
 
-                    foreach ($elementSiteIds as $siteId) {
-                        if ($siteId != $element->siteId) {
-                            // Make sure the site element wasn't updated more recently than the main one
-                            $siteElement = $this->getElementById($element->id, $elementType, $siteId);
-                            if ($siteElement === null || $siteElement->dateUpdated < $element->dateUpdated) {
-                                $siteElement ??= false;
-                                $this->_propagateElement($element, $supportedSites, $siteId, $siteElement);
+                        foreach ($elementSiteIds as $siteId) {
+                            if ($siteId != $element->siteId) {
+                                // Make sure the site element wasn't updated more recently than the main one
+                                $siteElement = $this->getElementById($element->id, $elementType, $siteId);
+                                if ($siteElement === null || $siteElement->dateUpdated < $element->dateUpdated) {
+                                    $siteElement ??= false;
+                                    $this->_propagateElement($element, $supportedSites, $siteId, $siteElement);
+                                }
                             }
                         }
+
+                        // It's now fully duplicated and propagated
+                        $element->markAsDirty();
+                        $element->afterPropagate(false);
+                    } catch (Throwable $e) {
+                        if (!$continueOnError) {
+                            throw $e;
+                        }
+                        Craft::$app->getErrorHandler()->logException($e);
                     }
 
-                    // It's now fully duplicated and propagated
-                    $element->markAsDirty();
-                    $element->afterPropagate(false);
-                } catch (Throwable $e) {
-                    if (!$continueOnError) {
-                        throw $e;
+                    // Fire an 'afterPropagateElement' event
+                    if ($this->hasEventHandlers(self::EVENT_AFTER_PROPAGATE_ELEMENT)) {
+                        $this->trigger(self::EVENT_AFTER_PROPAGATE_ELEMENT, new MultiElementActionEvent([
+                            'query' => $query,
+                            'element' => $element,
+                            'position' => $position,
+                            'exception' => $e,
+                        ]));
                     }
-                    Craft::$app->getErrorHandler()->logException($e);
-                }
 
-                // Fire an 'afterPropagateElement' event
-                if ($this->hasEventHandlers(self::EVENT_AFTER_PROPAGATE_ELEMENT)) {
-                    $this->trigger(self::EVENT_AFTER_PROPAGATE_ELEMENT, new MultiElementActionEvent([
-                        'query' => $query,
-                        'element' => $element,
-                        'position' => $position,
-                        'exception' => $e,
-                    ]));
-                }
+                    // Track this element in bulk operations
+                    $this->trackElementInBulkOps($element);
 
-                // Clear caches
-                $this->invalidateCachesForElement($element);
+                    // Clear caches
+                    $this->invalidateCachesForElement($element);
+                }
+            } catch (QueryAbortedException) {
+                // Fail silently
             }
-        } catch (QueryAbortedException) {
-            // Fail silently
-        }
+        });
 
         // Fire an 'afterPropagateElements' event
         if ($this->hasEventHandlers(self::EVENT_AFTER_PROPAGATE_ELEMENTS)) {
@@ -1639,119 +1739,129 @@ class Elements extends Component
             throw new InvalidElementException($mainClone, 'Element ' . $element->id . ' could not be duplicated because it doesn\'t validate.');
         }
 
-        $transaction = Craft::$app->getDb()->beginTransaction();
-        try {
-            // Start with $element’s site
-            if (!$this->_saveElementInternal($mainClone, false, false, null, $supportedSites)) {
-                throw new InvalidElementException($mainClone, 'Element ' . $element->id . ' could not be duplicated for site ' . $element->siteId);
-            }
-
-            // Should we add the clone to the source element’s structure?
-            if (
-                $placeInStructure &&
-                $mainClone->getIsCanonical() &&
-                !$mainClone->root &&
-                (!$mainClone->structureId || !$element->structureId || $mainClone->structureId == $element->structureId)
-            ) {
-                $canonical = $element->getCanonical(true);
-                if ($canonical->structureId && $canonical->root) {
-                    $mode = isset($newAttributes['id']) ? Structures::MODE_AUTO : Structures::MODE_INSERT;
-                    Craft::$app->getStructures()->moveAfter($canonical->structureId, $mainClone, $canonical, $mode);
+        $this->ensureBulkOp(function() use (
+            $mainClone,
+            $supportedSites,
+            $element,
+            $placeInStructure,
+            $newAttributes,
+            $behaviors,
+            $siteAttributes,
+        ) {
+            $transaction = Craft::$app->getDb()->beginTransaction();
+            try {
+                // Start with $element’s site
+                if (!$this->_saveElementInternal($mainClone, false, false, null, $supportedSites)) {
+                    throw new InvalidElementException($mainClone, 'Element ' . $element->id . ' could not be duplicated for site ' . $element->siteId);
                 }
-            }
 
-            $mainClone->newSiteIds = [];
-
-            // Propagate it
-            $otherSiteIds = ArrayHelper::withoutValue(array_keys($supportedSites), $mainClone->siteId);
-            if ($element->id && !empty($otherSiteIds)) {
-                $siteElements = $this->_localizedElementQuery($element)
-                    ->siteId($otherSiteIds)
-                    ->status(null)
-                    ->all();
-
-                foreach ($siteElements as $siteElement) {
-                    // Ensure all fields have been normalized
-                    $siteElement->getFieldValues();
-
-                    $siteClone = clone $siteElement;
-                    $siteClone->duplicateOf = $siteElement;
-                    $siteClone->propagating = true;
-                    $siteClone->id = $mainClone->id;
-                    $siteClone->uid = $mainClone->uid;
-                    $siteClone->structureId = $mainClone->structureId;
-                    $siteClone->root = $mainClone->root;
-                    $siteClone->lft = $mainClone->lft;
-                    $siteClone->rgt = $mainClone->rgt;
-                    $siteClone->level = $mainClone->level;
-                    $siteClone->enabled = $mainClone->enabled;
-                    $siteClone->siteSettingsId = null;
-                    $siteClone->dateCreated = $mainClone->dateCreated;
-                    $siteClone->dateUpdated = $mainClone->dateUpdated;
-                    $siteClone->dateLastMerged = null;
-                    $siteClone->setCanonicalId(null);
-
-                    // Attach behaviors
-                    foreach ($behaviors as $name => $behavior) {
-                        if ($behavior instanceof Behavior) {
-                            $behavior = clone $behavior;
-                        }
-                        $siteClone->attachBehavior($name, $behavior);
-                    }
-
-                    // Note: must use Craft::configure() rather than setAttributes() here,
-                    // so we're not limited to whatever attributes() returns
-                    Craft::configure($siteClone, ArrayHelper::merge(
-                        $newAttributes,
-                        $siteAttributes[$siteElement->siteId] ?? [],
-                    ));
-                    $siteClone->siteId = $siteElement->siteId;
-
-                    // Clone any field values that are objects (without affecting the dirty fields)
-                    $dirtyFields = $siteClone->getDirtyFields();
-                    foreach ($siteClone->getFieldValues() as $handle => $value) {
-                        if (is_object($value) && !$value instanceof UnitEnum) {
-                            $siteClone->setFieldValue($handle, clone $value);
-                        }
-                    }
-                    $siteClone->setDirtyFields($dirtyFields, false);
-
-                    if ($element::hasUris()) {
-                        // Make sure it has a valid slug
-                        (new SlugValidator())->validateAttribute($siteClone, 'slug');
-                        if ($siteClone->hasErrors('slug')) {
-                            throw new InvalidElementException($siteClone, "Element $element->id could not be duplicated for site $siteElement->siteId: " . $siteClone->getFirstError('slug'));
-                        }
-
-                        // Set a unique URI on the site clone
-                        try {
-                            $this->setElementUri($siteClone);
-                        } catch (OperationAbortedException) {
-                            // Oh well, not worth bailing over
-                        }
-                    }
-
-                    if (!$this->_saveElementInternal($siteClone, false, false, supportedSites: $supportedSites)) {
-                        throw new InvalidElementException($siteClone, "Element $element->id could not be duplicated for site $siteElement->siteId: " . implode(', ', $siteClone->getFirstErrors()));
-                    }
-
-                    if ($siteClone->isNewForSite) {
-                        $mainClone->newSiteIds[] = $siteClone->siteId;
+                // Should we add the clone to the source element’s structure?
+                if (
+                    $placeInStructure &&
+                    $mainClone->getIsCanonical() &&
+                    !$mainClone->root &&
+                    (!$mainClone->structureId || !$element->structureId || $mainClone->structureId == $element->structureId)
+                ) {
+                    $canonical = $element->getCanonical(true);
+                    if ($canonical->structureId && $canonical->root) {
+                        $mode = isset($newAttributes['id']) ? Structures::MODE_AUTO : Structures::MODE_INSERT;
+                        Craft::$app->getStructures()->moveAfter($canonical->structureId, $mainClone, $canonical, $mode);
                     }
                 }
+
+                $mainClone->newSiteIds = [];
+
+                // Propagate it
+                $otherSiteIds = ArrayHelper::withoutValue(array_keys($supportedSites), $mainClone->siteId);
+                if ($element->id && !empty($otherSiteIds)) {
+                    $siteElements = $this->_localizedElementQuery($element)
+                        ->siteId($otherSiteIds)
+                        ->status(null)
+                        ->all();
+
+                    foreach ($siteElements as $siteElement) {
+                        // Ensure all fields have been normalized
+                        $siteElement->getFieldValues();
+
+                        $siteClone = clone $siteElement;
+                        $siteClone->duplicateOf = $siteElement;
+                        $siteClone->propagating = true;
+                        $siteClone->id = $mainClone->id;
+                        $siteClone->uid = $mainClone->uid;
+                        $siteClone->structureId = $mainClone->structureId;
+                        $siteClone->root = $mainClone->root;
+                        $siteClone->lft = $mainClone->lft;
+                        $siteClone->rgt = $mainClone->rgt;
+                        $siteClone->level = $mainClone->level;
+                        $siteClone->enabled = $mainClone->enabled;
+                        $siteClone->siteSettingsId = null;
+                        $siteClone->dateCreated = $mainClone->dateCreated;
+                        $siteClone->dateUpdated = $mainClone->dateUpdated;
+                        $siteClone->dateLastMerged = null;
+                        $siteClone->setCanonicalId(null);
+
+                        // Attach behaviors
+                        foreach ($behaviors as $name => $behavior) {
+                            if ($behavior instanceof Behavior) {
+                                $behavior = clone $behavior;
+                            }
+                            $siteClone->attachBehavior($name, $behavior);
+                        }
+
+                        // Note: must use Craft::configure() rather than setAttributes() here,
+                        // so we're not limited to whatever attributes() returns
+                        Craft::configure($siteClone, ArrayHelper::merge(
+                            $newAttributes,
+                            $siteAttributes[$siteElement->siteId] ?? [],
+                        ));
+                        $siteClone->siteId = $siteElement->siteId;
+
+                        // Clone any field values that are objects (without affecting the dirty fields)
+                        $dirtyFields = $siteClone->getDirtyFields();
+                        foreach ($siteClone->getFieldValues() as $handle => $value) {
+                            if (is_object($value) && !$value instanceof UnitEnum) {
+                                $siteClone->setFieldValue($handle, clone $value);
+                            }
+                        }
+                        $siteClone->setDirtyFields($dirtyFields, false);
+
+                        if ($element::hasUris()) {
+                            // Make sure it has a valid slug
+                            (new SlugValidator())->validateAttribute($siteClone, 'slug');
+                            if ($siteClone->hasErrors('slug')) {
+                                throw new InvalidElementException($siteClone, "Element $element->id could not be duplicated for site $siteElement->siteId: " . $siteClone->getFirstError('slug'));
+                            }
+
+                            // Set a unique URI on the site clone
+                            try {
+                                $this->setElementUri($siteClone);
+                            } catch (OperationAbortedException) {
+                                // Oh well, not worth bailing over
+                            }
+                        }
+
+                        if (!$this->_saveElementInternal($siteClone, false, false, supportedSites: $supportedSites)) {
+                            throw new InvalidElementException($siteClone, "Element $element->id could not be duplicated for site $siteElement->siteId: " . implode(', ', $siteClone->getFirstErrors()));
+                        }
+
+                        if ($siteClone->isNewForSite) {
+                            $mainClone->newSiteIds[] = $siteClone->siteId;
+                        }
+                    }
+                }
+
+                // It's now fully duplicated and propagated
+                $mainClone->afterPropagate(empty($newAttributes['id']));
+
+                $transaction->commit();
+            } catch (Throwable $e) {
+                $transaction->rollBack();
+                throw $e;
             }
 
-            // It's now fully duplicated and propagated
-            $mainClone->afterPropagate(empty($newAttributes['id']));
-
-            $transaction->commit();
-        } catch (Throwable $e) {
-            $transaction->rollBack();
-            throw $e;
-        }
-
-        // Clean up our tracks
-        $mainClone->duplicateOf = null;
+            // Clean up our tracks
+            $mainClone->duplicateOf = null;
+        });
 
         return $mainClone;
     }
@@ -2086,55 +2196,62 @@ class Elements extends Component
             return false;
         }
 
-        $db = Craft::$app->getDb();
-        $transaction = $db->beginTransaction();
-        try {
-            // First delete any structure nodes with this element, so NestedSetBehavior can do its thing.
-            while (($record = StructureElementRecord::findOne(['elementId' => $element->id])) !== null) {
-                // If this element still has any children, move them up before the one getting deleted.
-                while (($child = $record->children(1)->one()) !== null) {
-                    /** @var StructureElementRecord $child */
-                    $child->insertBefore($record);
-                    // Re-fetch the record since its lft and rgt attributes just changed
-                    $record = StructureElementRecord::findOne($record->id);
+        $this->ensureBulkOp(function() use ($element) {
+            $db = Craft::$app->getDb();
+            $transaction = $db->beginTransaction();
+            try {
+                // First delete any structure nodes with this element, so NestedSetBehavior can do its thing.
+                while (($record = StructureElementRecord::findOne(['elementId' => $element->id])) !== null) {
+                    // If this element still has any children, move them up before the one getting deleted.
+                    while (($child = $record->children(1)->one()) !== null) {
+                        /** @var StructureElementRecord $child */
+                        $child->insertBefore($record);
+                        // Re-fetch the record since its lft and rgt attributes just changed
+                        $record = StructureElementRecord::findOne($record->id);
+                    }
+                    // Delete this element’s node
+                    $record->deleteWithChildren();
                 }
-                // Delete this element’s node
-                $record->deleteWithChildren();
+
+                // Invalidate any caches involving this element
+                $this->invalidateCachesForElement($element);
+
+                DateTimeHelper::pause();
+
+                if ($element->hardDelete) {
+                    Db::delete(Table::ELEMENTS, [
+                        'id' => $element->id,
+                    ]);
+                    Db::delete(Table::SEARCHINDEX, [
+                        'elementId' => $element->id,
+                    ]);
+                } else {
+                    // Soft delete the elements table row
+                    Db::update(Table::ELEMENTS, [
+                        'dateDeleted' => Db::prepareDateForDb(new DateTime()),
+                        'deletedWithOwner' => $element->deletedWithOwner,
+                    ], ['id' => $element->id]);
+
+                    // Also soft delete the element’s drafts & revisions
+                    $this->_cascadeDeleteDraftsAndRevisions($element->id);
+                }
+
+                $element->dateDeleted = DateTimeHelper::now();
+                $element->afterDelete();
+
+                if (!$element->hardDelete) {
+                    // Track this element in bulk operations
+                    $this->trackElementInBulkOps($element);
+                }
+
+                $transaction->commit();
+            } catch (Throwable $e) {
+                $transaction->rollBack();
+                throw $e;
+            } finally {
+                DateTimeHelper::resume();
             }
-
-            // Invalidate any caches involving this element
-            $this->invalidateCachesForElement($element);
-
-            DateTimeHelper::pause();
-
-            if ($element->hardDelete) {
-                Db::delete(Table::ELEMENTS, [
-                    'id' => $element->id,
-                ]);
-                Db::delete(Table::SEARCHINDEX, [
-                    'elementId' => $element->id,
-                ]);
-            } else {
-                // Soft delete the elements table row
-                Db::update(Table::ELEMENTS, [
-                    'dateDeleted' => Db::prepareDateForDb(new DateTime()),
-                    'deletedWithOwner' => $element->deletedWithOwner,
-                ], ['id' => $element->id]);
-
-                // Also soft delete the element’s drafts & revisions
-                $this->_cascadeDeleteDraftsAndRevisions($element->id);
-            }
-
-            $element->dateDeleted = DateTimeHelper::now();
-            $element->afterDelete();
-
-            $transaction->commit();
-        } catch (Throwable $e) {
-            $transaction->rollBack();
-            throw $e;
-        } finally {
-            DateTimeHelper::resume();
-        }
+        });
 
         // Fire an 'afterDeleteElement' event
         if ($this->hasEventHandlers(self::EVENT_AFTER_DELETE_ELEMENT)) {
@@ -3143,7 +3260,13 @@ class Elements extends Component
         ElementInterface|false|null $siteElement = null,
     ): ElementInterface {
         $supportedSites = ArrayHelper::index(ElementHelper::supportedSitesForElement($element), 'siteId');
-        $this->_propagateElement($element, $supportedSites, $siteId, $siteElement);
+
+        $this->ensureBulkOp(function() use ($element, $supportedSites, $siteId, $siteElement) {
+            $this->_propagateElement($element, $supportedSites, $siteId, $siteElement);
+
+            // Track this element in bulk operations
+            $this->trackElementInBulkOps($element);
+        });
 
         // Clear caches
         $this->invalidateCachesForElement($element);
@@ -3278,306 +3401,327 @@ class Elements extends Component
             }
         }
 
-        // Figure out whether we will be updating the search index (and memoize that for nested element saves)
-        $oldUpdateSearchIndex = $this->_updateSearchIndex;
-        $updateSearchIndex = $this->_updateSearchIndex = $updateSearchIndex ?? $this->_updateSearchIndex ?? true;
+        $this->ensureBulkOp(function() use (
+            $element,
+            $isNewElement,
+            $originalFirstSave,
+            $originalPropagateAll,
+            $forceTouch,
+            $trackChanges,
+            $dirtyAttributes,
+            $updateSearchIndex,
+            $fieldLayout,
+            $propagate,
+            $supportedSites,
+            $crossSiteValidate,
+            $runValidation,
+            $originalDateUpdated,
+            $dirtyFields,
+        ) {
+            // Figure out whether we will be updating the search index (and memoize that for nested element saves)
+            $oldUpdateSearchIndex = $this->_updateSearchIndex;
+            $updateSearchIndex = $this->_updateSearchIndex = $updateSearchIndex ?? $this->_updateSearchIndex ?? true;
 
-        $newSiteIds = $element->newSiteIds;
-        $element->newSiteIds = [];
+            $newSiteIds = $element->newSiteIds;
+            $element->newSiteIds = [];
 
-        $transaction = Craft::$app->getDb()->beginTransaction();
+            $transaction = Craft::$app->getDb()->beginTransaction();
 
-        try {
-            // No need to save the element record multiple times
-            if (!$element->propagating) {
-                // Get the element record
-                if (!$isNewElement) {
-                    $elementRecord = ElementRecord::findOne($element->id);
+            try {
+                // No need to save the element record multiple times
+                if (!$element->propagating) {
+                    // Get the element record
+                    if (!$isNewElement) {
+                        $elementRecord = ElementRecord::findOne($element->id);
 
-                    if (!$elementRecord) {
+                        if (!$elementRecord) {
+                            $element->firstSave = $originalFirstSave;
+                            $element->propagateAll = $originalPropagateAll;
+                            throw new ElementNotFoundException("No element exists with the ID '$element->id'");
+                        }
+                    } else {
+                        $elementRecord = new ElementRecord();
+                        $elementRecord->type = get_class($element);
+                    }
+
+                    // Set the attributes
+                    $elementRecord->uid = $element->uid;
+                    $elementRecord->canonicalId = $element->getIsDerivative() ? $element->getCanonicalId() : null;
+                    $elementRecord->draftId = (int)$element->draftId ?: null;
+                    $elementRecord->revisionId = (int)$element->revisionId ?: null;
+                    $elementRecord->fieldLayoutId = $element->fieldLayoutId = (int)($element->fieldLayoutId ?? $fieldLayout?->id ?? 0) ?: null;
+                    $elementRecord->enabled = (bool)$element->enabled;
+                    $elementRecord->archived = (bool)$element->archived;
+                    $elementRecord->dateLastMerged = Db::prepareDateForDb($element->dateLastMerged);
+                    $elementRecord->dateDeleted = Db::prepareDateForDb($element->dateDeleted);
+
+                    if ($isNewElement) {
+                        if (isset($element->dateCreated)) {
+                            $elementRecord->dateCreated = Db::prepareValueForDb($element->dateCreated);
+                        }
+                        if (isset($element->dateUpdated)) {
+                            $elementRecord->dateUpdated = Db::prepareValueForDb($element->dateUpdated);
+                        }
+                    } elseif ($element->resaving && !$forceTouch) {
+                        // Prevent ActiveRecord::prepareForDb() from changing the dateUpdated
+                        $elementRecord->markAttributeDirty('dateUpdated');
+                    } else {
+                        // Force a new dateUpdated value
+                        $elementRecord->dateUpdated = Db::prepareValueForDb(DateTimeHelper::now());
+                    }
+
+                    // Update our list of dirty attributes
+                    if ($trackChanges) {
+                        array_push($dirtyAttributes, ...array_keys($elementRecord->getDirtyAttributes([
+                            'fieldLayoutId',
+                            'enabled',
+                            'archived',
+                        ])));
+                    }
+
+                    // Save the element record
+                    $elementRecord->save(false);
+
+                    $dateCreated = DateTimeHelper::toDateTime($elementRecord->dateCreated);
+
+                    if ($dateCreated === false) {
                         $element->firstSave = $originalFirstSave;
                         $element->propagateAll = $originalPropagateAll;
-                        throw new ElementNotFoundException("No element exists with the ID '$element->id'");
+                        throw new Exception('There was a problem calculating dateCreated.');
                     }
-                } else {
-                    $elementRecord = new ElementRecord();
-                    $elementRecord->type = get_class($element);
-                }
 
-                // Set the attributes
-                $elementRecord->uid = $element->uid;
-                $elementRecord->canonicalId = $element->getIsDerivative() ? $element->getCanonicalId() : null;
-                $elementRecord->draftId = (int)$element->draftId ?: null;
-                $elementRecord->revisionId = (int)$element->revisionId ?: null;
-                $elementRecord->fieldLayoutId = $element->fieldLayoutId = (int)($element->fieldLayoutId ?? $fieldLayout?->id ?? 0) ?: null;
-                $elementRecord->enabled = (bool)$element->enabled;
-                $elementRecord->archived = (bool)$element->archived;
-                $elementRecord->dateLastMerged = Db::prepareDateForDb($element->dateLastMerged);
-                $elementRecord->dateDeleted = Db::prepareDateForDb($element->dateDeleted);
+                    $dateUpdated = DateTimeHelper::toDateTime($elementRecord->dateUpdated);
 
-                if ($isNewElement) {
-                    if (isset($element->dateCreated)) {
-                        $elementRecord->dateCreated = Db::prepareValueForDb($element->dateCreated);
+                    if ($dateUpdated === false) {
+                        throw new Exception('There was a problem calculating dateUpdated.');
                     }
-                    if (isset($element->dateUpdated)) {
-                        $elementRecord->dateUpdated = Db::prepareValueForDb($element->dateUpdated);
-                    }
-                } elseif ($element->resaving && !$forceTouch) {
-                    // Prevent ActiveRecord::prepareForDb() from changing the dateUpdated
-                    $elementRecord->markAttributeDirty('dateUpdated');
-                } else {
-                    // Force a new dateUpdated value
-                    $elementRecord->dateUpdated = Db::prepareValueForDb(DateTimeHelper::now());
-                }
 
-                // Update our list of dirty attributes
-                if ($trackChanges) {
-                    array_push($dirtyAttributes, ...array_keys($elementRecord->getDirtyAttributes([
-                        'fieldLayoutId',
-                        'enabled',
-                        'archived',
-                    ])));
-                }
+                    // Save the new dateCreated and dateUpdated dates on the model
+                    $element->dateCreated = $dateCreated;
+                    $element->dateUpdated = $dateUpdated;
 
-                // Save the element record
-                $elementRecord->save(false);
+                    if ($isNewElement) {
+                        // Save the element ID on the element model
+                        $element->id = $elementRecord->id;
 
-                $dateCreated = DateTimeHelper::toDateTime($elementRecord->dateCreated);
-
-                if ($dateCreated === false) {
-                    $element->firstSave = $originalFirstSave;
-                    $element->propagateAll = $originalPropagateAll;
-                    throw new Exception('There was a problem calculating dateCreated.');
-                }
-
-                $dateUpdated = DateTimeHelper::toDateTime($elementRecord->dateUpdated);
-
-                if ($dateUpdated === false) {
-                    throw new Exception('There was a problem calculating dateUpdated.');
-                }
-
-                // Save the new dateCreated and dateUpdated dates on the model
-                $element->dateCreated = $dateCreated;
-                $element->dateUpdated = $dateUpdated;
-
-                if ($isNewElement) {
-                    // Save the element ID on the element model
-                    $element->id = $elementRecord->id;
-
-                    // If there's a temp ID, update the URI
-                    if ($element->tempId && $element->uri) {
-                        $element->uri = str_replace($element->tempId, (string)$element->id, $element->uri);
-                        $element->tempId = null;
-                    }
-                }
-            }
-
-            // Save the element’s site settings record
-            if (!$isNewElement) {
-                $siteSettingsRecord = Element_SiteSettingsRecord::findOne([
-                    'elementId' => $element->id,
-                    'siteId' => $element->siteId,
-                ]);
-            }
-
-            if ($element->isNewForSite = empty($siteSettingsRecord)) {
-                // First time we've saved the element for this site
-                $siteSettingsRecord = new Element_SiteSettingsRecord();
-                $siteSettingsRecord->elementId = $element->id;
-                $siteSettingsRecord->siteId = $element->siteId;
-            }
-
-            $title = $element::hasTitles() ? $element->title : null;
-            $siteSettingsRecord->title = $title !== null && $title !== '' ? $title : null;
-            $siteSettingsRecord->slug = $element->slug;
-            $siteSettingsRecord->uri = $element->uri;
-
-            // Avoid `enabled` getting marked as dirty if it’s not really changing
-            $enabledForSite = $element->getEnabledForSite();
-            if ($siteSettingsRecord->getIsNewRecord() || $siteSettingsRecord->enabled != $enabledForSite) {
-                $siteSettingsRecord->enabled = $enabledForSite;
-            }
-
-            // Update our list of dirty attributes
-            if ($trackChanges && !$element->isNewForSite) {
-                array_push($dirtyAttributes, ...array_keys($siteSettingsRecord->getDirtyAttributes([
-                    'slug',
-                    'uri',
-                ])));
-                if ($siteSettingsRecord->isAttributeChanged('enabled')) {
-                    $dirtyAttributes[] = 'enabledForSite';
-                }
-            }
-
-            // Set the field values
-            $content = [];
-            if ($fieldLayout) {
-                foreach ($fieldLayout->getCustomFields() as $field) {
-                    if ($field::dbType() !== null) {
-                        $serializedValue = $field->serializeValue($element->getFieldValue($field->handle), $element);
-                        if ($serializedValue !== null) {
-                            $content[$field->layoutElement->uid] = $serializedValue;
+                        // If there's a temp ID, update the URI
+                        if ($element->tempId && $element->uri) {
+                            $element->uri = str_replace($element->tempId, (string)$element->id, $element->uri);
+                            $element->tempId = null;
                         }
                     }
                 }
-            }
-            $siteSettingsRecord->content = $content ?: null;
 
-            // Save the site settings record
-            if (!$siteSettingsRecord->save(false)) {
-                $element->firstSave = $originalFirstSave;
-                $element->propagateAll = $originalPropagateAll;
-                throw new Exception('Couldn’t save elements’ site settings record.');
-            }
+                // Save the element’s site settings record
+                if (!$isNewElement) {
+                    $siteSettingsRecord = Element_SiteSettingsRecord::findOne([
+                        'elementId' => $element->id,
+                        'siteId' => $element->siteId,
+                    ]);
+                }
 
-            $element->siteSettingsId = $siteSettingsRecord->id;
+                if ($element->isNewForSite = empty($siteSettingsRecord)) {
+                    // First time we've saved the element for this site
+                    $siteSettingsRecord = new Element_SiteSettingsRecord();
+                    $siteSettingsRecord->elementId = $element->id;
+                    $siteSettingsRecord->siteId = $element->siteId;
+                }
 
-            // Set all of the dirty attributes on the element, in case an event listener wants to know
-            if ($trackChanges) {
-                array_push($dirtyAttributes, ...$element->getDirtyAttributes());
-                $element->setDirtyAttributes($dirtyAttributes, false);
-            }
+                $title = $element::hasTitles() ? $element->title : null;
+                $siteSettingsRecord->title = $title !== null && $title !== '' ? $title : null;
+                $siteSettingsRecord->slug = $element->slug;
+                $siteSettingsRecord->uri = $element->uri;
 
-            // It is now officially saved
-            $element->afterSave($isNewElement);
+                // Avoid `enabled` getting marked as dirty if it’s not really changing
+                $enabledForSite = $element->getEnabledForSite();
+                if ($siteSettingsRecord->getIsNewRecord() || $siteSettingsRecord->enabled != $enabledForSite) {
+                    $siteSettingsRecord->enabled = $enabledForSite;
+                }
 
-            // Update the element across the other sites?
-            if ($propagate) {
-                $otherSiteIds = ArrayHelper::withoutValue(array_keys($supportedSites), $element->siteId);
-
-                if (!empty($otherSiteIds)) {
-                    if (!$isNewElement) {
-                        $siteElements = $this->_localizedElementQuery($element)
-                            ->siteId($otherSiteIds)
-                            ->status(null)
-                            ->indexBy('siteId')
-                            ->all();
-                    } else {
-                        $siteElements = [];
+                // Update our list of dirty attributes
+                if ($trackChanges && !$element->isNewForSite) {
+                    array_push($dirtyAttributes, ...array_keys($siteSettingsRecord->getDirtyAttributes([
+                        'slug',
+                        'uri',
+                    ])));
+                    if ($siteSettingsRecord->isAttributeChanged('enabled')) {
+                        $dirtyAttributes[] = 'enabledForSite';
                     }
+                }
 
-                    foreach (array_keys($supportedSites) as $siteId) {
-                        // Skip the initial site
-                        if ($siteId != $element->siteId) {
-                            $siteElement = $siteElements[$siteId] ?? false;
-                            if (!$this->_propagateElement(
-                                $element,
-                                $supportedSites,
-                                $siteId,
-                                $siteElement,
-                                crossSiteValidate: $runValidation && $crossSiteValidate,
-                            )) {
-                                throw new InvalidConfigException();
+                // Set the field values
+                $content = [];
+                if ($fieldLayout) {
+                    foreach ($fieldLayout->getCustomFields() as $field) {
+                        if ($field::dbType() !== null) {
+                            $serializedValue = $field->serializeValue($element->getFieldValue($field->handle), $element);
+                            if ($serializedValue !== null) {
+                                $content[$field->layoutElement->uid] = $serializedValue;
                             }
                         }
                     }
                 }
+                $siteSettingsRecord->content = $content ?: null;
+
+                // Save the site settings record
+                if (!$siteSettingsRecord->save(false)) {
+                    $element->firstSave = $originalFirstSave;
+                    $element->propagateAll = $originalPropagateAll;
+                    throw new Exception('Couldn’t save elements’ site settings record.');
+                }
+
+                $element->siteSettingsId = $siteSettingsRecord->id;
+
+                // Set all of the dirty attributes on the element, in case an event listener wants to know
+                if ($trackChanges) {
+                    array_push($dirtyAttributes, ...$element->getDirtyAttributes());
+                    $element->setDirtyAttributes($dirtyAttributes, false);
+                }
+
+                // It is now officially saved
+                $element->afterSave($isNewElement);
+
+                // Update the element across the other sites?
+                if ($propagate) {
+                    $otherSiteIds = ArrayHelper::withoutValue(array_keys($supportedSites), $element->siteId);
+
+                    if (!empty($otherSiteIds)) {
+                        if (!$isNewElement) {
+                            $siteElements = $this->_localizedElementQuery($element)
+                                ->siteId($otherSiteIds)
+                                ->status(null)
+                                ->indexBy('siteId')
+                                ->all();
+                        } else {
+                            $siteElements = [];
+                        }
+
+                        foreach (array_keys($supportedSites) as $siteId) {
+                            // Skip the initial site
+                            if ($siteId != $element->siteId) {
+                                $siteElement = $siteElements[$siteId] ?? false;
+                                if (!$this->_propagateElement(
+                                    $element,
+                                    $supportedSites,
+                                    $siteId,
+                                    $siteElement,
+                                    crossSiteValidate: $runValidation && $crossSiteValidate,
+                                )) {
+                                    throw new InvalidConfigException();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // It's now fully saved and propagated
+                if (
+                    !$element->propagating &&
+                    !$element->duplicateOf &&
+                    !$element->mergingCanonicalChanges
+                ) {
+                    $element->afterPropagate($isNewElement);
+
+                    // Track this element in bulk operations
+                    $this->trackElementInBulkOps($element);
+                }
+
+                $transaction->commit();
+            } catch (Throwable $e) {
+                $transaction->rollBack();
+                $element->firstSave = $originalFirstSave;
+                $element->propagateAll = $originalPropagateAll;
+                $element->dateUpdated = $originalDateUpdated;
+                if ($e instanceof InvalidConfigException) {
+                    return false;
+                }
+                throw $e;
+            } finally {
+                $this->_updateSearchIndex = $oldUpdateSearchIndex;
+                $element->newSiteIds = $newSiteIds;
             }
 
-            // It's now fully saved and propagated
-            if (
-                !$element->propagating &&
-                !$element->duplicateOf &&
-                !$element->mergingCanonicalChanges
-            ) {
-                $element->afterPropagate($isNewElement);
+            if (!$element->propagating) {
+                // Delete the rows that don't need to be there anymore
+                if (!$isNewElement) {
+                    Db::deleteIfExists(
+                        Table::ELEMENTS_SITES,
+                        [
+                            'and',
+                            ['elementId' => $element->id],
+                            ['not', ['siteId' => array_keys($supportedSites)]],
+                        ]
+                    );
+                }
+
+                // Invalidate any caches involving this element
+                $this->invalidateCachesForElement($element);
             }
 
-            $transaction->commit();
-        } catch (Throwable $e) {
-            $transaction->rollBack();
-            $element->firstSave = $originalFirstSave;
-            $element->propagateAll = $originalPropagateAll;
-            $element->dateUpdated = $originalDateUpdated;
-            if ($e instanceof InvalidConfigException) {
-                return false;
-            }
-            throw $e;
-        } finally {
-            $this->_updateSearchIndex = $oldUpdateSearchIndex;
-            $element->newSiteIds = $newSiteIds;
-        }
-
-        if (!$element->propagating) {
-            // Delete the rows that don't need to be there anymore
-            if (!$isNewElement) {
-                Db::deleteIfExists(
-                    Table::ELEMENTS_SITES,
-                    [
-                        'and',
-                        ['elementId' => $element->id],
-                        ['not', ['siteId' => array_keys($supportedSites)]],
-                    ]
+            // Update search index
+            if ($updateSearchIndex && !$element->getIsRevision() && !ElementHelper::isRevision($element)) {
+                $searchableDirtyFields = array_filter(
+                    $dirtyFields,
+                    fn(string $handle) => $fieldLayout?->getFieldByHandle($handle)?->searchable,
                 );
-            }
 
-            // Invalidate any caches involving this element
-            $this->invalidateCachesForElement($element);
-        }
-
-        // Update search index
-        if ($updateSearchIndex && !$element->getIsRevision() && !ElementHelper::isRevision($element)) {
-            $searchableDirtyFields = array_filter(
-                $dirtyFields,
-                fn(string $handle) => $fieldLayout?->getFieldByHandle($handle)?->searchable,
-            );
-
-            if (
-                !$trackChanges ||
-                !empty($searchableDirtyFields) ||
-                !empty(array_intersect($dirtyAttributes, ElementHelper::searchableAttributes($element)))
-            ) {
-                $event = new ElementEvent([
-                    'element' => $element,
-                ]);
-                $this->trigger(self::EVENT_BEFORE_UPDATE_SEARCH_INDEX, $event);
-                if ($event->isValid) {
-                    if (Craft::$app->getRequest()->getIsConsoleRequest()) {
-                        Craft::$app->getSearch()->indexElementAttributes($element, $searchableDirtyFields);
-                    } else {
-                        Queue::push(new UpdateSearchIndex([
-                            'elementType' => get_class($element),
-                            'elementId' => $element->id,
-                            'siteId' => $propagate ? '*' : $element->siteId,
-                            'fieldHandles' => $searchableDirtyFields,
-                        ]), 2048);
+                if (
+                    !$trackChanges ||
+                    !empty($searchableDirtyFields) ||
+                    !empty(array_intersect($dirtyAttributes, ElementHelper::searchableAttributes($element)))
+                ) {
+                    $event = new ElementEvent([
+                        'element' => $element,
+                    ]);
+                    $this->trigger(self::EVENT_BEFORE_UPDATE_SEARCH_INDEX, $event);
+                    if ($event->isValid) {
+                        if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+                            Craft::$app->getSearch()->indexElementAttributes($element, $searchableDirtyFields);
+                        } else {
+                            Queue::push(new UpdateSearchIndex([
+                                'elementType' => get_class($element),
+                                'elementId' => $element->id,
+                                'siteId' => $propagate ? '*' : $element->siteId,
+                                'fieldHandles' => $searchableDirtyFields,
+                            ]), 2048);
+                        }
                     }
                 }
             }
-        }
 
-        // Update the changed attributes & fields
-        if ($trackChanges) {
-            $userId = Craft::$app->getUser()->getId();
-            $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
+            // Update the changed attributes & fields
+            if ($trackChanges) {
+                $userId = Craft::$app->getUser()->getId();
+                $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
 
-            foreach ($dirtyAttributes as $attributeName) {
-                Db::upsert(Table::CHANGEDATTRIBUTES, [
-                    'elementId' => $element->id,
-                    'siteId' => $element->siteId,
-                    'attribute' => $attributeName,
-                    'dateUpdated' => $timestamp,
-                    'propagated' => $element->propagating,
-                    'userId' => $userId,
-                ]);
-            }
+                foreach ($dirtyAttributes as $attributeName) {
+                    Db::upsert(Table::CHANGEDATTRIBUTES, [
+                        'elementId' => $element->id,
+                        'siteId' => $element->siteId,
+                        'attribute' => $attributeName,
+                        'dateUpdated' => $timestamp,
+                        'propagated' => $element->propagating,
+                        'userId' => $userId,
+                    ]);
+                }
 
-            if ($fieldLayout) {
-                foreach ($dirtyFields as $fieldHandle) {
-                    if (($field = $fieldLayout->getFieldByHandle($fieldHandle)) !== null) {
-                        Db::upsert(Table::CHANGEDFIELDS, [
-                            'elementId' => $element->id,
-                            'siteId' => $element->siteId,
-                            'fieldId' => $field->id,
-                            'layoutElementUid' => $field->layoutElement->uid,
-                            'dateUpdated' => $timestamp,
-                            'propagated' => $element->propagating,
-                            'userId' => $userId,
-                        ]);
+                if ($fieldLayout) {
+                    foreach ($dirtyFields as $fieldHandle) {
+                        if (($field = $fieldLayout->getFieldByHandle($fieldHandle)) !== null) {
+                            Db::upsert(Table::CHANGEDFIELDS, [
+                                'elementId' => $element->id,
+                                'siteId' => $element->siteId,
+                                'fieldId' => $field->id,
+                                'layoutElementUid' => $field->layoutElement->uid,
+                                'dateUpdated' => $timestamp,
+                                'propagated' => $element->propagating,
+                                'userId' => $userId,
+                            ]);
+                        }
                     }
                 }
             }
-        }
+        });
 
         // Fire an 'afterSaveElement' event
         if ($this->hasEventHandlers(self::EVENT_AFTER_SAVE_ELEMENT)) {

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -116,7 +116,19 @@ class Elements extends Component
     public const EVENT_BEFORE_EAGER_LOAD_ELEMENTS = 'beforeEagerLoadElements';
 
     /**
+     * @event Event The event that is triggered before a bulk element operation has started.
+     *
+     * Note that this won’t necessarily fire from the same request as [[EVENT_AFTER_BULK_OP]].
+     *
+     * @since 5.0.0
+     */
+    public const EVENT_BEFORE_BULK_OP = 'beforeBulkOp';
+
+    /**
      * @event Event The event that is triggered after a bulk element operation is completed.
+     *
+     * Note that this won’t necessarily fire from the same request as [[EVENT_BEFORE_BULK_OP]].
+     *
      * @since 5.0.0
      */
     public const EVENT_AFTER_BULK_OP = 'afterBulkOp';
@@ -1057,6 +1069,13 @@ class Elements extends Component
     public function beginBulkOp(): string
     {
         $key = StringHelper::randomString(10);
+
+        if ($this->hasEventHandlers(self::EVENT_BEFORE_BULK_OP)) {
+            $this->trigger(self::EVENT_BEFORE_BULK_OP, new BulkElementOpEvent([
+                'key' => $key,
+            ]));
+        }
+
         $this->resumeBulkOp($key);
         return $key;
     }

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -103,6 +103,7 @@ class Gc extends Component
         $this->_deleteStaleSessions();
         $this->_deleteStaleAnnouncements();
         $this->_deleteStaleElementActivity();
+        $this->_deleteStaleBulkElementOps();
 
         // elements should always go first
         $this->hardDeleteElements();
@@ -415,6 +416,16 @@ SQL;
     {
         $this->_stdout('    > deleting stale element activity records ... ');
         Db::delete(Table::ELEMENTACTIVITY, ['<', 'timestamp', Db::prepareDateForDb(new DateTime('1 minute ago'))]);
+        $this->_stdout("done\n", Console::FG_GREEN);
+    }
+
+    /**
+     * Deletes any stale bulk element operation records.
+     */
+    private function _deleteStaleBulkElementOps(): void
+    {
+        $this->_stdout('    > deleting stale bulk element operation records ... ');
+        Db::delete(Table::ELEMENTBULKOPS, ['<', 'timestamp', Db::prepareDateForDb(new DateTime('2 weeks ago'))]);
         $this->_stdout("done\n", Console::FG_GREEN);
     }
 

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -425,7 +425,7 @@ SQL;
     private function _deleteStaleBulkElementOps(): void
     {
         $this->_stdout('    > deleting stale bulk element operation records ... ');
-        Db::delete(Table::ELEMENTBULKOPS, ['<', 'timestamp', Db::prepareDateForDb(new DateTime('2 weeks ago'))]);
+        Db::delete(Table::ELEMENTS_BULKOPS, ['<', 'timestamp', Db::prepareDateForDb(new DateTime('2 weeks ago'))]);
         $this->_stdout("done\n", Console::FG_GREEN);
     }
 


### PR DESCRIPTION
### Description

Adds the concept of bulk element operation tracking, giving plugins an opportunity to do things only after a bulk operation is fully completed, fetching all affected elements at once.

This could be useful for expensive actions like sitemap generation, static page generation, updating Algolia indexes, etc.

```php
use craft\elements\Entry;
use craft\events\BulkElementOpEvent;
use craft\services\Elements;
use yii\base\Event;

Event::on(Elements::class, Elements::EVENT_AFTER_BULK_OP, function(BulkElementOpEvent $event) {
    // Fetch all the entries that were affected
    $entries = Entry::find()
        ->inBulkOp($event->key)
        ->status(null)
        ->all();
    // ...
});
```

All built-in element (multi-)save and deletion actions will ensure that a bulk operation is active, even if only impacting a single element. So plugins could potentially stop listening to `Elements::EVENT_AFTER_SAVE_ELEMENT`/`Element::EVENT_AFTER_SAVE` altogether, and could go all-in on `EVENT_AFTER_BULK_OP`.

Plugins that are performing bulk operations on multiple elements can define their own bulk operations like so:

```php
$bulkKey = Craft::$app->elements->beginBulkOp();

// save/delete elements
// ...

Craft::$app->elements->endBulkOp($bulkKey);
```

There’s also a new `BaseBatchedElementJob` queue job class, which extends `BaseBatchedJob`, but ensures that all of the individual batches are wrapped in a single bulk element operation.

### Related issues

- #14000