### PR TITLE
Feature/cms 1261 use subdivisionupdater for addresses

### DIFF
--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -4,6 +4,7 @@ namespace craft\elements;
 
 use CommerceGuys\Addressing\AddressFormat\AddressField;
 use CommerceGuys\Addressing\AddressInterface;
+use CommerceGuys\Addressing\Subdivision\SubdivisionUpdater;
 use Craft;
 use craft\base\Element;
 use craft\base\NameTrait;
@@ -254,6 +255,24 @@ class Address extends Element implements AddressInterface, NestedElementInterfac
 
         if (array_key_exists('firstName', $values) || array_key_exists('lastName', $values)) {
             $this->fullName = null;
+        }
+
+        // commerceguys/addressing 2.0.x - remap changed subdivision IDs
+        // update the subdivision ID to its ISO code where available
+        if (isset($values['countryCode'])) {
+            if (isset($values['administrativeArea'])) {
+                $values['administrativeArea'] = SubdivisionUpdater::updateValue(
+                    $values['countryCode'],
+                    $values['administrativeArea']
+                );
+            }
+            // Andorra is the only country with remapped localities.
+            if ($values['countryCode'] == 'AD' && isset($values['locality'])) {
+                $values['locality'] = SubdivisionUpdater::updateValue(
+                    $values['countryCode'],
+                    $values['locality']
+                );
+            }
         }
 
         parent::setAttributes($values, $safeOnly);

--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -257,24 +257,6 @@ class Address extends Element implements AddressInterface, NestedElementInterfac
             $this->fullName = null;
         }
 
-        // commerceguys/addressing 2.0.x - remap changed subdivision IDs
-        // update the subdivision ID to its ISO code where available
-        if (isset($values['countryCode'])) {
-            if (isset($values['administrativeArea'])) {
-                $values['administrativeArea'] = SubdivisionUpdater::updateValue(
-                    $values['countryCode'],
-                    $values['administrativeArea']
-                );
-            }
-            // Andorra is the only country with remapped localities.
-            if ($values['countryCode'] == 'AD' && isset($values['locality'])) {
-                $values['locality'] = SubdivisionUpdater::updateValue(
-                    $values['countryCode'],
-                    $values['locality']
-                );
-            }
-        }
-
         parent::setAttributes($values, $safeOnly);
     }
 
@@ -600,6 +582,32 @@ class Address extends Element implements AddressInterface, NestedElementInterfac
         }
 
         return $tags;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beforeSave(bool $isNew): bool
+    {
+        // commerceguys/addressing 2.0.x - remap changed subdivision IDs
+        // update the subdivision ID to its ISO code where available
+        if (isset($this->countryCode)) {
+            if (isset($this->administrativeArea)) {
+                $this->administrativeArea = SubdivisionUpdater::updateValue(
+                    $this->countryCode,
+                    $this->administrativeArea,
+                );
+            }
+            // Andorra is the only country with remapped localities.
+            if ($this->countryCode == 'AD' && isset($this->locality)) {
+                $this->locality = SubdivisionUpdater::updateValue(
+                    $this->countryCode,
+                    $this->locality,
+                );
+            }
+        }
+
+        return parent::beforeSave($isNew);
     }
 
     /**

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -2082,10 +2082,10 @@ JS, [
                 $belongsToCurrentUser ? 'address-level2' : 'off',
                 isset($visibleFields['locality']),
                 isset($requiredFields['locality']),
-                array_filter([
+                array_values(array_filter([
                     $address->countryCode,
-                    array_key_exists('administrativeArea', $visibleFields) ? $address->administrativeArea : null,
-                ]),
+                    array_key_exists('administrativeArea', $visibleFields) ? $address->administrativeArea : false,
+                ], fn($v) => $v !== false)),
                 true,
             ) .
             self::_subdivisionField(
@@ -2094,11 +2094,11 @@ JS, [
                 $belongsToCurrentUser ? 'address-level3' : 'off',
                 isset($visibleFields['dependentLocality']),
                 isset($requiredFields['dependentLocality']),
-                array_filter([
+                array_values(array_filter([
                     $address->countryCode,
-                    array_key_exists('administrativeArea', $visibleFields) ? $address->administrativeArea : null,
-                    array_key_exists('locality', $visibleFields) ? $address->locality : null,
-                ]),
+                    array_key_exists('administrativeArea', $visibleFields) ? $address->administrativeArea : false,
+                    array_key_exists('locality', $visibleFields) ? $address->locality : false,
+                ], fn($v) => $v !== false)),
                 false,
             ) .
             static::textFieldHtml([

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -2082,7 +2082,10 @@ JS, [
                 $belongsToCurrentUser ? 'address-level2' : 'off',
                 isset($visibleFields['locality']),
                 isset($requiredFields['locality']),
-                [$address->countryCode, $address->administrativeArea],
+                array_merge(
+                    [$address->countryCode],
+                    array_key_exists('administrativeArea', $visibleFields) ? [$address->administrativeArea] : [],
+                ),
                 true,
             ) .
             self::_subdivisionField(
@@ -2091,7 +2094,11 @@ JS, [
                 $belongsToCurrentUser ? 'address-level3' : 'off',
                 isset($visibleFields['dependentLocality']),
                 isset($requiredFields['dependentLocality']),
-                [$address->countryCode, $address->administrativeArea, $address->locality],
+                array_merge(
+                    [$address->countryCode],
+                    array_key_exists('administrativeArea', $visibleFields) ? [$address->administrativeArea] : [],
+                    array_key_exists('locality', $visibleFields) ? [$address->locality] : [],
+                ),
                 false,
             ) .
             static::textFieldHtml([

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -2082,10 +2082,10 @@ JS, [
                 $belongsToCurrentUser ? 'address-level2' : 'off',
                 isset($visibleFields['locality']),
                 isset($requiredFields['locality']),
-                array_merge(
-                    [$address->countryCode],
-                    array_key_exists('administrativeArea', $visibleFields) ? [$address->administrativeArea] : [],
-                ),
+                array_filter([
+                    $address->countryCode,
+                    array_key_exists('administrativeArea', $visibleFields) ? $address->administrativeArea : null,
+                ]),
                 true,
             ) .
             self::_subdivisionField(
@@ -2094,11 +2094,11 @@ JS, [
                 $belongsToCurrentUser ? 'address-level3' : 'off',
                 isset($visibleFields['dependentLocality']),
                 isset($requiredFields['dependentLocality']),
-                array_merge(
-                    [$address->countryCode],
-                    array_key_exists('administrativeArea', $visibleFields) ? [$address->administrativeArea] : [],
-                    array_key_exists('locality', $visibleFields) ? [$address->locality] : [],
-                ),
+                array_filter([
+                    $address->countryCode,
+                    array_key_exists('administrativeArea', $visibleFields) ? $address->administrativeArea : null,
+                    array_key_exists('locality', $visibleFields) ? $address->locality : null,
+                ]),
                 false,
             ) .
             static::textFieldHtml([


### PR DESCRIPTION
### Description
As per the suggestion from https://github.com/craftcms/cms/pull/14322, I've hooked up `SubdivisionUpdater`, so that the subdivision IDs get remapped to their ISO code where available.

Tweaked what parents are passed to the `Cp::_subdivisionField()` when using `Cp::addressFieldsHtml()` based on whether they're visible or not.


### Related issues
[cms-1261](https://linear.app/craftcms/issue/CMS-1261/use-subdivisionupdater-for-addresses)
