### PR TITLE
removes no longer needed lang id mapping

### DIFF
--- a/src/i18n/PhpMessageSource.php
+++ b/src/i18n/PhpMessageSource.php
@@ -50,7 +50,6 @@ class PhpMessageSource extends \yii\i18n\PhpMessageSource
                 'de-CH' => 'de',
                 'fr-CA' => 'fr',
                 'nb', 'nn' => 'nb-NO',
-                'zh' => 'zh-CN',
                 default => $language,
             };
         }


### PR DESCRIPTION
### Description
Removes no longer needed language id mapping now that [Yii has moved](https://github.com/yiisoft/yii2/issues/19720) their Chinese translation file from `zh-CN` to `zh`.



### Related issues
#14287 
