### PR TITLE
don't duplicate indicators when the field label is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug where clicking on drag handles within element index tables could select the element. ([#14669](https://github.com/craftcms/cms/issues/14669))
 - Fixed a bug where nested related categories and entries weren’t removable when the Categories/Entries field’s “Maintain hierarchy” setting was enabled. ([#14843](https://github.com/craftcms/cms/issues/14843))
 - Fixed a SQL error that could occur on PostgreSQL. ([#14860](https://github.com/craftcms/cms/pull/14870))
+- Fixed a bug where field layout designers were showing redundant field indicators, for fields with hidden labels. ([#14859](https://github.com/craftcms/cms/issues/14859))
 
 ## 5.0.5 - 2024-04-23
 

--- a/src/fieldlayoutelements/BaseField.php
+++ b/src/fieldlayoutelements/BaseField.php
@@ -202,7 +202,6 @@ abstract class BaseField extends FieldLayoutElement
                 'class' => ['smalltext', 'light', 'code', 'fld-attribute-label'],
                 'title' => $this->attribute(),
             ]) .
-            ($label === null ? $indicatorHtml : '') .
             Html::endTag('div'); // .fld-attribute
 
         if ($indicatorHtml) {


### PR DESCRIPTION
### Description
When the field label is hidden, don’t duplicate the field indicators in the field layout designer.

Before:
<img width="1125" alt="Screenshot 2024-04-26 at 14 06 35" src="https://github.com/craftcms/cms/assets/4500340/93d54c01-e1f2-4a1c-b630-3c06b59a323d">

After:
<img width="1124" alt="Screenshot 2024-04-26 at 14 06 18" src="https://github.com/craftcms/cms/assets/4500340/3b145bf2-4045-4a8c-92e5-df61d12507d5">


### Related issues
#14859 
