### PR TITLE
check if option has value differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `craft\log\MonologTarget` instances are now created via `Craft::createObject()`. ([#13341](https://github.com/craftcms/cms/issues/13341))
 - Fixed a bug where `craft\helpers\Db::prepareValueForDb()` wasn’t converting objects to arrays for JSON columns.
-- Fixed a bug where Checkboxes, Multi-select, Dropdown, and Radio Buttons fields weren’t displaying `0` option labels within element indexes. ([#14127](https://github.com/craftcms/cms/issues/14127))
+- Fixed a bug where Checkboxes, Multi-select, Dropdown, and Radio Buttons fields weren’t displaying `0` options within element indexes or condition rules. ([#14127](https://github.com/craftcms/cms/issues/14127), [#14143](https://github.com/craftcms/cms/pull/14143))
 - Fixed a bug where `craft\db\Migration::renameTable()` was renaming the table for the primary database connection, rather than the migration’s connection. ([#14131](https://github.com/craftcms/cms/issues/14131))
 - Fixed a bug where `Craft.FormObserver` wasn’t working reliably for non-`<form>` containers.
 - Fixed a bug where Selectize inputs were triggering autosaves, even when the value didn’t change.

--- a/src/fields/conditions/OptionsFieldConditionRule.php
+++ b/src/fields/conditions/OptionsFieldConditionRule.php
@@ -24,7 +24,7 @@ class OptionsFieldConditionRule extends BaseMultiSelectConditionRule implements 
         /** @var BaseOptionsField $field */
         $field = $this->field();
         return Collection::make($field->options)
-            ->filter(fn(array $option) => !empty($option['value']) && !empty($option['label']))
+            ->filter(fn(array $option) => $option['value'] !== null && $option['value'] !== '' && !empty($option['label']))
             ->map(fn(array $option) => [
                 'value' => $option['value'],
                 'label' => $option['label'],


### PR DESCRIPTION
### Description
Part 2 of #14128.

When deciding which options to show in the options field condition rule, check if the value is not `null` and not an empty string instead of relying on `empty()`, so that an option with e.g. a value of `0` shows there too.


### Related issues
#14128 
