### PR TITLE
fix error when altering column to boolean in pgsql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a SQL error that could occur when converting a field to a Lightswitch field on PostgreSQL. ([#14792](https://github.com/craftcms/cms/issues/14792))
+
 ## 4.8.9 - 2024-04-10
 
 - Fixed a bug where element queries with the `relatedTo` param set to a list of element IDs were overly complex.

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -1728,8 +1728,12 @@ class Fields extends Component
             try {
                 $command = $db->createCommand()->alterColumn($table, $oldName, $type);
 
-                if ($db->getIsPgsql() && $type === Schema::TYPE_BOOLEAN) {
-                    $replacement = sprintf(' TYPE boolean USING CASE WHEN "%s" IS NULL THEN NULL WHEN length("%s") = 0 THEN FALSE ELSE TRUE END"', $oldName, $oldName);
+                if (
+                    $db->getIsPgsql() &&
+                    $type === Schema::TYPE_BOOLEAN &&
+                    Db::isTextualColumnType($db->getTableSchema($table)->getColumn($oldName)->dbType)
+                ) {
+                    $replacement = sprintf(' TYPE boolean USING CASE WHEN "%s" IS NULL THEN NULL WHEN length("%s") = 0 THEN FALSE ELSE TRUE END', $oldName, $oldName);
                     $sql = preg_replace('/\s+TYPE\s+boolean/i', $replacement, $command->getRawSql());
                     $command->setSql($sql);
                 }


### PR DESCRIPTION
### Description
When changing a field type from any to Lightswitch, the field’s column in the `content` table is altered to type boolean. 

This worked as expected in MySQL, but in PostgreSQL, `Datatype mismatch: 7 ERROR:  column "<field_name>" cannot be cast automatically to type boolean` error was thrown and caught, and the logic then attempted to create a column with the same name as one we’re trying to change.

I’ve altered the SQL that is being executed for PostgreSQL and the boolean type combination.


### Related issues
#14792
