### PR TITLE
apply draft - element can be a response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed an error that could occur when creating an entry via a slideout, if the slideout was submitted before the entry was autosaved. ([#15134](https://github.com/craftcms/cms/pull/15134))
+
 ## 5.1.8 - 2024-06-03
 
 - Added `craft\helpers\Gql::isIntrospectionQuery()`.

--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -1634,8 +1634,13 @@ JS, [
         $this->requirePostRequest();
         $elementsService = Craft::$app->getElements();
 
-        /** @var Element|DraftBehavior|null $element */
+        /** @var Element|DraftBehavior|Response|null $element */
         $element = $this->_element();
+
+        // this can happen if creating element via slideout, and we hit "create entry" before the autosave kicks in
+        if ($element instanceof Response) {
+            return $element;
+        }
 
         if (!$element || !$element->getIsDraft()) {
             throw new BadRequestHttpException('No draft was identified by the request.');


### PR DESCRIPTION
### Description
Fixes an error that can occur when creating an element via a slideout, and the “Create {type}” button is activated before the autosave kicks in.


### Related issues
n/a
