### PR TITLE
DB backup/restore refinements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,1 +1,10 @@
 # Release notes for Craft CMS 4.10 (WIP)
+
+### Administration
+- Added the `--format` option to the `db/backup` and `db/restore` commands for PostgreSQL installs. ([#14931](https://github.com/craftcms/cms/pull/14931))
+
+### Extensibility
+- Added `craft\db\getBackupFormat()`.
+- Added `craft\db\getRestoreFormat()`.
+- Added `craft\db\setBackupFormat()`.
+- Added `craft\db\setRestoreFormat()`.

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -2,6 +2,7 @@
 
 ### Administration
 - Added the `--format` option to the `db/backup` and `db/restore` commands for PostgreSQL installs. ([#14931](https://github.com/craftcms/cms/pull/14931))
+- The `db/restore` command now autodetects the backup format for PostgreSQL installs, if `--format` isn’t passed. ([#14931](https://github.com/craftcms/cms/pull/14931))
 
 ### Extensibility
 - Added `craft\db\getBackupFormat()`.

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -451,7 +451,7 @@ class GeneralConfig extends BaseConfig
     public string|null|false|Closure $backupCommand = null;
 
     /**
-     * @var string|null The output format for backup commands using `pg_dump`.
+     * @var string|null The output format that database backups should use (PostgreSQL only).
      *
      * This setting has no effect with MySQL databases.
      *
@@ -3604,7 +3604,7 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * The output format for backup commands using `pg_dump`.
+     * The output format that database backups should use (PostgreSQL only).
      *
      * This setting has no effect with MySQL databases.
      *

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -451,7 +451,7 @@ class GeneralConfig extends BaseConfig
     public string|null|false|Closure $backupCommand = null;
 
     /**
-     * @var string|null The output format to pass to `pg_dump` when backing up the database.
+     * @var string|null The output format for backup commands using `pg_dump`.
      *
      * This setting has no effect with MySQL databases.
      *
@@ -3604,7 +3604,7 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * The output format to pass to `pg_dump` when backing up the database.
+     * The output format for backup commands using `pg_dump`.
      *
      * This setting has no effect with MySQL databases.
      *

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -34,6 +34,13 @@ class DbController extends Controller
      */
     public bool $zip = false;
 
+    /**
+     * @var string|null The output format that should be used (`custom`, `directory`, `tar`, or `plain`).
+     *
+     * The `backupCommandFormat` config setting will be used by default.
+     *
+     * @since 4.10.0
+     */
     public ?string $format = null;
 
     /**
@@ -182,7 +189,7 @@ class DbController extends Controller
         $this->stdout('Backing up the database ... ');
         $db = Craft::$app->getDb();
 
-        if ($this->format && $db->getIsPgsql()) {
+        if (isset($this->format) && $db->getIsPgsql()) {
             $db->getSchema()->setBackupFormat($this->format);
         }
 

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -318,16 +318,17 @@ class DbController extends Controller
         $this->stdout('Restoring database backup ... ');
 
         try {
-            if (Craft::$app->getDb()->getIsPgsql()) {
-                Craft::$app->getDb()->getSchema()->restoreFormat = $this->format ?? match (FileHelper::getMimeType($path)) {
+            $db = Craft::$app->getDb();
+            if ($db->getIsPgsql()) {
+                $restoreFormat = $this->format ?? match (FileHelper::getMimeType($path)) {
                     'application/octet-stream' => 'custom',
                     'application/x-tar' => 'tar',
                     'directory' => 'directory',
                     default => null,
                 };
+                $db->getSchema()->setRestoreFormat($restoreFormat);
             }
-
-            Craft::$app->getDb()->restore($path);
+            $db->restore($path);
         } catch (Throwable $e) {
             Craft::$app->getErrorHandler()->logException($e);
             $this->stderr('error: ' . $e->getMessage() . PHP_EOL, Console::FG_RED);

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -257,12 +257,7 @@ class DbController extends Controller
     public function actionRestore(?string $path = null): int
     {
         if (!is_readable($path)) {
-            if (!is_dir($path) && Craft::$app->getConfig()->getGeneral()->backupCommandFormat === 'directory') {
-                $this->stderr("Backup directory doesn't exist: $path" . PHP_EOL);
-            } else {
-                $this->stderr("Backup file doesn't exist: $path" . PHP_EOL);
-            }
-
+            $this->stderr("Backup path doesn't exist: $path" . PHP_EOL);
             return ExitCode::UNSPECIFIED_ERROR;
         }
 
@@ -314,6 +309,7 @@ class DbController extends Controller
                 Craft::$app->getDb()->getSchema()->restoreFormat = $this->format ?? match (FileHelper::getMimeType($path)) {
                     'application/octet-stream' => 'custom',
                     'application/x-tar' => 'tar',
+                    'directory' => 'directory',
                     default => null,
                 };
             }

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -238,8 +238,14 @@ class DbController extends Controller
         }
 
         $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
-        $size = Craft::$app->getFormatter()->asShortSize(filesize($path));
-        $this->stdout("Backup file: $path ($size)" . PHP_EOL);
+
+        if (is_dir($path)) {
+            $this->stdout("Backup directory: $path" . PHP_EOL);
+        } else {
+            $size = Craft::$app->getFormatter()->asShortSize(filesize($path));
+            $this->stdout("Backup file: $path ($size)" . PHP_EOL);
+        }
+
         return ExitCode::OK;
     }
 

--- a/src/db/Connection.php
+++ b/src/db/Connection.php
@@ -450,6 +450,19 @@ class Connection extends \yii\db\Connection
         }
     }
 
+    private function _getDumpExtension(): string
+    {
+        $backupFormat = $this->getIsPgsql()
+            ? $this->getSchema()->getBackupFormat()
+            : null;
+
+        return match ($backupFormat) {
+            'custom', 'directory' => '.dump',
+            'tar' => '.tar',
+            default => '.sql',
+        };
+    }
+
     /**
      * @inheritdoc
      */
@@ -465,11 +478,6 @@ class Connection extends \yii\db\Connection
         }
 
         parent::trigger($name, $event);
-    }
-
-    private function _getDumpExtension(): string
-    {
-        return $this->getIsPgsql() && $this->getSchema()->usePgRestore() ? '.dump' : '.sql';
     }
 
     /**

--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -174,7 +174,8 @@ class Schema extends \yii\db\pgsql\Schema
                 ->addArg('--no-owner')
                 ->addArg('--no-acl')
                 ->addArg('--schema=', '{schema}')
-                ->addArg('--single-transaction');
+                ->addArg('--single-transaction')
+                ->addArg('{file}');
         }
 
         $commandFromConfig = Craft::$app->getConfig()->getGeneral()->restoreCommand;

--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -23,8 +23,16 @@ use yii\db\Exception;
  */
 class Schema extends \yii\db\pgsql\Schema
 {
-    private ?string $_backupFormat = null;
-    public ?string $restoreFormat = null;
+    /**
+     * @see getBackupFormat()
+     * @see setBackupFormat()
+     */
+    private ?string $backupFormat = null;
+    /**
+     * @see getRestoreFormat()
+     * @see setRestoreFormat()
+     */
+    private ?string $restoreFormat = null;
 
     /**
      * @var int The maximum length that objects' names can be.
@@ -257,7 +265,7 @@ class Schema extends \yii\db\pgsql\Schema
      */
     public function usePgRestore(): bool
     {
-        return $this->restoreFormat && $this->restoreFormat !== 'plain';
+        return isset($this->restoreFormat) && $this->restoreFormat !== 'plain';
     }
 
     /**
@@ -375,7 +383,7 @@ ORDER BY i.relname, k';
      */
     public function getBackupFormat(): ?string
     {
-        return $this->_backupFormat ?? Craft::$app->getConfig()->getGeneral()->backupCommandFormat;
+        return $this->backupFormat ?? Craft::$app->getConfig()->getGeneral()->backupCommandFormat;
     }
 
     /**
@@ -386,6 +394,28 @@ ORDER BY i.relname, k';
      */
     public function setBackupFormat(?string $backupFormat): void
     {
-        $this->_backupFormat = $backupFormat;
+        $this->backupFormat = $backupFormat;
+    }
+
+    /**
+     * Returns the backup format that should be used (`custom`, `directory`, `tar`, or `plain`).
+     *
+     * @return string|null
+     * @since 4.10.0
+     */
+    public function getRestoreFormat(): ?string
+    {
+        return $this->restoreFormat;
+    }
+
+    /**
+     * Sets the backup format that should be used (`custom`, `directory`, `tar`, or `plain`).
+     *
+     * @param string|null $restoreFormat
+     * @since 4.10.0
+     */
+    public function setRestoreFormat(?string $restoreFormat): void
+    {
+        $this->restoreFormat = $restoreFormat;
     }
 }

--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -367,11 +367,23 @@ ORDER BY i.relname, k';
         return Platform::isWindows() ? 'set PGPASSWORD="{password}" && ' : 'PGPASSWORD="{password}" ';
     }
 
+    /**
+     * Returns the backup format that should be used (`custom`, `directory`, `tar`, or `plain`).
+     *
+     * @return string|null
+     * @since 4.10.0
+     */
     public function getBackupFormat(): ?string
     {
         return $this->_backupFormat ?? Craft::$app->getConfig()->getGeneral()->backupCommandFormat;
     }
 
+    /**
+     * Sets the backup format that should be used (`custom`, `directory`, `tar`, or `plain`).
+     *
+     * @param string|null $backupFormat
+     * @since 4.10.0
+     */
     public function setBackupFormat(?string $backupFormat): void
     {
         $this->_backupFormat = $backupFormat;

--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -23,6 +23,9 @@ use yii\db\Exception;
  */
 class Schema extends \yii\db\pgsql\Schema
 {
+    private ?string $_backupFormat = null;
+    public ?string $restoreFormat = null;
+
     /**
      * @var int The maximum length that objects' names can be.
      */
@@ -131,7 +134,7 @@ class Schema extends \yii\db\pgsql\Schema
             ->addArg('--schema=', '{schema}');
 
         $ignoreTables = $ignoreTables ?? Craft::$app->getDb()->getIgnoredBackupTables();
-        $format = Craft::$app->getConfig()->getGeneral()->backupCommandFormat;
+        $format = $this->getBackupFormat();
         $commandFromConfig = Craft::$app->getConfig()->getGeneral()->backupCommand;
 
         foreach ($ignoreTables as $table) {
@@ -163,6 +166,16 @@ class Schema extends \yii\db\pgsql\Schema
             ->addArg('--port=', '{port}')
             ->addArg('--username=', '{user}')
             ->addArg('--no-password');
+
+        if ($this->usePgRestore()) {
+            $command
+                ->addArg('--clean')
+                ->addArg('--if-exists')
+                ->addArg('--no-owner')
+                ->addArg('--no-acl')
+                ->addArg('--schema=', '{schema}')
+                ->addArg('--single-transaction');
+        }
 
         $commandFromConfig = Craft::$app->getConfig()->getGeneral()->restoreCommand;
 
@@ -240,17 +253,14 @@ class Schema extends \yii\db\pgsql\Schema
     }
 
     /**
-     * Whether `pg_restore` should be used by default for the backup command.
+     * Whether `pg_restore` should be used for the restore command.
      *
      * @return bool
      * @since 4.9.0
      */
     public function usePgRestore(): bool
     {
-        return in_array(Craft::$app->getConfig()->getGeneral()->backupCommandFormat, [
-            'custom',
-            'directory',
-        ], true);
+        return $this->restoreFormat && $this->restoreFormat !== 'plain';
     }
 
     /**
@@ -358,5 +368,15 @@ ORDER BY i.relname, k';
     private function _pgpasswordCommand(): string
     {
         return Platform::isWindows() ? 'set PGPASSWORD="{password}" && ' : 'PGPASSWORD="{password}" ';
+    }
+
+    public function getBackupFormat(): ?string
+    {
+        return $this->_backupFormat ?? Craft::$app->getConfig()->getGeneral()->backupCommandFormat;
+    }
+
+    public function setBackupFormat(?string $backupFormat): void
+    {
+        $this->_backupFormat = $backupFormat;
     }
 }

--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -175,16 +175,12 @@ class Schema extends \yii\db\pgsql\Schema
                 ->addArg('--no-acl')
                 ->addArg('--schema=', '{schema}')
                 ->addArg('--single-transaction')
+
+                // If we're using pg_restore, we can't use STDIN, as it may be a directory
                 ->addArg('{file}');
         }
 
         $commandFromConfig = Craft::$app->getConfig()->getGeneral()->restoreCommand;
-
-
-        // If we're using pg_restore, we can't use STDIN, as it may be a directory
-        if ($this->usePgRestore()) {
-            $command->addArg('{file}');
-        }
 
         if ($commandFromConfig instanceof \Closure) {
             $command = $commandFromConfig($command);

--- a/src/db/pgsql/Schema.php
+++ b/src/db/pgsql/Schema.php
@@ -398,7 +398,7 @@ ORDER BY i.relname, k';
     }
 
     /**
-     * Returns the backup format that should be used (`custom`, `directory`, `tar`, or `plain`).
+     * Returns the restore format that should be used (`custom`, `directory`, `tar`, or `plain`).
      *
      * @return string|null
      * @since 4.10.0
@@ -409,7 +409,7 @@ ORDER BY i.relname, k';
     }
 
     /**
-     * Sets the backup format that should be used (`custom`, `directory`, `tar`, or `plain`).
+     * Sets the restore format that should be used (`custom`, `directory`, `tar`, or `plain`).
      *
      * @param string|null $restoreFormat
      * @since 4.10.0


### PR DESCRIPTION
### Description
https://github.com/craftcms/cms/pull/14897 tied the format set for backups (`backupCommandFormat`) with what is used for restoring, which is not ideal.

This PR:
- separates `backupCommandFormat` from what is used for restore
- adds `--format` options for `db/restore` and `db/backup` (for PG)
- For `db/restore`, if no `--format` is passed, it will attempt to detect which pg_restore format should be used (`custom`, `directory`, `tar`)
- Adds flags to the default restore command to allow postgres dumps to work (including Craft Cloud).
- Adds some allowances so the path for `db/restore` can be a directory, which is applicable for pg_restore.