### PR TITLE
Swap single quotes for double, for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where the `db/backup` command could fail on Windows. ([#15090](https://github.com/craftcms/cms/issues/15090))
+
 ## 4.9.6 - 2024-06-03
 
 - Added `craft\helpers\Gql::isIntrospectionQuery()`.

--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -204,7 +204,11 @@ class Schema extends \yii\db\mysql\Schema
             $dataDump = $commandFromConfig($dataDump);
         }
 
-        return "{$schemaDump->getExecCommand()} && {$dataDump->getExecCommand()} >> '{file}'";
+        return sprintf(
+            '%s && %s >> "{file}"',
+            $schemaDump->getExecCommand(),
+            $dataDump->getExecCommand(),
+        );
     }
 
     /**


### PR DESCRIPTION
### Description
Use double quotes for the output file of `db/backup`, to make Windows happy.

### Related issues
Fixes https://github.com/craftcms/cms/issues/15090
