### PR TITLE
Defer instantiation for memoizable array items (Craft 4)

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -18,4 +18,6 @@
 - Added `craft\services\Elements::setElementUri()`.
 - Added `craft\services\Elements::EVENT_SET_ELEMENT_URI`. ([#13930](https://github.com/craftcms/cms/discussions/13930))
 - Added `craft\services\Search::createDbQuery()`.
+- `craft\base\MemoizableArray` now supports passing a normalizer method to the constructor, which will be lazily applied to each array item once, only if returned by `all()` or `firstWhere()`.
+- `craft\helpers\ArrayHelper::firstWhere()` now has a `$valueKey` argument, which can be passed a variable by reference that should be set to the resulting value’s key in the array.
 - Admin tables now have `footerActions`, `moveToPageAction`, `onCellClicked`, `onCellDoubleClicked`, `onRowClicked`, `onRowDoubleClicked`, and `paginatedReorderAction` settings. ([#14051](https://github.com/craftcms/cms/pull/14051))

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -18,6 +18,6 @@
 - Added `craft\services\Elements::setElementUri()`.
 - Added `craft\services\Elements::EVENT_SET_ELEMENT_URI`. ([#13930](https://github.com/craftcms/cms/discussions/13930))
 - Added `craft\services\Search::createDbQuery()`.
-- `craft\base\MemoizableArray` now supports passing a normalizer method to the constructor, which will be lazily applied to each array item once, only if returned by `all()` or `firstWhere()`.
+- `craft\base\MemoizableArray` now supports passing a normalizer method to the constructor, which will be lazily applied to each array item once, only if returned by `all()` or `firstWhere()`. ([#14104](https://github.com/craftcms/cms/pull/14104))
 - `craft\helpers\ArrayHelper::firstWhere()` now has a `$valueKey` argument, which can be passed a variable by reference that should be set to the resulting value’s key in the array.
 - Admin tables now have `footerActions`, `moveToPageAction`, `onCellClicked`, `onCellDoubleClicked`, `onRowClicked`, `onRowDoubleClicked`, and `paginatedReorderAction` settings. ([#14051](https://github.com/craftcms/cms/pull/14051))

--- a/src/base/MemoizableArray.php
+++ b/src/base/MemoizableArray.php
@@ -40,16 +40,57 @@ class MemoizableArray implements IteratorAggregate, Countable
     private array $_elements;
 
     /**
+     * @var callable|null Normalizer method
+     */
+    private $_normalizer;
+
+    /**
+     * @var array Normalized elements
+     */
+    private array $_normalized = [];
+
+    /**
      * @var array Memoized array elements
      */
     private array $_memoized = [];
 
     /**
      * Constructor
+     *
+     * @param array $elements The items to be memoized
+     * @param callable|null $normalizer A method that the items should be normalized with when first returned by
+     * [[all()]] or [[firstWhere()]].
      */
-    public function __construct(array $elements)
+    public function __construct(array $elements, ?callable $normalizer = null)
     {
         $this->_elements = $elements;
+        $this->_normalizer = $normalizer;
+    }
+
+    private function normalize(array $elements): array
+    {
+        if (!isset($this->_normalizer)) {
+            return $elements;
+        }
+
+        return array_values(array_map(fn($key) => $this->normalizeByKey($key), array_keys($elements)));
+    }
+
+    private function normalizeByKey(int|string|null $key): mixed
+    {
+        if ($key === null) {
+            return null;
+        }
+
+        if (!isset($this->_normalizer)) {
+            return $this->_elements[$key];
+        }
+
+        if (!isset($this->_normalized[$key])) {
+            $this->_normalized[$key] = call_user_func($this->_normalizer, $this->_elements[$key], $key);
+        }
+
+        return $this->_normalized[$key];
     }
 
     /**
@@ -60,7 +101,7 @@ class MemoizableArray implements IteratorAggregate, Countable
      */
     public function all(): array
     {
-        return $this->_elements;
+        return $this->normalize($this->_elements);
     }
 
     /**
@@ -78,7 +119,10 @@ class MemoizableArray implements IteratorAggregate, Countable
         $memKey = $this->_memKey(__METHOD__, $key, $value, $strict);
 
         if (!isset($this->_memoized[$memKey])) {
-            $this->_memoized[$memKey] = new MemoizableArray(ArrayHelper::where($this, $key, $value, $strict, false));
+            $this->_memoized[$memKey] = new MemoizableArray(
+                ArrayHelper::where($this->_elements, $key, $value, $strict),
+                isset($this->_normalizer) ? fn($element, $key) => $this->normalizeByKey($key) : null,
+            );
         }
 
         return $this->_memoized[$memKey];
@@ -100,7 +144,10 @@ class MemoizableArray implements IteratorAggregate, Countable
         $memKey = $this->_memKey(__METHOD__, $key, $values, $strict);
 
         if (!isset($this->_memoized[$memKey])) {
-            $this->_memoized[$memKey] = new MemoizableArray(ArrayHelper::whereIn($this, $key, $values, $strict, false));
+            $this->_memoized[$memKey] = new MemoizableArray(
+                ArrayHelper::whereIn($this->_elements, $key, $values, $strict),
+                isset($this->_normalizer) ? fn($element, $key) => $this->normalizeByKey($key) : null,
+            );
         }
 
         return $this->_memoized[$memKey];
@@ -120,7 +167,8 @@ class MemoizableArray implements IteratorAggregate, Countable
 
         // Use array_key_exists() because it could be null
         if (!array_key_exists($memKey, $this->_memoized)) {
-            $this->_memoized[$memKey] = ArrayHelper::firstWhere($this, $key, $value, $strict);
+            ArrayHelper::firstWhere($this->_elements, $key, $value, $strict, valueKey: $valueKey);
+            $this->_memoized[$memKey] = $this->normalizeByKey($valueKey);
         }
 
         return $this->_memoized[$memKey];
@@ -148,7 +196,7 @@ class MemoizableArray implements IteratorAggregate, Countable
      */
     public function getIterator(): ArrayIterator
     {
-        return new ArrayIterator($this->_elements);
+        return new ArrayIterator($this->normalize($this->_elements));
     }
 
     /**

--- a/src/base/MemoizableArray.php
+++ b/src/base/MemoizableArray.php
@@ -159,7 +159,7 @@ class MemoizableArray implements IteratorAggregate, Countable
      * @param string $key the column name whose result will be used to index the array
      * @param mixed $value the value that `$key` should be compared with
      * @param bool $strict whether a strict type comparison should be used when checking array element values against `$value`
-     * @return T the first matching value, or `null` if no match is found
+     * @return T|null the first matching value, or `null` if no match is found
      */
     public function firstWhere(string $key, mixed $value = true, bool $strict = false)
     {

--- a/src/helpers/ArrayHelper.php
+++ b/src/helpers/ArrayHelper.php
@@ -237,12 +237,18 @@ class ArrayHelper extends \yii\helpers\ArrayHelper
      * @param callable|string $key the column name or anonymous function which must be set to $value
      * @param mixed $value the value that $key should be compared with
      * @param bool $strict whether a strict type comparison should be used when checking array element values against $value
+     * @param int|string|null $valueKey The key of the resulting value, or null if it can't be found
      * @return mixed the value, or null if it can't be found
      * @since 3.1.0
      */
-    public static function firstWhere(iterable $array, callable|string $key, mixed $value = true, bool $strict = false): mixed
-    {
-        foreach ($array as $element) {
+    public static function firstWhere(
+        iterable $array,
+        callable|string $key,
+        mixed $value = true,
+        bool $strict = false,
+        int|string|null &$valueKey = null,
+    ): mixed {
+        foreach ($array as $valueKey => $element) {
             $elementValue = static::getValue($element, $key);
             /** @noinspection TypeUnsafeComparisonInspection */
             if (($strict && $elementValue === $value) || (!$strict && $elementValue == $value)) {
@@ -250,6 +256,7 @@ class ArrayHelper extends \yii\helpers\ArrayHelper
             }
         }
 
+        $valueKey = null;
         return null;
     }
 

--- a/src/services/Categories.php
+++ b/src/services/Categories.php
@@ -116,19 +116,15 @@ class Categories extends Component
     private function _groups(): MemoizableArray
     {
         if (!isset($this->_groups)) {
-            $groups = [];
-
-            /** @var CategoryGroupRecord[] $groupRecords */
             $groupRecords = CategoryGroupRecord::find()
                 ->orderBy(['name' => SORT_ASC])
                 ->with('structure')
                 ->all();
 
-            foreach ($groupRecords as $groupRecord) {
-                $groups[] = $this->_createCategoryGroupFromRecord($groupRecord);
-            }
-
-            $this->_groups = new MemoizableArray($groups);
+            $this->_groups = new MemoizableArray(
+                $groupRecords,
+                fn(CategoryGroupRecord $record) => $this->_createCategoryGroupFromRecord($record),
+            );
         }
 
         return $this->_groups;

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -235,11 +235,7 @@ class Fields extends Component
     private function _groups(): MemoizableArray
     {
         if (!isset($this->_groups)) {
-            $groups = [];
-            foreach ($this->_createGroupQuery()->all() as $result) {
-                $groups[] = new FieldGroup($result);
-            }
-            $this->_groups = new MemoizableArray($groups);
+            $this->_groups = new MemoizableArray($this->_createGroupQuery()->all(), fn(array $result) => new FieldGroup($result));
         }
 
         return $this->_groups;

--- a/src/services/Fs.php
+++ b/src/services/Fs.php
@@ -117,12 +117,12 @@ class Fs extends Component
     {
         if (!isset($this->_filesystems)) {
             $configs = Craft::$app->getProjectConfig()->get(ProjectConfig::PATH_FS) ?? [];
-            $filesystems = array_map(function(string $handle, array $config) {
+            $configs = array_map(function(string $handle, array $config) {
                 $config['handle'] = $handle;
                 $config['settings'] = ProjectConfigHelper::unpackAssociativeArrays($config['settings'] ?? []);
-                return $this->createFilesystem($config);
+                return $config;
             }, array_keys($configs), $configs);
-            $this->_filesystems = new MemoizableArray($filesystems);
+            $this->_filesystems = new MemoizableArray($configs, fn(array $config) => $this->createFilesystem($config));
         }
 
         return $this->_filesystems;

--- a/src/services/ImageTransforms.php
+++ b/src/services/ImageTransforms.php
@@ -126,11 +126,10 @@ class ImageTransforms extends Component
     private function _transforms(): MemoizableArray
     {
         if (!isset($this->_transforms)) {
-            $transforms = [];
-            foreach ($this->_createTransformQuery()->all() as $result) {
-                $transforms[] = new ImageTransform($result);
-            }
-            $this->_transforms = new MemoizableArray($transforms);
+            $this->_transforms = new MemoizableArray(
+                $this->_createTransformQuery()->all(),
+                fn(array $result) => new ImageTransform($result),
+            );
         }
 
         return $this->_transforms;

--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -983,22 +983,10 @@ SQL)->execute();
     private function _entryTypes(): MemoizableArray
     {
         if (!isset($this->_entryTypes)) {
-            $entryTypes = [];
-            foreach ($this->_createEntryTypeQuery()->all() as $result) {
-                $entryTypes[] = new EntryType($result);
-            }
-            $this->_entryTypes = new MemoizableArray($entryTypes);
-
-            if (!empty($entryTypes) && Craft::$app->getRequest()->getIsCpRequest()) {
-                // Eager load the field layouts
-                /** @var EntryType[] $entryTypesByLayoutId */
-                $entryTypesByLayoutId = ArrayHelper::index($entryTypes, 'fieldLayoutId');
-                $allLayouts = Craft::$app->getFields()->getLayoutsByIds(array_filter(array_keys($entryTypesByLayoutId)));
-
-                foreach ($allLayouts as $layout) {
-                    $entryTypesByLayoutId[$layout->id]->setFieldLayout($layout);
-                }
-            }
+            $this->_entryTypes = new MemoizableArray(
+                $this->_createEntryTypeQuery()->all(),
+                fn(array $result) => new EntryType($result),
+            );
         }
 
         return $this->_entryTypes;

--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -194,34 +194,35 @@ class Sections extends Component
     private function _sections(): MemoizableArray
     {
         if (!isset($this->_sections)) {
-            $sections = [];
+            $results = $this->_createSectionQuery()->all();
+            $siteSettingsBySection = [];
 
-            foreach ($this->_createSectionQuery()->all() as $result) {
+            if (!empty($results) && Craft::$app->getRequest()->getIsCpRequest()) {
+                // Eager load the site settings
+                $sectionIds = array_map(fn(array $result) => $result['id'], $results);
+                $siteSettingsBySection = ArrayHelper::index(
+                    $this->_createSectionSiteSettingsQuery()->where(['sections_sites.sectionId' => $sectionIds])->all(),
+                    null,
+                    ['sectionId'],
+                );
+            }
+
+            $this->_sections = new MemoizableArray($results, function(array $result) use (&$siteSettingsBySection) {
                 if (!empty($result['previewTargets'])) {
                     $result['previewTargets'] = Json::decode($result['previewTargets']);
                 } else {
                     $result['previewTargets'] = [];
                 }
-                $sections[$result['id']] = new Section($result);
-            }
-
-            $this->_sections = new MemoizableArray(array_values($sections));
-
-            if (!empty($sections) && Craft::$app->getRequest()->getIsCpRequest()) {
-                // Eager load the site settings
-                $allSiteSettings = $this->_createSectionSiteSettingsQuery()
-                    ->where(['sections_sites.sectionId' => array_keys($sections)])
-                    ->all();
-
-                $siteSettingsBySection = [];
-                foreach ($allSiteSettings as $siteSettings) {
-                    $siteSettingsBySection[$siteSettings['sectionId']][] = new Section_SiteSettings($siteSettings);
+                $section = new Section($result);
+                /** @phpstan-ignore-next-line */
+                $siteSettings = ArrayHelper::remove($siteSettingsBySection, $section->id);
+                if ($siteSettings !== null) {
+                    $section->setSiteSettings(
+                        array_map(fn(array $config) => new Section_SiteSettings($config), $siteSettings),
+                    );
                 }
-
-                foreach ($siteSettingsBySection as $sectionId => $sectionSiteSettings) {
-                    $sections[$sectionId]->setSiteSettings($sectionSiteSettings);
-                }
-            }
+                return $section;
+            });
         }
 
         return $this->_sections;

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -194,11 +194,10 @@ class Sites extends Component
     private function _groups(): MemoizableArray
     {
         if (!isset($this->_groups)) {
-            $groups = [];
-            foreach ($this->_createGroupQuery()->all() as $result) {
-                $groups[] = new SiteGroup($result);
-            }
-            $this->_groups = new MemoizableArray($groups);
+            $this->_groups = new MemoizableArray(
+                $this->_createGroupQuery()->all(),
+                fn(array $result) => new SiteGroup($result),
+            );
         }
 
         return $this->_groups;

--- a/src/services/Tags.php
+++ b/src/services/Tags.php
@@ -99,17 +99,14 @@ class Tags extends Component
     private function _tagGroups(): MemoizableArray
     {
         if (!isset($this->_tagGroups)) {
-            $groups = [];
-            /** @var TagGroupRecord[] $records */
             $records = TagGroupRecord::find()
                 ->orderBy(['name' => SORT_ASC])
                 ->all();
 
-            foreach ($records as $record) {
-                $groups[] = $this->_createTagGroupFromRecord($record);
-            }
-
-            $this->_tagGroups = new MemoizableArray($groups);
+            $this->_tagGroups = new MemoizableArray(
+                $records,
+                fn(TagGroupRecord $record) => $this->_createTagGroupFromRecord($record),
+            );
         }
 
         return $this->_tagGroups;

--- a/src/services/Volumes.php
+++ b/src/services/Volumes.php
@@ -161,11 +161,10 @@ class Volumes extends Component
     private function _volumes(): MemoizableArray
     {
         if (!isset($this->_volumes)) {
-            $volumes = [];
-            foreach ($this->_createVolumeQuery()->all() as $result) {
-                $volumes[] = Craft::createObject(Volume::class, [$result]);
-            }
-            $this->_volumes = new MemoizableArray($volumes);
+            $this->_volumes = new MemoizableArray(
+                $this->_createVolumeQuery()->all(),
+                fn(array $result) => Craft::createObject(Volume::class, [$result]),
+            );
         }
 
         return $this->_volumes;


### PR DESCRIPTION
## Description

Adds a new `$normalizer` argument to `craft\base\MemoizableArray`’s constructor, which can be used to lazy-instantiate any items within it, once they’re actually requested by `all()` or `firstWhere()`.

We’re now taking advantage of this everywhere we can, as an initial measure to reducing the number of things that need to get instantiated in any given request.

## Related issues

- #14006