### PR TITLE
Allow a Matrix-based Entry to be accessible via `Craft.MatrixInputEntry`

### DIFF
--- a/src/web/assets/matrix/src/MatrixInput.js
+++ b/src/web/assets/matrix/src/MatrixInput.js
@@ -108,7 +108,7 @@ import $ from 'jquery';
 
         for (let i = 0; i < $entries.length; i++) {
           const $entry = $($entries[i]);
-          const entry = new Entry(this, $entry);
+          const entry = new Craft.MatrixInputEntry(this, $entry);
 
           if (entry.id && $.inArray('' + entry.id, collapsedEntries) !== -1) {
             entry.collapse();
@@ -283,7 +283,7 @@ import $ from 'jquery';
             Craft.initUiElements($entry.children('.fields'));
             await Craft.appendHeadHtml(data.headHtml);
             await Craft.appendBodyHtml(data.bodyHtml);
-            new Entry(this, $entry);
+            new Craft.MatrixInputEntry(this, $entry);
             this.entrySort.addItems($entry);
             this.entrySelect.addItems($entry);
             this.updateAddEntryBtn();
@@ -451,7 +451,7 @@ import $ from 'jquery';
     }
   );
 
-  const Entry = Garnish.Base.extend({
+  Craft.MatrixInputEntry = Garnish.Base.extend({
     /**
      * @type {Craft.MatrixInput}
      */


### PR DESCRIPTION
Rather than a private `const Entry()` variable, it'd be great if that was exposed to other plugins. [Smith](https://github.com/verbb/smith/blob/c2397f92da4206c92162e3fe321cdd6e48c13276/src/resources/src/js/smith.js#L209) in particular uses this to create a new Matrix entry from an existing cloned entry.

It'd be neat not to [duplicate code](https://github.com/verbb/smith/blob/c2397f92da4206c92162e3fe321cdd6e48c13276/src/resources/src/js/smith.js#L266)