### PR TITLE
check if field layout element belongs to an enabled plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - It’s now possible to select the temp asset volume within Assets fields, if the temp upload location includes a subpath. ([#14246](https://github.com/craftcms/cms/pull/14246))
 - Fixed a bug where it wasn’t possible to set the “Formatting Locale” user preference back to “Same as language” once another value had been selected.
+- Fixed a bug where layout components provided by disabled plugins weren’t getting omitted. ([#14236](https://github.com/craftcms/cms/pull/14236))
 
 ## 4.7.1 - 2024-01-29
 

--- a/src/models/FieldLayoutTab.php
+++ b/src/models/FieldLayoutTab.php
@@ -280,6 +280,7 @@ class FieldLayoutTab extends FieldLayoutComponent
     public function setElements(array $elements): void
     {
         $fieldsService = Craft::$app->getFields();
+        $pluginsService = Craft::$app->getPlugins();
         $this->_elements = [];
 
         foreach ($elements as $layoutElement) {
@@ -296,8 +297,12 @@ class FieldLayoutTab extends FieldLayoutComponent
                 }
             }
 
-            $layoutElement->setLayout($this->getLayout());
-            $this->_elements[] = $layoutElement;
+            // if layout element belongs to a plugin, ensure the plugin is installed
+            $pluginHandle = $pluginsService->getPluginHandleByClass($layoutElement::class);
+            if ($pluginHandle === null || $pluginsService->isPluginEnabled($pluginHandle)) {
+                $layoutElement->setLayout($this->getLayout());
+                $this->_elements[] = $layoutElement;
+            }
         }
     }
 


### PR DESCRIPTION
### Description
When adding a field layout element to a tab, check if it belongs to a disabled plugin, and if it does - don’t add it as an element.

This PR checks if the layout element belongs to a plugin and only adds it to the layout’s tab if it doesn’t or if the plugin it belongs to is enabled.

Same fix as https://github.com/craftcms/cms/pull/14219.


### Related issues
n/a
