### PR TITLE
ignore ids that start with placeholder too

### DIFF
--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -656,7 +656,8 @@ class Html extends \yii\helpers\Html
     public static function id(string $id = ''): string
     {
         // Ignore if it looks like a placeholder
-        if (preg_match('/^__[A-Z_]+__$/', $id)) {
+        // or starts with a placeholder (e.g. widgets > __NAMESPACE__-fieldId)
+        if (preg_match('/^__[A-Z_]+__(-)?/', $id)) {
             return $id;
         }
 

--- a/tests/unit/helpers/HtmlHelperTest.php
+++ b/tests/unit/helpers/HtmlHelperTest.php
@@ -520,6 +520,7 @@ class HtmlHelperTest extends TestCase
             ['foo__', '__foo__', null],
             ['__FOO__', '__FOO__', null],
             ['__FOO_BAR__', '__FOO_BAR__', null],
+            ['__FOO_BAR__-baz', '__FOO_BAR__-baz', null],
         ];
     }
 


### PR DESCRIPTION
### Description
Nathaniel pointed out that he had problems with dashboard widgets in v5. If you have a selectize field in your widget (and potentially other JS-related elements like menu buttons), adding such a widget to the dashboard triggeres a JS error.

Replication steps:
- add the following snippet to the Recent Entries widget settings.twig:
```
{{ forms.selectizeField({
    id: 'test',
    name: 'test',
    value: 'foo',
    options: [{label: 'Foo', value: 'foo'}, {label: 'Bar', value: 'bar'}],
    multi: true,
}) }}
```
- try to add the Recent Entries widget to the dashboard
- see `Uncaught TypeError: selectize is undefined` in the console

Fixed by adjusting the ID normalisation to ignore not only IDs that look like a placeholder but also start with something that looks like a placeholder. 

In the case of widgets, the attributes will be adjusted to `__NAMESPACE__-fieldName` first and then when the JS is evaluated, that ID was being changed to `NAMESPACE__-fieldName`, causing the error to be triggered.

### Related issues
n/a
