### PR TITLE
pgsql jsonContains cast the target sql to jsonb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a bug where admin tables weren’t displaying disabled statuses. ([#14861](https://github.com/craftcms/cms/issues/14861))
 - Fixed a bug where clicking on drag handles within element index tables could select the element. ([#14669](https://github.com/craftcms/cms/issues/14669))
 - Fixed a bug where nested related categories and entries weren’t removable when the Categories/Entries field’s “Maintain hierarchy” setting was enabled. ([#14843](https://github.com/craftcms/cms/issues/14843))
+- Fixed a SQL error that could occur on PostgreSQL. ([#14860](https://github.com/craftcms/cms/pull/14870))
 
 ## 5.0.5 - 2024-04-23
 

--- a/src/db/pgsql/QueryBuilder.php
+++ b/src/db/pgsql/QueryBuilder.php
@@ -153,6 +153,6 @@ class QueryBuilder extends \yii\db\pgsql\QueryBuilder
     public function jsonContains(string $targetSql, mixed $value): string
     {
         $value = $this->db->quoteValue(Json::encode($value));
-        return "($targetSql @> $value::jsonb)";
+        return "($targetSql::jsonb @> $value::jsonb)";
     }
 }


### PR DESCRIPTION
### Description
For Postgres, when checking if json contains a given value, cast the target SQL to `jsonb` first.


### Related issues
#14860 
