### PR TITLE
Accept closure for backup/restore commands

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -7,6 +7,7 @@
 
 namespace craft\config;
 
+use Closure;
 use Craft;
 use craft\helpers\ConfigHelper;
 use craft\helpers\DateTimeHelper;
@@ -419,7 +420,7 @@ class GeneralConfig extends BaseConfig
     public bool $backupOnUpdate = true;
 
     /**
-     * @var string|null|false The shell command that Craft should execute to create a database backup.
+     * @var string|null|false|Closure The shell command that Craft should execute to create a database backup.
      *
      * When set to `null` (default), Craft will run `mysqldump` or `pg_dump`, provided that those libraries are in the `$PATH` variable
      * for the system user running the web server.
@@ -447,7 +448,7 @@ class GeneralConfig extends BaseConfig
      *
      * @group Environment
      */
-    public string|null|false $backupCommand = null;
+    public string|null|false|Closure $backupCommand = null;
 
     /**
      * @var string|null The base URL Craft should use when generating control panel URLs.
@@ -2412,7 +2413,7 @@ class GeneralConfig extends BaseConfig
     public string $resourceBaseUrl = '@web/cpresources';
 
     /**
-     * @var string|null|false The shell command Craft should execute to restore a database backup.
+     * @var string|null|false|Closure The shell command Craft should execute to restore a database backup.
      *
      * By default Craft will run `mysql` or `psql`, provided those libraries are in the `$PATH` variable for the user the web server is running as.
      *
@@ -2438,7 +2439,7 @@ class GeneralConfig extends BaseConfig
      *
      * @group Environment
      */
-    public string|null|false $restoreCommand = null;
+    public string|null|false|Closure $restoreCommand = null;
 
     /**
      * @var bool Whether asset URLs should be revved so browsers don’t load cached versions when they’re modified.
@@ -3531,12 +3532,12 @@ class GeneralConfig extends BaseConfig
      * ```
      *
      * @group Environment
-     * @param string|null|false $value
+     * @param string|null|false|Closure $value
      * @return self
      * @see $backupCommand
      * @since 4.2.0
      */
