### PR TITLE
showFirstAndLastNameFields conifg setting

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -8,6 +8,7 @@
 - “Updating search indexes” jobs are no longer queued when saving elements with change tracking enabled, if no searchable fields or attributes were changed. ([#13917](https://github.com/craftcms/cms/issues/13917))
 - Edit Field pages now have a “Save and add another” action. ([#13865](https://github.com/craftcms/cms/discussions/13865))
 - Added the `disabledUtilities` config setting. ([#14044](https://github.com/craftcms/cms/discussions/14044))
+- Added the `showFirstAndLastNameFields` config setting. ([#14097](https://github.com/craftcms/cms/pull/14097))
 - `resave` commands now pass an empty string (`''`) to fields’ `normalizeValue()` methods when `--to` is set to `:empty:`. ([#13951](https://github.com/craftcms/cms/issues/13951))
 - The `sections/create` command now supports `--name`, `--handle`, `--type`, `--no-versioning`, `--uri-format`, and `--template` options, and can now be run non-interactively. ([#13864](https://github.com/craftcms/cms/discussions/13864))
 - The `index-assets/one` and `index-assets/all` commands now accept a `--delete-empty-folders` option. ([#13947](https://github.com/craftcms/cms/discussions/13947))

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -2761,6 +2761,23 @@ class GeneralConfig extends BaseConfig
     public ?array $secureProtocolHeaders = null;
 
     /**
+     * @var bool Whether “First Name” and “Last Name” fields should be shown in place of “Full Name” fields.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->showFirstAndLastNameFields()
+     * ```
+     * ```shell Environment Override
+     * CRAFT_SHOW_FIRST_AND_LAST_NAME_FIELDS=true
+     * ```
+     * :::
+     *
+     * @group Users
+     * @since 4.6.0
+     */
+    public bool $showFirstAndLastNameFields = false;
+
+    /**
      * @var mixed The amount of time before a soft-deleted item will be up for hard-deletion by garbage collection.
      *
      * Set to `0` if you don’t ever want to delete soft-deleted items.
@@ -6180,6 +6197,25 @@ class GeneralConfig extends BaseConfig
     public function secureProtocolHeaders(?array $value): self
     {
         $this->secureProtocolHeaders = $value;
+        return $this;
+    }
+
+    /**
+     * Whether “First Name” and “Last Name” fields should be shown in place of “Full Name” fields.
+     *
+     * ```php
+     * ->showFirstAndLastNameFields()
+     * ```
+     *
+     * @group Users
+     * @param bool $value
+     * @return self
+     * @see $showFirstAndLastNameFields
+     * @since 4.6.0
+     */
+    public function showFirstAndLastNameFields(bool $value = true): self
+    {
+        $this->showFirstAndLastNameFields = $value;
         return $this;
     }
 

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -905,6 +905,10 @@ class User extends Element implements IdentityInterface
             unset($values['email'], $values['unverifiedEmail']);
         }
 
+        if (array_key_exists('firstName', $values) || array_key_exists('lastName', $values)) {
+            $this->fullName = null;
+        }
+
         parent::setAttributes($values, $safeOnly);
     }
 
@@ -1688,6 +1692,7 @@ XML;
                 'user' => $this,
                 'isNewUser' => !$this->id,
                 'static' => $static,
+                'meta' => true,
             ]),
             parent::metaFieldsHtml($static),
         ]);

--- a/src/fieldlayoutelements/FullNameField.php
+++ b/src/fieldlayoutelements/FullNameField.php
@@ -9,6 +9,8 @@ namespace craft\fieldlayoutelements;
 
 use Craft;
 use craft\base\ElementInterface;
+use craft\helpers\Cp;
+use craft\helpers\Html as HtmlHelper;
 
 /**
  * Class FullNameField.
@@ -56,6 +58,72 @@ class FullNameField extends TextField
             $fields['autofocus']
         );
         return $fields;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function formHtml(?ElementInterface $element = null, bool $static = false): ?string
+    {
+        if (
+            $element &&
+            Craft::$app->getConfig()->getGeneral()->showFirstAndLastNameFields &&
+            count(array_intersect($element->safeAttributes(), ['firstName', 'lastName'])) === 2
+        ) {
+            return $this->firstAndLastNameFields($element, $static);
+        }
+
+        return parent::formHtml($element, $static);
+    }
+
+    private function firstAndLastNameFields(?ElementInterface $element, bool $static): string
+    {
+        $statusClass = $this->statusClass($element);
+        $status = $statusClass ? [$statusClass, $this->statusLabel($element, $static) ?? ucfirst($statusClass)] : null;
+        $required = !$static && $this->required;
+
+        return HtmlHelper::beginTag('div', ['class' => ['flex', 'flex-nowrap', 'fullwidth']]) .
+            Cp::textFieldHtml([
+                'id' => 'firstName',
+                'status' => $status,
+                'fieldClass' => 'flex-grow',
+                'label' => Craft::t('app', 'First Name'),
+                'attribute' => 'firstName',
+                'showAttribute' => $this->showAttribute(),
+                'required' => $required,
+                'autocomplete' => false,
+                'name' => 'firstName',
+                'value' => $element->firstName ?? null,
+                'errors' => !$static ? $this->errors($element) : [],
+                'disabled' => $static,
+            ]) .
+            Cp::textFieldHtml([
+                'id' => 'lastName',
+                'status' => $status,
+                'fieldClass' => 'flex-grow',
+                'label' => Craft::t('app', 'Last Name'),
+                'attribute' => 'lastName',
+                'showAttribute' => $this->showAttribute(),
+                'required' => $required,
+                'autocomplete' => false,
+                'name' => 'lastName',
+                'value' => $element->lastName ?? null,
+                'disabled' => $static,
+            ]) .
+            HtmlHelper::endTag('div');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function settingsHtml(): ?string
+    {
+        if (Craft::$app->getConfig()->getGeneral()->showFirstAndLastNameFields) {
+            // can't know for sure if the element will support firstName and lastName, but probably?
+            return null;
+        }
+
+        return parent::settingsHtml();
     }
 
     /**

--- a/src/templates/users/_accountfields.twig
+++ b/src/templates/users/_accountfields.twig
@@ -1,6 +1,7 @@
 {% import '_includes/forms.twig' as forms %}
 {% set isCurrentUser = isCurrentUser ?? (user is defined and user.getIsCurrent()) %}
 {% set static = static ?? false %}
+{% set meta = meta ?? false %}
 
 {% if not craft.app.config.general.useEmailAsUsername %}
     {{ forms.textField({
@@ -20,16 +21,52 @@
     }) }}
 {% endif %}
 
-{{ forms.textField({
-    label: "Full Name"|t('app'),
-    id: 'fullName',
-    name: 'fullName',
-    value: user.fullName,
-    autocomplete: isCurrentUser ? 'name' : false,
-    errors: user.getErrors('fullName'),
-    autofocus: craft.app.config.general.useEmailAsUsername,
-    inputAttributes: {
-        data: {lpignore: 'true'},
-    },
-    disabled: static,
-}) }}
+{% if craft.app.config.general.showFirstAndLastNameFields %}
+    {% if not meta %}
+        <div class="flex flex-nowrap fullwidth">
+    {% endif %}
+    {{ forms.textField({
+        fieldClass: not meta ? 'flex-grow',
+        label: 'First Name'|t('app'),
+        id: 'firstName',
+        name: 'firstName',
+        value: user.firstName,
+        autocomplete: isCurrentUser ? 'given-name' : false,
+        errors: user.getErrors('firstName'),
+        autofocus: craft.app.config.general.useEmailAsUsername,
+        inputAttributes: {
+            data: {lpignore: 'true'},
+        },
+        disabled: static,
+    }) }}
+    {{ forms.textField({
+        fieldClass: not meta ? 'flex-grow',
+        label: 'Last Name'|t('app'),
+        id: 'lastName',
+        name: 'lastName',
+        value: user.lastName,
+        autocomplete: isCurrentUser ? 'family-name' : false,
+        errors: user.getErrors('lastName'),
+        inputAttributes: {
+            data: {lpignore: 'true'},
+        },
+        disabled: static,
+    }) }}
+    {% if not meta %}
+        </div>
+    {% endif %}
+{% else %}
+    {{ forms.textField({
+        label: "Full Name"|t('app'),
+        id: 'fullName',
+        name: 'fullName',
+        value: user.fullName,
+        autocomplete: isCurrentUser ? 'name' : false,
+        errors: user.getErrors('fullName'),
+        autofocus: craft.app.config.general.useEmailAsUsername,
+        inputAttributes: {
+            data: {lpignore: 'true'},
+        },
+        disabled: static,
+    }) }}
+{% endif %}


### PR DESCRIPTION
### Description

Adds a new `showFirstAndLastNameFields` config setting, which causes “Full Name” fields to be replaced with “First Name” and “Last Name” fields, for users and addresses.

`craft\fieldlayoutelements\FullNameField` will respect the setting whenever it’s used on an element that includes rules for `firstName` and `lastName` in its `defineRules()` method.

![“First Name” and “Last Name” fields](https://github.com/craftcms/cms/assets/47792/14f857b8-8610-425c-956e-ef578357d53b)

### Related issues

- #12933