### PR TITLE
allow entries and product variants in related to rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+- Added `craft\services\Fields::getRelationalFieldTypes()`.
 - Fixed a bug where `craft\helpers\Typecast::properties()` wasn’t typecasting numeric strings to ints for `int|string|null` properties. ([#14618](https://github.com/craftcms/cms/issues/14618))
+- Fixed a bug where “Related To” conditions weren’t allowing entries to be selected. ([#15058](https://github.com/craftcms/cms/issues/15058))
 
 ## 5.1.5 - 2024-05-22
 

--- a/src/elements/conditions/RelatedToConditionRule.php
+++ b/src/elements/conditions/RelatedToConditionRule.php
@@ -94,8 +94,9 @@ class RelatedToConditionRule extends BaseElementSelectConditionRule implements E
     private function _elementTypeOptions(): array
     {
         $options = [];
-        /** @var string|BaseRelationField $field */
-        foreach (Craft::$app->getFields()->getAllRelationalFieldTypes() as $field) {
+        foreach (Craft::$app->getFields()->getRelationalFieldTypes() as $field) {
+            /** @var string|BaseRelationField $field */
+            /** @var string|ElementInterface $elementType */
             $elementType = $field::elementType();
             $options[] = [
                 'value' => $elementType,

--- a/src/elements/conditions/RelatedToConditionRule.php
+++ b/src/elements/conditions/RelatedToConditionRule.php
@@ -5,9 +5,9 @@ namespace craft\elements\conditions;
 use Craft;
 use craft\base\conditions\BaseElementSelectConditionRule;
 use craft\base\ElementInterface;
-use craft\base\NestedElementInterface;
 use craft\elements\db\ElementQueryInterface;
 use craft\elements\Entry;
+use craft\fields\BaseRelationField;
 use craft\helpers\Cp;
 use craft\helpers\Html;
 use craft\helpers\UrlHelper;
@@ -94,15 +94,13 @@ class RelatedToConditionRule extends BaseElementSelectConditionRule implements E
     private function _elementTypeOptions(): array
     {
         $options = [];
-        foreach (Craft::$app->getElements()->getAllElementTypes() as $elementType) {
-            /** @var string|ElementInterface $elementType */
-            /** @phpstan-var class-string<ElementInterface>|ElementInterface $elementType */
-            if (!is_subclass_of($elementType, NestedElementInterface::class)) {
-                $options[] = [
-                    'value' => $elementType,
-                    'label' => $elementType::displayName(),
-                ];
-            }
+        /** @var string|BaseRelationField $field */
+        foreach (Craft::$app->getFields()->getAllRelationalFieldTypes() as $field) {
+            $elementType = $field::elementType();
+            $options[] = [
+                'value' => $elementType,
+                'label' => $elementType::displayName(),
+            ];
         }
         return $options;
     }

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -331,6 +331,25 @@ class Fields extends Component
     }
 
     /**
+     * Returns all available relational field type classes.
+     *
+     * @return string[] The available relational field type classes
+     * @phpstan-return class-string<BaseRelationField>[]
+     * @since 5.1.6
+     */
+    public function getRelationalFieldTypes(): array
+    {
+        $relationalFields = [];
+        foreach ($this->getAllFieldTypes() as $fieldClass) {
+            if (is_subclass_of($fieldClass, BaseRelationField::class)) {
+                $relationalFields[] = $fieldClass;
+            }
+        }
+
+        return $relationalFields;
+    }
+
+    /**
      * Creates a field with a given config.
      *
      * @template T of FieldInterface
@@ -1394,24 +1413,6 @@ class Fields extends Component
         $pagination = AdminTable::paginationLinks($page, $total, $limit);
 
         return [$pagination, $tableData];
-    }
-
-    /**
-     * Returns all available relational field type classes.
-     *
-     * @return string[] The available relational field type classes
-     * @phpstan-return class-string<FieldInterface>[]
-     */
-    public function getAllRelationalFieldTypes(): array
-    {
-        $relationalFields = [];
-        foreach ($this->getAllFieldTypes() as $fieldClass) {
-            if (is_subclass_of($fieldClass, BaseRelationField::class)) {
-                $relationalFields[] = $fieldClass;
-            }
-        }
-
-        return $relationalFields;
     }
 
     /**

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -27,6 +27,7 @@ use craft\fieldlayoutelements\BaseField;
 use craft\fieldlayoutelements\CustomField;
 use craft\fields\Addresses as AddressesField;
 use craft\fields\Assets as AssetsField;
+use craft\fields\BaseRelationField;
 use craft\fields\Categories as CategoriesField;
 use craft\fields\Checkboxes;
 use craft\fields\Color;
@@ -1393,6 +1394,24 @@ class Fields extends Component
         $pagination = AdminTable::paginationLinks($page, $total, $limit);
 
         return [$pagination, $tableData];
+    }
+
+    /**
+     * Returns all available relational field type classes.
+     *
+     * @return string[] The available relational field type classes
+     * @phpstan-return class-string<FieldInterface>[]
+     */
+    public function getAllRelationalFieldTypes(): array
+    {
+        $relationalFields = [];
+        foreach ($this->getAllFieldTypes() as $fieldClass) {
+            if (is_subclass_of($fieldClass, BaseRelationField::class)) {
+                $relationalFields[] = $fieldClass;
+            }
+        }
+
+        return $relationalFields;
     }
 
     /**


### PR DESCRIPTION
### Description
A different approach to getting element types for the `RelatedToConditionRule`. Instead of relying on checking the element type, get all field types of `BaseRelationField`, get the element type for each of those, and allow that type to be used in the "related to" condition.


### Related issues
#15058 
