### PR TITLE
sort field types consistently when creating and editing a fied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed a bug where nested related categories and entries weren’t removable when the Categories/Entries field’s “Maintain hierarchy” setting was enabled. ([#14843](https://github.com/craftcms/cms/issues/14843))
 - Fixed a SQL error that could occur on PostgreSQL. ([#14860](https://github.com/craftcms/cms/pull/14870))
 - Fixed a bug where field layout designers were showing redundant field indicators, for fields with hidden labels. ([#14859](https://github.com/craftcms/cms/issues/14859))
+- Fixed a bug where field type names weren’t sorted alphabetically when editing an existing field. ([#14858](https://github.com/craftcms/cms/issues/14858))
 
 ## 5.0.5 - 2024-04-23
 

--- a/src/controllers/FieldsController.php
+++ b/src/controllers/FieldsController.php
@@ -132,6 +132,7 @@ class FieldsController extends Controller
                 $option = [
                     'icon' => $class::icon(),
                     'value' => $class,
+                    'sortKey' => $class::displayName(),
                 ];
                 if ($compatible) {
                     $option['label'] = $class::displayName();
@@ -146,7 +147,12 @@ class FieldsController extends Controller
         }
 
         // Sort them by name
-        ArrayHelper::multisort($fieldTypeOptions, 'label');
+        ArrayHelper::multisort($fieldTypeOptions, 'sortKey');
+
+        // and remove the sort key as it's no longer needed
+        array_walk($fieldTypeOptions, function(&$item, $key) {
+            unset($item['sortKey']);
+        });
 
         if ($field instanceof MissingField) {
             if ($foundCurrent) {

--- a/src/controllers/FieldsController.php
+++ b/src/controllers/FieldsController.php
@@ -113,6 +113,7 @@ class FieldsController extends Controller
 
         /** @var string[]|FieldInterface[] $compatibleFieldTypes */
         $fieldTypeOptions = [];
+        $fieldTypeNames = [];
         $foundCurrent = false;
         $missingFieldPlaceholder = null;
         $multiInstanceTypesOnly = (bool)$this->request->getParam('multiInstanceTypesOnly');
@@ -129,30 +130,26 @@ class FieldsController extends Controller
                 )
             ) {
                 $compatible = $isCurrent || in_array($class, $compatibleFieldTypes, true);
+                $name = $class::displayName();
                 $option = [
                     'icon' => $class::icon(),
                     'value' => $class,
-                    'sortKey' => $class::displayName(),
                 ];
                 if ($compatible) {
-                    $option['label'] = $class::displayName();
+                    $option['label'] = $name;
                 } else {
                     $option['labelHtml'] = Html::beginTag('div', ['class' => 'inline-flex']) .
-                        Html::tag('span', Html::encode($class::displayName())) .
+                        Html::tag('span', Html::encode($name)) .
                         Html::tag('span', Cp::iconSvg('triangle-exclamation'), ['class' => ['cp-icon', 'small', 'warning']]) .
                         Html::endTag('div');
                 }
                 $fieldTypeOptions[] = $option;
+                $fieldTypeNames[] = $name;
             }
         }
 
         // Sort them by name
-        ArrayHelper::multisort($fieldTypeOptions, 'sortKey');
-
-        // and remove the sort key as it's no longer needed
-        array_walk($fieldTypeOptions, function(&$item, $key) {
-            unset($item['sortKey']);
-        });
+        array_multisort($fieldTypeNames, $fieldTypeOptions);
 
         if ($field instanceof MissingField) {
             if ($foundCurrent) {


### PR DESCRIPTION
### Description
The order of field types in languages other than English was not consistent between editing an existing field and creating a new one. This PR ensures the sort order is always alphabetical in the user’s language in both cases.


### Related issues
#14858 
