### PR TITLE
Fix unquoted backup path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where the `serve` command wasn’t serving paths with non-ASCII characters. ([#14977](https://github.com/craftcms/cms/issues/14977))
 - Fixed a bug where element chips within element selection tables had insufficient contrast. ([#14963](https://github.com/craftcms/cms/issues/14963))
 - Fixed a bug where `craft\helpers\Html::explodeStyle()` and `normalizeTagAttributes()` weren’t handling styles with encoded images via `url()` properly. ([#14964](https://github.com/craftcms/cms/issues/14964))
+- Fixed a bug where the `db/backup` command would fail if the destination path contained a space.
 
 ## 4.9.2 - 2024-05-07
 

--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -204,7 +204,7 @@ class Schema extends \yii\db\mysql\Schema
             $dataDump = $commandFromConfig($dataDump);
         }
 
-        return "{$schemaDump->getExecCommand()} && {$dataDump->getExecCommand()} >> {file}";
+        return "{$schemaDump->getExecCommand()} && {$dataDump->getExecCommand()} >> '{file}'";
     }
 
     /**


### PR DESCRIPTION
### Description
Regression from https://github.com/craftcms/cms/pull/14897

`db/backup` would fail the the destination directory contained a space.
