### PR TITLE
Fix `@since` version

### DIFF
--- a/src/base/Batchable.php
+++ b/src/base/Batchable.php
@@ -14,7 +14,7 @@ use Countable;
  * provide items which can be counted and accessed in slices.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 3.4.0
+ * @since 4.4.0
  */
 interface Batchable extends Countable
 {


### PR DESCRIPTION
Fixes the version number, _since_ this class was added in 4.4.0.
https://github.com/craftcms/cms/blob/develop/CHANGELOG.md#440---2023-03-08