### PR TITLE
Feature/env example updates for webpack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 DEV_SERVER_PUBLIC=http://localhost:8085/
 DEV_SERVER_PORT=8085
 DEV_SERVER_LOOPBACK=http://host.docker.internal:8085
+# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads e.g. on node 20, npm 10 via nvm
 
 # Running webpack-dev-server within container
 # DEV_SERVER_PUBLIC=http://my-project.tld:3000/

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DEV_SERVER_PUBLIC=http://localhost:8085/
 DEV_SERVER_PORT=8085
 DEV_SERVER_LOOPBACK=http://host.docker.internal:8085
-# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads e.g. on node 20, npm 10 via nvm
+# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads not working
 
 # Running webpack-dev-server within container
 # DEV_SERVER_PUBLIC=http://my-project.tld:3000/

--- a/src/web/assets/admintable/.env.example
+++ b/src/web/assets/admintable/.env.example
@@ -1,4 +1,4 @@
 DEV_SERVER_PUBLIC="http://localhost:8082/"
 DEV_SERVER_PORT="8082"
 DEV_SERVER_LOOPBACK="http://host.docker.internal:8082"
-# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads e.g. on node 20, npm 10 via nvm
+# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads not working

--- a/src/web/assets/admintable/.env.example
+++ b/src/web/assets/admintable/.env.example
@@ -1,3 +1,4 @@
 DEV_SERVER_PUBLIC="http://localhost:8082/"
 DEV_SERVER_PORT="8082"
 DEV_SERVER_LOOPBACK="http://host.docker.internal:8082"
+# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads e.g. on node 20, npm 10 via nvm

--- a/src/web/assets/pluginstore/.env.example
+++ b/src/web/assets/pluginstore/.env.example
@@ -2,6 +2,7 @@
 DEV_SERVER_PUBLIC="http://localhost:8085/"
 DEV_SERVER_PORT="8085"
 DEV_SERVER_LOOPBACK="http://host.docker.internal:8085"
+# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads e.g. on node 20, npm 10 via nvm
 
 # Running webpack-dev-server within container
 # DEV_SERVER_PUBLIC="http://craft.ddev.site:3000/"

--- a/src/web/assets/pluginstore/.env.example
+++ b/src/web/assets/pluginstore/.env.example
@@ -2,7 +2,7 @@
 DEV_SERVER_PUBLIC="http://localhost:8085/"
 DEV_SERVER_PORT="8085"
 DEV_SERVER_LOOPBACK="http://host.docker.internal:8085"
-# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads e.g. on node 20, npm 10 via nvm
+# DEV_SERVER_HOST=127.0.0.1 # you might needed it if you have a problem with hot reloads not working
 
 # Running webpack-dev-server within container
 # DEV_SERVER_PUBLIC="http://craft.ddev.site:3000/"


### PR DESCRIPTION
### Description
Updates existing `.env.example` files with useful info about potentially having to define the `DEV_SERVER_HOST` var too.

Backstory: I ran into an issue where hot reloads weren’t working after installing `nvm` via `brew` and switching to node 20 and npm 10. Long story short, Nathaniel figured out that this was the missing link.

### Related issues
N/A
