### PR TITLE
Fixes incorrect return in description

### DIFF
--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -853,7 +853,7 @@ class Assets extends Component
     }
 
     /**
-     * Ensures a folder entry exists in the DB for the full path and return its ID. Depending on the use, it's possible to also ensure a physical folder exists.
+     * Ensures a folder entry exists in the DB for the full path. Depending on the use, it’s also possible to ensure a physical folder exists.
      *
      * @param string $fullPath The path to ensure the folder exists at.
      * @param Volume $volume


### PR DESCRIPTION
### Description

`ensureFolderByFullPathAndVolume` returns a `VolumeFolder` as of v4.0.0, but the text description still says it returns the folder’s ID.
