### PR TITLE
remove element condition warning which is no longer true

### DIFF
--- a/src/base/FieldLayoutComponent.php
+++ b/src/base/FieldLayoutComponent.php
@@ -261,12 +261,6 @@ abstract class FieldLayoutComponent extends Model
                     'instructions' => Craft::t('app', 'Only show when editing {type} that match the following rules:', [
                         'type' => $elementType::pluralLowerDisplayName(),
                     ]),
-                    'warning' => !Craft::$app->getConfig()->getGeneral()->autosaveDrafts
-                        ? sprintf(
-                            '`autosaveDrafts` must be enabled for this condition to take effect automatically when editing %s.',
-                            $elementType::pluralLowerDisplayName(),
-                        )
-                        : null,
                 ]);
             }
         }


### PR DESCRIPTION
### Description
Thanks to #14115, as of `4.6`, it’s no longer required to have the `autosaveDrafts` enabled in order for the condition to take effect automatically when editing.

This PR removes the no longer relevant warning that showed under the element condition field.

Before:
<img width="1621" alt="Screenshot 2024-01-16 at 11 18 57" src="https://github.com/craftcms/cms/assets/4500340/e11e3306-20d5-4a9a-9d10-cc01d078f87f">

After:
<img width="1620" alt="Screenshot 2024-01-16 at 11 19 15" src="https://github.com/craftcms/cms/assets/4500340/52185062-fa71-4689-bafe-eabefd7d1607">


### Related issues
#14115
