### PR TITLE
fixes TypeError for some field types

### DIFF
--- a/src/controllers/UtilitiesController.php
+++ b/src/controllers/UtilitiesController.php
@@ -350,7 +350,7 @@ class UtilitiesController extends Controller
     {
         /** @var string|UtilityInterface $class */
         /** @phpstan-var class-string<UtilityInterface>|UtilityInterface $class */
-        return $this->getView()->renderTemplate('_includes/defaulticon.svg.twig', [
+        return $this->getView()->renderTemplate('_includes/fallback-icon.svg.twig', [
             'label' => $class::displayName(),
         ]);
     }

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -511,15 +511,17 @@ class NestedElementManager extends Component
 
             if (!empty($config['createAttributes'])) {
                 $settings['createAttributes'] = $config['createAttributes'];
-                if (count($settings['createAttributes']) === 1 && ArrayHelper::isIndexed($settings['createAttributes'])) {
-                    $settings['createAttributes'] = ArrayHelper::firstValue($settings['createAttributes'])['attributes'];
-                } else {
-                    $settings['createAttributes'] = array_map(function(array $attributes) {
-                        if (isset($attributes['icon'])) {
-                            $attributes['icon'] = Cp::iconSvg($attributes['icon']);
-                        }
-                        return $attributes;
-                    }, $settings['createAttributes']);
+                if (ArrayHelper::isIndexed($settings['createAttributes'])) {
+                    if (count($settings['createAttributes']) === 1) {
+                        $settings['createAttributes'] = ArrayHelper::firstValue($settings['createAttributes'])['attributes'];
+                    } else {
+                        $settings['createAttributes'] = array_map(function(array $attributes) {
+                            if (isset($attributes['icon'])) {
+                                $attributes['icon'] = Cp::iconSvg($attributes['icon']);
+                            }
+                            return $attributes;
+                        }, $settings['createAttributes']);
+                    }
                 }
             }
 

--- a/src/templates/_layouts/components/global-sidebar.twig
+++ b/src/templates/_layouts/components/global-sidebar.twig
@@ -34,7 +34,7 @@
                             {%- elseif item.fontIcon is defined -%}
                                 <span data-icon="{{ item.fontIcon }}"></span>
                             {%- else -%}
-                                {% include "_includes/defaulticon.svg.twig" with { label: item.label } %}
+                                {% include "_includes/fallback-icon.svg.twig" with { label: item.label } %}
                             {%- endif -%}
                         </span>
 

--- a/tests/unit/helpers/ComponentHelperTest.php
+++ b/tests/unit/helpers/ComponentHelperTest.php
@@ -15,6 +15,7 @@ use craft\errors\MissingComponentException;
 use craft\fieldlayoutelements\HorizontalRule;
 use craft\fields\PlainText;
 use craft\helpers\Component;
+use craft\helpers\Cp;
 use craft\test\mockclasses\components\ComponentExample;
 use craft\test\mockclasses\components\DependencyHeavyComponentExample;
 use craft\test\mockclasses\components\ExtendedComponentExample;
@@ -112,7 +113,11 @@ class ComponentHelperTest extends TestCase
      */
     public function testIconSvg(string $needle, ?string $icon, string $label): void
     {
-        self::assertStringContainsString($needle, Component::iconSvg($icon, $label));
+        if ($icon === null) {
+            self::assertStringContainsString($needle, Cp::fallbackIconSvg($label));
+        } else {
+            self::assertStringContainsString($needle, Cp::iconSvg($icon, $label));
+        }
     }
 
     /**
@@ -307,7 +312,7 @@ class ComponentHelperTest extends TestCase
     {
         return [
             'default' => ['<title>Default</title>', null, 'Default'],
-            'svg-contents' => ['<svg aria-hidden="true"/>', '<svg/>', 'Testing'],
+            'svg-contents' => ['<svg aria-hidden="true">', '<svg/>', 'Testing'],
             'svg-file' => ['<svg ', dirname(__DIR__, 2) . '/_data/assets/files/craft-logo.svg', 'Default'],
             'file-does-not-exist' => ['<title>Default</title>', '/file/does/not/exist.svg', 'Default'],
             'not-an-svg' => ['<title>Default</title>', dirname(__DIR__, 2) . '/_data/assets/files/background.jpeg', 'Default'],


### PR DESCRIPTION
### Description
Fixes `TypeError` (`craft\elements\NestedElementManager::craft\elements\{closure}(): Argument #1 ($attributes) must be of type array, int given`) that was thrown by e.g. Addresses field.

[Addresses field](https://github.com/craftcms/cms/blob/5.0/src/fields/Addresses.php#L635-L637) only passes `'fieldId' => $id` in the `createAttributes` config, which was throwing off the [new code in NestedElementManager](https://github.com/craftcms/cms/pull/14169/files?short_path=6127a79#diff-b044fa075b1d0470bc191e4dbeaf6d6547d5775f409e5a63f1a7f37563bb1778).

### Related issues
#14169
