### PR TITLE
[WIP] Add extraOptions property to transforms

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1837,6 +1837,7 @@ JS,[
                 'quality',
                 'width',
                 'fill',
+                'extraOptions',
             ]) : [];
 
             if ($unit === 'w') {

--- a/src/helpers/ImageTransforms.php
+++ b/src/helpers/ImageTransforms.php
@@ -121,6 +121,7 @@ class ImageTransforms
                 'quality',
                 'interlace',
                 'transformer',
+                'extraOptions',
             ];
 
             $nullables = [
@@ -304,6 +305,7 @@ class ImageTransforms
                 'upscale',
                 'quality',
                 'interlace',
+                'extraOptions',
             ]);
         }
 

--- a/src/models/ImageTransform.php
+++ b/src/models/ImageTransform.php
@@ -107,6 +107,12 @@ class ImageTransform extends Model
     public ?bool $upscale = null;
 
     /**
+     * @var array|null Extra options
+     * @since 4.4.0
+     */
+    public ?array $extraOptions = null;
+
+    /**
      * @var string The image transformer to use.
      * @phpstan-var class-string<ImageTransformerInterface>
      */
@@ -318,6 +324,7 @@ class ImageTransform extends Model
             'quality' => $this->quality,
             'upscale' => $this->upscale ?? Craft::$app->getConfig()->getGeneral()->upscaleImages,
             'width' => $this->width,
+            'extraOptions' => $this->extraOptions,
         ];
     }
 }


### PR DESCRIPTION
### Description

This PR adds a new `extraOptions` property to `ImageTransforms`. 

### Why is this needed?

While creating a custom Imgix module I wanted to pass imgix parameters into the transform. To achieve this I added a new behaviour to the `ImageTransform`

```php
<?php

namespace Newism\Imgix\behaviors;

use yii\base\Behavior;

class ImageTransformBehavior extends Behavior
{
    public array $imgixParams = [];
}
```

I then added an `EVENT_BEFORE_GENERATE_TRANSFORM` event listener that created an Imgix url.

```php
Event::on(
            Asset::class,
            Asset::EVENT_BEFORE_GENERATE_TRANSFORM,
            function (GenerateTransformEvent $event) {

                /** @var Asset $asset */
                $asset = $event->asset;

                /** @var ImageTransform|ImageTransformBehavior $transform */
                $transform = $event->transform;

                // Pull the imgix params from the behaviour
                $imgixParams = $transform->imgixParams;

                // Do a bunch of stuff here to create the URL
                $url = '…'

                $event->url = $url;
            }
        );
```

This worked fine until I added `srcset` behaviour.

The current `Asset::getUrlsBySize()` normalises the current image transform, creates a new `ImageTransform` by copying the properties and generating the URL.

The issue form me was the `imgixParams` value defined by the custom behaviour was not passed to the new sizeTransforms.

### Solution

This PR adds a new `extraOptions` property to `ImageTransforms`.  This property is passed down to the `sizeTransforms` and therefore can be accessed in the `Asset::EVENT_BEFORE_GENERATE_TRANSFORM` event or anywhere else the transform is accessed.

### TODO

- [ ] Add `extraOptions` to the GraphQL code / implementation
- [ ] Add `extraOptions` to `ImageTransforms:createTransformFromString` and `ImageTransforms:parseTransformString` … I assume these are used in filenames, db columns… probably need to base64 the serialised array content.
