### PR TITLE
check if field layout element belongs to an enabled plugin

### DIFF
--- a/src/models/FieldLayoutTab.php
+++ b/src/models/FieldLayoutTab.php
@@ -247,6 +247,7 @@ class FieldLayoutTab extends FieldLayoutComponent
     public function setElements(array $elements): void
     {
         $fieldsService = Craft::$app->getFields();
+        $pluginsService = Craft::$app->getPlugins();
         $this->_elements = [];
 
         foreach ($elements as $layoutElement) {
@@ -263,8 +264,12 @@ class FieldLayoutTab extends FieldLayoutComponent
                 }
             }
 
-            $layoutElement->setLayout($this->getLayout());
-            $this->_elements[] = $layoutElement;
+            // if layout element belongs to a plugin, ensure the plugin is installed
+            $pluginHandle = $pluginsService->getPluginHandleByClass($layoutElement::class);
+            if ($pluginHandle === null || $pluginsService->isPluginEnabled($pluginHandle)) {
+                $layoutElement->setLayout($this->getLayout());
+                $this->_elements[] = $layoutElement;
+            }
         }
     }
 


### PR DESCRIPTION
### Description
When adding a field layout element to a tab, check if it belongs to a disabled plugin, and if it does - don’t add it as an element.

**Scenario:**
Commerce plugin is installed, Addresses field layout is adjusted - from that point on, there’s a reference to `UserAddressSettings` (attribute `commerceSettings`) in the Address element field layout.
If you now disabled the Commerce plugin and try to edit or add an address (e.g. to your account) or try to edit the Address element field layout, you’ll get `Invalid Configuration; Unable to locate message source for category 'commerce'.` error.

This PR checks if the layout element belongs to a plugin and only adds it to the layout’s tab if it doesn’t or if the plugin it belongs to is enabled.

### Related issues
n/a
