### PR TITLE
correct logic for database backup use of single-transaction

### DIFF
--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -172,9 +172,10 @@ class Schema extends \yii\db\mysql\Schema
         $commandFromConfig = Craft::$app->getConfig()->getGeneral()->backupCommand;
 
         // https://bugs.mysql.com/bug.php?id=109685
-        $useSingleTransaction =
+        $useSingleTransaction = !(
             ($isMySQL5 && version_compare($serverVersion, '5.7.41', '>=')) ||
-            ($isMySQL8 && version_compare($serverVersion, '8.0.32', '>='));
+            ($isMySQL8 && version_compare($serverVersion, '8.0.32', '>='))
+        );
 
         if ($useSingleTransaction) {
             $baseCommand->addArg('--single-transaction');


### PR DESCRIPTION
### Description
The recent release of 4.9.0 and 5.1.0 has a bug which makes MySQL backups fail. Because in this commit, the logic of when to use `--single-transaction` was reversed. 
https://github.com/craftcms/cms/pull/14897/commits/97da6ca6d5cc73700c332f0a89e9a924cb9651cf#diff-83d39a4592b31403e3830a3100e22c596322d8dd9a240e07f6ecf173ec1d7bb7

#### Breaking change in detail
Before the commit if mysql version is newer than 5.7.41 or 8.0.32 results in **FALSE** 
```
if (($isMySQL5 && version_compare($serverVersion, '5.7.41', '>=')) ||
     ($isMySQL8 && version_compare($serverVersion, '8.0.32', '>='))) {
     $useSingleTransaction = false;
 }
```

After the commit if mysql version is newer than 5.7.41 or 8.0.32 results in **TRUE**
```
 $useSingleTransaction =
     ($isMySQL5 && version_compare($serverVersion, '5.7.41', '>=')) ||
     ($isMySQL8 && version_compare($serverVersion, '8.0.32', '>='));
```

#### Why do we even check MySQL versions?
This check is done because after those versions, mysqldump will require the FLUSH TABLES privileges to run, which shared hosting usually will not give, as it is considered system privileges. Thus breaking any use of mysqldump. (See https://github.com/craftcms/cms/issues/12557)

### Related issues

This fixes: https://github.com/craftcms/cms/issues/14922