### PR TITLE
mysql - when casting to decimals ensure sufficient scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## Unreleased
 
 - Added `craft\base\conditions\BaseNumberConditionRule::$step`.
+- Added `craft\helpers\Db::parseColumnPrecisionAndScale()`.
 - Added `Garnish.muteResizeEvents()`.
 - Fixed a JavaScript performance degradation bug. ([#14510](https://github.com/craftcms/cms/issues/14510))
 - Fixed a bug where scalar element queries weren’t working if `distinct`, `groupBy`, `having,` or `union` params were set on them during query preparation. ([#15001](https://github.com/craftcms/cms/issues/15001))
 - Fixed a bug where Edit Asset screens would warn about losing unsaved changes when navigating away, if the file was replaced but nothing else had changed.
 - Fixed a bug where Edit Asset screens would show a notification with a “Reload” button after the file was replaced.
 - Fixed a bug where Number fields’ condition rules weren’t allowing decimal values. ([#15222](https://github.com/craftcms/cms/issues/15222))
+- Fixed a bug where Number field element query params didn’t respect decimal values. ([#15222](https://github.com/craftcms/cms/issues/15222))
 - Fixed a bug where asset thumbnails weren’t getting updated after using the “Replace file” action. ([#15217](https://github.com/craftcms/cms/issues/15217))
 
 ## 5.2.1 - 2024-06-17

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -861,6 +861,20 @@ abstract class Field extends SavableComponent implements FieldInterface
                 if ($length = Db::parseColumnLength($dbType)) {
                     $castType = preg_replace('/\(\d+\)/', "($length)", $castType);
                 }
+
+                // if length attributes were specified, replace the defaults with that
+                if ($lengthAttributes = Db::parseColumnLengthAttributes($dbType)) {
+                    if (count($lengthAttributes) === 2) {
+                        $lengthAttributes = implode(',',$lengthAttributes);
+                        $castType = preg_replace('/\(\d+,\d+\)/', "($lengthAttributes)", $castType);
+                    }
+                }
+
+                // finally, check for any cast precision overrides
+                if (method_exists($this, 'castPrecision')) {
+                    $castType = $this->castPrecision($castType);
+                }
+
                 $sql = "CAST($sql AS $castType)";
             }
         }

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -862,14 +862,6 @@ abstract class Field extends SavableComponent implements FieldInterface
                     $castType = preg_replace('/\(\d+\)/', "($length)", $castType);
                 }
 
-                // if length attributes were specified, replace the defaults with that
-                if ($lengthAttributes = Db::parseColumnLengthAttributes($dbType)) {
-                    if (count($lengthAttributes) === 2) {
-                        $lengthAttributes = implode(',',$lengthAttributes);
-                        $castType = preg_replace('/\(\d+,\d+\)/', "($lengthAttributes)", $castType);
-                    }
-                }
-
                 // finally, check for any cast precision overrides
                 if (method_exists($this, 'castPrecision')) {
                     $castType = $this->castPrecision($castType);

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -858,13 +858,14 @@ abstract class Field extends SavableComponent implements FieldInterface
             };
             if ($castType !== null) {
                 // if a length was specified, replace the default with that
-                if ($length = Db::parseColumnLength($dbType)) {
+                $length = Db::parseColumnLength($dbType);
+                if ($length) {
                     $castType = preg_replace('/\(\d+\)/', "($length)", $castType);
-                }
-
-                // finally, check for any cast precision overrides
-                if (method_exists($this, 'castPrecision')) {
-                    $castType = $this->castPrecision($castType);
+                } elseif ($castType === 'DECIMAL') {
+                    [$precision, $scale] = Db::parseColumnPrecisionAndScale($dbType) ?? [null, null];
+                    if ($precision && $scale) {
+                        $castType .= "($precision,$scale)";
+                    }
                 }
 
                 $sql = "CAST($sql AS $castType)";

--- a/src/fields/Number.php
+++ b/src/fields/Number.php
@@ -191,6 +191,28 @@ class Number extends Field implements InlineEditableFieldInterface, SortableFiel
     }
 
     /**
+     * Set the precision to max allowed (65).
+     * Set the scale to the number of decimal points specified for this field.
+     *
+     * @param string $castType
+     * @return string
+     */
+    protected function castPrecision(string $castType): string
+    {
+        $db = Craft::$app->getDb();
+
+        if ($db->getIsPgsql()) {
+            return $castType;
+        }
+
+        if ($this->decimals > 0) {
+            return sprintf('%s(65,%s)', $castType, min($this->decimals, 30));
+        }
+
+        return $castType;
+    }
+
+    /**
      * @inheritdoc
      */
     public function normalizeValue(mixed $value, ?ElementInterface $element): mixed

--- a/src/fields/Number.php
+++ b/src/fields/Number.php
@@ -72,7 +72,8 @@ class Number extends Field implements InlineEditableFieldInterface, SortableFiel
      */
     public static function dbType(): string
     {
-        return Schema::TYPE_DECIMAL;
+        $db = Craft::$app->getDb();
+        return $db->getIsMysql() ? sprintf('%s(65,16)', Schema::TYPE_DECIMAL) : Schema::TYPE_DECIMAL;
     }
 
     /**
@@ -188,28 +189,6 @@ class Number extends Field implements InlineEditableFieldInterface, SortableFiel
             [
                 'field' => $this,
             ]);
-    }
-
-    /**
-     * Set the precision to max allowed (65).
-     * Set the scale to the number of decimal points specified for this field.
-     *
-     * @param string $castType
-     * @return string
-     */
-    protected function castPrecision(string $castType): string
-    {
-        $db = Craft::$app->getDb();
-
-        if ($db->getIsPgsql()) {
-            return $castType;
-        }
-
-        if ($this->decimals > 0) {
-            return sprintf('%s(65,%s)', $castType, min($this->decimals, 30));
-        }
-
-        return $castType;
     }
 
     /**

--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -395,22 +395,6 @@ class Db
     }
 
     /**
-     * Parses a column type definition and returns just the column length attributes.
-     * To be used in cases where there more than one length/size attribute is used, e.g. decimals(10,5)
-     *
-     * @param string $columnType
-     * @return array|null
-     */
-    public static function parseColumnLengthAttributes(string $columnType): ?array
-    {
-        if (!preg_match('/^\w+\((\d+),(\d+)\)/', $columnType, $matches)) {
-            return null;
-        }
-
-        return [(int)$matches[1], (int)$matches[2]];
-    }
-
-    /**
      * Returns a simplified version of a given column type.
      *
      * @param string $columnType

--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -395,6 +395,22 @@ class Db
     }
 
     /**
+     * Parses a column type definition and returns just the column length attributes.
+     * To be used in cases where there more than one length/size attribute is used, e.g. decimals(10,5)
+     *
+     * @param string $columnType
+     * @return array|null
+     */
+    public static function parseColumnLengthAttributes(string $columnType): ?array
+    {
+        if (!preg_match('/^\w+\((\d+),(\d+)\)/', $columnType, $matches)) {
+            return null;
+        }
+
+        return [(int)$matches[1], (int)$matches[2]];
+    }
+
+    /**
      * Returns a simplified version of a given column type.
      *
      * @param string $columnType

--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -395,6 +395,22 @@ class Db
     }
 
     /**
+     * Parses a decimal column type definition and returns just the column precision and scale.
+     *
+     * @param string $columnType
+     * @return array{0:int,1:int}|null
+     * @since 5.2.2
+     */
+    public static function parseColumnPrecisionAndScale(string $columnType): ?array
+    {
+        if (!preg_match('/^\w+\((\d+),\s*(\d+)\)/', $columnType, $matches)) {
+            return null;
+        }
+
+        return [(int)$matches[1], (int)$matches[2]];
+    }
+
+    /**
      * Returns a simplified version of a given column type.
      *
      * @param string $columnType


### PR DESCRIPTION
### Description
In MySQL, when casting the value to decimals, we need to ensure it has sufficient scale.

If the Number type field specifies Decimal Points and that value is greater than zero, adjust the cast function to use the highest precision (65) and the exact scale as specified under Decimal Points (ensuring it doesn’t exceed 30, as that’s the allowed max).

Note: The Money type field doesn’t look to be affected as it uses 4 decimals at most.


### Related issues
#15222 
