### PR TITLE
#14676 - Login request sent to wrong host when using baseCpUrl to host CP on separate domain

### DIFF
--- a/src/helpers/UrlHelper.php
+++ b/src/helpers/UrlHelper.php
@@ -161,7 +161,7 @@ class UrlHelper
     public static function urlWithToken(string $url, string $token, bool $cp = false): string
     {
         $scheme = static::getSchemeForTokenizedUrl($cp);
-        $url = static::urlWithScheme($url, $scheme);
+        $url = static::urlWithScheme($url, $scheme, $cp);
 
         return static::urlWithParams($url, [
             Craft::$app->getConfig()->getGeneral()->tokenParam => $token,
@@ -173,10 +173,11 @@ class UrlHelper
      *
      * @param string $url the URL
      * @param string $scheme the scheme ('http' or 'https')
+     * @param bool $cpUrl if this is a URL for the Control Panel or not
      * @return string
      * @throws SiteNotFoundException
      */
-    public static function urlWithScheme(string $url, string $scheme): string
+    public static function urlWithScheme(string $url, string $scheme, bool $cpUrl = false): string
     {
         if (!$url || !$scheme) {
             return $url;
@@ -188,7 +189,7 @@ class UrlHelper
 
         if (static::isRootRelativeUrl($url)) {
             // Prepend the current request’s scheme and hostname
-            $url = static::siteHost() . $url;
+            $url = ($cpUrl ? static::cpHost() : static::siteHost()) . $url;
         }
 
         return preg_replace('/^https?:/', $scheme . ':', $url);
@@ -643,7 +644,7 @@ class UrlHelper
 
         if ($scheme !== null) {
             // Make sure we're using the right scheme
-            $baseUrl = static::urlWithScheme($baseUrl, $scheme);
+            $baseUrl = static::urlWithScheme($baseUrl, $scheme, $cpUrl);
         }
 
         // Put it all together

--- a/tests/unit/helpers/UrlHelperTest.php
+++ b/tests/unit/helpers/UrlHelperTest.php
@@ -115,10 +115,11 @@ class UrlHelperTest extends TestCase
      * @param string $expected
      * @param string $url
      * @param string $scheme
+     * @param string $cpUrl
      */
-    public function testUrlWithScheme(string $expected, string $url, string $scheme): void
+    public function testUrlWithScheme(string $expected, string $url, string $scheme, bool $cpUrl=false): void
     {
-        self::assertSame($expected, UrlHelper::urlWithScheme($url, $scheme));
+        self::assertSame($expected, UrlHelper::urlWithScheme($url, $scheme, $cpUrl));
     }
 
     /**


### PR DESCRIPTION
Fixes #14676

### What happened?

### Description

Since CraftCMS 4.8.3 the `actionUrl` is wrong when using 

It may be related to this:

```
Fixed a bug where action URLs weren’t respecting the subpath specified by the @web alias, if it wasn’t present in the local URL to index.php.
```

### Steps to reproduce

1. Set up site with `baseCpUrl` set to a different domain from default site's URL.
2. Go to `/admin/login` (assuming `cpTrigger` = admin)
3. View source
4. See:

```
 window.Craft = {
        ...,
        "actionUrl": "{{default site url}}/index.php?p=admin\/actions\/",
        ...
 }
```

5. This means that the login request (and others) are sent to the wrong domain, potentially (e.g. in our case) leading to CORS issues.

### Expected behavior

```
 window.Craft = {
        ...,
        "actionUrl": "{{CP URL}}/index.php?p=admin\/actions\/",
        ...
 }
```

### Actual behavior

```
 window.Craft = {
        ...,
        "actionUrl": "{{default site url}}/index.php?p=admin\/actions\/",
        ...
 }
```

### Craft CMS version

Since 4.8.3