### PR TITLE
Bugfix/assets urls and preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Previewing PDF/video assets without public URLs now displays a “Preview not supported.” message. ([#15235](https://github.com/craftcms/cms/pull/15235))
+- Fixed a bug where Edit Asset pages showed a “View” button for assets without URLs. ([#15235](https://github.com/craftcms/cms/pull/15235))
+- Fixed a bug where asset indexes attempted to link to assets without URLs. ([#15235](https://github.com/craftcms/cms/pull/15235))
+
 ## 4.10.2 - 2024-06-18
 
 - Added `craft\base\conditions\BaseNumberConditionRule::$step`.

--- a/src/assetpreviews/Pdf.php
+++ b/src/assetpreviews/Pdf.php
@@ -26,7 +26,7 @@ class Pdf extends AssetPreviewHandler
     {
         $url = $this->asset->getUrl();
 
-        if ($url === null) {
+        if ($url === null || !$this->asset->getVolume()->getFs()->hasUrls) {
             throw new NotSupportedException('Preview not supported.');
         }
 

--- a/src/assetpreviews/Video.php
+++ b/src/assetpreviews/Video.php
@@ -26,7 +26,7 @@ class Video extends AssetPreviewHandler
     {
         $url = $this->asset->getUrl();
 
-        if ($url === null) {
+        if ($url === null || !$this->asset->getVolume()->getFs()->hasUrls) {
             throw new NotSupportedException('Preview not supported.');
         }
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1437,7 +1437,7 @@ class Asset extends Element
 
         $html = Html::beginTag('div', ['class' => 'btngroup']);
 
-        if (($url = $this->getUrl()) !== null) {
+        if ($volume->getFs()->hasUrls && ($url = $this->getUrl()) !== null) {
             $html .= Html::a(Craft::t('app', 'View'), $url, [
                 'class' => 'btn',
                 'target' => '_blank',
@@ -2521,6 +2521,11 @@ JS;
 
             case 'location':
                 return $this->locationHtml();
+
+            case 'link':
+                if (!$this->getVolume()->getFs()->hasUrls) {
+                    return '';
+                }
         }
 
         return parent::tableAttributeHtml($attribute);


### PR DESCRIPTION
### Description
When an asset belongs to a filesystem that doesn’t have public URLs:
- don’t show the “View” button on the asset edit page
- don’t show the globe icon on the assets index page
- when attempting to preview a PDF or Video, show “Preview not supported.” instead of showing the asset index page in the iframe (for PDFs) or mime type not supported message (for videos)

Note: this works as expected in v5 already.

### Related issues
n/a
