### PR TITLE
Custom user edit screen support

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -9,5 +9,8 @@
 - `resave` commands now support an `--if-invalid` option. ([#14731](https://github.com/craftcms/cms/issues/14731))
 
 ### Extensibility
+- Added `craft\controllers\EditUserTrait`. ([#14789](https://github.com/craftcms/cms/pull/14789))
+- Added `craft\controllers\UsersController::EVENT_DEFINE_EDIT_SCREENS`. ([#14789](https://github.com/craftcms/cms/pull/14789))
+- Added `craft\events\DefineEditUserScreensEvent`. ([#14789](https://github.com/craftcms/cms/pull/14789))
 - `craft\base\NameTrait::prepareNamesForSave()` no longer updates the name properties if `fullName`, `firstName`, and `lastName` are already set. ([#14665](https://github.com/craftcms/cms/issues/14665))
 - Added `Craft.MatrixInput.Entry`. ([#14730](https://github.com/craftcms/cms/pull/14730))

--- a/src/controllers/EditUserTrait.php
+++ b/src/controllers/EditUserTrait.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\controllers;
+
+use Craft;
+use craft\base\Event;
+use craft\elements\User;
+use craft\enums\CmsEdition;
+use craft\events\DefineEditUserScreensEvent;
+use craft\helpers\Cp;
+use craft\helpers\UrlHelper;
+use craft\web\Controller;
+use yii\web\BadRequestHttpException;
+use yii\web\ForbiddenHttpException;
+use yii\web\Response;
+
+/**
+ * Trait EditUserTrait
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.1.0
+ * @mixin Controller
+ * @phpstan-require-extends Controller
+ */
+trait EditUserTrait
+{
+    private const SCREEN_PROFILE = 'profile';
+    private const SCREEN_ADDRESSES = 'addresses';
+    private const SCREEN_PERMISSIONS = 'permissions';
+    private const SCREEN_PREFERENCES = 'preferences';
+    private const SCREEN_PASSWORD = 'password';
+    private const SCREEN_PASSKEYS = 'passkeys';
+
+    /**
+     * Returns the user being edited.
+     *
+     * @param int|null $userId The user’s ID, if specified in the request URI
+     * @return User
+     * @throws BadRequestHttpException
+     */
+    protected function editedUser(?int $userId): User
+    {
+        if ($userId === null) {
+            return static::currentUser();
+        }
+
+        /** @var User|null $user */
+        $user = User::find()
+            ->addSelect(['users.password', 'users.passwordResetRequired'])
+            ->id($userId)
+            ->drafts(null)
+            ->status(null)
+            ->one();
+
+        if (!$user) {
+            throw new BadRequestHttpException('No user was identified by the request.');
+        }
+
+        if (!$user->getIsCurrent()) {
+            // Make sure they have permission to edit other users
+            $this->requirePermission('editUsers');
+        }
+
+        return $user;
+    }
+
+    /**
+     * Prepares the response for a user management screen.
+     *
+     * @param User $user
+     * @param string $screen
+     * @return Response
+     * @throws ForbiddenHttpException
+     */
+    protected function asEditUserScreen(User $user, string $screen): Response
+    {
+        $currentUser = static::currentUser();
+
+        $screens = [
+            self::SCREEN_PROFILE => ['label' => Craft::t('app', 'Profile')],
+            self::SCREEN_ADDRESSES => ['label' => Craft::t('app', 'Addresses')],
+        ];
+
+        if (
+            Craft::$app->edition === CmsEdition::Pro &&
+            ($currentUser->can('assignUserPermissions') || $currentUser->canAssignUserGroups())
+        ) {
+            $screens[self::SCREEN_PERMISSIONS] = ['label' => Craft::t('app', 'Permissions')];
+        }
+
+        if ($user->getIsCurrent()) {
+            $screens[self::SCREEN_PREFERENCES] = ['label' => Craft::t('app', 'Preferences')];
+        }
+
+        $event = new DefineEditUserScreensEvent([
+            'currentUser' => $currentUser,
+            'editedUser' => $user,
+            'screens' => $screens,
+        ]);
+        Event::trigger(UsersController::class, UsersController::EVENT_DEFINE_EDIT_SCREENS, $event);
+
+        $screens = $event->screens;
+
+        if ($user->getIsCurrent()) {
+            $screens[self::SCREEN_PASSWORD] = ['label' => Craft::t('app', 'Password & Verification')];
+            $screens[self::SCREEN_PASSKEYS] = ['label' => Craft::t('app', 'Passkeys')];
+        }
+
+        if (!isset($screens[$screen])) {
+            throw new ForbiddenHttpException('User not authorized to perform this action.');
+        }
+
+        $response = $this->asCpScreen();
+        if ($user->getIsCurrent()) {
+            $response->title(Craft::t('app', 'My Account'));
+        } else {
+            $response->title($user->getUiLabel());
+        }
+
+        $navItems = [];
+        $currentNavItems = &$navItems;
+
+        foreach ($screens as $s => $screenInfo) {
+            if ($s === self::SCREEN_PASSWORD) {
+                $navItem = [
+                    'heading' => Craft::t('app', 'Account Security'),
+                    'nested' => [],
+                ];
+                $navItems[] = &$navItem;
+                $currentNavItems = &$navItem['nested'];
+            }
+
+            $currentNavItems[] = [
+                'label' => $screenInfo['label'],
+                'url' => $screenInfo['url'] ?? $this->editUserScreenUrl($user, $s),
+                'selected' => $s === $screen,
+            ];
+        }
+
+        $response->pageSidebarTemplate('_includes/nav', [
+            'label' => Craft::t('app', 'Account'),
+            'items' => $navItems,
+        ]);
+
+        if ($screen !== self::SCREEN_PROFILE) {
+            $response->crumbs([
+                ...$user->getCrumbs(),
+                [
+                    'html' => Cp::elementChipHtml($user, ['showDraftName' => false]),
+                    'current' => true,
+                ],
+            ]);
+
+            $response->actionMenuItems(fn() => array_filter(
+                $user->getActionMenuItems(),
+                fn(array $item) => !str_starts_with($item['id'] ?? '', 'action-edit-'),
+            ));
+
+            $response->metaSidebarHtml($user->getSidebarHtml(false) . Cp::metadataHtml($user->getMetadata()));
+        }
+
+        return $response;
+    }
+
+    private function editUserScreenUrl(User $user, string $screen): string
+    {
+        $basePath = $user->getIsCurrent() ? 'myaccount' : "users/$user->id";
+        $path = match ($screen) {
+            self::SCREEN_PROFILE => $basePath,
+            default => "$basePath/$screen",
+        };
+        return UrlHelper::cpUrl($path);
+    }
+}

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -27,7 +27,6 @@ use craft\events\UserEvent;
 use craft\helpers\App;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Assets;
-use craft\helpers\Cp;
 use craft\helpers\Db;
 use craft\helpers\FileHelper;
 use craft\helpers\Html;
@@ -76,6 +75,8 @@ use yii\web\ServerErrorHttpException;
  */
 class UsersController extends Controller
 {
+    use EditUserTrait;
+
     /**
      * @event FindLoginUserEvent The event that is triggered before attempting to find a user to sign in
      *
@@ -114,6 +115,13 @@ class UsersController extends Controller
     public const EVENT_LOGIN_FAILURE = 'loginFailure';
 
     /**
+     * @event DefineEditUserScreensEvent The event that is triggered when defining the screens that should be
+     * shown for the user being edited.
+     * @since 5.1.0
+     */
+    public const EVENT_DEFINE_EDIT_SCREENS = 'defineEditScreens';
+
+    /**
      * @event UserEvent The event that is triggered BEFORE user groups and permissions ARE assigned to the user getting saved
      * @since 3.5.13
      */
@@ -148,13 +156,6 @@ class UsersController extends Controller
      * @since 3.6.5
      */
     public const EVENT_INVALID_USER_TOKEN = 'invalidUserToken';
-
-    private const SCREEN_PROFILE = 'profile';
-    private const SCREEN_ADDRESSES = 'addresses';
-    private const SCREEN_PERMISSIONS = 'permissions';
-    private const SCREEN_PREFERENCES = 'preferences';
-    private const SCREEN_PASSWORD = 'password';
-    private const SCREEN_PASSKEYS = 'passkeys';
 
     /**
      * @inheritdoc
@@ -992,14 +993,14 @@ class UsersController extends Controller
     {
         $this->requireCpRequest();
 
-        $element ??= $this->editScreenUser($userId);
+        $element ??= $this->editedUser($userId);
 
         // let the elements/edit action do most of the work
         Craft::$app->runAction('elements/edit', [
             'element' => $element,
         ]);
 
-        return $this->asEditScreen($element, self::SCREEN_PROFILE);
+        return $this->asEditUserScreen($element, self::SCREEN_PROFILE);
     }
 
     /**
@@ -1012,10 +1013,9 @@ class UsersController extends Controller
     public function actionAddresses(?int $userId = null): Response
     {
         $this->requireCpRequest();
-
-        $user = $this->editScreenUser($userId);
+        $user = $this->editedUser($userId);
         /** @var Response|CpScreenResponseBehavior $response */
-        $response = $this->asEditScreen($user, self::SCREEN_ADDRESSES);
+        $response = $this->asEditUserScreen($user, self::SCREEN_ADDRESSES);
 
         $response->contentHtml(function() use ($user) {
             $config = [
@@ -1046,10 +1046,9 @@ class UsersController extends Controller
     public function actionPermissions(?int $userId = null): Response
     {
         $this->requireCpRequest();
-
-        $user = $this->editScreenUser($userId);
+        $user = $this->editedUser($userId);
         /** @var Response|CpScreenResponseBehavior $response */
-        $response = $this->asEditScreen($user, self::SCREEN_PERMISSIONS);
+        $response = $this->asEditUserScreen($user, self::SCREEN_PERMISSIONS);
 
         $response->action('users/save-permissions');
         $response->contentTemplate('users/_permissions', [
@@ -1071,7 +1070,7 @@ class UsersController extends Controller
         $this->requireCpRequest();
 
         $currentUser = static::currentUser();
-        $user = $this->editScreenUser((int)$this->request->getRequiredBodyParam('userId'));
+        $user = $this->editedUser((int)$this->request->getRequiredBodyParam('userId'));
 
         // Is their admin status changing?
         if ($currentUser->admin) {
@@ -1116,10 +1115,9 @@ class UsersController extends Controller
     public function actionPreferences(): Response
     {
         $this->requireCpRequest();
-
         $user = static::currentUser();
         /** @var Response|CpScreenResponseBehavior $response */
-        $response = $this->asEditScreen($user, self::SCREEN_PREFERENCES);
+        $response = $this->asEditUserScreen($user, self::SCREEN_PREFERENCES);
 
         $i18n = Craft::$app->getI18n();
 
@@ -1204,12 +1202,12 @@ class UsersController extends Controller
     public function actionPassword(?User $user = null): Response
     {
         $this->requireCpRequest();
+        $user ??= static::currentUser();
+        /** @var Response|CpScreenResponseBehavior $response */
+        $response = $this->asEditUserScreen($user, self::SCREEN_PASSWORD);
 
         $this->getView()->registerAssetBundle(AuthMethodSetupAsset::class);
 
-        $user ??= static::currentUser();
-        /** @var Response|CpScreenResponseBehavior $response */
-        $response = $this->asEditScreen($user, self::SCREEN_PASSWORD);
         $response->action('users/save-password');
         $response->contentTemplate('users/_password', compact('user'));
 
@@ -1260,6 +1258,9 @@ class UsersController extends Controller
     public function actionPasskeys(): Response
     {
         $this->requireCpRequest();
+        $user = static::currentUser();
+        /** @var Response|CpScreenResponseBehavior $response */
+        $response = $this->asEditUserScreen($user, self::SCREEN_PASSKEYS);
 
         $view = $this->getView();
         $view->registerAssetBundle(PasskeySetupAsset::class);
@@ -1267,113 +1268,11 @@ class UsersController extends Controller
 new Craft.PasskeySetup();
 JS);
 
-        $user = static::currentUser();
         $passkeys = Craft::$app->getAuth()->getPasskeys($user);
-
-        /** @var Response|CpScreenResponseBehavior $response */
-        $response = $this->asEditScreen($user, self::SCREEN_PASSKEYS);
-
         $response->contentTemplate('users/_passkeys', [
             'user' => $user,
             'passkeys' => $passkeys,
         ]);
-
-        return $response;
-    }
-
-    private function editScreenUser(?int $userId): User
-    {
-        if ($userId === null) {
-            return static::currentUser();
-        }
-
-        /** @var User|null $user */
-        $user = User::find()
-            ->addSelect(['users.password', 'users.passwordResetRequired'])
-            ->id($userId)
-            ->drafts(null)
-            ->status(null)
-            ->one();
-
-        if (!$user) {
-            throw new BadRequestHttpException('No user was identified by the request.');
-        }
-
-        if (!$user->getIsCurrent()) {
-            // Make sure they have permission to edit other users
-            $this->requirePermission('editUsers');
-        }
-
-        return $user;
-    }
-
-    private function asEditScreen(User $user, string $currentScreen): Response
-    {
-        $currentUser = static::currentUser();
-        $includeScreens = array_keys(array_filter([
-            self::SCREEN_PROFILE => true,
-            self::SCREEN_ADDRESSES => $user->id,
-            self::SCREEN_PERMISSIONS => (
-                Craft::$app->edition === CmsEdition::Pro &&
-                ($currentUser->can('assignUserPermissions') || $currentUser->canAssignUserGroups())
-            ),
-            self::SCREEN_PREFERENCES => $user->getIsCurrent(),
-            self::SCREEN_PASSWORD => $user->getIsCurrent(),
-            self::SCREEN_PASSKEYS => $user->getIsCurrent(),
-        ]));
-
-        if (!in_array($currentScreen, $includeScreens)) {
-            throw new ForbiddenHttpException('User not authorized to perform this action.');
-        }
-
-        $response = $this->asCpScreen();
-        if ($user->getIsCurrent()) {
-            $response->title(Craft::t('app', 'My Account'));
-        } else {
-            $response->title($user->getUiLabel());
-        }
-
-        $navItems = [];
-        $currentNavItems = &$navItems;
-
-        foreach ($includeScreens as $screen) {
-            if ($screen === self::SCREEN_PASSWORD) {
-                $navItem = [
-                    'heading' => Craft::t('app', 'Account Security'),
-                    'nested' => [],
-                ];
-                $navItems[] = &$navItem;
-                $currentNavItems = &$navItem['nested'];
-            }
-
-            $currentNavItems[] = [
-                'label' => $this->editScreenTitle($screen),
-                'url' => $this->editScreenUrl($user, $screen),
-                'selected' => $screen === $currentScreen,
-            ];
-        }
-
-        $response->pageSidebarTemplate('_includes/nav', [
-            'label' => Craft::t('app', 'Account'),
-            'items' => $navItems,
-        ]);
-
-        if ($currentScreen !== self::SCREEN_PROFILE) {
-            $response->crumbs([
-                ...$user->getCrumbs(),
-                [
-                    'html' => Cp::elementChipHtml($user, ['showDraftName' => false]),
-                    'current' => true,
-                ],
-            ]);
-
-            $response->actionMenuItems(fn() => array_filter(
-                $user->getActionMenuItems(),
-                fn(array $item) => !str_starts_with($item['id'] ?? '', 'action-edit-'),
-            ));
-
-            $response->metaSidebarHtml($user->getSidebarHtml(false) . Cp::metadataHtml($user->getMetadata()));
-        }
 
         return $response;
     }
@@ -1391,32 +1290,6 @@ JS);
         $this->getView()->registerAssetBundle(AuthMethodSetupAsset::class);
 
         return $this->renderTemplate('_special/setup-2fa.twig');
-    }
-
-    /**
-     * @param self::SCREEN_* $screen
-     * @return string
-     */
-    private function editScreenTitle(string $screen): string
-    {
-        return match ($screen) {
-            self::SCREEN_PROFILE => Craft::t('app', 'Profile'),
-            self::SCREEN_ADDRESSES => Craft::t('app', 'Addresses'),
-            self::SCREEN_PERMISSIONS => Craft::t('app', 'Permissions'),
-            self::SCREEN_PREFERENCES => Craft::t('app', 'Preferences'),
-            self::SCREEN_PASSWORD => Craft::t('app', 'Password & Verification'),
-            self::SCREEN_PASSKEYS => Craft::t('app', 'Passkeys'),
-        };
-    }
-
-    private function editScreenUrl(User $user, string $screen): string
-    {
-        $basePath = $user->getIsCurrent() ? 'myaccount' : "users/$user->id";
-        $path = match ($screen) {
-            self::SCREEN_PROFILE => $basePath,
-            default => "$basePath/$screen",
-        };
-        return UrlHelper::cpUrl($path);
     }
 
     /**

--- a/src/events/DefineEditUserScreensEvent.php
+++ b/src/events/DefineEditUserScreensEvent.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use craft\base\Event;
+use craft\elements\User;
+
+/**
+ * Class DefineEditUserScreensEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.0.0
+ */
+class DefineEditUserScreensEvent extends Event
+{
+    /**
+     * @var User The currently logged-in user
+     */
+    public User $currentUser;
+
+    /**
+     * @var User The user being edited.
+     */
+    public User $editedUser;
+
+    /**
+     * @var array<string,array> The screens that should be shown for the user being edited.
+     *
+     * Each screen should be represented by a sub-array whose key is the screen ID, and which has the following keys:
+     *
+     * - `label` – The screen’s nav item label.
+     * - `url` – The screen’s URL (optional; a URL like `myaccount/screen-key`
+     *   or `users/x/screen-key` will be used by default).
+     */
+    public array $screens;
+}


### PR DESCRIPTION
### Description

Makes it possible for plugins to register custom user edit screens.

To do that, they must use `craft\controllers\UsersController::EVENT_DEFINE_EDIT_SCREENS` and add additional screen definitions to `$event->screens`.

Then, they must define a route to handle the screen URI, and point it to a controller class which uses `craft\controllers\EditUserTrait`.

The controller action should then fetch the edited user (ideally using `$this->editedUser()`, and then fetch the prepared response object via `$this->asEditUserScreen()`, modify its contents, and return it.
