### PR TITLE
Update French translation

### DIFF
--- a/src/translations/fr/app.php
+++ b/src/translations/fr/app.php
@@ -880,7 +880,7 @@ return [
     'List all tabs' => 'Répertorier tous les onglets',
     'List empty folders' => 'Répertorier les dossiers vides',
     'List' => 'Liste',
-    'Live' => 'En direct',
+    'Live' => 'Activé',
     'Load this template' => 'Charger ce template',
     'Loaded Project Config Data' => 'Configuration du projet chargée',
     'Loading Plugin Store…' => 'Chargement de la boutique de plugins…',


### PR DESCRIPTION
Change the "Live" status translation to match the "Enabled" switch translation.

### Description
The "status“ mention "Live"  is translated in French by "En direct", which means something like "On air". Not very clear.
I think this mention should be the same as the "Enabled" switch label, considering that this switch determines the status of an entry.
So I suggest translating the "Live" mention by "Activé" which is the same mention for the entry switch. 


### Related issues

