### PR TITLE
Fix an error with ElementSelect JS for `selectable = false`

### DIFF
--- a/src/web/assets/cp/src/js/BaseElementSelectInput.js
+++ b/src/web/assets/cp/src/js/BaseElementSelectInput.js
@@ -573,7 +573,7 @@ Craft.BaseElementSelectInput = Garnish.Base.extend(
         const lastElementIndex = this.$elements.index($elements.last());
         $nextElement = this.$elements.eq(lastElementIndex + 1);
       }
-      if ($nextElement.length) {
+      if ($nextElement && $nextElement.length) {
         $nextElement.focus();
       } else {
         this.focusNextLogicalElement();


### PR DESCRIPTION
When `this.settings.selectable = false` a JS error will be thrown when removing the element.

```js
Cannot read properties of undefined (reading 'length')
```
