### PR TITLE
check if an option has a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where `craft\helpers\Db::prepareValueForDb()` wasn’t converting objects to arrays for JSON columns.
+- Fixed a bug where Checkboxes, Multi-select, Dropdown, and Radio Buttons fields weren’t displaying `0` option labels within element indexes. ([#14127](https://github.com/craftcms/cms/issues/14127))
 
 ## 4.6.0 - 2024-01-09
 

--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -498,7 +498,7 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
     {
         /** @var MultiOptionsFieldData|SingleOptionFieldData $value */
         if ($value instanceof SingleOptionFieldData) {
-            return $value->value === null || $value->value === '';
+            return !$this->hasValue($value->value);
         }
 
         return count($value) === 0;
@@ -515,7 +515,7 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
 
             foreach ($value as $option) {
                 /** @var OptionData $option */
-                if ($option->value) {
+                if ($this->hasValue($option->value)) {
                     $labels[] = Craft::t('site', $option->label);
                 }
             }
@@ -524,7 +524,7 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
         }
 
         /** @var SingleOptionFieldData $value */
-        return $value->value ? Craft::t('site', (string)$value->label) : '';
+        return $this->hasValue($value->value) ? Craft::t('site', (string)$value->label) : '';
     }
 
     /**
@@ -571,6 +571,17 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
             'type' => $this->multi ? Type::listOf(Type::string()) : Type::string(),
             'description' => Craft::t('app', 'The allowed values are [{values}]', ['values' => implode(', ', $values)]),
         ];
+    }
+
+    /**
+     * Returns if passed in data has value.
+     *
+     * @param string|null $value
+     * @return bool
+     */
+    public function hasValue(?string $value): bool
+    {
+        return $value !== null && $value !== '';
     }
 
     /**
@@ -667,7 +678,7 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
             $value = $value->value;
         }
 
-        if ($value === null || $value === '') {
+        if (!$this->hasValue($value)) {
             return $value;
         }
 

--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -496,15 +496,11 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
      */
     public function isValueEmpty(mixed $value, ElementInterface $element): bool
     {
-        if ($value instanceof SingleOptionFieldData) {
-            return $value->value === null || $value->value === '';
-        }
-
         if ($value instanceof MultiOptionsFieldData) {
             return count($value) === 0;
         }
 
-        return $value === null || $value === '';
+        return $value->value === null || $value->value === '';
     }
 
     /**

--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -496,12 +496,15 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
      */
     public function isValueEmpty(mixed $value, ElementInterface $element): bool
     {
-        /** @var MultiOptionsFieldData|SingleOptionFieldData $value */
         if ($value instanceof SingleOptionFieldData) {
-            return !$this->hasValue($value->value);
+            return $value->value === null || $value->value === '';
         }
 
-        return count($value) === 0;
+        if ($value instanceof MultiOptionsFieldData) {
+            return count($value) === 0;
+        }
+
+        return $value === null || $value === '';
     }
 
     /**
@@ -515,7 +518,7 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
 
             foreach ($value as $option) {
                 /** @var OptionData $option */
-                if ($this->hasValue($option->value)) {
+                if (!$this->isValueEmpty($option, $element)) {
                     $labels[] = Craft::t('site', $option->label);
                 }
             }
@@ -524,7 +527,7 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
         }
 
         /** @var SingleOptionFieldData $value */
-        return $this->hasValue($value->value) ? Craft::t('site', (string)$value->label) : '';
+        return !$this->isValueEmpty($value, $element) ? Craft::t('site', (string)$value->label) : '';
     }
 
     /**
@@ -571,17 +574,6 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
             'type' => $this->multi ? Type::listOf(Type::string()) : Type::string(),
             'description' => Craft::t('app', 'The allowed values are [{values}]', ['values' => implode(', ', $values)]),
         ];
-    }
-
-    /**
-     * Returns if passed in data has value.
-     *
-     * @param string|null $value
-     * @return bool
-     */
-    public function hasValue(?string $value): bool
-    {
-        return $value !== null && $value !== '';
     }
 
     /**
@@ -678,7 +670,7 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
             $value = $value->value;
         }
 
-        if (!$this->hasValue($value)) {
+        if ($value === null || $value === '') {
             return $value;
         }
 


### PR DESCRIPTION
### Description
Adds `hasValue()` method to the `BaseOptionsField`, which should be used to check if selected value(s) have... value (are not `null` and are not an empty string).

element index table with entry that has the following values selected for checkboxes and multi-select: `'0'`, `'1'`, '`2`', `'false'`, `'true'`, `'someString'` and `'0'` for the dropdown.

before:
<img width="1491" alt="Screenshot 2024-01-11 at 14 52 40" src="https://github.com/craftcms/cms/assets/4500340/84efe1eb-40fc-4736-834e-58c447fbafc9">

and after:
<img width="1486" alt="Screenshot 2024-01-11 at 14 52 52" src="https://github.com/craftcms/cms/assets/4500340/abd234bd-edc2-4583-a584-eef2424a31c5">



### Related issues
#14127 
