### PR TITLE
Fix db transactions for Codeception Tests

### DIFF
--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -164,6 +164,9 @@ class Craft extends Yii2
 
         parent::_before($test);
 
+        // transaction events are registered now, so it's ok to open the connection
+        \Craft::$app->db->open();
+
         // If full mock, create the mock app and don't perform to any further actions
         if ($this->_getConfig('fullMock') === true) {
             /** @var ConsoleApplication|WebApplication|MockObject $mockApp */

--- a/src/test/CraftConnector.php
+++ b/src/test/CraftConnector.php
@@ -125,4 +125,20 @@ class CraftConnector extends Yii2
         Db::reset();
         Session::reset();
     }
+
+    /**
+     * Closes the db connection after initializing Craft. The Yii2 module will
+     * try to initialize transaction listeners before each test. If we don't
+     * close the connection first, those listeners will never get picked up.
+     * We'll open the connection after all of the transaction listeners are
+     * registered.
+     *
+     * @inheritDoc
+     */
+    public function startApp(\yii\log\Logger $logger = null)
+    {
+        parent::startApp($logger);
+
+        \Craft::$app->db->close();
+    }
 }


### PR DESCRIPTION
 ### Description
Transactions not working in Codeception tests in Craft seems to be a long running issue. The problem stems from when Yii registers transaction listeners. Before each test, the Codeception Craft module sets up the Craft application. At that point, the initial PDO connection is made and cached in the `Connection` class. After the application is booted up, Yii then tries to register listeners on the `Connection::EVENT_AFTER_OPEN` event. The problem with that though is since Craft already opened a connection when being setup, those events are never fired. 

This pull request aims to fix that by first closing the connection immediately after Craft is setup. Then before each test, open the connection again after Yii registers it's transaction handlers. 

I tested this on a base craft 5 install using ddev and it works exactly as expected. I created a test that saved a user in the database. Before this change, my user persisted in the users table after tests were run. With this change, the user is not there after tests run. 

### Related issues
#7615 
