### PR TITLE
strip LTR and RTL chars from filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where `craft\helpers\ElementHelper::siteStatusesForElement()` wasn’t working for soft-deleted elements. ([#14753](https://github.com/craftcms/cms/issues/14753))
 - Fixed a bug where the Queue Manager was listing delayed jobs before others. ([#14755](https://github.com/craftcms/cms/discussions/14755))
+- Fixed a bug where LTR and RTL characters weren’t getting stripped from sanitized asset filenames. ([#14711](https://github.com/craftcms/cms/issues/14711))
 
 ## 4.8.7 - 2024-04-03
 

--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -257,9 +257,10 @@ class FileHelper extends \yii\helpers\FileHelper
         // https://github.com/craftcms/cms/issues/12741
         // Remove soft hyphens (00ad), no break (0083),
         // zero width space (200b), zero width non-joiner (200c), zero width joiner (200d),
+        // LTR character (200e), RTL character (200f),
         // invisible times (2062), invisible comma (2063), invisible plus (2064),
-        // zero width non-brak space (feff) in the name
-        $filename = preg_replace('/\\x{00ad}|\\x{0083}|\\x{200b}|\\x{200c}|\\x{200d}|\\x{2062}|\\x{2063}|\\x{2064}|\\x{feff}/iu', '', $filename);
+        // zero width non-break space (feff) in the filename
+        $filename = preg_replace('/\\x{00ad}|\\x{0083}|\\x{200b}|\\x{200c}|\\x{200d}|\\x{200e}|\\x{200f}|\\x{2062}|\\x{2063}|\\x{2064}|\\x{feff}/iu', '', $filename);
 
         // Strip any characters not allowed.
         $filename = str_replace($disallowedChars, '', strip_tags($filename));


### PR DESCRIPTION
### Description
Strip LTR and RTL special chars from filenames. 
(Followup to https://github.com/craftcms/cms/pull/12759.)


### Related issues
#14711 
