### PR TITLE
Bugfix/14189 console help command craft alias

### DIFF
--- a/src/console/controllers/HelpController.php
+++ b/src/console/controllers/HelpController.php
@@ -82,6 +82,10 @@ class HelpController extends BaseHelpController
      */
     public function actionIndex($command = null): int
     {
+        // @craft alias needs to be set for console help command,
+        // because the controllers path is, in this case, deducted from the controller's namespace
+        Craft::setAlias('@craft', Craft::getAlias('@app'));
+
         // If they don't want JSON, let the parent do its thing
         if (!$this->asJson) {
             parent::actionIndex($command);

--- a/src/console/controllers/HelpController.php
+++ b/src/console/controllers/HelpController.php
@@ -82,9 +82,11 @@ class HelpController extends BaseHelpController
      */
     public function actionIndex($command = null): int
     {
-        // @craft alias needs to be set for console help command,
-        // because the controllers path is, in this case, deducted from the controller's namespace
-        Craft::setAlias('@craft', Craft::getAlias('@app'));
+        if ($command === null) {
+            // @craft alias needs to be set for console help command,
+            // because the controllers path is, in this case, deducted from the controller's namespace
+            Craft::setAlias('@craft', Craft::getAlias('@app'));
+        }
 
         // If they don't want JSON, let the parent do its thing
         if (!$this->asJson) {


### PR DESCRIPTION
### Description
The `@craft` alias is still required for the help console command to work. The [automatic rewriting](https://github.com/craftcms/cms/commit/5e84968ea65819ecf804e1d65005b6045db8eef3#diff-21e22a30e7c48265a4dcedc1b1c8b9372eca5d3fdeff6d72c7d9c6b671365c56) of `@craft` to `@app` is not triggered in this case.


### Related issues
#14189 
