### PR TITLE
handle inline editing for asset folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a bug where filesystems’ `afterSave()` and `afterDelete()` methods weren’t getting called. ([#14634](https://github.com/craftcms/cms/pull/14634))
 - Fixed an error that could occur on `elements/recent-activity` Ajax requests when editing an element. ([#14635](https://github.com/craftcms/cms/issues/14635))
 - Fixed a bug where asset queries’ `hasAlt` param wasn’t working. ([#14642](https://github.com/craftcms/cms/pull/14642))
+- Fixed an error that occurred when inline-editing assets. ([#14646](https://github.com/craftcms/cms/issues/14646))
 
 ## 5.0.0-beta.10 - 2024-03-19
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2606,6 +2606,18 @@ JS,[
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getInlineAttributeInputHtml(string $attribute): string
+    {
+        if ($this->isFolder) {
+            return '';
+        }
+
+        return parent::getInlineAttributeInputHtml($attribute);
+    }
+
+    /**
      * Returns the HTML for asset previews.
      *
      * @return string


### PR DESCRIPTION
### Description
Fixes error that occurred when trying to inline edit assets when folders were also showing on the index page.
Fixes an error where when inline editing assets, edit inputs were also showing for the folders.


### Related issues
#14646 
