### PR TITLE
make temp uploads volume changes factor in the temp subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- It’s now allowed to select the temp asset volume within Assets fields, if the temp upload location includes a subpath. ([#14246](https://github.com/craftcms/cms/pull/14246))
+
 ## 4.7.1 - 2024-01-29
 
 - Unpublished drafts no longer show “Created at” or “Updated at” metadata values. ([#14204](https://github.com/craftcms/cms/issues/14204))

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -274,7 +274,7 @@ class Assets extends BaseRelationField
                     ($attribute == 'restrictedLocationSource' && $this->restrictedLocationSource === $tempVolumeKey)
                 ) {
                     // intentionally not translating this since it's short-lived (>= 4.7, < 5.0) and dev-facing only.
-                    $this->addError($attribute, "Volume “{$tempVolume->name}” is used to store temporary asset uploads, so it cannot be used in an Assets field.");
+                    $this->addError($attribute, "Temporary asset uploads are being stored in $tempVolume->name, so the same volume cannot be used by an Assets field.");
                 }
             } else {
                 if (
@@ -286,7 +286,7 @@ class Assets extends BaseRelationField
                     $this->restrictedLocationSubpath == $tempSubpath)
                 ) {
                     // intentionally not translating this since it's short-lived (>= 4.7, < 5.0) and dev-facing only.
-                    $this->addError($attribute, "The combination of volume “{$tempVolume->name}” and “{$tempSubpath}“ subpath is used to store temporary asset uploads, so it cannot be used in an Assets field.");
+                    $this->addError($attribute, "Temporary asset uploads are being stored in $tempVolume->name/$tempSubpath, so the same location cannot be used by an Assets field.");
                 }
             }
         }

--- a/src/templates/settings/assets/settings.twig
+++ b/src/templates/settings/assets/settings.twig
@@ -54,7 +54,7 @@
             id: 'tempUploadLocation',
             label: 'Temp Uploads Location'|t('app'),
             instructions: 'Where do you want to store temporary asset uploads?'|t('app'),
-            warning: allVolumes is empty ? 'No volumes exist yet.'|t('app') : 'Don’t select a volume that’s used by any Assets fields.',
+            warning: allVolumes is empty ? 'No volumes exist yet.'|t('app') : 'It’s not recommended to choose a volume that’s used by any Assets fields.',
         }, tempVolumeInput) }}
 
         <div class="buttons">


### PR DESCRIPTION
### Description
Makes temp uploads volume changes from https://github.com/craftcms/cms/pull/14141 and https://github.com/craftcms/cms/commit/97a08f8094a8c389253576228c0ff86eae283de7 more forgiving by factoring in the temp uploads location subpath.

If the Temp Uploads Location is set to a volume and a subpath is also defined, the volume is allowed to be used in the Assets field. (If the subpath is not specified, the volume is not allowed.)
An additional check is added to validate the default and restricted source + subpath combinations to ensure they’re not the same as specified in the Temp Uploads Location setting.


### Related issues
#11405 
