### PR TITLE
Fix FS settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where some characters were getting misinterpreted as elisions when normalizing search keywords.
 - Fixed a bug where `craft\helpers\UrlHelper::actionUrl()` was using the site URL rather than the requested URL. ([#14440](https://github.com/craftcms/cms/issues/14440))
 - Fixed a bug where `craft\helpers\Html::parseTagAttribute()` wasn’t handling attribute values with newlines. ([#14498](https://github.com/craftcms/cms/issues/14498))
+- Fixed a bug where the “Filesystem Type” setting wasn’t toggling type-specific settings when editing a filesystem via a slideout. ([#14522](https://github.com/craftcms/cms/issues/14522))
 
 ## 4.8.0 - 2024-02-26
 

--- a/src/templates/_includes/forms/radioGroup.twig
+++ b/src/templates/_includes/forms/radioGroup.twig
@@ -10,7 +10,7 @@
 {%- set containerAttributes = {
     class: class,
     data: {
-        'target-prefix': targetPrefix ?? false,
+        'target-prefix': (toggle ?? false) ? (targetPrefix ?? '#') : false,
     },
 }|merge(containerAttributes ?? [], recursive=true) %}
 

--- a/src/templates/_includes/forms/select.twig
+++ b/src/templates/_includes/forms/select.twig
@@ -29,7 +29,7 @@
         labelledby: (inputAttributes.aria.label ?? false) ? false : (labelledBy ?? false),
     },
     data: {
-        'target-prefix': (toggle ?? false) ? (targetPrefix ?? '') : false,
+        'target-prefix': (toggle ?? false) ? (targetPrefix ?? '#') : false,
     },
 }|merge(inputAttributes ?? [], recursive=true) %}
 

--- a/src/templates/settings/filesystems/_edit.twig
+++ b/src/templates/settings/filesystems/_edit.twig
@@ -36,7 +36,8 @@
         name: 'type',
         options: fsOptions,
         value: className(filesystem),
-        toggle: true
+        toggle: true,
+        targetPrefix: '#'
     }) }}
 {% endif %}
 

--- a/src/templates/settings/filesystems/_edit.twig
+++ b/src/templates/settings/filesystems/_edit.twig
@@ -36,8 +36,7 @@
         name: 'type',
         options: fsOptions,
         value: className(filesystem),
-        toggle: true,
-        targetPrefix: '#'
+        toggle: true
     }) }}
 {% endif %}
 

--- a/tests/unit/helpers/HtmlHelperTest.php
+++ b/tests/unit/helpers/HtmlHelperTest.php
@@ -568,6 +568,8 @@ class HtmlHelperTest extends TestCase
             ['<style>.foo-a, .foo-b:hover</style>', '<style>.a, .b:hover</style>', 'foo', true],
             ['<div id="foo-bar"></div><div data-reverse-target="#foo-bar, .foo"></div>', '<div id="bar"></div><div data-reverse-target="#bar, .foo"></div>', 'foo', false],
             ['<div id="foo-bar"></div><div data-reverse-target="#foo-bar, #foo-bar .foo"></div>', '<div id="bar"></div><div data-reverse-target="#bar, #bar .foo"></div>', 'foo', false],
+            ['<div id="foo-bar"></div><div data-target-prefix="#foo-"></div>', '<div id="bar"></div><div data-target-prefix="#"></div>', 'foo', false],
+            ['<div id="foo-bar"></div><div data-target-prefix></div>', '<div id="bar"></div><div data-target-prefix></div>', 'foo', false],
         ];
     }
 


### PR DESCRIPTION
It looks like https://github.com/craftcms/cms/commit/3979735f8826308b8c2da27dea259a799bad7a60 broke FS settings within a slideout. From what @timkelty and I can tell, this is the only instance that had a `toggle` setting without an explicit `targetPrefix` on it.