### PR TITLE
report newLocation error in asset slideout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where read/write splitting was always getting disabled for GraphQL POST requests. ([#14324](https://github.com/craftcms/cms/issues/14324))
 - Fixed a bug where GraphQL schema edit pages could include empty category headings.
+- Fixed a bug where asset slideouts weren’t showing validation errors on the Filename field. ([#14329](https://github.com/craftcms/cms/issues/14329))
 
 ## 4.7.2.1 - 2024-02-08
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2666,6 +2666,7 @@ JS;
         return implode("\n", [
             Cp::textFieldHtml([
                 'label' => Craft::t('app', 'Filename'),
+                'attribute' => 'newLocation',
                 'id' => 'new-filename',
                 'name' => 'newFilename',
                 'value' => $this->_filename,
@@ -2674,9 +2675,6 @@ JS;
                 'required' => true,
                 'class' => ['text', 'filename'],
                 'disabled' => $static,
-                'data' => [
-                    'attribute' => 'newLocation',
-                ],
             ]),
             parent::metaFieldsHtml($static),
         ]);

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2674,6 +2674,9 @@ JS;
                 'required' => true,
                 'class' => ['text', 'filename'],
                 'disabled' => $static,
+                'data' => [
+                    'attribute' => 'newLocation',
+                ],
             ]),
             parent::metaFieldsHtml($static),
         ]);

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -777,7 +777,7 @@ class Cp
                     'class' => $fieldClass,
                     'id' => $fieldId,
                     'data' => [
-                        'attribute' => $config['data']['attribute'] ?? $attribute,
+                        'attribute' => $attribute,
                     ],
                 ],
                 $config['fieldAttributes'] ?? []

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -777,7 +777,7 @@ class Cp
                     'class' => $fieldClass,
                     'id' => $fieldId,
                     'data' => [
-                        'attribute' => $attribute,
+                        'attribute' => $config['data']['attribute'] ?? $attribute,
                     ],
                 ],
                 $config['fieldAttributes'] ?? []


### PR DESCRIPTION
### Description
Report `newLocation` error when editing asset in a slideout.

<img width="1616" alt="Screenshot 2024-02-09 at 07 57 28" src="https://github.com/craftcms/cms/assets/4500340/e4f4a609-aebd-414b-b65f-a49b583136e7">

### Related issues
#14329 
