### PR TITLE
retain structure data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed a bug where it wasn’t possible to query for authors via GraphQL on the Team edition. ([#15187](https://github.com/craftcms/cms/issues/15187))
 - Fixed a bug where it wasn’t possible to close elevated session modals. ([#15202](https://github.com/craftcms/cms/issues/15202))
 - Fixed a bug where element chips and cards were displaying provisional draft data even if the current user didn’t create the draft. ([#15208](https://github.com/craftcms/cms/issues/15208))
+- Fixed a bug where element indexes weren’t displaying structured elements correctly if they had a provisional draft. ([#15214](https://github.com/craftcms/cms/issues/15214))
 
 ## 5.2.0 - 2024-06-12
 

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -982,8 +982,10 @@ class ElementHelper
         foreach ($canonicalElements as $i => $element) {
             if (isset($drafts[$element->id])) {
                 $draft = $drafts[$element->id];
+
                 // retain canonical element structure data => ['root', 'lft', 'rgt', 'level']
                 if ($element->structureId !== null) {
+                    $draft->structureId = $element->structureId;
                     $draft->root = $element->root;
                     $draft->lft = $element->lft;
                     $draft->rgt = $element->rgt;

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -981,7 +981,16 @@ class ElementHelper
         // array_filter() preserves keys, so it's safe to loop through it rather than $elements here
         foreach ($canonicalElements as $i => $element) {
             if (isset($drafts[$element->id])) {
-                $elements[$i] = $drafts[$element->id];
+                $draft = $drafts[$element->id];
+                // retain canonical element structure data => ['root', 'lft', 'rgt', 'level']
+                if ($element->structureId !== null) {
+                    $draft->root = $element->root;
+                    $draft->lft = $element->lft;
+                    $draft->rgt = $element->rgt;
+                    $draft->level = $element->level;
+                }
+
+                $elements[$i] = $draft;
             }
         }
     }


### PR DESCRIPTION
### Description
Provisional drafts don’t have structure information. When swapping in provisional drafts on the element index pages, ensure that the structure data from the canonical element is retained. 

(I am submitting this as a draft as there are a couple of other related things I’d like to discuss first.)


### Related issues
#15214 
