### PR TITLE
Remove transaction from ProjectConfig::removeInternalConfigValuesByPaths

### DIFF
--- a/src/services/ProjectConfig.php
+++ b/src/services/ProjectConfig.php
@@ -886,14 +886,11 @@ class ProjectConfig extends Component
     protected function removeInternalConfigValuesByPaths(array $paths): void
     {
         $chunks = array_chunk($paths, 1000);
-        $db = Craft::$app->getDb();
-        $db->transaction(function() use ($chunks, $db) {
-            foreach ($chunks as $chunk) {
-                Db::delete(Table::PROJECTCONFIG, [
-                    'path' => $chunk,
-                ], db: $db);
-            }
-        });
+        foreach ($chunks as $chunk) {
+            Db::delete(Table::PROJECTCONFIG, [
+                'path' => $chunk,
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
`ProjectConfig::removeInternalConfigValuesByPaths` is already always being called from within a transaction:

https://github.com/craftcms/cms/blob/5.x/src/services/ProjectConfig.php#L798-L804
https://github.com/craftcms/cms/blob/5.x/src/services/ProjectConfig.php#L855-L856

Fixes https://github.com/craftcms/cms/issues/14977#issuecomment-2141806757