### PR TITLE
`ElementQuery::_loopInCustomFields()` adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed an error that could occur when executing an element query with a custom field param. ([#15147](https://github.com/craftcms/cms/issues/15147))
+
 ## 5.2.0-beta.2 - 2024-06-04
 
 - Element indexes will now show a confirmation dialog when cancelling a bulk inline edit. ([#15139](https://github.com/craftcms/cms/issues/15139), [#15142](https://github.com/craftcms/cms/pull/15142))

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -2570,7 +2570,7 @@ class ElementQuery extends Query implements ElementQueryInterface
             /** @var FieldInterface[][][] $fieldsByHandle */
             $fieldsByHandle = [];
             foreach ($this->customFields as $field) {
-                $fieldsByHandle[$field->handle][$field->uid] = $field;
+                $fieldsByHandle[$field->handle][$field->uid][] = $field;
             }
 
             foreach ($fieldsByHandle as $handle => $instancesByUid) {


### PR DESCRIPTION
### Description
Following a change to `ElementQuery::_loopInCustomFields()` to avoid the use of `ArrayHelper::index()`, the content of `$fieldsByHandle[$field->handle][$field->uid]` should continue to be an array of fields.


### Related issues
#15147 
