### PR TITLE
Update tooltip to work on disabled elements

### DIFF
--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -886,23 +886,26 @@ class ElementsController extends Controller
         if ($isDraft && !$isCurrent && $canSave && $canSaveCanonical) {
             /** @phpstan-ignore-next-line */
             $disabled = $canonical->hasMethod('isEntryTypeCompatible') && !$element->isEntryTypeCompatible();
-            $btnContent = Craft::t('app', 'Apply draft');
-            if ($disabled) {
-                $btnContent .= ' <craft-tooltip>' .
-                    Craft::t(
-                        'app',
-                        'The Entry Type for this draft is no longer available. You can still view it, but not apply it.'
-                    ) .
-                    '</craft-tooltip>';
-            }
-            $components[] = Html::button($btnContent, [
-                //TODO: uncomment or remove once Brian says if the tooltip can work on disabled elements too
-                'class' => ['btn', 'secondary', 'formsubmit', /*$disabled ? 'disabled' : ''*/],
+
+            $button = Html::button(Craft::t('app', 'Apply draft'), [
+                'class' => ['btn', 'secondary', 'formsubmit', $disabled ? 'disabled' : ''],
+                'disabled' => $disabled,
                 'data' => [
                     'action' => 'elements/apply-draft',
                     'redirect' => Craft::$app->getSecurity()->hashData('{cpEditUrl}'),
                 ],
             ]);
+
+            if ($disabled) {
+                $button = Html::tag('craft-tooltip', $button, [
+                    'aria-label' => Craft::t(
+                        'app',
+                        'The Entry Type for this draft is no longer available. You can still view it, but not apply it.'
+                    ),
+                ]);
+            }
+
+            $components[] = $button;
         }
 
         // Revert content from this revision

--- a/src/web/assets/cp/src/css/_craft-tooltip.scss
+++ b/src/web/assets/cp/src/css/_craft-tooltip.scss
@@ -1,4 +1,4 @@
-craft-tooltip {
+.craft-tooltip {
   position: fixed;
   white-space: normal;
   opacity: 0;
@@ -13,7 +13,7 @@ craft-tooltip {
   z-index: 99;
 }
 
-craft-tooltip > .inner {
+.craft-tooltip > .inner {
   position: relative;
   display: inline-block;
   background-color: var(--white);
@@ -27,7 +27,7 @@ craft-tooltip > .inner {
   font-weight: 400;
 }
 
-craft-tooltip .arrow {
+.craft-tooltip .arrow {
   position: absolute;
   background: var(--white);
   width: 8px;

--- a/src/web/assets/cp/src/js/CraftElementLabel.js
+++ b/src/web/assets/cp/src/js/CraftElementLabel.js
@@ -63,7 +63,8 @@ class CraftElementLabel extends HTMLElement {
 
   createTooltip() {
     this.tooltip = document.createElement('craft-tooltip');
-    this.tooltip.innerText = this.innerText;
+    this.tooltip.setAttribute('self-managed', 'true');
+    this.tooltip.setAttribute('aria-label', this.innerText);
 
     // If there's a context label, make it a little nicer
     const contextLabel = this.querySelector('.context-label');


### PR DESCRIPTION
Updates the `craft-tooltip` to work for disabled elements. To pull this off, we changed the API just a bit. The biggest change is that the tooltip now grabs the text for the tooltip from `aria-label` rather than from the `innerText`. 

To use the tooltip with disabled elements, you can wrap the element with the `<craft-tooltip`. The previous behavior is still available if you add a `self-managed` property to the tooltip. 

When `craft-tooltip` is used as a wrapper, it will look for an `a`, `button` or `[role="button"]` and use that as the trigger for the tooltip. 

```html
<craft-tooltip aria-label="Text for the tooltip">
  <button type="button" disabled>Some Action</button>
</craft-tooltip>
```

This brings our tooltip more in line with [spectrum's API](https://spectrum.adobe.com/page/tooltip/) and [GitHub Primer](https://primer.style/components/tooltip). 