### PR TITLE
respect provided path when deleting missing assets (v4)

### DIFF
--- a/src/console/controllers/IndexAssetsController.php
+++ b/src/console/controllers/IndexAssetsController.php
@@ -219,7 +219,7 @@ class IndexAssetsController extends Controller
 
         // Manually close the indexing session.
         $session->actionRequired = true;
-        $missingEntries = $assetIndexer->getMissingEntriesForSession($session);
+        $missingEntries = $assetIndexer->getMissingEntriesForSession($session, $path);
         $missingFiles = $missingEntries['files'];
         $missingFolders = $missingEntries['folders'];
 

--- a/src/services/AssetIndexer.php
+++ b/src/services/AssetIndexer.php
@@ -377,12 +377,13 @@ class AssetIndexer extends Component
      * Get missing entries after an indexing session.
      *
      * @param AssetIndexingSession $session
+     * @param string $path
      * @return array with `files` and `folders` keys, containing missing entries.
      * @phpstan-return array{folders:array<int,string>,files:array<int,string>}
      * @throws AssetException
      * @since 4.0.0
      */
-    public function getMissingEntriesForSession(AssetIndexingSession $session): array
+    public function getMissingEntriesForSession(AssetIndexingSession $session, string $path = ''): array
     {
         if (!$session->actionRequired) {
             throw new AssetException('A session must be finished before missing entries can be fetched');
@@ -410,6 +411,10 @@ class AssetIndexer extends Component
             ->andWhere(['folders.volumeId' => $volumeList])
             ->andWhere(['not', ['folders.parentId' => null]]);
 
+        if ($path !== '') {
+            $missingFoldersQuery->andWhere(['like', 'folders.path', "$path%", false]);
+        }
+
         if (!$session->listEmptyFolders) {
             $missingFoldersQuery
                 ->leftJoin(['indexData' => Table::ASSETINDEXDATA], ['and', '[[folders.id]] = [[indexData.recordId]]', ['indexData.isDir' => true]])
@@ -418,7 +423,7 @@ class AssetIndexer extends Component
 
         $missingFolders = $missingFoldersQuery->all();
 
-        $missingFiles = (new Query())
+        $missingFilesQuery = (new Query())
             ->select(['path' => 'folders.path', 'volumeName' => 'volumes.name', 'filename' => 'assets.filename', 'assetId' => 'assets.id'])
             ->from(['assets' => Table::ASSETS])
             ->leftJoin(['elements' => Table::ELEMENTS], '[[elements.id]] = [[assets.id]]')
@@ -428,8 +433,13 @@ class AssetIndexer extends Component
             ->where(['<', 'assets.dateCreated', $cutoff])
             ->andWhere(['assets.volumeId' => $volumeList])
             ->andWhere(['elements.dateDeleted' => null])
-            ->andWhere(['indexData.id' => null])
-            ->all();
+            ->andWhere(['indexData.id' => null]);
+
+        if ($path !== '') {
+            $missingFilesQuery->andWhere(['like', 'folders.path', "$path%", false]);
+        }
+
+        $missingFiles = $missingFilesQuery->all();
 
         foreach ($missingFolders as ['folderId' => $folderId, 'path' => $path, 'volumeName' => $volumeName, 'volumeId' => $volumeId]) {
             /**


### PR DESCRIPTION
### Description
When indexing a single asset volume and providing not only the volume handle but also a volume sub-path, respect that sub-path when dealing with missing files.

Separate [PR raised](https://github.com/craftcms/cms/pull/14095) for v3.


### Related issues
#14087 