-    public function backupCommand(string|null|false $value): self
+    public function backupCommand(string|null|false|Closure $value): self
     {
         $this->backupCommand = $value;
         return $this;
@@ -5820,12 +5821,12 @@ class GeneralConfig extends BaseConfig
      * ```
      *
      * @group Environment
-     * @param string|null|false $value
+     * @param string|null|false|Closure $value
      * @return self
      * @see $restoreCommand
      * @since 4.2.0
      */
-    public function restoreCommand(string|null|false $value): self
+    public function restoreCommand(string|null|false|Closure $value): self
     {
         $this->restoreCommand = $value;
         return $this;

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -451,6 +451,28 @@ class GeneralConfig extends BaseConfig
     public string|null|false|Closure $backupCommand = null;
 
     /**
+     * @var string|null The output format to pass to `pg_dump` when backing up the database.
+     *
+     * This setting has no effect with MySQL databases.
+     *
+     * Valid options are `custom`, `directory`, `tar`, or `plain`.
+     * When set to `null` (default), `pg_restore` will default to `plain`
+     * @see https://www.postgresql.org/docs/current/app-pgdump.html
+     *
+     *  ::: code
+     *  ```php Static Config
+     *  ->backupCommandFormat('custom')
+     *  ```
+     *  ```shell Environment Override
+     *  CRAFT_BACKUP_COMMAND_FORMAT=custom
+     *  ```
+     *  :::
+     *
+     * @group Environment
+     */
+    public ?string $backupCommandFormat = null;
+
+    /**
      * @var string|null The base URL Craft should use when generating control panel URLs.
      *
      * It will be determined automatically if left blank.
@@ -3540,6 +3562,27 @@ class GeneralConfig extends BaseConfig
     public function backupCommand(string|null|false|Closure $value): self
     {
         $this->backupCommand = $value;
+        return $this;
+    }
+
+    /**
+     * The output format to pass to `pg_dump` when backing up the database.
+     *
+     * This setting has no effect with MySQL databases.
+     *
+     * Valid options are `custom`, `directory`, `tar`, or `plain`.
+     * When set to `null` (default), `pg_restore` will default to `plain`
+     * @see https://www.postgresql.org/docs/current/app-pgdump.html
+     *
+     * @group Environment
+     * @param string $value
+     * @return self
+     * @see $backupCommandFormat
+     * @since 4.9.0
+     */
+    public function backupCommandFormat(string $value): self
+    {
+        $this->backupCommandFormat = $value;
         return $this;
     }
 

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -214,7 +214,7 @@ class DbController extends Controller
             $db->backupTo($path);
             if ($this->zip) {
                 $zipPath = FileHelper::zip($path);
-                unlink($path);
+                FileHelper::unlink($path);
                 $path = $zipPath;
             }
         } catch (Throwable $e) {

--- a/src/db/Connection.php
+++ b/src/db/Connection.php
@@ -338,10 +338,8 @@ class Connection extends \yii\db\Connection
 
         if ($restoreCommand === false) {
             throw new Exception('Database not restored because the restore command is false.');
-        } elseif ($restoreCommand === null) {
+        } elseif ($restoreCommand === null || $restoreCommand instanceof \Closure) {
             $restoreCommand = $this->getSchema()->getDefaultRestoreCommand();
-        } elseif ($restoreCommand instanceof \Closure) {
-            $restoreCommand = $restoreCommand($this->getSchema()->getDefaultRestoreCommand());
         }
 
         // Create the shell command

--- a/src/db/Connection.php
+++ b/src/db/Connection.php
@@ -271,12 +271,12 @@ class Connection extends \yii\db\Connection
         // Determine the command that should be executed
         $backupCommand = Craft::$app->getConfig()->getGeneral()->backupCommand;
 
-        if ($backupCommand === null) {
-            $backupCommand = $this->getSchema()->getDefaultBackupCommand($event->ignoreTables);
-        }
-
         if ($backupCommand === false) {
             throw new Exception('Database not backed up because the backup command is false.');
+        } elseif ($backupCommand === null) {
+            $backupCommand = $this->getSchema()->getDefaultBackupCommand($event->ignoreTables);
+        } elseif ($backupCommand instanceof \Closure) {
+            $backupCommand = $backupCommand($this->getSchema()->getDefaultBackupCommand($event->ignoreTables));
         }
 
         // Create the shell command
@@ -337,12 +337,12 @@ class Connection extends \yii\db\Connection
         // Determine the command that should be executed
         $restoreCommand = Craft::$app->getConfig()->getGeneral()->restoreCommand;
 
-        if ($restoreCommand === null) {
-            $restoreCommand = $this->getSchema()->getDefaultRestoreCommand();
-        }
-
         if ($restoreCommand === false) {
             throw new Exception('Database not restored because the restore command is false.');
+        } elseif ($restoreCommand === null) {
+            $restoreCommand = $this->getSchema()->getDefaultRestoreCommand();
+        } elseif ($restoreCommand instanceof \Closure) {
+            $restoreCommand = $restoreCommand($this->getSchema()->getDefaultRestoreCommand());
         }
 
         // Create the shell command

--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -193,7 +193,7 @@ class Schema extends \yii\db\mysql\Schema
             ->addArg('--no-create-info');
 
         foreach ($ignoreTables as $table) {
-            $table = Craft::$app->getDb()->getSchema()->getRawTableName($table);
+            $table = $this->getRawTableName($table);
             $dataDump->addArg('--ignore-table', "{schema}.$table");
         }
 

--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -152,79 +152,57 @@ class Schema extends \yii\db\mysql\Schema
      */
     public function getDefaultBackupCommand(?array $ignoreTables = null): string
     {
-        $useSingleTransaction = true;
-        $serverVersion = App::normalizeVersion($this->getServerVersion());
+        $baseCommand = (new ShellCommand('mysqldump'))
+            ->addArg('--defaults-file=', $this->_createDumpConfigFile())
+            ->addArg('--add-drop-table')
+            ->addArg('--comments')
+            ->addArg('--create-options')
+            ->addArg('--dump-date')
+            ->addArg('--no-autocommit')
+            ->addArg('--routines')
+            ->addArg('--default-character-set=', Craft::$app->getConfig()->getDb()->charset)
+            ->addArg('--set-charset')
+            ->addArg('--triggers')
+            ->addArg('--no-tablespaces');
 
+        $serverVersion = App::normalizeVersion(Craft::$app->getDb()->getServerVersion());
         $isMySQL5 = version_compare($serverVersion, '8', '<');
         $isMySQL8 = version_compare($serverVersion, '8', '>=');
+        $ignoreTables = $ignoreTables ?? Craft::$app->getDb()->getIgnoredBackupTables();
+        $commandFromConfig = Craft::$app->getConfig()->getGeneral()->backupCommand;
 
         // https://bugs.mysql.com/bug.php?id=109685
-        if (($isMySQL5 && version_compare($serverVersion, '5.7.41', '>=')) ||
-            ($isMySQL8 && version_compare($serverVersion, '8.0.32', '>='))) {
-            $useSingleTransaction = false;
-        }
-
-        $defaultArgs =
-            ' --defaults-file="' . $this->_createDumpConfigFile() . '"' .
-            ' --add-drop-table' .
-            ' --comments' .
-            ' --create-options' .
-            ' --dump-date' .
-            ' --no-autocommit' .
-            ' --routines' .
-            ' --default-character-set=' . Craft::$app->getConfig()->getDb()->charset .
-            ' --set-charset' .
-            ' --triggers' .
-            ' --no-tablespaces';
+        $useSingleTransaction =
+            ($isMySQL5 && version_compare($serverVersion, '5.7.41', '>=')) ||
+            ($isMySQL8 && version_compare($serverVersion, '8.0.32', '>='));
 
         if ($useSingleTransaction) {
-            $defaultArgs .= ' --single-transaction';
+            $baseCommand->addArg('--single-transaction');
         }
 
-        // Find out if the db/dump client supports column-statistics
-        $shellCommand = new ShellCommand();
-
-        if (Platform::isWindows()) {
-            $shellCommand->setCommand('mysqldump --help | findstr "column-statistics"');
-        } else {
-            $shellCommand->setCommand('mysqldump --help | grep "column-statistics"');
+        if ($this->supportsColumnStatistics()) {
+            $baseCommand->addArg('--column-statistics=', '0');
         }
 
-        // If we don't have proc_open, maybe we've got exec
-        if (!function_exists('proc_open') && function_exists('exec')) {
-            $shellCommand->useExec = true;
-        }
+        $schemaDump = (clone $baseCommand)
+            ->addArg('--no-data')
+            ->addArg('--result-file=', '{file}')
+            ->addArg('{database}');
 
-        $success = $shellCommand->execute();
+        $dataDump = (clone $baseCommand)
+            ->addArg('--no-create-info');
 
-        // if there was output, then column-statistics is supported and we should disable it
-        if ($success && $shellCommand->getOutput()) {
-            $defaultArgs .= ' --column-statistics=0';
-        }
-
-        if ($ignoreTables === null) {
-            $ignoreTables = $this->db->getIgnoredBackupTables();
-        }
-        $ignoreTableArgs = [];
         foreach ($ignoreTables as $table) {
-            $table = $this->getRawTableName($table);
-            $ignoreTableArgs[] = "--ignore-table={database}.$table";
+            $table = Craft::$app->getDb()->getSchema()->getRawTableName($table);
+            $dataDump->addArg('--ignore-table', "{schema}.$table");
         }
 
-        $schemaDump = 'mysqldump' .
-            $defaultArgs .
-            ' --no-data' .
-            ' --result-file="{file}"' .
-            ' {database}';
+        if ($commandFromConfig instanceof \Closure) {
+            $schemaDump = $commandFromConfig($schemaDump);
+            $dataDump = $commandFromConfig($dataDump);
+        }
 
-        $dataDump = 'mysqldump' .
-            $defaultArgs .
-            ' --no-create-info' .
-            ' ' . implode(' ', $ignoreTableArgs) .
-            ' {database}' .
-            ' >> "{file}"';
-
-        return $schemaDump . ' && ' . $dataDump;
+        return "{$schemaDump->getExecCommand()} && {$dataDump->getExecCommand()} >> {file}";
     }
 
     /**
@@ -235,10 +213,16 @@ class Schema extends \yii\db\mysql\Schema
      */
     public function getDefaultRestoreCommand(): string
     {
-        return 'mysql' .
-            ' --defaults-file="' . $this->_createDumpConfigFile() . '"' .
-            ' {database}' .
-            ' < "{file}"';
+        $commandFromConfig = Craft::$app->getConfig()->getGeneral()->backupCommand;
+        $command = (new ShellCommand('mysql'))
+            ->addArg('--defaults-file=', $this->_createDumpConfigFile())
+            ->addArg('{database}');
+
+        if ($commandFromConfig instanceof \Closure) {
+            $command = $commandFromConfig($command);
+        }
+
+        return $command->getExecCommand() . ' < "{file}"';
     }
 
     /**
@@ -381,6 +365,28 @@ SQL;
                 $table->foreignKeys = array_values($table->foreignKeys);
             }
         }
+    }
+
+    protected function supportsColumnStatistics(): bool
+    {
+        // Find out if the db/dump client supports column-statistics
+        $shellCommand = new ShellCommand();
+
+        if (Platform::isWindows()) {
+            $shellCommand->setCommand('mysqldump --help | findstr "column-statistics"');
+        } else {
+            $shellCommand->setCommand('mysqldump --help | grep "column-statistics"');
+        }
+
+        // If we don't have proc_open, maybe we've got exec
+        if (!function_exists('proc_open') && function_exists('exec')) {
+            $shellCommand->useExec = true;
+        }
+
+        $success = $shellCommand->execute();
+
+        // if there was output, then column-statistics is supported
+        return $success && $shellCommand->getOutput();
     }
 
     /**

--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -213,7 +213,7 @@ class Schema extends \yii\db\mysql\Schema
      */
     public function getDefaultRestoreCommand(): string
     {
-        $commandFromConfig = Craft::$app->getConfig()->getGeneral()->backupCommand;
+        $commandFromConfig = Craft::$app->getConfig()->getGeneral()->restoreCommand;
         $command = (new ShellCommand('mysql'))
             ->addArg('--defaults-file=', $this->_createDumpConfigFile())
             ->addArg('{database}');

--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -135,7 +135,7 @@ class Schema extends \yii\db\pgsql\Schema
         $commandFromConfig = Craft::$app->getConfig()->getGeneral()->backupCommand;
 
         foreach ($ignoreTables as $table) {
-            $table = Craft::$app->getDb()->getSchema()->getRawTableName($table);
+            $table = $this->getRawTableName($table);
             $command->addArg('--exclude-table-data', "{schema}.$table");
         }
 


### PR DESCRIPTION
### Description
- adds `\Closure` as an accepted type for `\craft\config\GeneralConfig::$restoreCommand` and `\craft\config\GeneralConfig::$backupCommand`
  - `function(ShellCommand $command) => ShellCommand`
- adds `\craft\config\GeneralConfig::$backupCommandFormat` (pg only) for using archive format
  - also changes restore to use `pg_restore` to be compatible with create dumps
  - changes extension to be `.dump`

### Example usage

```
<?php
use craft\config\GeneralConfig;

return GeneralConfig::create()
    ->backupCommandFormat('custom')
    ->backupCommand(fn(\mikehaertl\shellcommand\Command $command) => $command
        ->addArg('--clean')
        ->addArg('--if-exists')
    );
```

### Related issues
Replaces https://github.com/craftcms/cms/pull/14586

### Notes
- For MySQL, both the "schema dump" and the "data dump" get passed through the `\Callable`. This would allow someone to have different behavior in either one by looking for `--no-data` or `--no-create-info`.
- It might make more sense to have `backupCommandFormat` be in `\craft\config\DbConfig`, but it felt weird to have it separated from `backupCommand`.