### PR TITLE
Fix UI and layout issues with cp header and sidebar

### DIFF
--- a/src/templates/_layouts/cp.twig
+++ b/src/templates/_layouts/cp.twig
@@ -221,12 +221,12 @@ history.replaceState(undefined, undefined, window.location.href.match(/^[^#]*/)[
                                             {% endblock %}
                                         </div>
                                         {% if toolbar %}
-                                            <div id="toolbar" class="flex">
+                                            <div id="toolbar" class="flex" tabindex="2">
                                                 {{ toolbar|raw }}
                                             </div>
                                         {% endif %}
                                         {% if actionButton or additionalButtons %}
-                                            <div id="action-buttons" class="flex">
+                                            <div id="action-buttons" class="flex" tabindex="1">
                                                 {{ additionalButtons|raw }}
                                                 {{ actionButton|raw }}
 
@@ -254,17 +254,17 @@ history.replaceState(undefined, undefined, window.location.href.match(/^[^#]*/)[
                         <div id="main-content" class="{{ mainContentClasses|join(' ') }}">
                             {# sidebar #}
                             {% if sidebar %}
-                                <div id="sidebar-toggle-container">
+                                <h2 id="sidebar-toggle-container">
                                     <button
                                         type="button"
                                         id="sidebar-toggle"
-                                        class="btn menubtn"
+                                        class="btn menubtn chromeless"
                                         aria-controls="sidebar-container"
                                         aria-expanded="false"
                                     >
-                                        {{ 'Show sidebar'|t('app') }}
+                                        <span id="content-heading"></span>
                                     </button>
-                                </div>
+                                </h2>
                                 <div id="sidebar-container">
                                     <div id="sidebar" class="sidebar">
                                         {{ sidebar|raw }}
@@ -274,9 +274,6 @@ history.replaceState(undefined, undefined, window.location.href.match(/^[^#]*/)[
 
                             {# content-container #}
                             <div id="content-container">
-                                {% if sidebar %}
-                                    <h2 id="content-heading"></h2>
-                                {% endif %}
                                 {% block main %}
                                     {% if errorSummary is not empty %}
                                         {{ errorSummary is defined ? errorSummary|raw }}

--- a/src/templates/_layouts/cp.twig
+++ b/src/templates/_layouts/cp.twig
@@ -221,12 +221,12 @@ history.replaceState(undefined, undefined, window.location.href.match(/^[^#]*/)[
                                             {% endblock %}
                                         </div>
                                         {% if toolbar %}
-                                            <div id="toolbar" class="flex" tabindex="2">
+                                            <div id="toolbar" class="flex">
                                                 {{ toolbar|raw }}
                                             </div>
                                         {% endif %}
                                         {% if actionButton or additionalButtons %}
-                                            <div id="action-buttons" class="flex" tabindex="1">
+                                            <div id="action-buttons" class="flex">
                                                 {{ additionalButtons|raw }}
                                                 {{ actionButton|raw }}
 

--- a/src/web/assets/cp/src/css/_cp.scss
+++ b/src/web/assets/cp/src/css/_cp.scss
@@ -1029,6 +1029,9 @@ li.breadcrumb-toggle-wrapper {
       }
     }
   }
+  .skip-link {
+    margin: 0 var(--s);
+  }
 }
 
 #content-container {
@@ -1041,13 +1044,13 @@ li.breadcrumb-toggle-wrapper {
   width: 400px;
 }
 
-#content-heading {
-  margin-top: var(--xl) !important;
+// #content-heading {
+//   margin-top: var(--xl) !important;
 
-  @media only screen and (min-width: $minHorizontalUiWidth) {
-    @include visually-hidden;
-  }
-}
+//   @media only screen and (min-width: $minHorizontalUiWidth) {
+//     @include visually-hidden;
+//   }
+// }
 
 .content-pane {
   @include pane;
@@ -1221,13 +1224,17 @@ li.breadcrumb-toggle-wrapper {
 
   #main-content {
     width: 100vw;
+    &.has-sidebar {
+      padding-left: 0;
+    }
   }
 }
 
 // Rearrange #main-content to flow vertically at < 999
 @media only screen and (max-width: $minHorizontalUiWidth - calc(1rem/16)) {
   #header {
-    display: block;
+    display: flex;
+    flex-wrap: wrap;
 
     .flex:not(#toolbar) {
       margin-top: 10px;
@@ -1236,10 +1243,17 @@ li.breadcrumb-toggle-wrapper {
 
   #toolbar {
     flex-wrap: wrap !important;
+    order: 3;
+    width: 100%;
+    flex: auto;
 
     & > * {
       margin-top: 10px !important;
     }
+  }
+
+  #action-buttons {
+    order: 2;
   }
 
   body.fixed-header #header .flex:first-child {
@@ -1248,6 +1262,23 @@ li.breadcrumb-toggle-wrapper {
 
   #main-content {
     display: block;
+    &.has-sidebar {
+      padding: 0 var(--padding) 48px;
+    }
+  }
+
+  #sidebar {
+    nav {
+      margin-left: -40px;
+      margin-right: -40px;
+    }
+    .skip-link {
+      margin: 0;
+    }
+  }
+
+  #source-actions {
+    margin-left: -9px;
   }
 
   #sidebar-toggle-container {
@@ -1258,18 +1289,10 @@ li.breadcrumb-toggle-wrapper {
   #sidebar-toggle {
     &:after {
       top: 0;
-      transform: rotate(-45deg);
+      transform: rotate(45deg);
 
       body.rtl & {
         transform: rotate(135deg);
-      }
-    }
-
-    body.showing-sidebar & {
-      background-color: darken($grey200, 10%) !important;
-
-      &:after {
-        transform: rotate(45deg);
       }
     }
   }
@@ -1291,7 +1314,7 @@ li.breadcrumb-toggle-wrapper {
 
   #sidebar,
   #details {
-    position: static !important;
+    position: relative !important;
     overflow-y: visible !important;
     max-height: none !important;
     width: auto;


### PR DESCRIPTION
### Description
I've optimized the layout and fixed the spacing issues with the cp header and sidebar. I've tried to keep structural changes to a minimum. I think this layout feels much cleaner while maintaining accessibility.

The only minor concession is that the tab index remains the same even though the New Entry button is now visually before the toolbar in mobile layout. But since this is for the mobile layout, it doesn't seem like a big deal.

- Fixed inconsistent padding in sidebar
- Fixed "Skip to Entries" button being out of the sidebar element on mobile
- Turned the element index heading into a dropdown button that reveals the sidebar, rather than having a show sidebar button
- Changed order of toolbar an action buttons to visually flow nicer and conserve vertical space.

#### New Mobile Layout

![new-mobile](https://github.com/craftcms/cms/assets/373889/e59c3b57-47e1-483e-9505-7d79b4ab24f6)

#### New Mobile Layout - Sidebar opened

![new-mobile-2](https://github.com/craftcms/cms/assets/373889/a5f3dbfc-37bc-4bc9-9f20-b8f7b4158199)

#### New Mobile Layout - Skip Button

![new-mobile-skip-button](https://github.com/craftcms/cms/assets/373889/3b4a3cb3-baca-499c-a884-fb0ac0b599e5)

#### New Tablet Layout - Fixed spacing

![new-tablet](https://github.com/craftcms/cms/assets/373889/511f17ff-c96b-4daa-9ff4-690546aa74ac)

#### Desktop Layout
Remains the same. The Skip to Entries button spacing is fixed.

![desktop](https://github.com/craftcms/cms/assets/373889/1c7c91c7-85ac-4af5-a1a8-939968118431)


### Related issues
#14900

