### PR TITLE
allow removing alt text

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '5.0.0-beta.11',
-    'schemaVersion' => '5.0.0.20',
+    'schemaVersion' => '5.0.0.21',
     'minVersionRequired' => '4.4.0',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -3083,10 +3083,24 @@ JS;
             }
         }
 
+        $isPrimaryAlt = (new Query())
+            ->select('isPrimaryAlt')
+            ->from([Table::ASSETS_SITES])
+            ->where([
+                'assetId' => $this->id,
+                'siteId' => $this->siteId,
+            ])
+            ->scalar();
+
+        if (!$isPrimaryAlt && isset($record) && $record->alt !== null) {
+            $isPrimaryAlt = 1;
+        }
+
         Db::upsert(Table::ASSETS_SITES, [
             'assetId' => $this->id,
             'siteId' => $this->siteId,
             'alt' => $this->alt,
+            'isPrimaryAlt' => $isPrimaryAlt,
         ]);
 
         parent::afterSave($isNew);

--- a/src/elements/db/AssetQuery.php
+++ b/src/elements/db/AssetQuery.php
@@ -920,6 +920,7 @@ class AssetQuery extends ElementQuery
             'assets.keptFile',
             'assets.dateModified',
             'siteAlt' => 'assets_sites.alt',
+            'isPrimaryAlt' => 'assets_sites.isPrimaryAlt',
             'folderPath' => 'volumeFolders.path',
         ]);
 
@@ -1115,7 +1116,8 @@ class AssetQuery extends ElementQuery
     {
         // Use the site-specific alt text, if set
         $siteAlt = ArrayHelper::remove($row, 'siteAlt');
-        if ($siteAlt !== null && $siteAlt !== '') {
+        $isPrimaryAlt = ArrayHelper::remove($row, 'isPrimaryAlt');
+        if ($isPrimaryAlt) {
             $row['alt'] = $siteAlt;
         }
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -180,6 +180,7 @@ class Install extends Migration
             'assetId' => $this->integer()->notNull(),
             'siteId' => $this->integer()->notNull(),
             'alt' => $this->text(),
+            'isPrimaryAlt' => $this->boolean()->defaultValue(0),
             'PRIMARY KEY([[assetId]], [[siteId]])',
         ]);
         $this->createTable(Table::IMAGETRANSFORMINDEX, [

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -180,7 +180,7 @@ class Install extends Migration
             'assetId' => $this->integer()->notNull(),
             'siteId' => $this->integer()->notNull(),
             'alt' => $this->text(),
-            'isPrimaryAlt' => $this->boolean()->defaultValue(0),
+            'isPrimaryAlt' => $this->boolean()->defaultValue(false),
             'PRIMARY KEY([[assetId]], [[siteId]])',
         ]);
         $this->createTable(Table::IMAGETRANSFORMINDEX, [

--- a/src/migrations/m240325_120656_add_is_primary_alt.php
+++ b/src/migrations/m240325_120656_add_is_primary_alt.php
@@ -15,7 +15,7 @@ class m240325_120656_add_is_primary_alt extends Migration
      */
     public function safeUp(): bool
     {
-        $this->addColumn(Table::ASSETS_SITES, 'isPrimaryAlt', $this->boolean()->defaultValue(0)->after('alt'));
+        $this->addColumn(Table::ASSETS_SITES, 'isPrimaryAlt', $this->boolean()->defaultValue(false)->after('alt'));
 
         return true;
     }

--- a/src/migrations/m240325_120656_add_is_primary_alt.php
+++ b/src/migrations/m240325_120656_add_is_primary_alt.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m240325_120656_add_is_primary_alt migration.
+ */
+class m240325_120656_add_is_primary_alt extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn(Table::ASSETS_SITES, 'isPrimaryAlt', $this->boolean()->defaultValue(0)->after('alt'));
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m240325_120656_add_is_primary_alt cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
### Description
Adds the `isPrimaryAlt` flag to the `assets_sites` table. 
When you first upload an asset - `isPrimaryAlt` is set to `0`.
When you add the alt text, `isPrimaryAlt` becomes `1` for the site you edited the alt for.
When you edit the asset and amend alt text for another site, its `isPrimaryAlt` also becomes `1`.
`isPrimaryAlt` should never revert from `1` to `0`.

The flag is then used in `AssetQuery::createElement()` to ensure the alt text can be set to an empty value and displayed as such.


### Related issues
[cms-1284](https://linear.app/craftcms/issue/CMS-1284/translatable-alt-text-unable-to-remove-text-for-a-site)
