### PR TITLE
ensure the correct status label is shown crumbs

### DIFF
--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -615,6 +615,7 @@ class ElementsController extends Controller
 
     private function _crumbs(ElementInterface $element, bool $current = true): array
     {
+        $isProvisionalDraft = $element->isProvisionalDraft;
         if ($element->isProvisionalDraft) {
             $element = $element->getCanonical(true);
         }
@@ -622,7 +623,10 @@ class ElementsController extends Controller
         return [
             ...$element->getCrumbs(),
             [
-                'html' => Cp::elementChipHtml($element, ['showDraftName' => !$current]),
+                'html' => Cp::elementChipHtml($element, [
+                    'showDraftName' => !$current,
+                    'isProvisionalDraft' => $isProvisionalDraft,
+                ]),
                 'current' => $current,
             ],
         ];

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -489,8 +489,11 @@ class Cp
                 fn() => $element->getChipLabelHtml(),
             );
 
-            if ($element->isProvisionalDraft) {
+            // $config['isProvisionalDraft'] is used by the crumbs
+            // see https://github.com/craftcms/cms/issues/15244
+            if ($element->isProvisionalDraft || (isset($config['isProvisionalDraft']) && $config['isProvisionalDraft'])) {
                 $config['labelHtml'] .= self::changeStatusLabelHtml();
+                unset($config['isProvisionalDraft']);
             }
         }
 


### PR DESCRIPTION
### Description
Ensure that the “Edited” indicator shows in the crumbs after reloading a provisional draft.


### Related issues
#15244 
