### PR TITLE
delete global set without layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed a bug where field conditions weren’t working reliably for nested entries within Matrix fields set to the inline-editable blocks view mode. ([#15104](https://github.com/craftcms/cms/issues/15104))
 - Fixed a bug where the `serve` command could hang. ([#14977](https://github.com/craftcms/cms/issues/14977))
 - Fixed a bug where nested entry edit pages would always redirect to the Entries index, even if they were nested under a different element type. ([#15101](https://github.com/craftcms/cms/issues/15101))
+- Fixed an error that occurred when attempting to delete a global set without a field layout. ([#15123](https://github.com/craftcms/cms/issues/15123))
 
 ## 5.1.7 - 2024-05-25
 

--- a/src/services/Globals.php
+++ b/src/services/Globals.php
@@ -506,13 +506,15 @@ class Globals extends Component
                 ->where(['id' => $globalSetRecord->id])
                 ->scalar();
 
-            $fieldLayout = Craft::$app->getFields()->getLayoutById($fieldLayoutId);
-
             Craft::$app->getElements()->deleteElementById($globalSetRecord->id);
 
-            // Delete the field layout after the element has been deleted
-            if ($fieldLayout) {
-                Craft::$app->getFields()->deleteLayout($fieldLayout);
+            if ($fieldLayoutId) {
+                $fieldLayout = Craft::$app->getFields()->getLayoutById($fieldLayoutId);
+
+                // Delete the field layout after the element has been deleted
+                if ($fieldLayout) {
+                    Craft::$app->getFields()->deleteLayout($fieldLayout);
+                }
             }
 
             $transaction->commit();


### PR DESCRIPTION
### Description
Fixes an error that could occur if deleting a global set that doesn’t have a layout.


### Related issues
#15123 
