### PR TITLE
Ensure response is not cached when generating a CSRF token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Craft now sends no-cache headers for any request that generates a CSRF token. ([#15281](https://github.com/craftcms/cms/pull/15281), [verbb/formie#1963](https://github.com/verbb/formie/issues/1963))
 - Fixed a JavaScript error that occurred when creating a new custom element source, preventing the Default Sort and Default Table Columns fields from showing up.
 - Fixed a bug where the control panel was getting asynchronous CSRF inputs if the `asyncCsrfInputs` config setting was enabled.
 - Fixed a bug where Craft’s Twig implementation wasn’t respecting sandboxing rules for object properties. ([#15278](https://github.com/craftcms/cms/issues/15278))

--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -1391,6 +1391,9 @@ class Request extends \yii\web\Request
      */
     protected function generateCsrfToken(): string
     {
+        // Ensure the response is not cached by the browser or static cache proxies.
+        Craft::$app->getResponse()->setNoCacheHeaders();
+
         $existingToken = $this->loadCsrfToken();
 
         // They have an existing CSRF token.


### PR DESCRIPTION
### Description
Prevents accidental caching when generating CSRF. Technically we could now remove [this explicit call](https://github.com/craftcms/cms/blob/4.x/src/helpers/Html.php#L104) to `setNoCacheHeaders`, but I left it for now.


### Related issues
- https://github.com/verbb/formie/issues/1963
