### PR TITLE
Don't catch exceptions when a non-existent template is extended

### DIFF
--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -908,7 +908,10 @@ class ElementHelper
             $variables[$refHandle] = $element;
             try {
                 $output[] = $view->renderTemplate($template, $variables, View::TEMPLATE_MODE_SITE);
-            } catch (TwigLoaderError) {
+            } catch (TwigLoaderError $error) {
+                if ($error->getSourceContext() !== null) {
+                    throw $error;
+                }
                 // fallback to the string representation of the element
                 $output[] = Html::tag('p', Html::encode((string)$element));
             }


### PR DESCRIPTION
Throws full exception views instead of silently discarding the error, if the element partial exists, but extends a non-existant template.

### Description

We can distinguish between an error thrown because the element partial template doesn't exist or because the template being extended doesn't exist by checking `$error->getSourceContext()`. There is always a source context if the error comes from the template being rendered, but there is _no_ source context when the template being rendered doesn't exist.

### Related issues

#15176