### PR TITLE
disable fk checks while altering charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a SQL error that could occur when converting a field to a Lightswitch field on PostgreSQL. ([#14792](https://github.com/craftcms/cms/issues/14792))
 - Fixed a bug where the Database Backup utility was present when the `backupCommand` config setting was set to `false`.
+- Fixed an error that occurred when running the `db/convert-charset` command, if any tables contained `char` or `varchar` foreign key columns. ([#14815](https://github.com/craftcms/cms/issues/14815))
 
 ## 4.8.9 - 2024-04-10
 

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -358,6 +358,10 @@ class DbController extends Controller
             ]);
         }
 
+        // Disable FK checks
+        $queryBuilder = $db->getSchema()->getQueryBuilder();
+        $db->createCommand($queryBuilder->checkIntegrity(false))->execute();
+
         foreach ($tableNames as $tableName) {
             $tableName = $schema->getRawTableName($tableName);
             $this->stdout('Converting ');
@@ -366,6 +370,8 @@ class DbController extends Controller
             $db->createCommand("ALTER TABLE `$tableName` CONVERT TO CHARACTER SET $charset COLLATE $collation")->execute();
             $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
         }
+
+        $db->createCommand()->checkIntegrity(true)->execute();
 
         $this->stdout("Finished converting tables to $charset/$collation." . PHP_EOL, Console::FG_GREEN);
         return ExitCode::OK;


### PR DESCRIPTION
### Description
Disables foreign key checks before converting charset and re-enables them once the conversion is done.


### Related issues
#14815 
