### PR TITLE
adjust when we delete file for remove volume when generating transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where the “Save and add another” element action wasn’t redirecting to a new element edit page, when editing an unpublished draft.
 - Fixed a bug where `craft\helpers\DateTimeHelper::nextYear()` and `lastYear()` weren’t returning the correct dates. ([#14109](https://github.com/craftcms/cms/issues/14109))
+- Fixed a bug where image transforms weren’t getting created for remote assets, if `maxCachedCloudImageSize` was set to `0`. ([#14100](https://github.com/craftcms/cms/issues/14100))
 
 ## 4.5.14 - 2024-01-02
 

--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -900,13 +900,11 @@ class FileHelper extends \yii\helpers\FileHelper
      */
     public static function deleteFileAfterRequest(string $filename): void
     {
-        self::$_filesToBeDeleted[] = $filename;
-
-        if (count(self::$_filesToBeDeleted) === 1) {
-            Craft::$app->onAfterRequest(function() {
-                static::deleteQueuedFiles();
-            });
+        if (empty(self::$_filesToBeDeleted)) {
+            register_shutdown_function([static::class, 'deleteQueuedFiles']);
         }
+
+        self::$_filesToBeDeleted[] = $filename;
     }
 
     /**

--- a/src/helpers/ImageTransforms.php
+++ b/src/helpers/ImageTransforms.php
@@ -37,11 +37,6 @@ class ImageTransforms
     public const TRANSFORM_STRING_PATTERN = '/_(?P<width>\d+|AUTO)x(?P<height>\d+|AUTO)_(?P<mode>[a-z]+)(?:_(?P<position>[a-z\-]+))?(?:_(?P<quality>\d+))?(?:_(?P<interlace>[a-z]+))?(?:_(?P<fill>[0-9a-f]{6}|transparent))?(?:_(?P<upscale>ns))?/i';
 
     /**
-     * @var bool Whether we should delete the image source (on after request)
-     */
-    public static bool $deleteImageSourceAfterRequest = false;
-
-    /**
      * Create an AssetImageTransform model from a string.
      *
      * @param string $transformString
@@ -206,18 +201,9 @@ class ImageTransforms
                     // we've downloaded the file, now store it
                     self::storeLocalSource($tempFilePath, $imageSourcePath);
 
-                    $generalConfig = Craft::$app->getConfig()->getGeneral();
                     // And delete it after the request, if nobody wants it.
-                    if ($generalConfig->maxCachedCloudImageSize == 0) {
-                        // this works fine for the CP requests,
-                        // but for non-cp requests where we have maxCachedCloudImageSize set to zero
-                        // and generateTransformsBeforePageLoad set to true, we need to defer the deletion further
-                        // see https://github.com/craftcms/cms/issues/14100 for more details
-                        if (!$generalConfig->generateTransformsBeforePageLoad || Craft::$app->getRequest()->getIsCpRequest()) {
-                            FileHelper::deleteFileAfterRequest($imageSourcePath);
-                        } else {
-                            self::$deleteImageSourceAfterRequest = true;
-                        }
+                    if (Craft::$app->getConfig()->getGeneral()->maxCachedCloudImageSize == 0) {
+                        FileHelper::deleteFileAfterRequest($imageSourcePath);
                     }
 
                     if (!FileHelper::unlink($tempFilePath)) {
@@ -494,11 +480,6 @@ class ImageTransforms
         $tempPath = Craft::$app->getPath()->getTempPath() . DIRECTORY_SEPARATOR . $tempFilename;
         $image->saveAs($tempPath);
         clearstatcache(true, $tempPath);
-
-        // if we couldn't delete the source image before, we should delete it now
-        if (self::$deleteImageSourceAfterRequest) {
-            FileHelper::deleteFileAfterRequest($imageSource);
-        }
 
         return $tempPath;
     }


### PR DESCRIPTION
### Description
If you have a volume with a remote filesystem (e.g. AWS S3) and you have `maxCachedCloudImageSize` set to `0` and `generateTransformsBeforePageLoad` set to `true` when generating transform not in the control panel, the downloaded file was being deleted before the transform was generated.

Since 4.5.11, the `FileHelper::deleteFileAfterRequest()` calls `ApplicationTrait::onAfterRequest()`, and in the case of generating transforms (not in the CP), the application state at this point is already `STATE_SENDING_RESPONSE` causing the file to be deleted immediately.


### Related issues
#14100 
