### PR TITLE
respect provided path when deleting missing assets (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where meta fields weren’t immediately showing change indicators when entries were autosaved.
+- Fixed a bug where the `index-assets/one` command was overly-destructive when run with a subpath and the `--delete-missing-assets` option. ([#14087](https://github.com/craftcms/cms/issues/14087))
 - Fixed a privilege escalation vulnerability.
 
 ## 3.9.6 - 2023-11-16

--- a/src/console/controllers/IndexAssetsController.php
+++ b/src/console/controllers/IndexAssetsController.php
@@ -183,7 +183,7 @@ class IndexAssetsController extends Controller
             }
         }
 
-        $missingFiles = $assetIndexer->getMissingFiles($sessionId);
+        $missingFiles = $assetIndexer->getMissingFiles($sessionId, $path);
         $maybes = false;
 
         if (!empty($missingFiles)) {


### PR DESCRIPTION
### Description
When indexing a single asset volume and providing not only the volume handle but also a volume sub-path, respect that sub-path when dealing with missing files.

Separate PR ~~is coming~~ [raised](https://github.com/craftcms/cms/pull/14096) for v4.


### Related issues
#14087 
