### PR TITLE
disallow more actions for asset folders

### DIFF
--- a/src/elements/actions/CopyReferenceTag.php
+++ b/src/elements/actions/CopyReferenceTag.php
@@ -46,6 +46,13 @@ class CopyReferenceTag extends ElementAction
     new Craft.ElementActionTrigger({
         type: $type,
         bulk: false,
+        validateSelection: (selectedItems, elementIndex) => {
+          if (Garnish.hasAttr(selectedItems.find('.element'), 'data-is-folder')) {
+            return false;
+          }
+          
+          return true;
+        },
         activate: (selectedItems, elementIndex) => {
             Craft.ui.createCopyTextPrompt({
                 label: Craft.t('app', 'Copy the reference tag'),

--- a/src/elements/actions/DownloadAssetFile.php
+++ b/src/elements/actions/DownloadAssetFile.php
@@ -35,6 +35,16 @@ class DownloadAssetFile extends ElementAction
 (() => {
     new Craft.ElementActionTrigger({
         type: $type,
+        validateSelection: (selectedItems, elementIndex) => {
+          for (let i = 0; i < selectedItems.length; i++) {
+            const element = selectedItems.eq(i).find('.element');
+            if (Garnish.hasAttr(element, 'data-is-folder')) {
+              return false;
+            }
+          }
+          
+          return true;
+        },
         activate: (selectedItems, elementIndex) => {
             var \$form = Craft.createForm().appendTo(Garnish.\$bod);
             $(Craft.getCsrfInput()).appendTo(\$form);

--- a/src/elements/actions/PreviewAsset.php
+++ b/src/elements/actions/PreviewAsset.php
@@ -51,7 +51,13 @@ class PreviewAsset extends ElementAction
     new Craft.ElementActionTrigger({
         type: $type,
         bulk: false,
-        validateSelection: (selectedItems, elementIndex) => selectedItems.length === 1,
+        validateSelection: (selectedItems, elementIndex) => {
+          if (Garnish.hasAttr(selectedItems.find('.element'), 'data-is-folder')) {
+            return false;
+          }
+          
+          return true;
+        },
         activate: (selectedItems, elementIndex) => {
             const \$element = selectedItems.find('.element');
             const settings = {};

--- a/src/elements/actions/RenameFile.php
+++ b/src/elements/actions/RenameFile.php
@@ -37,7 +37,10 @@ class RenameFile extends ElementAction
     new Craft.ElementActionTrigger({
         type: $type,
         bulk: false,
-        validateSelection: (selectedItems, elementIndex) => Garnish.hasAttr(selectedItems.find('.element'), 'data-movable'),
+        validateSelection: (selectedItems, elementIndex) => {
+          return !Garnish.hasAttr(selectedItems.find('.element'), 'data-is-folder') && 
+            Garnish.hasAttr(selectedItems.find('.element'), 'data-movable')
+        },
         activate: (selectedItems, elementIndex) => {
             const \$element = selectedItems.find('.element')
             const assetId = \$element.data('id');


### PR DESCRIPTION
### Description
Disallow “Preview file”, “Download”, “Rename file”, and “Copy reference tag” actions from being performed on folders.

(Tested on v4, and those actions are already disallowed.)

### Related issues
#15301 
