### PR TITLE
rootElement - catch error when getting the owner

### DIFF
--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -440,7 +440,11 @@ class ElementHelper
     public static function rootElement(ElementInterface $element): ElementInterface
     {
         if ($element instanceof BlockElementInterface) {
-            $owner = $element->getOwner();
+            try {
+                $owner = $element->getOwner();
+            } catch (\Throwable $e) {
+                $owner = null;
+            }
             if ($owner) {
                 return static::rootElement($owner);
             }


### PR DESCRIPTION
### Description
When getting the element’s root, catch any exceptions that might come from `getOwner()`. 


### Related issues
#13948 
