### PR TITLE
allow alt text to be inline editable

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2658,8 +2658,6 @@ JS,[
             if ($altField) {
                 $altField->label = '__blank__'; // so that we don't show the label when inline editing
                 return $altField->formHtml($this, false);
-            } else {
-                return '';
             }
         }
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2648,6 +2648,25 @@ JS,[
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function inlineAttributeInputHtml(string $attribute): string
+    {
+        if ($attribute === 'alt') {
+            $altField = $this->getFieldLayout()->getFirstVisibleElementByType(AltField::class, $this);
+
+            if ($altField) {
+                $altField->label = '__blank__'; // so that we don't show the label when inline editing
+                return $altField->formHtml($this, false);
+            } else {
+                return '';
+            }
+        }
+
+        return parent::inlineAttributeInputHtml($attribute);
+    }
+
+    /**
      * Returns the HTML for asset previews.
      *
      * @return string


### PR DESCRIPTION
### Description
Adds support for inline editing of the Alt Text native field.


### Related issues
#15027 
