### PR TITLE
Log info to console, don't log context by default

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -14,3 +14,4 @@
 - Craft now calls `setlocale()` based on the target language, so that `SORT_LOCALE_STRING` behaves as expected. ([#14509](https://github.com/craftcms/cms/issues/14509), [#14513](https://github.com/craftcms/cms/pull/14513))
 - Improved the performance of scalar element queries like `count()`.
 - Fixed a bug where `craft\elements\db\ElementQuery::count()` could return the wrong number if the query had a cached result, with `offset` or `limit` params.
+- Console requests no longer filter out info logs. ([#14434](https://github.com/craftcms/cms/pull/14434))

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -14,4 +14,4 @@
 - Craft now calls `setlocale()` based on the target language, so that `SORT_LOCALE_STRING` behaves as expected. ([#14509](https://github.com/craftcms/cms/issues/14509), [#14513](https://github.com/craftcms/cms/pull/14513))
 - Improved the performance of scalar element queries like `count()`.
 - Fixed a bug where `craft\elements\db\ElementQuery::count()` could return the wrong number if the query had a cached result, with `offset` or `limit` params.
-- Console requests no longer filter out info logs. ([#14434](https://github.com/craftcms/cms/pull/14434))
+- Console requests no longer filter out info logs. ([#14280](https://github.com/craftcms/cms/issues/14280), [#14434](https://github.com/craftcms/cms/pull/14434))

--- a/src/log/Dispatcher.php
+++ b/src/log/Dispatcher.php
@@ -75,6 +75,7 @@ class Dispatcher extends \yii\log\Dispatcher
                     'extractExceptionTrace' => !App::devMode(),
                     'allowLineBreaks' => $allowLineBreaks,
                     'level' => App::devMode() ? LogLevel::INFO : LogLevel::WARNING,
+                    'logContext' => !Craft::$app->getRequest()->getIsConsoleRequest(),
                 ];
 
             $target = Craft::createObject($config);

--- a/src/log/MonologTarget.php
+++ b/src/log/MonologTarget.php
@@ -191,14 +191,11 @@ class MonologTarget extends PsrTarget
                 bubble: false,
             ))->setFormatter($this->formatter));
 
-            // Don't pollute console request output
-            if (!Craft::$app->getRequest()->getIsConsoleRequest()) {
-                $logger->pushHandler((new StreamHandler(
-                    'php://stdout',
-                    $this->level,
-                    bubble: false,
-                ))->setFormatter($this->formatter));
-            }
+            $logger->pushHandler((new StreamHandler(
+                'php://stdout',
+                $this->level,
+                bubble: false,
+            ))->setFormatter($this->formatter));
         } else {
             $logger->pushHandler((new RotatingFileHandler(
                 App::parseEnv(sprintf('@storage/logs/%s.log', $name)),


### PR DESCRIPTION
### Description
Since we moved to Monolog, we explicitly silenced logs below warnings when `CRAFT_STREAM_LOG=1` AND the current request was a console request. This was done intentionally, so you didn't have console output mixed in with log output, but now that seems a bit short-sighted.

This PR removes that condition, so logs will go to stderr/out as configured by `monologTargetConfig.level`, or determined by `devMode` by default. Additionally, it doesn't log request context by default for console requests, which was likely the annoyance that cause this to be this way in the first place.

### Related issues
Fixes https://github.com/craftcms/cms/issues/14280