### PR TITLE
make EVENT_DEFINE_ADDITIONAL_BUTTONS work for User element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where some condition rules weren’t getting added when applying project config changes, if they depended on another component which hadn’t been added yet. ([#15037](https://github.com/craftcms/cms/issues/15037))
+- Fixed a bug where the `craft\base\Element::EVENT_DEFINE_ADDITIONAL_BUTTONS` event wasn’t being respected for user edit pages. ([#15095](https://github.com/craftcms/cms/issues/15095))
 
 ## 4.9.5 - 2024-05-22
 

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1035,6 +1035,11 @@ class UsersController extends Controller
             $title = Craft::t('app', 'Create a new user');
         }
 
+        // Trigger EVENT_DEFINE_ADDITIONAL_BUTTONS
+        // ---------------------------------------------------------------------
+
+        $additionalButtons = $user->getAdditionalButtons();
+
         // Prep the form tabs & content
         // ---------------------------------------------------------------------
 
@@ -1209,7 +1214,8 @@ JS,
             'showPhotoField',
             'showPermissionsTab',
             'canAssignUserGroups',
-            'fieldsHtml'
+            'fieldsHtml',
+            'additionalButtons',
         ));
     }
 


### PR DESCRIPTION
### Description
Trigger `Element::EVENT_DEFINE_ADDITIONAL_BUTTONS` for the `User` element for v4. (It already works as expected on v5.)

Before:
<img width="1214" alt="Screenshot 2024-05-29 at 16 10 23" src="https://github.com/craftcms/cms/assets/4500340/91d6e1b7-9542-4021-92f9-da5620c8a43c">

After:
<img width="1219" alt="Screenshot 2024-05-29 at 16 10 07" src="https://github.com/craftcms/cms/assets/4500340/558cc1d3-1260-4d92-b0a9-b1bde22ca5bb">

### Related issues
#15095 
