### PR TITLE
Actions: Remove Duplicate Setup Step

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -43,14 +43,6 @@ jobs:
           php-version: 8.2.0
           tools: composer:v2
 
-      - name: 'Set up PHP for Craft 5'
-        uses: shivammathur/setup-php@2.23.0
-        if: ${{ startsWith(github.event.client_payload.version, '5.') }}
-        with:
-          extensions: bcmath, curl, dom, json, intl, mbstring, mcrypt, openssl, pcre, pdo, zip
-          php-version: 8.2.0
-          tools: composer:v2
-
       - name: 'Initialize Craft 3 starter project'
         if: ${{ startsWith(github.event.client_payload.version, '3.') }}
         run: 'composer create-project craftcms/craft:^3 ${{ env.PROJECT_DIRECTORY }}'


### PR DESCRIPTION
[Recent release actions](https://github.com/craftcms/cms/actions/runs/9554109228/job/26334447693) have been creating two "Set up PHP for Craft 5" steps.

As best I can tell, these are exact duplicates of one another—maybe something left over from testing 5.x prereleases?

https://github.com/craftcms/cms/blame/9beea769b1dfa4c9c4bff38f7af5da9f4e96cbe9/.github/workflows/create-release.yml#L38-L53