### PR TITLE
ProjectConfig Service: Enable access to $_appliedChanges [4.x]

### DIFF
--- a/src/services/ProjectConfig.php
+++ b/src/services/ProjectConfig.php
@@ -911,6 +911,16 @@ class ProjectConfig extends Component
     }
 
     /**
+     * Get the list of applied changes
+     *
+     * @return array
+     */
+    public function getAppliedChanges(): array
+    {
+        return $this->_appliedChanges;
+    }
+
+    /**
      * Returns whether all schema versions stored in the config are compatible with the actual codebase.
      * The schemas must match exactly to avoid unpredictable behavior that can occur when running migrations
      * and applying project config changes at the same time.


### PR DESCRIPTION
### Description

Exposes the $_appliedChanges array from the ProjectConfig service for plugins/modules to access.

### Related issues

This should resolve #14851