### PR TITLE
when getting nested element, get its sort order too

### DIFF
--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -2090,7 +2090,7 @@ JS, [
         // if this is a nested entry, and we don't have a sort order - let's get it,
         // so we can keep passing it around and set it correctly
         // https://github.com/craftcms/cms/issues/14427
-        if ($element->getPrimaryOwnerId() && $element->sortOrder === null) {
+        if (method_exists($elementType, 'getPrimaryOwnerId') && $element->getPrimaryOwnerId() && $element->sortOrder === null) {
             $element->sortOrder = (new Query())
                 ->select(['sortOrder'])
                 ->from(['eo' => Table::ELEMENTS_OWNERS])


### PR DESCRIPTION
### Description
When a nested element was duplicated to a draft, the draft was created with the highest sort order +1. Then, when it was being applied, the sort order of the canonical element was set to another +1. So if we had a nested element with sort order `1` and another with sort order `2` and we edited the first one and saved it, the new sort order for that element was set to `4`, causing it to go to the bottom of the list.

If we get the sort order when initially getting the element and keep passing it around, the draft created via `duplicateElement` will have the same sort order as its canonical and then be applied with a correct sort order.


### Related issues
#14427 
