### PR TITLE
Add missing `@extends` PHPdoc to `ElementCollection`

### DIFF
--- a/src/elements/ElementCollection.php
+++ b/src/elements/ElementCollection.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Collection;
  *
  * @template TKey of array-key
  * @template TValue of ElementInterface
+ * @extends Collection<TKey, TValue>
  *
  * @method TValue one(callable|null $callback, mixed $default)
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>


### PR DESCRIPTION
### Description
The `ElementCollection` class is missing its `@extends` line in the PHPdoc