### PR TITLE
ensure currentUser exists first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a SQL error that could occur when querying relations with `eagerly()`.
 - Fixed a bug where element actions weren’t working for elements that were added to a relational field.
 - Fixed a bug where very wide tables could bleed off the page.
+- Fixed an error that occurred when activating a new user. ([#14316](https://github.com/craftcms/cms/issues/14316))
 
 ## 5.0.0-alpha.13 - 2024-02-06
 

--- a/src/templates/_includes/forms/autosuggest.twig
+++ b/src/templates/_includes/forms/autosuggest.twig
@@ -60,7 +60,7 @@ new Vue({
                 name: (name ?? '')|namespaceInputName,
                 size: size ?? '',
                 maxlength: maxlength ?? '',
-                autofocus: (autofocus ?? false) and currentUser.getAutofocusPreferred() and not craft.app.request.isMobileBrowser(true),
+                autofocus: (autofocus ?? false) and currentUser and currentUser.getAutofocusPreferred() and not craft.app.request.isMobileBrowser(true),
                 disabled: disabled ?? false,
                 title: title ?? '',
                 placeholder: placeholder ?? '',

--- a/src/templates/_includes/forms/text.twig
+++ b/src/templates/_includes/forms/text.twig
@@ -17,7 +17,7 @@
     name: name ?? false,
     value: value ?? false,
     maxlength: maxlength ?? false,
-    autofocus: (autofocus ?? false) and currentUser.getAutofocusPreferred() and not craft.app.request.isMobileBrowser(true),
+    autofocus: (autofocus ?? false) and currentUser and currentUser.getAutofocusPreferred() and not craft.app.request.isMobileBrowser(true),
     autocomplete: autocomplete is boolean ? (autocomplete ? 'on' : 'off') : autocomplete,
     autocorrect: (autocorrect ?? true) ? false : 'off',
     autocapitalize: (autocapitalize ?? true) ? false : 'none',


### PR DESCRIPTION
### Description
Ensure `currentUser` exists before trying to check `getAutofocusPreferred`.


### Related issues
#14316 
