### PR TITLE
Prevent responses being cached with CSRF tags

### DIFF
--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -96,6 +96,10 @@ class Html extends \yii\helpers\Html
     public static function csrfInput(array $options = []): string
     {
         $request = Craft::$app->getRequest();
+
+        // Prevent response from being cached with token
+        Craft::$app->getResponse()->setNoCacheHeaders();
+
         return static::hiddenInput($request->csrfParam, $request->getCsrfToken(), $options);
     }
 
@@ -1057,7 +1061,7 @@ class Html extends \yii\helpers\Html
             $offset = $tag['end'];
         }
     }
-    
+
     /**
      * Returns the contents of a given SVG file.
      *


### PR DESCRIPTION
### Description
This helps by telling the browser not to serve a cached version, but also hinting to static caches that the response should not be cached.