### PR TITLE
user addresses page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improved the performance of element indexes that contained asset thumbnails.
 - Fixed a bug where `craft\elements\db\ElementQuery::exists()` would return `true` if `setCachedResult()` had been called, even if an empty array was passed.
 - Fixed a bug where `eagerly()` wasn’t working when a custom alias was passed in.
+- Fixed an error that occurred on users’ Addresses screens. ([#15018](https://github.com/craftcms/cms/pull/15018))
 
 ## 5.1.3 - 2024-05-14
 

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -382,11 +382,20 @@ class NestedElementManager extends Component
                     'class' => 'nested-element-cards',
                 ]);
 
-                /** @var NestedElementInterface[] $elements */
-                $elements = $this->getValue($owner)
-                    ->status(null)
-                    ->limit(null)
-                    ->all();
+
+                /** @var ElementQueryInterface|ElementCollection $value */
+                $value = $this->getValue($owner);
+                if ($value instanceof ElementCollection) {
+                    /** @var NestedElementInterface[] $elements */
+                    $elements = $value->all();
+                } else {
+                    /** @var NestedElementInterface[] $elements */
+                    $elements = $value
+                        ->status(null)
+                        ->limit(null)
+                        ->all();
+                }
+
                 $this->setOwnerOnNestedElements($owner, $elements);
 
                 if (!empty($elements)) {


### PR DESCRIPTION
### Description
After changes in #14980, the user’s addresses page throws `BadMethodCallException`. That’s because `User->getAddresses()` returns a collection. I’ve adjusted the `NestedElementManager->getCardsHtml()` to consider that and verified that #14973 still works as expected.


### Related issues
n/a
