### PR TITLE
keep the "old" scalar queries behaviour with offset or limit

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1608,6 +1608,10 @@ class ElementQuery extends Query implements ElementQueryInterface
             return count($cachedResult);
         }
 
+        if ($this->offset || $this->limit) {
+            return parent::count($q, $db) ?: 0;
+        }
+
         try {
             return $this->prepareSubquery()->count($q, $db) ?: 0;
         } catch (QueryAbortedException) {
@@ -1620,6 +1624,10 @@ class ElementQuery extends Query implements ElementQueryInterface
      */
     public function sum($q, $db = null)
     {
+        if ($this->offset || $this->limit) {
+            return parent::sum($q, $db) ?: 0;
+        }
+
         try {
             return $this->prepareSubquery()->sum($q, $db);
         } catch (QueryAbortedException) {
@@ -1632,6 +1640,10 @@ class ElementQuery extends Query implements ElementQueryInterface
      */
     public function average($q, $db = null)
     {
+        if ($this->offset || $this->limit) {
+            return parent::average($q, $db) ?: 0;
+        }
+
         try {
             return $this->prepareSubquery()->average($q, $db);
         } catch (QueryAbortedException) {
@@ -1644,6 +1656,10 @@ class ElementQuery extends Query implements ElementQueryInterface
      */
     public function min($q, $db = null)
     {
+        if ($this->offset || $this->limit) {
+            return parent::min($q, $db) ?: 0;
+        }
+
         try {
             return $this->prepareSubquery()->min($q, $db);
         } catch (QueryAbortedException) {
@@ -1656,6 +1672,10 @@ class ElementQuery extends Query implements ElementQueryInterface
      */
     public function max($q, $db = null)
     {
+        if ($this->offset || $this->limit) {
+            return parent::max($q, $db) ?: 0;
+        }
+
         try {
             return $this->prepareSubquery()->max($q, $db);
         } catch (QueryAbortedException) {


### PR DESCRIPTION
### Description
The performance changes from https://github.com/craftcms/cms/commit/0ff4796abd9d073d8c3d15a934e381f90cb403fc are causing slightly different behaviour when running scalar element queries.

The first reported case points out that before 4.9, in the `EntryQuery::EVENT_BEFORE_PREPARE`, for the scalar queries, the `$event->sender->orderBy` used to return `null`, but now it’s returning an empty string.

The second reported case is a combination of `search`, `limit`, and `orderBy('score')` params. Prior to 4.9, running `count()` on a query that contained all three would still return the total count, but now, it respects the passed-in limit. That’s because, in this case, the prepared subquery contains the IDs of the searched elements and the query that got those IDs respected the set limit. (Using the `offset` param would result in the same non-total count now.)

I raised a PR to go back to the “old” approach when the query contains `offset` or `limit`. 

I’m raising this as a draft in case we want to discuss this further in the CMS meeting.


### Related issues
#15001 
