### PR TITLE
Fix nav template

### DIFF
--- a/src/templates/_includes/nav.twig
+++ b/src/templates/_includes/nav.twig
@@ -9,7 +9,7 @@
         } %}
           {% if item.heading is defined %}
             <span>{{ item.heading }}</span>
-            {{ _self.list(item.nested) }}
+            {{ _self.list(item.nested, selectedItem) }}
           {% else %}
             {{ tag('a', {
               class: {


### PR DESCRIPTION
### Description

The `_includes/nav` template doesn't pass the `selectedItem` to a nested list. This PR fixes that.

