### PR TITLE
Add strict Twig comparison

### DIFF
--- a/src/templates/_layouts/elementindex.twig
+++ b/src/templates/_layouts/elementindex.twig
@@ -11,7 +11,7 @@
 {% set sources = craft.app.elementSources.getSources(elementType, 'index', true) %}
 
 {% set showSiteMenu = (craft.app.getIsMultiSite() ? (showSiteMenu ?? 'auto') : false) %}
-{% if showSiteMenu == 'auto' %}
+{% if showSiteMenu is same as('auto') %}
     {% set showSiteMenu = elementInstance.isLocalized() %}
 {% endif %}
 


### PR DESCRIPTION
This PR replaces the loose `==` comparison with a strict `is same as()` comparison (the equivalent of `===` in PHP). This is necessary because in Twig, `true == 'auto'` evaluates to `true`.

So in this example:

```twig
{% extends '_layouts/elementindex' %}

{% set showSiteMenu = true %}
```

`showSiteMenu` is converted to `auto`.

After applying this PR, `showSiteMenu` remains `true`.

Reference: https://twig.symfony.com/doc/3.x/tests/sameas.html

If merged, this PR should be applied to the `5.0` branch as well.