### PR TITLE
Fixes a type comparison that was returning true unexpectedly

### DIFF
--- a/src/templates/_elements/toolbar.twig
+++ b/src/templates/_elements/toolbar.twig
@@ -14,7 +14,7 @@
 {% set isAdministrative = context in ['index', 'embedded-index'] %}
 {% set showStatusMenu = (showStatusMenu is defined and showStatusMenu != 'auto' ? showStatusMenu : elementInstance.hasStatuses()) %}
 {% set showSiteMenu = (craft.app.getIsMultiSite() ? (showSiteMenu ?? 'auto') : false) %}
-{% if showSiteMenu == 'auto' %}
+{% if showSiteMenu is same as ('auto') %}
     {% set showSiteMenu = elementInstance.isLocalized() %}
 {% endif %}
 {% set idPrefix = "elementtoolbar#{random()}-" %}

--- a/src/templates/_layouts/elementindex.twig
+++ b/src/templates/_layouts/elementindex.twig
@@ -11,7 +11,7 @@
 {% set sources = craft.app.elementSources.getSources(elementType, 'index', true) %}
 
 {% set showSiteMenu = (craft.app.getIsMultiSite() ? (showSiteMenu ?? 'auto') : false) %}
-{% if showSiteMenu == 'auto' %}
+{% if showSiteMenu is same as ('auto') %}
     {% set showSiteMenu = elementInstance.isLocalized() %}
 {% endif %}
 


### PR DESCRIPTION
### Description

Fixes a type comparison that was returning true unexpectedly.

Reproduction:

```twig
{% set mytruval = true %}

{% if mytruval == 'auto' %}
    This will show up.
{% endif %}
```

Twig 3.4.3


