### PR TITLE
user group condition selectable when applying pc

### DIFF
--- a/src/elements/conditions/users/GroupConditionRule.php
+++ b/src/elements/conditions/users/GroupConditionRule.php
@@ -10,6 +10,7 @@ use craft\elements\db\ElementQueryInterface;
 use craft\elements\db\UserQuery;
 use craft\elements\User;
 use craft\helpers\ArrayHelper;
+use craft\helpers\ProjectConfig;
 use craft\models\UserGroup;
 
 /**
@@ -41,7 +42,9 @@ class GroupConditionRule extends BaseMultiSelectConditionRule implements Element
      */
     public static function isSelectable(): bool
     {
-        return !empty(Craft::$app->getUserGroups()->getAllGroups());
+        // make this condition selectable if we're applying PC changes, and we're about to add group(s)
+        $addingUserGroups = ProjectConfig::areUserGroupsBeingAdded();
+        return (!empty(Craft::$app->getUserGroups()->getAllGroups()) || $addingUserGroups);
     }
 
     /**

--- a/src/helpers/ProjectConfig.php
+++ b/src/helpers/ProjectConfig.php
@@ -777,4 +777,41 @@ class ProjectConfig
         array_pop($segments);
         return !empty($segments) ? implode('.', $segments) : null;
     }
+
+    /**
+     * Checks if we're applying external PC changes, and if we're likely to be adding a User Group.
+     *
+     * @return bool
+     */
+    public static function areUserGroupsBeingAdded(): bool
+    {
+        $projectConfig = Craft::$app->getProjectConfig();
+
+        if (!$projectConfig->isApplyingExternalChanges) {
+            return false;
+        }
+
+        if (!$projectConfig->areChangesPending(ProjectConfigService::PATH_USER_GROUPS)) {
+            return false;
+        }
+
+        // if we're applying external changes
+        // and there are pending changes for user groups
+        $changesSummary = $projectConfig->getPendingChangeSummary();
+        // return false if we don't have 'users.groups' under 'newItems'
+        // and if all the summary groups are not empty
+        // (when adding groups, $changesSummary will at some point be empty as we go through it)
+        if (
+            !isset($changesSummary['newItems']['users.groups']) &&
+            (
+                !empty($changesSummary['newItems']) ||
+                !empty($changesSummary['changedItems']) ||
+                !empty($changesSummary['removedItems'])
+            )
+        ) {
+            return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
### Description
Allow the User Group condition to be selectable if we’re applying external project config changes (if the changes are likely to add user group(s).

At the moment, if you’re installing a new project using the existing config (or if you were to add the first user group and a rule that depends on it to an existing project in one go), the User Group condition won’t be added as the `craft\elements\conditions\users\GroupConditionRule->isSelectable()` will always be `false` (because there are no groups for the project yet). Since adding user groups can’t happen earlier on, we need to check if the user groups are likely to be added when applying changes, and if so, allow this rule to be selectable.


### Related issues
#15037 
