### PR TITLE
Remove `TKey` template keyword in `ElementCollection generics

### DIFF
--- a/src/elements/ElementCollection.php
+++ b/src/elements/ElementCollection.php
@@ -14,9 +14,8 @@ use Illuminate\Support\Collection;
 /**
  * ElementCollection represents a collection of elements.
  *
- * @template TKey of array-key
  * @template TValue of ElementInterface
- * @extends Collection<TKey, TValue>
+ * @extends Collection<array-key, TValue>
  *
  * @method TValue one(callable|null $callback, mixed $default)
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
@@ -27,7 +26,7 @@ class ElementCollection extends Collection
     /**
      * Returns a collection of the elements’ IDs.
      *
-     * @return Collection<TKey,int>
+     * @return Collection<array-key, int>
      */
     public function ids(): Collection
     {


### PR DESCRIPTION
### Description
Currently, we are specifying two generics keywords, however we are never needing to specify the first one (`TKey`) anywhere in the code.

Removing it simplifies anything trying to extend or implement the `ElementCollection` class as you do not need to specify both values.

> When using `@extends` or `@var` tags they can take multiple arguments, separated by comma - in the same order the types are defined in the class

This change means we can go from `ElementCollection<array-key, Address>` to simply `ElementCollection<Address>` as we are now only specifying one `@template` keyword.