### PR TITLE
Allow configuration of SVG sanitizer

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -2555,6 +2555,16 @@ class GeneralConfig extends BaseConfig
      * ```
      * :::
      *
+     * Alternatively, this maybe set to a closure that accepts a [[\enshrined\svgSanitize\Sanitizer]] instance and returns
+     * a [[\enshrined\svgSanitize\Sanitizer]] instance further customization.
+     *
+     * ```php
+     * ->sanitizeSvgUploads(function(\enshrined\svgSanitize\Sanitizer $sanitizer): \enshrined\svgSanitize\Sanitizer {
+     *     $sanitizer->removeRemoteReferences(true);
+     *     return $sanitizer;
+     * })
+     * ```
+     *
      * @group Security
      */
     public bool|Closure $sanitizeSvgUploads = true;
@@ -5952,16 +5962,6 @@ class GeneralConfig extends BaseConfig
      * ```php
      * ->sanitizeSvgUploads(false)
      * ```
-     *
-     * Alternatively, this maybe set to a closure that accepts a [[\enshrined\svgSanitize\Sanitizer]] instance and returns
-     * a [[\enshrined\svgSanitize\Sanitizer]] instance further customization.
-     *
-     *  ```php
-     *  ->sanitizeSvgUploads(function(\enshrined\svgSanitize\Sanitizer $sanitizer): \enshrined\svgSanitize\Sanitizer {
-     *      $sanitizer->removeRemoteReferences(true);
-     *      return $sanitizer;
-     *  })
-     *  ```
      *
      * @group Security
      * @param bool|Closure(Sanitizer):Sanitizer $value

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -7,6 +7,7 @@
 
 namespace craft\config;
 
+use Closure;
 use Craft;
 use craft\helpers\ConfigHelper;
 use craft\helpers\DateTimeHelper;
@@ -14,6 +15,7 @@ use craft\helpers\Localization;
 use craft\helpers\StringHelper;
 use craft\services\Config;
 use DateInterval;
+use enshrined\svgSanitize\Sanitizer;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 use yii\base\UnknownPropertyException;
@@ -2540,7 +2542,7 @@ class GeneralConfig extends BaseConfig
     public ?string $sameSiteCookieValue = null;
 
     /**
-     * @var bool Whether Craft should sanitize uploaded SVG files and strip out potential malicious-looking content.
+     * @var bool|Closure Whether Craft should sanitize uploaded SVG files and strip out potential malicious-looking content.
      *
      * This should definitely be enabled if you are accepting SVG uploads from untrusted sources.
      *
@@ -2555,7 +2557,7 @@ class GeneralConfig extends BaseConfig
      *
      * @group Security
      */
-    public bool $sanitizeSvgUploads = true;
+    public bool|Closure $sanitizeSvgUploads = true;
 
     /**
      * @var string A private, random, cryptographically-secure key that is used for hashing and encrypting data in [[\craft\services\Security]].
@@ -5951,13 +5953,23 @@ class GeneralConfig extends BaseConfig
      * ->sanitizeSvgUploads(false)
      * ```
      *
+     * Alternatively, this maybe set to a closure that accepts a [[\enshrined\svgSanitize\Sanitizer]] instance and returns
+     * a [[\enshrined\svgSanitize\Sanitizer]] instance further customization.
+     *
+     *  ```php
+     *  ->sanitizeSvgUploads(function(\enshrined\svgSanitize\Sanitizer $sanitizer): \enshrined\svgSanitize\Sanitizer {
+     *      $sanitizer->removeRemoteReferences(true);
+     *      return $sanitizer;
+     *  })
+     *  ```
+     *
      * @group Security
-     * @param bool $value
+     * @param bool|Closure(Sanitizer):Sanitizer $value
      * @return self
      * @see $sanitizeSvgUploads
      * @since 4.2.0
      */
-    public function sanitizeSvgUploads(bool $value = true): self
+    public function sanitizeSvgUploads(bool|Closure $value = true): self
     {
         $this->sanitizeSvgUploads = $value;
         return $this;

--- a/src/services/Images.php
+++ b/src/services/Images.php
@@ -7,6 +7,7 @@
 
 namespace craft\services;
 
+use Closure;
 use Craft;
 use craft\base\Image;
 use craft\helpers\App;
@@ -19,7 +20,6 @@ use craft\image\SvgAllowedAttributes;
 use enshrined\svgSanitize\Sanitizer;
 use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Image\Format;
-use Imagine\Imagick\Imagick;
 use Imagine\Imagick\Imagine as ImagickImagine;
 use Throwable;
 use yii\base\Component;
@@ -320,12 +320,19 @@ class Images extends Component
 
         // Special case for SVG files.
         if (FileHelper::isSvg($filePath)) {
-            if (!Craft::$app->getConfig()->getGeneral()->sanitizeSvgUploads) {
+            $sanitizeSvgUploads = Craft::$app->getConfig()->getGeneral()->sanitizeSvgUploads;
+
+            if (!$sanitizeSvgUploads) {
                 return;
             }
 
             $sanitizer = new Sanitizer();
             $sanitizer->setAllowedAttrs(new SvgAllowedAttributes());
+
+            if ($sanitizeSvgUploads instanceof Closure) {
+                $sanitizer = ($sanitizeSvgUploads)($sanitizer);
+            }
+
             $svgContents = file_get_contents($filePath);
             $svgContents = $sanitizer->sanitize($svgContents);
 


### PR DESCRIPTION
### Description
Allows configuration of the SVG sanitizer by accepting `bool|callable`.
A more flexible alternative to https://github.com/craftcms/cms/pull/14492, which exposes a new dedicated for `sanitizeSvgRemoteRefs`.

### Related issues
https://github.com/craftcms/cms/pull/14492