### PR TITLE
Improve search performance

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,9 +1,11 @@
 # Release notes for Craft CMS 4.6 (WIP)
 
 - Added the “Country” field type. ([#13789](https://github.com/craftcms/cms/discussions/13789))
+- Improved element search performance. ([#14055](https://github.com/craftcms/cms/pull/14055))
 - Added partial support for field types storing data in JSON columns (excluding MariaDB). ([#13916](https://github.com/craftcms/cms/issues/13916))
 - “Updating search indexes” jobs are no longer queued when saving elements with change tracking enabled, if no searchable fields or attributes were changed. ([#13917](https://github.com/craftcms/cms/issues/13917))
 - `resave` commands now pass an empty string (`''`) to fields’ `normalizeValue()` methods when `--to` is set to `:empty:`. ([#13951](https://github.com/craftcms/cms/issues/13951))
 - Added `craft\helpers\ElementHelper::searchableAttributes()`.
 - Added `craft\services\Elements::setElementUri()`.
 - Added `craft\services\Elements::EVENT_SET_ELEMENT_URI`. ([#13930](https://github.com/craftcms/cms/discussions/13930))
+- Added `craft\services\Search::createDbQuery()`.


### PR DESCRIPTION
### Description

Improves search performance in three ways:

1. When querying for elements with pre-scored search results, the scoring array is now sliced based on the element query’s `offset` and `limit`, so only the current result set’s element IDs are included in the query.
2. Scored element queries now use a fixed order expression rather than a case expression in the `order by` clause.
3. Non-scored element queries no longer execute a keyword query separately. Instead the keyword query is added a subquery of the main element query within the `where` clause.

### Related issues

- #9867