### PR TITLE
use auto_position to position selectize dropdown

### DIFF
--- a/src/templates/_includes/forms/selectize.twig
+++ b/src/templates/_includes/forms/selectize.twig
@@ -1,7 +1,7 @@
 {% set id = id ?? "selectize#{random()}" %}
 {% set selectizeOptions = {
     dropdownParent: 'body',
-    plugins: ['auto_position']
+    plugins: ['auto_position'],
 }|merge(selectizeOptions ?? []) %}
 
 {% set multi = multi ?? false %}

--- a/src/templates/_includes/forms/selectize.twig
+++ b/src/templates/_includes/forms/selectize.twig
@@ -1,6 +1,7 @@
 {% set id = id ?? "selectize#{random()}" %}
 {% set selectizeOptions = {
     dropdownParent: 'body',
+    plugins: ['auto_position']
 }|merge(selectizeOptions ?? []) %}
 
 {% set multi = multi ?? false %}
@@ -160,30 +161,6 @@
         }
     };
 
-    const positionDropdown = () => {
-        const selectize = $select.data('selectize');
-
-        // adjust dropdown position - if there's not enough space to display it below the field
-        // display it above the field
-        const bodyHeight = $('body').height();
-        const windowInnerHeight = window.innerHeight;
-        let offsetAdjustment = 0;
-        if (bodyHeight > windowInnerHeight) {
-            offsetAdjustment = bodyHeight - windowInnerHeight;
-        }
-
-        const controlOffset = selectize.settings.dropdownParent === 'body' ? selectize.$control.offset() : selectize.$control.position();
-        const controlHeight = selectize.$control.outerHeight();
-        const dropdownHeight = selectize.$dropdown.outerHeight();
-        const exceededWindowHeight = (controlOffset.top - offsetAdjustment + controlHeight + dropdownHeight) > windowInnerHeight;
-
-        if (exceededWindowHeight) {
-            selectize.$dropdown.css({
-                top: controlOffset.top - dropdownHeight - 4,
-            });
-        }
-    };
-
     {% if not multi %}
         const selectizeDropdownOpenEvent = new Event("selectizedropdownopen");
         const selectizeDropdownCloseEvent = new Event("selectizedropdownclose");
@@ -232,7 +209,6 @@
             }
         },
         onDropdownOpen: function() {
-            positionDropdown();
             {% if not multi %}
                 $select[0].dispatchEvent(selectizeDropdownOpenEvent);
             {% endif %}
@@ -242,7 +218,6 @@
                 $select[0].dispatchEvent(selectizeDropdownCloseEvent);
             {% endif %}
         },
-        onItemAdd: positionDropdown,
     }, {{ selectizeOptions|json_encode|raw }}));
 
     onChange();


### PR DESCRIPTION
### Description
Position selectize dropdown above/below the field depending on how much space there’s left in the window.

The issue was originally fixed with the custom code in `4.4.6` as the `auto_position` plugin didn’t seem to do the trick back then. It looks like this broke again in 4.5.0, but now the `auto_position` plugin works as expected, so using it instead of the custom code.

Before screenshots are in the issue.

After screenshots:
<img width="1176" alt="Screenshot 2024-01-18 at 15 34 55" src="https://github.com/craftcms/cms/assets/4500340/faad6a0a-c76a-4a4c-be9f-15d735f756b1">
<img width="1174" alt="Screenshot 2024-01-18 at 15 43 50" src="https://github.com/craftcms/cms/assets/4500340/b8d4e851-a466-4ef2-b5ff-c680fe870dc3">


<img width="1169" alt="Screenshot 2024-01-18 at 15 35 03" src="https://github.com/craftcms/cms/assets/4500340/aa470166-889e-456b-85d2-f9a5b2294315">
<img width="2281" alt="Screenshot 2024-01-18 at 15 35 18" src="https://github.com/craftcms/cms/assets/4500340/c5a5e952-4c0f-4c29-8c1e-82d60990e086">



### Related issues
#14159 
