### PR TITLE
use essentials scenario when inline editing unpublished drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where the `db/backup` command could fail on Windows. ([#15090](https://github.com/craftcms/cms/issues/15090))
 - Fixed an error that could occur when creating an entry via a slideout, if the slideout was submitted before the entry was autosaved. ([#15134](https://github.com/craftcms/cms/pull/15134))
 - Fixed a bug where upgrading from Craft CMS 4.4 was allowed even though the migrations assumed 4.5 or later was installed. ([#15133](https://github.com/craftcms/cms/issues/15133))
+- Fixed an error that occurred when bulk inline editing an unpublished draft. ([#15138](https://github.com/craftcms/cms/issues/15138))
 
 ## 5.1.8 - 2024-06-03
 

--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -559,7 +559,9 @@ class ElementIndexesController extends BaseElementsController
 
             $element->setFieldValuesFromRequest("$namespace.element-$element->id.fields");
 
-            if ($element->enabled && $element->getEnabledForSite()) {
+            if ($element->getIsUnpublishedDraft()) {
+                $element->setScenario(Element::SCENARIO_ESSENTIALS);
+            } elseif ($element->enabled && $element->getEnabledForSite()) {
                 $element->setScenario(Element::SCENARIO_LIVE);
             }
 


### PR DESCRIPTION
### Description
When inline editing unpublished draft, use `Element::SCENARIO_ESSENTIALS` when saving such element.


### Related issues
#15138 
