### PR TITLE
Improve batched job progress indicator

### DIFF
--- a/src/queue/BaseBatchedJob.php
+++ b/src/queue/BaseBatchedJob.php
@@ -115,7 +115,6 @@ abstract class BaseBatchedJob extends BaseJob
     public function execute($queue): void
     {
         $items = $this->data()->getSlice($this->itemOffset, $this->batchSize);
-        $totalInBatch = is_array($items) ? count($items) : iterator_count($items);
 
         $memoryLimit = ConfigHelper::sizeInBytes(ini_get('memory_limit'));
         $startMemory = $memoryLimit != -1 ? memory_get_usage() : null;
@@ -129,9 +128,11 @@ abstract class BaseBatchedJob extends BaseJob
         $i = 0;
 
         foreach ($items as $item) {
-            $this->setProgress($queue, $i / $totalInBatch, Translation::prep('app', '{step, number} of {total, number}', [
-                'step' => $this->itemOffset + 1,
-                'total' => $this->totalItems(),
+            $step = $this->itemOffset + 1;
+            $total = $this->totalItems();
+            $this->setProgress($queue, $step / $total, Translation::prep('app', '{step, number} of {total, number}', [
+                'step' => $step,
+                'total' => $total,
             ]));
             $this->processItem($item);
             $this->itemOffset++;


### PR DESCRIPTION
This PR improves the batched job progress indicator by making it work more like the base job progress indicator, meaning that the percentage and indicator will move from 0% to 100% across all batches, rather than once for each batch. 

In this example, a sendout is being sent to 5 recipients with a batch size of 2 (to help demonstrate the issue).

**Before:**

The progress of 50% is calculated as step 1 of 2 items in the current batch.

![screenshot-pvvU3pIR@2x](https://github.com/craftcms/cms/assets/57572400/72c06be6-8df7-46b1-9d96-535c58dc17f3)
![screenshot-IP2yqgcq@2x](https://github.com/craftcms/cms/assets/57572400/4eafbd91-99c9-4998-ac81-e70b576c5a3e)

**After:**

The progress of 80% is calculated as step 4 of 5 total items in the job.

![screenshot-eV4s9A0X@2x](https://github.com/craftcms/cms/assets/57572400/abdad88f-ad3d-4417-9d80-b85ab6f22549)
![screenshot-AKWIGtsC@2x](https://github.com/craftcms/cms/assets/57572400/ac3061b3-6e02-4740-8729-fe08bddb88dd)

Here’s a real-world example that shows how the percentage and the “step of total” being out of sync can be confusing:

![320714358-3df99d17-71c7-4f47-8ffa-71828377c3ab](https://github.com/craftcms/cms/assets/57572400/0724997a-bd6f-4dd1-a559-b79c1011dfae)

Source: https://github.com/putyourlightson/craft-campaign/issues/464

Ideally it would be backported to 4.x too.