### PR TITLE
CLI Help Banner

### DIFF
--- a/src/console/controllers/HelpController.php
+++ b/src/console/controllers/HelpController.php
@@ -9,6 +9,7 @@ namespace craft\console\controllers;
 
 use Craft;
 use craft\helpers\App;
+use craft\helpers\Console;
 use craft\helpers\Json;
 use ReflectionFunctionAbstract;
 use Throwable;
@@ -17,7 +18,6 @@ use yii\console\Controller;
 use yii\console\controllers\HelpController as BaseHelpController;
 use yii\console\Exception;
 use yii\console\ExitCode;
-use yii\helpers\Console;
 use yii\helpers\Inflector;
 
 /**

--- a/src/console/controllers/HelpController.php
+++ b/src/console/controllers/HelpController.php
@@ -104,6 +104,28 @@ class HelpController extends BaseHelpController
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function getDefaultHelpHeader()
+    {
+        return join("\n", [
+            '', // Blank line
+            Console::ansiFormat('╭───╮', [Console::FG_RED]),
+            Console::ansiFormat('│ ', [Console::FG_RED]) . Console::ansiFormat('C', [Console::ITALIC]) . Console::ansiFormat(' │ ', [Console::FG_RED]) . Console::ansiFormat('Craft CMS', [Console::ITALIC, Console::FG_RED]),
+            Console::ansiFormat('╰───╯', [Console::FG_RED]),
+            '', // Blank line
+            sprintf('Welcome to Craft CMS version %s (Yii %s)', Console::ansiFormat(Craft::$app->getVersion(), [Console::FG_BLUE]), Console::ansiFormat(\Yii::getVersion(), [Console::FG_BLUE])),
+            '', // Blank line
+            Console::ansiFormat('Getting Help', [Console::BOLD]),
+            '', // Blank line
+            Console::ansiFormat('→', [Console::FG_BLUE]) . ' Official Documentation: https://craftcms.com/docs',
+            Console::ansiFormat('→', [Console::FG_BLUE]) . ' Knowledge Base: https://craftcms.com/knowledge-base',
+            Console::ansiFormat('→', [Console::FG_BLUE]) . ' Support: https://craftcms.com/contact',
+            '', // Blank line
+        ]);
+    }
+
+    /**
      * Return an array of information on the passed in CLI $command
      *
      * @param string $command


### PR DESCRIPTION
Running `craft help` has always produced an awkward header that only included information about Yii.

This adds a cute ANSI-formatted Craft banner, as well as the current Craft + Yii versions. Links are included, pointing to the Documentation, Knowledge Base, and Support:

![Screen Shot 2024-01-30 at 11 59 37](https://github.com/craftcms/cms/assets/1895522/8178aad9-772b-4e43-8ae5-0ff0be5cb094)

Logo is a little squished, but I think it will always be sort of wonky depending on the line height and font in the user’s terminal.