### PR TITLE
when deleting structures, ensure elements are not part of a revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Scalar element queries now set `$select` to the scalar expression, and `$orderBy`, `$limit`, and `$offset` to `null`, on the element query. ([#15001](https://github.com/craftcms/cms/issues/15001))
 - Fixed a bug where `craft\helpers\Assets::prepareAssetName()` wasn’t sanitizing filenames if `$preventPluginModifications` was `true`.
 - Fixed a bug where element queries’ `count()` methods were factoring in the `limit` param when searching with `orderBy` set to `score`. ([#15001](https://github.com/craftcms/cms/issues/15001))
+- Fixed a bug where soft-deleted structure data associated with elements that belonged to a revision could be deleted by garbage collection. ([#14995](https://github.com/craftcms/cms/pull/14995))
 - Fixed an error that occurred on the current user’s Profile screen if they didn’t have permission to access the primary site. ([#15022](https://github.com/craftcms/cms/issues/15022))
 - Fixed a bug where non-localizable elements’ edit screens were displaying a site breadcrumb.
 

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -137,8 +137,9 @@ class Gc extends Component
         $this->_deleteOrphanedRelations();
         $this->_deleteOrphanedStructureElements();
 
+        $this->_hardDeleteStructures();
+
         $this->hardDelete([
-            Table::STRUCTURES,
             Table::FIELDLAYOUTS,
             Table::SITES,
         ]);
@@ -649,6 +650,65 @@ SQL;
 
         $this->db->createCommand($sql)->execute();
         $this->_stdout("done\n", Console::FG_GREEN);
+    }
+
+    /**
+     * Hard delete structures data
+     * Any soft-deleted structure elements which have revisions will be skipped, as their revisions may still be needed by the owner element.
+     *
+     * @return void
+     * @throws \yii\db\Exception
+     */
+    private function _hardDeleteStructures(): void
+    {
+        // get IDs of structures that can be deleted;
+        // those are the ones for which the elements don't have any revisions
+        $structuresTable = Table::STRUCTURES;
+        $structureElementsTable = Table::STRUCTUREELEMENTS;
+        $elementsTable = Table::ELEMENTS;
+        $revisionsTable = Table::REVISIONS;
+
+        $params = [];
+
+        $structureIds = (new Query())
+            ->select('[[s.id]]')
+            ->distinct()
+            ->from(['s' => $structuresTable])
+            ->leftJoin(['se' => $structureElementsTable], '[[s.id]] = [[se.structureId]]')
+            ->leftJoin(['e' => $elementsTable], '[[e.id]] = [[se.elementId]]')
+            ->leftJoin(['r' => $revisionsTable], '[[r.canonicalId]] = coalesce([[e.canonicalId]],[[e.id]])')
+            ->where([
+                'and',
+                $this->_hardDeleteCondition('s'),
+                [
+                    'r.canonicalId' => null,
+                ],
+            ])
+            ->column();
+
+        if (!empty($structureIds)) {
+            $ids = implode(',', $structureIds);
+            $conditionSql = $this->db->getQueryBuilder()->buildCondition($this->_hardDeleteCondition('s'), $params);
+
+            // and now perform the actual deletion based on those IDs
+            if ($this->db->getIsMysql()) {
+                $sql = <<<SQL
+DELETE [[s]].* FROM $structuresTable [[s]]
+WHERE [[s.id]] NOT IN ($ids)
+AND $conditionSql
+SQL;
+            } else {
+                $sql = <<<SQL
+DELETE FROM $structuresTable
+USING $structuresTable [[s]]
+WHERE 
+    $structuresTable.[[id]] = [[s.id]] AND 
+    [[s.id]] NOT IN ($ids) AND
+    $conditionSql
+SQL;
+            }
+            $this->db->createCommand($sql, $params)->execute();
+        }
     }
 
     private function _gcCache(): void


### PR DESCRIPTION
### Description
v5 version of https://github.com/craftcms/cms/pull/14995

When deleting structures, first check if the elements that are part of that structure are not part of a revision. This ensures the neo blocks that are part of a revision don’t get deleted via garbage collection.

(Handling of soft-deleted nested elements was done via #14967.)


### Related issues
