### PR TITLE
allow duplicating of root element

### DIFF
--- a/src/elements/actions/Duplicate.php
+++ b/src/elements/actions/Duplicate.php
@@ -130,7 +130,10 @@ JS, [static::class]);
 
             // If the element was loaded for a non-primary owner, set its primary owner to it
             if ($element instanceof NestedElementInterface) {
-                $attributes['primaryOwner'] = $element->getOwner();
+                $owner = $element->getOwner();
+                if ($owner !== null) {
+                    $attributes['primaryOwner'] = $owner;
+                }
             }
 
             try {


### PR DESCRIPTION
### Description
There was an issue preventing the root element (e.g. entry on the main entry index page) from being duplicated.

Checking if the entry has an owner and only setting the `primaryOwner` to be passed to the `duplicateElement()` `newAttributes` param fixes it.


### Related issues
n/a
