### PR TITLE
Remove `align-items` CSS property

### DIFF
--- a/src/web/assets/cp/src/css/_main.scss
+++ b/src/web/assets/cp/src/css/_main.scss
@@ -4836,7 +4836,6 @@ ul.tree,
       color: var(--medium-text-color);
 
       & > .data {
-        align-items: baseline;
         min-height: auto;
 
         & > .heading,


### PR DESCRIPTION
This PR takes a somewhat heavy-handed approach to fixing the vertical alignment issue created by the markup generated by `Cp::elementChipHtml` in Craft 5.0.0-beta.2, that is affecting the data heading. 

It may be better to target a more specific class, as this may affect other metadata elements, but this is what it looks like...

Before:

![Screenshot 2024-02-16 at 19 27 17](https://github.com/craftcms/cms/assets/57572400/67a3ccbf-76df-4d6d-ab27-cffb5ff8021a)

And after:

![Screenshot 2024-02-16 at 19 27 25](https://github.com/craftcms/cms/assets/57572400/4ce0f833-841c-41c1-995d-2bb766fd822c)