### PR TITLE
Fix extra space next to element action buttons (Option 1)

### DIFF
--- a/src/web/assets/cp/src/css/_main.scss
+++ b/src/web/assets/cp/src/css/_main.scss
@@ -6059,6 +6059,9 @@ $min2ColWidth: 400px;
 .activity-container {
   &:not(:last-child) {
     @include margin-right(var(--s));
+    &:empty {
+      display: none;
+    }
   }
 
   ul {


### PR DESCRIPTION
### Description

- Remove extra space next to element entry page action buttons

#### Issue:
![Screenshot 2024-04-26 223541](https://github.com/craftcms/cms/assets/373889/2ff62ea4-08de-4c80-9fde-46d38a1cdad8)

#### Fix:
![Screenshot 2024-04-26 223608](https://github.com/craftcms/cms/assets/373889/0c504eeb-7987-416f-9957-1b9fb1822744)

### Related issues
#14885

### Alternative Fix Option
#14886
