### PR TITLE
Return better FS error if stream fails

### DIFF
--- a/src/fs/Local.php
+++ b/src/fs/Local.php
@@ -260,7 +260,7 @@ class Local extends Fs implements LocalFsInterface
 
         $targetStream = @fopen($fullPath, 'w+b');
 
-        if (!@stream_copy_to_stream($stream, $targetStream)) {
+        if (!$targetStream || !@stream_copy_to_stream($stream, $targetStream)) {
             throw new FsException("Unable to copy stream to `$fullPath`");
         }
 


### PR DESCRIPTION
### Description
Returns a better error if stream fails, eg, you're trying to use a local volume on Cloud.
