### PR TITLE
Add event when creating log target

### DIFF
--- a/src/events/LogTargetEvent.php
+++ b/src/events/LogTargetEvent.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use craft\base\Event;
+use craft\log\MonologTarget;
+
+/**
+ * Log target event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.7.0
+ */
+class LogTargetEvent extends Event
+{
+    public MonologTarget $target;
+}

--- a/src/log/Dispatcher.php
+++ b/src/log/Dispatcher.php
@@ -34,6 +34,7 @@ class Dispatcher extends \yii\log\Dispatcher
 
     /**
      * @var array Config to pass to each MonologTarget
+     * @deprecated Use createTarget event instead
      * @since 4.0.0
      */
     public array $monologTargetConfig = [];

--- a/src/log/Dispatcher.php
+++ b/src/log/Dispatcher.php
@@ -8,6 +8,7 @@
 namespace craft\log;
 
 use Craft;
+use craft\events\LogTargetEvent;
 use craft\helpers\App;
 use Illuminate\Support\Collection;
 use Psr\Log\LogLevel;
@@ -28,6 +29,8 @@ class Dispatcher extends \yii\log\Dispatcher
 
     /** @since 4.0.0 */
     public const TARGET_QUEUE = 'queue';
+
+    public const EVENT_CREATE_TARGET = 'createTarget';
 
     /**
      * @var array Config to pass to each MonologTarget
@@ -67,7 +70,9 @@ class Dispatcher extends \yii\log\Dispatcher
             static::TARGET_QUEUE,
         ])->mapWithKeys(function($name) {
             $allowLineBreaks = (bool) (App::env('CRAFT_LOG_ALLOW_LINE_BREAKS') ?? App::devMode());
-            $config = $this->monologTargetConfig + [
+            $config = [
+                'class' => MonologTarget::class,
+            ] + $this->monologTargetConfig + [
                 'name' => $name,
                 'enabled' => false,
                 'extractExceptionTrace' => !App::devMode(),
@@ -75,7 +80,12 @@ class Dispatcher extends \yii\log\Dispatcher
                 'level' => App::devMode() ? LogLevel::INFO : LogLevel::WARNING,
             ];
 
-            return [$name => new MonologTarget($config)];
+            $target = Craft::createObject($config);
+            $this->trigger(static::EVENT_CREATE_TARGET, new LogTargetEvent([
+                'target' => $target,
+            ]));
+
+            return [$name => $target];
         });
 
         // Queue is enabled via QueueLogBehavior


### PR DESCRIPTION
### Description
Allows early access to our log targets (and their loggers). This allows configuring the Monolog logger without having to pass every supported prop down through our dispatcher.

### Related issues
- Fixes https://github.com/craftcms/cms/issues/13341
- https://linear.app/craftcms/issue/CMS-676/monolog-direct-configuration-get-current-logger

### Example usage

Changing the timezone use by Monolog via `app.php`:

```
<?php
return [
    'components' => [
            'log' => [
                'class' => \craft\log\Dispatcher::class,
                'on createTarget' => function(\craft\events\LogTargetEvent $event) {
                    $event->target->getLogger()->setTimezone(new DateTimeZone('America/Detroit'));
                }
            ],
    ],
];
```

This is better solution than `\craft\log\Dispatcher::$monologTargetConfig`, but it's probably to late to drop that for v5. I did mark is as deprecated.