### PR TITLE
feat: Allow optional context variables to be passed in to the Element `.render()` method

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -6018,14 +6018,15 @@ JS,
      *
      * If no partial template exists for the element, its string representation will be output instead.
      *
+     * @param array $variables
      * @return Markup
      * @throws InvalidConfigException
      * @throws NotSupportedException
      * @see ElementHelper::renderElements()
      * @since 5.0.0
      */
-    public function render(): Markup
+    public function render(array $variables = []): Markup
     {
-        return ElementHelper::renderElements([$this]);
+        return ElementHelper::renderElements([$this], $variables);
     }
 }

--- a/src/elements/ElementCollection.php
+++ b/src/elements/ElementCollection.php
@@ -76,14 +76,15 @@ class ElementCollection extends Collection
      *
      * If no partial template exists for an element, its string representation will be output instead.
      *
+     * @param array $variables
      * @return Markup
      * @throws InvalidConfigException
      * @throws NotSupportedException
      * @see ElementHelper::renderElements()
      * @since 5.0.0
      */
-    public function render(): Markup
+    public function render(array $variables = []): Markup
     {
-        return ElementHelper::renderElements($this->items);
+        return ElementHelper::renderElements($this->items, $variables);
     }
 }

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1836,15 +1836,16 @@ class ElementQuery extends Query implements ElementQueryInterface
      *
      * If no partial template exists for an element, its string representation will be output instead.
      *
+     * @param array $variables
      * @return Markup
      * @throws InvalidConfigException
      * @throws NotSupportedException
      * @see ElementHelper::renderElements()
      * @since 5.0.0
      */
-    public function render(): Markup
+    public function render(array $variables = []): Markup
     {
-        return ElementHelper::renderElements($this->all());
+        return ElementHelper::renderElements($this->all(), $variables);
     }
 
     /**

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -882,12 +882,13 @@ class ElementHelper
      * If no partial template exists for an element, its string representation will be output instead.
      *
      * @param ElementInterface[] $elements
+     * @param array $variables
      * @return Markup
      * @throws InvalidConfigException
      * @throws NotSupportedException
      * @since 5.0.0
      */
-    public static function renderElements(array $elements): Markup
+    public static function renderElements(array $elements, array $variables = []): Markup
     {
         $view = Craft::$app->getView();
         $generalConfig = Craft::$app->getConfig()->getGeneral();
@@ -904,7 +905,7 @@ class ElementHelper
             }
             $template = sprintf('%s/%s/%s', $generalConfig->partialTemplatesPath, $refHandle, $providerHandle);
             try {
-                $output[] = $view->renderTemplate($template, [$refHandle => $element], View::TEMPLATE_MODE_SITE);
+                $output[] = $view->renderTemplate($template, array_merge($variables, [$refHandle => $element]), View::TEMPLATE_MODE_SITE);
             } catch (TwigLoaderError) {
                 // fallback to the string representation of the element
                 $output[] = Html::tag('p', Html::encode((string)$element));


### PR DESCRIPTION
### Description

Allow optional context variables to be passed in to the Element `.render()` method

### Related issues

Discord discussion, people wanted to be able to pass in some context variables to the `.render()` function