### PR TITLE
Protect against empty values

### DIFF
--- a/src/helpers/Api.php
+++ b/src/helpers/Api.php
@@ -188,7 +188,7 @@ abstract class Api
         if (isset($headers['x-craft-license-info'])) {
             $oldLicenseInfo = $cache->get('licenseInfo') ?: [];
             $licenseInfo = [];
-            $allCombinedInfo = explode(',', reset($headers['x-craft-license-info']));
+            $allCombinedInfo = array_filter(explode(',', reset($headers['x-craft-license-info'])));
             foreach ($allCombinedInfo as $combinedInfo) {
                 [$handle, $combinedValues] = explode(':', $combinedInfo, 2);
                 if ($combinedValues === LicenseKeyStatus::Invalid) {


### PR DESCRIPTION
Prevent a potential php error when a `x-craft-license-info` header is present, but empty.
Fixes https://linear.app/craftcms/issue/CLD-408/plugin-store-doesnt-load-on-fresh-install