### PR TITLE
don't set cache results to empty array for nested matrix entry with b…

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -677,7 +677,10 @@ class Matrix extends Field implements
 
         // Set the initially matched elements if $value is already set, which is the case if there was a validation
         // error or we're loading an entry revision.
-        if ($value === '') {
+        // But we should exclude matrix entries in block view nested in matrix entries from this caching:
+        // https://github.com/craftcms/cms/issues/14947
+        /** @var Entry $element */
+        if ($value === '' && !($fromRequest && $this->viewMode === self::VIEW_MODE_BLOCKS && $element->fieldId && $element->saveOwnership)) {
             $query->setCachedResult([]);
         } elseif ($element && is_array($value)) {
             $query->setCachedResult($this->_createEntriesFromSerializedData($value, $element, $fromRequest));


### PR DESCRIPTION
### Description
In a matrix in a matrix setup where both matrix fields are in “as inline-editable blocks” mode and the nested matrix has min entries set to at least 1, the title is hidden, and URI format references the slug; if you add a new top-level matrix entry, the draft won’t be saved because of slug validation issue. 

Replication steps:
- create `matrixEt1` entry type with “show the title field” and “show the skug field” disabled
- create `myMatrix1`field, type: matrix, entry type: `matrixEt1`, URI: sth/{slug}, min entries: 1, view mode: blocks
- create a `matrixEt2` entry type with the `myMatrix1` field in it
- create `myMatrix2` field, type: matrix, entry type `matrixEt2`, view mode: blocks
- create a `contentBuilder` entry type with the `myMatrix2` field in it
- create a section that uses the `contentBuilder` entry type
- create an entry in the above section & add an entry (block) to the `myMatrix2`

The issue is triggered because when the entry (block) is added, [the empty value is being cached](https://github.com/craftcms/cms/blob/5.x/src/fields/Matrix.php#L681), causing the nested entry to be an [empty “skeleton”](https://github.com/craftcms/cms/blob/5.x/src/fields/Matrix.php#L986) one without a title or slug, which prevents the slug from being correctly set based on the title attribute.

If you reload the page after adding the entry (block), the draft will start being saved as expected.

This PR excludes nested matrix entries from being cached as empty array when normalising field value from request if it’s a nested entry in the blocks view mode.

Screenshot of the replication setup: 
<img width="1416" alt="Screenshot 2024-05-07 at 17 27 42" src="https://github.com/craftcms/cms/assets/4500340/071c9fc9-ff6a-416d-bbee-5cc14aea9fb0">


### Related issues
#14947 
