### PR TITLE
[5.x]: Fix incorrect merge, removing `_fields` prop from fields' service cache-clearing

### DIFF
--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -729,6 +729,7 @@ class Fields extends Component
         }
 
         // Clear caches
+        $this->_fields = null;
         $this->_fieldConfigs = null;
 
         // Update the field version
@@ -755,6 +756,7 @@ class Fields extends Component
      */
     public function refreshFields(): void
     {
+        $this->_fields = null;
         $this->_fieldConfigs = null;
         $this->updateFieldVersion();
     }


### PR DESCRIPTION
I think there may have been a regression due to an incorrect merge from 4.x.

Appreciate the field service performance improvements added in https://github.com/craftcms/cms/commit/81f6766212b67fb20b8e55e64ae8f43479af8c92#

However the merge from [Craft 4.x](https://github.com/craftcms/cms/commit/81f6766212b67fb20b8e55e64ae8f43479af8c92#diff-14f8825c113f2761fd0b189fb1cb0ba3d2b606d5b95dfe3964c39286d02cd27bL1092) incorrectly (I believe) removed some references to clearing `$this->_fields` from the internal cache. This adds them back.

For reference, these are show in the merge [here](https://github.com/craftcms/cms/commit/97b88b18c6b4f169e376660b40564b3014e5f78d#diff-14f8825c113f2761fd0b189fb1cb0ba3d2b606d5b95dfe3964c39286d02cd27bL707) and [here](https://github.com/craftcms/cms/commit/97b88b18c6b4f169e376660b40564b3014e5f78d#diff-14f8825c113f2761fd0b189fb1cb0ba3d2b606d5b95dfe3964c39286d02cd27bL733)

My testing shows that you should clear both `$this->_fieldConfigs` and `$this->_fields`.