### PR TITLE
Handle OPTIONS requests for login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Craft now sends no-cache headers for any request that calls `craft\web\Request::getCsrfToken()`. ([#15293](https://github.com/craftcms/cms/pull/15293), [#15281](https://github.com/craftcms/cms/pull/15281))
 - Fixed a bug where `craft\helpers\ElementHelper::isDraft()`, `isRevision()`, and `isDraftOrRevision()` weren’t returning `true` if a nested draft/revision element was passed in, but the root element was canonical. ([#15303](https://github.com/craftcms/cms/issues/15303))
+- Fixed a bug where preflight requests to `users/login` could return a 404 response. ([#15309](https://github.com/craftcms/cms/pull/15309))
 
 ## 4.10.4 - 2024-07-02
 

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -192,6 +192,13 @@ class UsersController extends Controller
             return $this->_handleSuccessfulLogin($userSession->getIdentity());
         }
 
+        if ($this->request->getIsOptions()) {
+            // This is just a preflight request, no need to route to the real controller action yet.
+            $this->response->format = Response::FORMAT_RAW;
+            $this->response->data = '';
+            return $this->response;
+        }
+
         if (!$this->request->getIsPost()) {
             return null;
         }


### PR DESCRIPTION
When we [return null](https://github.com/craftcms/cms/blob/427fabe1d339e720cefefe2b7d7e60234cb04838/src/controllers/UsersController.php#L196) in the `UsersController` we'll miss the [check for if we're dealing with an action request](https://github.com/craftcms/cms/blob/12599c2dca42fc66f5c72ce9ded070ea20a246a4/src/web/Application.php#L301-L304) and end up with a 404. Returning a 404 from the OPTIONS request will end up in an error when trying to login from a cross-origin request (like from a headless app). 

