### PR TITLE
Fix an error with element migrations and no field layout

### DIFF
--- a/src/migrations/BaseContentRefactorMigration.php
+++ b/src/migrations/BaseContentRefactorMigration.php
@@ -151,9 +151,11 @@ class BaseContentRefactorMigration extends Migration
         }
 
         // make sure the elements’ fieldLayoutId values are accurate
-        $this->update(Table::ELEMENTS, [
-            'fieldLayoutId' => $fieldLayout->id,
-        ], ['in', 'id', $ids], updateTimestamp: false);
+        if ($fieldLayout) {
+            $this->update(Table::ELEMENTS, [
+                'fieldLayoutId' => $fieldLayout->id,
+            ], ['in', 'id', $ids], updateTimestamp: false);
+        }
 
         if (!empty($fieldsByUid)) {
             $caseSql = 'CASE ';


### PR DESCRIPTION
Because you can call `updateElements` with `$fieldLayout` being `null`, this fragment will throw an error.

In my case, I just want to ensure that the title is copied across for an element, and there's not always guaranteed a field layout (as the user controls that - whether to use a "Form Template" to allow field layouts). This is for Formie.