### PR TITLE
Correct GraphQL CLI Prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `craft\web\View::getModifiedDeltaNames()`.
 - `craft\web\View::registerDeltaName()` now has a `$forceModified` argument.
 - Fixed a bug where changed field values could be forgotten within Matrix fields, if a validation error occurred. ([#15190](https://github.com/craftcms/cms/issues/15190))
+- Fixed a bug where the `graphql/create-token` command was prompting for the schema name, when it meant the token name. ([#15205](https://github.com/craftcms/cms/pull/15205))
 
 ## 4.10.0 - 2024-06-12
 

--- a/src/console/controllers/GraphqlController.php
+++ b/src/console/controllers/GraphqlController.php
@@ -174,7 +174,7 @@ class GraphqlController extends Controller
 
         $token = new GqlToken();
         $token->schemaId = $schema->id;
-        $token->name = $this->name ?? $this->prompt('Schema name:', [
+        $token->name = $this->name ?? $this->prompt('Token name:', [
                 'required' => true,
             ]);
         $token->accessToken = Craft::$app->getSecurity()->generateRandomString(32);


### PR DESCRIPTION
The `graphql/create-token` action prompts the user for a "Schema name", but it’s actually asking for a name for the new token! 😅