### PR TITLE
fix for optgroup and "0" label in options field condition rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed a bug where empty Dropdown fields were getting treated as dirty when unchanged.
 - Fixed a bug where Recent Entries widgets were getting mangled when new entries were created via Quick Post widgets.
+- Fixed an error that occurred when adding a Dropdown field condition rule, if the field contained any optgroups. ([#14224](https://github.com/craftcms/cms/issues/14224))
+- Fixed a bug where Dropdown field condition rules weren’t displaying `0` options. ([#14232](https://github.com/craftcms/cms/pull/14232))
 
 ## 4.7.0 - 2024-01-23
 

--- a/src/fields/conditions/OptionsFieldConditionRule.php
+++ b/src/fields/conditions/OptionsFieldConditionRule.php
@@ -24,7 +24,12 @@ class OptionsFieldConditionRule extends BaseMultiSelectConditionRule implements 
         /** @var BaseOptionsField $field */
         $field = $this->field();
         return Collection::make($field->options)
-            ->filter(fn(array $option) => $option['value'] !== null && $option['value'] !== '' && !empty($option['label']))
+            ->filter(fn(array $option) => (array_key_exists('value', $option) &&
+                $option['value'] !== null &&
+                $option['value'] !== '' &&
+                $option['label'] !== null &&
+                $option['label'] !== ''
+            ))
             ->map(fn(array $option) => [
                 'value' => $option['value'],
                 'label' => $option['label'],


### PR DESCRIPTION
### Description
Fixes an error for condition on a Dropdown field with an Optgroup. 
Fixes an issue where an option wouldn't show if it's label was set to `0`.


### Related issues
#14224 
