### PR TITLE
[5.x]: Fix JS modules not loading correctly in the control panel

### DIFF
--- a/src/web/assets/cp/src/js/Craft.js
+++ b/src/web/assets/cp/src/js/Craft.js
@@ -1916,7 +1916,7 @@ $.extend(Craft, {
       return;
     }
 
-    const scripts = [];
+    const scriptUrls = [];
 
     const nodes = $.parseHTML(html.trim(), true).filter((node) => {
       if (node.nodeName === 'LINK' && node.href) {
@@ -1942,11 +1942,7 @@ $.extend(Craft, {
         }
 
         if (!this._existingJs.includes(node.src)) {
-          scripts.push({
-            type: node.type || 'script',
-            src: node.src,
-          });
-          
+          scriptUrls.push(node.src);
           this._existingJs.push(node.src);
         }
 
@@ -1957,39 +1953,29 @@ $.extend(Craft, {
       return true;
     });
 
-    await this._loadScripts(scripts);
+    await this._loadScripts(scriptUrls);
     $parent.append(nodes);
   },
 
-  _loadScripts: function (scripts) {
+  _loadScripts: function (urls) {
     return new Promise((resolve) => {
-      if (!scripts.length) {
+      if (!urls.length) {
         resolve();
         return;
       }
 
-      const script = scripts.shift();
+      const url = urls.shift();
+      $.ajaxSetup({cache: true});
 
-      const getScript = function(script, callback) {
-        return new Promise((resolve, reject) => {
-          const $script = document.createElement('script');
-          $script.src = script.src;
-          $script.type = script.type;
-      
-          $script.onload = () => resolve();
-          $script.onerror = (error) => reject(error);
-      
-          document.body.appendChild($script);
-        });
-      }
-
-      getScript(script)
-        .then(() => {
-          this._loadScripts(scripts).then(resolve);
+      $.getScript(url)
+        .done(() => {
+          $.ajaxSetup({cache: false});
+          this._loadScripts(urls).then(resolve);
         })
-        .catch((error) => {
-          console.error(`Failed to load ${url}: ${error}`);
-          this._loadScripts(scripts).then(resolve);
+        .fail(() => {
+          console.error(`Failed to load ${url}:`);
+          $.ajaxSetup({cache: false});
+          this._loadScripts(urls).then(resolve);
         });
     });
   },

--- a/src/web/assets/cp/src/js/Craft.js
+++ b/src/web/assets/cp/src/js/Craft.js
@@ -1942,8 +1942,15 @@ $.extend(Craft, {
         }
 
         if (!this._existingJs.includes(node.src)) {
-          scriptUrls.push(node.src);
           this._existingJs.push(node.src);
+
+          // Ignore loading module scripts, as they don't work with `$.getScript()`,
+          // but still need to be appended so return early
+          if (node.type === 'module') {
+            return true;
+          } else {
+            scriptUrls.push(node.src);
+          }
         }
 
         // return false either way since we are going to load it ourselves


### PR DESCRIPTION
There's an issue for any field that contains a `<script type="module">` in its assets when loading its field settings. From a new field interface, selecting the field via dropdown will load the HTML/CSS/JS for the field asynchronously. This is notable with Vizy, Hyper, Icon Picker and others, where we use Vue and Vite to handle field settings.

This results in an error when trying to load a script that's a module - the browser can't handle it.

![image](https://github.com/craftcms/cms/assets/1221575/d80b8c0f-3dac-49c5-a6ac-8e15bcba7784)

This seems to stem from this [change](https://github.com/craftcms/cms/commit/94ed5f9a2bdc80d3eb489bce76df1527d17f5504#diff-b9705a5250928f8dd378beb6ff7f2cc8cd708130275220eb153ee3278d2eb766R1873-R1882) where you fetch the script first via jQuery's `$.getScript()` function, but this doesn't work well with modules. In addition, you're only passing in an array of URLs to this function, whereas we need to know if the URL is a module or not.

I did toy with fetching all attributes of the `<script>` element and use that, but decided to keep it simple.

So firstly, we store the script type and src, and pass into `_loadScripts()`. We then have to swap out jQuery's `$.getScript()` function for our own, but I've tried to keep it almost 1-for-1.

Sorry for the noisy PR, but figured I should rename some variables for clarity. I also didn't touch `this._existingJs` because it's just comparing URLs, not loading them.