### PR TITLE
Bugfix/15256 inline matrix in matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed a bug where element indexes could display “Nothing yet” at the bottom of populated table views. ([#15241](https://github.com/craftcms/cms/issues/15241))
 - Fixed a bug where element edit pages initially showed the canonical element’s chip in the crumb bar, for provisional drafts. ([#15244](https://github.com/craftcms/cms/issues/15244))
 - Fixed an error that occurred when opening an element’s editor slideout via its “Edit” action menu item, if the element had provisional changes. ([#15248](https://github.com/craftcms/cms/pull/15248))
+- Fixed a bug where recursively-nested Matrix entries could be lost if multiple of them were edited, and not immediately saved. ([#15256](https://github.com/craftcms/cms/issues/15256))
 
 ## 5.2.3 - 2024-06-20
 

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -746,7 +746,8 @@ JS, [
                         $element->getPrimaryOwnerId() === $owner->id &&
                         $element->getIsDraft() &&
                         !$element->getIsUnpublishedDraft() &&
-                        ($owner->getIsDraft() || !$owner->isCanonical) &&
+                        // $owner could be a draft or a non-canonical Matrix entry, etc.
+                        (!$owner->getIsCanonical()) &&
                         !$owner->getIsUnpublishedDraft()
                     ) {
                         /** @var NestedElementInterface $canonical */

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -746,7 +746,7 @@ JS, [
                         $element->getPrimaryOwnerId() === $owner->id &&
                         $element->getIsDraft() &&
                         !$element->getIsUnpublishedDraft() &&
-                        $owner->getIsDraft() &&
+                        ($owner->getIsDraft() || !$owner->isCanonical) &&
                         !$owner->getIsUnpublishedDraft()
                     ) {
                         /** @var NestedElementInterface $canonical */

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1442,7 +1442,14 @@ JS;
                 $forceSave = !empty($entryData);
 
                 // Is this a derivative element, and does the entry primarily belong to the canonical?
-                if ($forceSave && $element->getIsDerivative() && $entry->getPrimaryOwnerId() === $element->getCanonicalId()) {
+                if (
+                    $forceSave &&
+                    $element->getIsDerivative() &&
+                    $entry->getPrimaryOwnerId() === $element->getCanonicalId() &&
+                    // this is so that extra drafts don't get created for matrix in matrix scenario
+                    // where both are set to inline-editable blocks view mode
+                    Craft::$app->getRequest()->actionSegments !== ['elements', 'update-field-layout']
+                ) {
                     // Duplicate it as a draft. (We'll drop its draft status from NestedElementManager::saveNestedElements().)
                     $entry = Craft::$app->getDrafts()->createDraft($entry, Craft::$app->getUser()->getId(), null, null, [
                         'canonicalId' => $entry->id,


### PR DESCRIPTION
### Description
Issue 1:
With a matrix in a matrix setup, where both are set to inline-editable blocks view mode, once the owner matrix entry is not canonical, the checks inside `NestedElementManager::saveNestedElements()` don’t recognise all entries that should have their draft data dropped.

Fixed by checking if the owner is canonical, too.

Issue 2:
With a matrix in a matrix setup, where both are set to inline-editable blocks view mode, we shouldn’t duplicate entries as a draft when updating the field layout.


### Related issues
#15256 
