### PR TITLE
save alt translation method and key format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed a bug where users’ addresses weren’t getting deleted immediately when a user was deleted.
 - Fixed a bug where nested addresses and entries would lose their position within the parent Addresses/Entries field if edited directly. ([#14427](https://github.com/craftcms/cms/issues/14427))
 - Fixed a bug where element thumbnails within hidden tabs weren’t always getting loaded when their tab was selected.
+- Fixed a bug where volumes’ Alternative Text Translation Method settings weren’t getting saved. ([#14442](https://github.com/craftcms/cms/issues/14442))
 - Fixed a JavaScript error that could occur when switching between asset sources, if the user had permission to upload assets to some but not others. ([#14403](https://github.com/craftcms/cms/issues/14403))
 - Fixed a bug where setting `showSiteMenu` to `true` on element index templates was being treated as `'auto'`. ([#14404](https://github.com/craftcms/cms/pull/14404))
 - Fixed a bug where `data-target` and `data-reverse-target` attributes weren’t getting properly namespaced if they included a class name selector.

--- a/src/controllers/VolumesController.php
+++ b/src/controllers/VolumesController.php
@@ -172,6 +172,8 @@ class VolumesController extends Controller
             'transformSubpath' => $this->request->getBodyParam('transformSubpath', ""),
             'titleTranslationMethod' => $this->request->getBodyParam('titleTranslationMethod', Field::TRANSLATION_METHOD_SITE),
             'titleTranslationKeyFormat' => $this->request->getBodyParam('titleTranslationKeyFormat'),
+            'altTranslationMethod' => $this->request->getBodyParam('altTranslationMethod', Field::TRANSLATION_METHOD_SITE),
+            'altTranslationKeyFormat' => $this->request->getBodyParam('altTranslationKeyFormat'),
         ]);
 
         // Set the field layout

--- a/src/controllers/VolumesController.php
+++ b/src/controllers/VolumesController.php
@@ -172,7 +172,7 @@ class VolumesController extends Controller
             'transformSubpath' => $this->request->getBodyParam('transformSubpath', ""),
             'titleTranslationMethod' => $this->request->getBodyParam('titleTranslationMethod', Field::TRANSLATION_METHOD_SITE),
             'titleTranslationKeyFormat' => $this->request->getBodyParam('titleTranslationKeyFormat'),
-            'altTranslationMethod' => $this->request->getBodyParam('altTranslationMethod', Field::TRANSLATION_METHOD_SITE),
+            'altTranslationMethod' => $this->request->getBodyParam('altTranslationMethod', Field::TRANSLATION_METHOD_NONE),
             'altTranslationKeyFormat' => $this->request->getBodyParam('altTranslationKeyFormat'),
         ]);
 

--- a/src/models/Volume.php
+++ b/src/models/Volume.php
@@ -480,6 +480,8 @@ class Volume extends Model implements
             'transformSubpath' => $this->transformSubpath,
             'titleTranslationMethod' => $this->titleTranslationMethod,
             'titleTranslationKeyFormat' => $this->titleTranslationKeyFormat ?: null,
+            'altTranslationMethod' => $this->altTranslationMethod,
+            'altTranslationKeyFormat' => $this->altTranslationKeyFormat ?: null,
             'sortOrder' => $this->sortOrder,
         ];
 

--- a/src/records/Volume.php
+++ b/src/records/Volume.php
@@ -26,6 +26,8 @@ use yii2tech\ar\softdelete\SoftDeleteBehavior;
  * @property string $transformSubpath The transform filesystem subpath for storing transforms
  * @property string $titleTranslationMethod
  * @property string|null $titleTranslationKeyFormat
+ * @property string $altTranslationMethod
+ * @property string|null $altTranslationKeyFormat
  * @property int $sortOrder Sort order
  * @property FieldLayout $fieldLayout Field layout
  * @mixin SoftDeleteBehavior

--- a/src/services/Volumes.php
+++ b/src/services/Volumes.php
@@ -341,6 +341,8 @@ class Volumes extends Component
             $volumeRecord->sortOrder = $data['sortOrder'];
             $volumeRecord->titleTranslationMethod = $data['titleTranslationMethod'] ?? Field::TRANSLATION_METHOD_SITE;
             $volumeRecord->titleTranslationKeyFormat = $data['titleTranslationKeyFormat'] ?? null;
+            $volumeRecord->altTranslationMethod = $data['altTranslationMethod'] ?? Field::TRANSLATION_METHOD_SITE;
+            $volumeRecord->altTranslationKeyFormat = $data['altTranslationKeyFormat'] ?? null;
             $volumeRecord->uid = $volumeUid;
 
             if (!empty($data['fieldLayouts'])) {

--- a/src/services/Volumes.php
+++ b/src/services/Volumes.php
@@ -341,7 +341,7 @@ class Volumes extends Component
             $volumeRecord->sortOrder = $data['sortOrder'];
             $volumeRecord->titleTranslationMethod = $data['titleTranslationMethod'] ?? Field::TRANSLATION_METHOD_SITE;
             $volumeRecord->titleTranslationKeyFormat = $data['titleTranslationKeyFormat'] ?? null;
-            $volumeRecord->altTranslationMethod = $data['altTranslationMethod'] ?? Field::TRANSLATION_METHOD_SITE;
+            $volumeRecord->altTranslationMethod = $data['altTranslationMethod'] ?? Field::TRANSLATION_METHOD_NONE;
             $volumeRecord->altTranslationKeyFormat = $data['altTranslationKeyFormat'] ?? null;
             $volumeRecord->uid = $volumeUid;
 


### PR DESCRIPTION
### Description
Save the selected "Alternative Text Translation Method" and "Alternative Text Translation Key Format" to the project config and database.


### Related issues
#14442 
