### PR TITLE
queryScalar - check subquery before changing params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `Garnish.muteResizeEvents()`.
 - Fixed a JavaScript performance degradation bug. ([#14510](https://github.com/craftcms/cms/issues/14510))
+- Fixed a bug where scalar element queries weren’t working if `distinct`, `groupBy`, `having,` or `union` params were set on them during query preparation. ([#15001](https://github.com/craftcms/cms/issues/15001))
 
 ## 4.10.1 - 2024-06-17
 

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1878,10 +1878,21 @@ class ElementQuery extends Query implements ElementQueryInterface
 
             try {
                 $subquery = $this->prepareSubquery();
-                $subquery->select = [$selectExpression];
-                $subquery->orderBy = null;
-                $subquery->limit = null;
-                $subquery->offset = null;
+
+                // we can only do this if the subquery doesn't have distinct, groupBy, having or union
+                // see https://github.com/craftcms/cms/issues/15001#issuecomment-2174563927
+                if (
+                    !$subquery->distinct
+                    && empty($subquery->groupBy)
+                    && empty($subquery->having)
+                    && empty($subquery->union)
+                ) {
+                    $subquery->select = [$selectExpression];
+                    $subquery->orderBy = null;
+                    $subquery->limit = null;
+                    $subquery->offset = null;
+                }
+
                 $command = $subquery->createCommand($db);
             } catch (QueryAbortedException) {
                 return false;

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -1879,7 +1879,7 @@ class ElementQuery extends Query implements ElementQueryInterface
             try {
                 $subquery = $this->prepareSubquery();
 
-                // we can only do this if the subquery doesn't have distinct, groupBy, having or union
+                // If distinct, et al. were set by prepare(), don't mess with it
                 // see https://github.com/craftcms/cms/issues/15001#issuecomment-2174563927
                 if (
                     !$subquery->distinct
@@ -1891,9 +1891,8 @@ class ElementQuery extends Query implements ElementQueryInterface
                     $subquery->orderBy = null;
                     $subquery->limit = null;
                     $subquery->offset = null;
+                    return $subquery->createCommand($db)->queryScalar();
                 }
-
-                $command = $subquery->createCommand($db);
             } catch (QueryAbortedException) {
                 return false;
             } finally {
@@ -1902,8 +1901,6 @@ class ElementQuery extends Query implements ElementQueryInterface
                 $this->limit = $limit;
                 $this->offset = $offset;
             }
-
-            return $command->queryScalar();
         }
 
         return parent::queryScalar($selectExpression, $db);


### PR DESCRIPTION
### Description
When running a query through our version of `queryScalar`, check if the subquery doesn’t have `distinct`, `groupBy`, `having` or `union` and only overwrite its `select`, `orderBy`, `limit`, and `offset` params if it doesn’t.


### Related issues
#15001
