### PR TITLE
query assets with hasAlt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Selectize inputs no longer automatically select the hovered option on <kbd>Tab</kbd> press. ([selectize/selectize.js#2085](https://github.com/selectize/selectize.js/issues/2085))
 - Fixed a bug where filesystems’ `afterSave()` and `afterDelete()` methods weren’t getting called. ([#14634](https://github.com/craftcms/cms/pull/14634))
 - Fixed an error that could occur on `elements/recent-activity` Ajax requests when editing an element. ([#14635](https://github.com/craftcms/cms/issues/14635))
+- Fixed a bug where asset queries’ `hasAlt` param wasn’t working. ([#14642](https://github.com/craftcms/cms/pull/14642))
 
 ## 5.0.0-beta.10 - 2024-03-19
 

--- a/src/elements/db/AssetQuery.php
+++ b/src/elements/db/AssetQuery.php
@@ -966,21 +966,6 @@ class AssetQuery extends ElementQuery
             $this->subQuery->andWhere($kindCondition);
         }
 
-        if ($this->hasAlt !== null) {
-            $hasAltCondition = [
-                'or',
-                ['assets.alt' => null],
-                ['assets_site.alt' => null],
-            ];
-            $this->subQuery
-                ->leftJoin(['assets_sites' => Table::ASSETS_SITES], [
-                    'and',
-                    '[[assets_sites.assetId]] = [[assets.id]]',
-                    '[[assets_sites.siteId]] = [[elements_sites.siteId]]',
-                ])
-                ->andWhere($this->hasAlt ? ['not', $hasAltCondition] : $hasAltCondition);
-        }
-
         if ($this->width) {
             $this->subQuery->andWhere(Db::parseNumericParam('assets.width', $this->width));
         }
@@ -1001,6 +986,30 @@ class AssetQuery extends ElementQuery
         $this->_applyAuthParam($this->savable, 'saveAssets', 'savePeerAssets');
 
         return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function afterPrepare(): bool
+    {
+        if ($this->hasAlt !== null) {
+            $hasAltCondition = [
+                'or',
+                ['assets.alt' => null],
+                ['assets_sites.alt' => null],
+            ];
+
+            $this->subQuery
+                ->leftJoin(['assets_sites' => Table::ASSETS_SITES], [
+                    'and',
+                    '[[assets_sites.assetId]] = [[assets.id]]',
+                    '[[assets_sites.siteId]] = [[elements_sites.siteId]]',
+                ])
+                ->andWhere($this->hasAlt ? ['not', $hasAltCondition] : $hasAltCondition);
+        }
+
+        return parent::afterPrepare();
     }
 
     /**


### PR DESCRIPTION
### Description
Fixed a type-o in `$hasAltCondition` (`assets_site.alt` => `assets_sites.alt`).
Moved `hasAlt` processing to `afterPrepare` where the `subQuery` is already joined with the `elements_sites` table. It’s not joined yet in `beforePrepare`, and adding it the second time seemed redundant, but please LMK if that’s the wrong way to go.


### Related issues
#14640 
