### PR TITLE
Stop updating name properties if all are already set

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -14,6 +14,7 @@
 - Added `craft\services\Sites::getSitesByLanguage()`.
 - Added `craft\web\ErrorHandler::exceptionAsArray()`.
 - Added `craft\web\ErrorHandler::showExceptionDetails()`.
+- `craft\base\NameTrait::prepareNamesForSave()` no longer updates the name properties if `fullName`, `firstName`, and `lastName` are already set. ([#14665](https://github.com/craftcms/cms/issues/14665))
 
 ### System
 - Craft now calls `setlocale()` based on the target language, so that `SORT_LOCALE_STRING` behaves as expected. ([#14509](https://github.com/craftcms/cms/issues/14509), [#14513](https://github.com/craftcms/cms/pull/14513))

--- a/src/base/NameTrait.php
+++ b/src/base/NameTrait.php
@@ -57,6 +57,12 @@ trait NameTrait
     protected function prepareNamesForSave(): void
     {
         if ($this->fullName !== null) {
+            // if firstName/lastName are also set, just leave them alone
+            // (https://github.com/craftcms/cms/issues/14665)
+            if ($this->firstName !== null || $this->lastName !== null) {
+                return;
+            }
+
             $generalConfig = Craft::$app->getConfig()->getGeneral();
             $languages = [
                 // Load our custom language file first so config settings can override the defaults

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -2695,15 +2695,20 @@ JS,
 
         if ($fullName !== null) {
             $model->fullName = $fullName;
+
+            // Unset firstName and lastName so NameTrait::prepareNamesForSave() can set them
+            $model->firstName = $model->lastName = null;
         } else {
             // Still check for firstName/lastName in case a front-end form is still posting them
             $firstName = $this->request->getBodyParam('firstName');
             $lastName = $this->request->getBodyParam('lastName');
 
             if ($firstName !== null || $lastName !== null) {
-                $model->fullName = null;
                 $model->firstName = $firstName ?? $model->firstName;
                 $model->lastName = $lastName ?? $model->lastName;
+
+                // Unset fullName so NameTrait::prepareNamesForSave() can set it
+                $model->fullName = null;
             }
         }
     }

--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -264,7 +264,11 @@ class Address extends Element implements AddressInterface, BlockElementInterface
         }
 
         if (array_key_exists('firstName', $values) || array_key_exists('lastName', $values)) {
+            // Unset fullName so NameTrait::prepareNamesForSave() can set it
             $this->fullName = null;
+        } elseif (array_key_exists('fullName', $values)) {
+            // Unset firstName and lastName so NameTrait::prepareNamesForSave() can set them
+            $this->firstName = $this->lastName = null;
         }
 
         parent::setAttributes($values, $safeOnly);

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -906,7 +906,11 @@ class User extends Element implements IdentityInterface
         }
 
         if (array_key_exists('firstName', $values) || array_key_exists('lastName', $values)) {
+            // Unset fullName so NameTrait::prepareNamesForSave() can set it
             $this->fullName = null;
+        } elseif (array_key_exists('fullName', $values)) {
+            // Unset firstName and lastName so NameTrait::prepareNamesForSave() can set them
+            $this->firstName = $this->lastName = null;
         }
 
         parent::setAttributes($values, $safeOnly);


### PR DESCRIPTION
### Description

- `NameTrait::prepareNamesForSave()` no longer makes any changes if `fullName` and `firstName`/`lastName` are already set on the model.
- `User::setAttributes()`, `Address::setAttributes()`, and `UsersController::populateNameAttributes()` now unset `firstName` and `lastName` if `fullName` was posted (in addition to already unsetting `fullName` if `firstName`/`lastName` were posted).

With those changes, it’s now possible to load up a user/address and resave them programmatically without affecting the name properties.

### Related issues

- #14665