### PR TITLE
[5.x]: Remove `error` key from response data

### DIFF
--- a/src/web/ErrorHandler.php
+++ b/src/web/ErrorHandler.php
@@ -137,8 +137,6 @@ class ErrorHandler extends \yii\web\ErrorHandler
                 'name' => ($exception instanceof Exception || $exception instanceof ErrorException) ? $exception->getName() : 'Exception',
                 'message' => $message,
                 'code' => $exception->getCode(),
-                // TODO: remove in v5; error message should only be in `message`
-                'error' => $message,
             ];
 
             if ($exception instanceof HttpException) {


### PR DESCRIPTION
This PR fulfils the `TODO` by removing the `error` key from the response data.

Note that a `TODO: review for v5` still exists in the file.