### PR TITLE
only validate if tempAssetUploadFs is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed an error that occurred when indexing search keywords for an element with multiple instances of the same custom field. ([#13987](https://github.com/craftcms/cms/issues/13987))
 - Fixed a bug where changed element attributes weren’t getting recorded.
 - Fixed an error that could occur when updating to Craft 5. ([#14086](https://github.com/craftcms/cms/issues/14086))
+- Fixed a bug where volume filesystem settings were getting unnecessary validation errors when the `tempAssetUploadFs` config setting wasn’t set. ([#14071](https://github.com/craftcms/cms/issues/14071))
 
 ## 5.0.0-alpha.3 - 2023-12-21
 

--- a/src/models/Volume.php
+++ b/src/models/Volume.php
@@ -200,25 +200,26 @@ class Volume extends Model implements BaseFsInterface, FieldLayoutProviderInterf
         ];
         $rules[] = [['fieldLayout'], 'validateFieldLayout'];
         $rules[] = [['subpath'], fn($attribute) => $this->validateUniqueSubpath($attribute), 'skipOnEmpty' => false];
+
         $tempAssetUploadFs = App::parseEnv(Craft::$app->getConfig()->getGeneral()->tempAssetUploadFs);
-        $rules[] = [
-            ['fsHandle'],
-            'compare',
-            'when' => fn() => $tempAssetUploadFs !== null,
-            'compareAttribute' => 'fsHandle',
-            'compareValue' => $tempAssetUploadFs,
-            'operator' => '!=',
-            'message' => Craft::t('app', 'This filesystem has been reserved for temporary asset uploads. Please choose a different one for your volume.'),
-        ];
-        $rules[] = [
-            ['transformFsHandle'],
-            'compare',
-            'when' => fn() => $tempAssetUploadFs !== null,
-            'compareAttribute' => 'transformFsHandle',
-            'compareValue' => $tempAssetUploadFs,
-            'operator' => '!=',
-            'message' => Craft::t('app', 'This filesystem has been reserved for temporary asset uploads. Please choose a different one for your volume.'),
-        ];
+        if ($tempAssetUploadFs) {
+            $rules[] = [
+                ['fsHandle'],
+                'compare',
+                'compareAttribute' => 'fsHandle',
+                'compareValue' => $tempAssetUploadFs,
+                'operator' => '!=',
+                'message' => Craft::t('app', 'This filesystem has been reserved for temporary asset uploads. Please choose a different one for your volume.'),
+            ];
+            $rules[] = [
+                ['transformFsHandle'],
+                'compare',
+                'compareAttribute' => 'transformFsHandle',
+                'compareValue' => $tempAssetUploadFs,
+                'operator' => '!=',
+                'message' => Craft::t('app', 'This filesystem has been reserved for temporary asset uploads. Please choose a different one for your volume.'),
+            ];
+        }
 
         return $rules;
     }

--- a/src/models/Volume.php
+++ b/src/models/Volume.php
@@ -200,19 +200,22 @@ class Volume extends Model implements BaseFsInterface, FieldLayoutProviderInterf
         ];
         $rules[] = [['fieldLayout'], 'validateFieldLayout'];
         $rules[] = [['subpath'], fn($attribute) => $this->validateUniqueSubpath($attribute), 'skipOnEmpty' => false];
+        $tempAssetUploadFs = App::parseEnv(Craft::$app->getConfig()->getGeneral()->tempAssetUploadFs);
         $rules[] = [
             ['fsHandle'],
             'compare',
+            'when' => fn() => $tempAssetUploadFs !== null,
             'compareAttribute' => 'fsHandle',
-            'compareValue' => App::parseEnv(Craft::$app->getConfig()->getGeneral()->tempAssetUploadFs),
+            'compareValue' => $tempAssetUploadFs,
             'operator' => '!=',
             'message' => Craft::t('app', 'This filesystem has been reserved for temporary asset uploads. Please choose a different one for your volume.'),
         ];
         $rules[] = [
             ['transformFsHandle'],
             'compare',
+            'when' => fn() => $tempAssetUploadFs !== null,
             'compareAttribute' => 'transformFsHandle',
-            'compareValue' => App::parseEnv(Craft::$app->getConfig()->getGeneral()->tempAssetUploadFs),
+            'compareValue' => $tempAssetUploadFs,
             'operator' => '!=',
             'message' => Craft::t('app', 'This filesystem has been reserved for temporary asset uploads. Please choose a different one for your volume.'),
         ];


### PR DESCRIPTION
### Description
When creating a Volume, only validate the Asset Filesystem and Transform Filesystem against the Temporary Asset Upload Filesystem if the `tempAssetUploadFs` config is set.

### Related issues
#14071
