### PR TITLE
Docs: 5.x “anchor prefixes”

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -210,7 +210,7 @@ class GeneralConfig extends BaseConfig
     /**
      * @var bool Whether Craft should allow system and plugin updates in the control panel, and plugin installation from the Plugin Store.
      *
-     * This setting will automatically be disabled if <config4:allowAdminChanges> is disabled.
+     * This setting will automatically be disabled if <config5:allowAdminChanges> is disabled.
      *
      * ::: code
      * ```php Static Config
@@ -480,7 +480,7 @@ class GeneralConfig extends BaseConfig
      * It will be determined automatically if left blank.
      *
      * ::: tip
-     * The base control panel URL should **not** include the [control panel trigger word](config4:cpTrigger) (e.g. `/admin`).
+     * The base control panel URL should **not** include the [control panel trigger word](config5:cpTrigger) (e.g. `/admin`).
      * :::
      *
      * ::: code
@@ -653,14 +653,14 @@ class GeneralConfig extends BaseConfig
      * the front-end website.
      *
      * This can be set to `null` if you have a dedicated hostname for the control panel (e.g. `cms.my-project.tld`), or you are running Craft in
-     * [Headless Mode](config4:headlessMode). If you do that, you will need to ensure that the control panel is being served from its own web root
+     * [Headless Mode](config5:headlessMode). If you do that, you will need to ensure that the control panel is being served from its own web root
      * directory on your server, with an `index.php` file that defines the `CRAFT_CP` PHP constant.
      *
      * ```php
      * define('CRAFT_CP', true);
      * ```
      *
-     * Alternatively, you can set the <config4:baseCpUrl> config setting, but then you will run the risk of losing access to portions of your
+     * Alternatively, you can set the <config5:baseCpUrl> config setting, but then you will run the risk of losing access to portions of your
      * control panel due to URI conflicts with actual folders/files in your main web root.
      *
      * (For example, if you have an `assets/` folder, that would conflict with the `/assets` page in the control panel.)
@@ -679,7 +679,7 @@ class GeneralConfig extends BaseConfig
     public ?string $cpTrigger = 'admin';
 
     /**
-     * @var string The name of CSRF token used for CSRF validation if <config4:enableCsrfProtection> is set to `true`.
+     * @var string The name of CSRF token used for CSRF validation if <config5:enableCsrfProtection> is set to `true`.
      *
      * ::: code
      * ```php Static Config
@@ -752,7 +752,7 @@ class GeneralConfig extends BaseConfig
      * @var string|null The default locale the control panel should use for date/number formatting, for users who haven’t set
      * a preferred language or formatting locale.
      *
-     * If this is `null`, the <config4:defaultCpLanguage> config setting will determine which locale is used for date/number formatting by default.
+     * If this is `null`, the <config5:defaultCpLanguage> config setting will determine which locale is used for date/number formatting by default.
      *
      * ::: code
      * ```php Static Config
@@ -1074,7 +1074,7 @@ class GeneralConfig extends BaseConfig
     public bool $enableBasicHttpAuth = false;
 
     /**
-     * @var bool Whether to use a cookie to persist the CSRF token if <config4:enableCsrfProtection> is enabled. If false, the CSRF token will be
+     * @var bool Whether to use a cookie to persist the CSRF token if <config5:enableCsrfProtection> is enabled. If false, the CSRF token will be
      * stored in session under the `csrfTokenName` config setting name. Note that while storing CSRF tokens in session increases security,
      * it requires starting a session for every page that a CSRF token is needed, which may degrade site performance.
      *
@@ -1243,7 +1243,7 @@ class GeneralConfig extends BaseConfig
     public string $errorTemplatePrefix = '';
 
     /**
-     * @var string[]|null List of file extensions that will be merged into the <config4:allowedFileExtensions> config setting.
+     * @var string[]|null List of file extensions that will be merged into the <config5:allowedFileExtensions> config setting.
      *
      * ::: code
      * ```php Static Config
@@ -1296,7 +1296,7 @@ class GeneralConfig extends BaseConfig
      *
      * ::: tip
      * File extensions listed here won’t immediately be allowed to be uploaded. You will also need to list them with
-     * the <config4:extraAllowedFileExtensions> config setting.
+     * the <config5:extraAllowedFileExtensions> config setting.
      * :::
      *
      * @group Assets
@@ -1437,11 +1437,11 @@ class GeneralConfig extends BaseConfig
      * - Front-end routing will skip checks for element and template requests.
      * - Front-end responses will be JSON-formatted rather than HTML by default.
      * - Twig will be configured to escape unsafe strings for JavaScript/JSON rather than HTML by default for front-end requests.
-     * - The <config4:loginPath>, <config4:logoutPath>, <config4:setPasswordPath>, and <config4:verifyEmailPath> settings will be ignored.
+     * - The <config5:loginPath>, <config5:logoutPath>, <config5:setPasswordPath>, and <config5:verifyEmailPath> settings will be ignored.
      *
      * ::: tip
      * With Headless Mode enabled, users may only set passwords and verify email addresses via the control panel. Be sure to grant “Access the control
-     * panel” permission to all content editors and administrators. You’ll also need to set the <config4:baseCpUrl> config setting if the control
+     * panel” permission to all content editors and administrators. You’ll also need to set the <config5:baseCpUrl> config setting if the control
      * panel is located on a different domain than your front end.
      * :::
      *
@@ -1659,7 +1659,7 @@ class GeneralConfig extends BaseConfig
      *
      * This can be set to `false` to disable front-end login.
      *
-     * Note that this config setting is ignored when <config4:headlessMode> is enabled.
+     * Note that this config setting is ignored when <config5:headlessMode> is enabled.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
      *
@@ -1682,7 +1682,7 @@ class GeneralConfig extends BaseConfig
      *
      * This can be set to `false` to disable front-end logout.
      *
-     * Note that this config setting is ignored when <config4:headlessMode> is enabled.
+     * Note that this config setting is ignored when <config5:headlessMode> is enabled.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
      *
@@ -1897,7 +1897,7 @@ class GeneralConfig extends BaseConfig
      *
      * ::: tip
      * Even when this is set to `true`, the script name could still be included in some action URLs.
-     * If you want to ensure that `index.php` is fully omitted from **all** generated URLs, set the <config4:pathParam>
+     * If you want to ensure that `index.php` is fully omitted from **all** generated URLs, set the <config5:pathParam>
      * config setting to `null`.
      * :::
      *
@@ -1935,7 +1935,7 @@ class GeneralConfig extends BaseConfig
      * `?page` | `/news?page=5`
      *
      * ::: tip
-     * If you want to set this to `?p` (e.g. `/news?p=5`), you’ll also need to change your <config4:pathParam> setting which defaults to `p`.
+     * If you want to set this to `?p` (e.g. `/news?p=5`), you’ll also need to change your <config5:pathParam> setting which defaults to `p`.
      * If your server is running Apache, you’ll need to update the redirect code in your `.htaccess` file to match your new `pathParam` value.
      * :::
      *
@@ -2084,7 +2084,7 @@ class GeneralConfig extends BaseConfig
     /**
      * @var mixed The path users should be redirected to after logging in from the front-end site.
      *
-     * This setting will also come into effect if the user visits the login page (as specified by the <config4:loginPath> config setting) when
+     * This setting will also come into effect if the user visits the login page (as specified by the <config5:loginPath> config setting) when
      * they are already logged in.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
@@ -2123,7 +2123,7 @@ class GeneralConfig extends BaseConfig
     public mixed $postLogoutRedirect = '';
 
     /**
-     * @var bool Whether the <config4:gqlTypePrefix> config setting should have an impact on `query`, `mutation`, and `subscription` types.
+     * @var bool Whether the <config5:gqlTypePrefix> config setting should have an impact on `query`, `mutation`, and `subscription` types.
      *
      * ::: code
      * ```php Static Config
@@ -2259,7 +2259,7 @@ class GeneralConfig extends BaseConfig
     /**
      * @var mixed The amount of time content preview tokens can be used before expiring.
      *
-     * Defaults to <config4:defaultTokenDuration> value.
+     * Defaults to <config5:defaultTokenDuration> value.
      *
      * See [[ConfigHelper::durationInSeconds()]] for a list of supported value types.
      *
@@ -2376,7 +2376,7 @@ class GeneralConfig extends BaseConfig
     /**
      * @var bool Whether SVG thumbnails should be rasterized.
      *
-     * This will only work if ImageMagick is installed, and <config4:imageDriver> is set to either `auto` or `imagick`.
+     * This will only work if ImageMagick is installed, and <config5:imageDriver> is set to either `auto` or `imagick`.
      *
      * ::: code
      * ```php Static Config
@@ -2713,12 +2713,12 @@ class GeneralConfig extends BaseConfig
     /**
      * @var mixed The URI or URL that Craft should use for Set Password forms on the front end.
      *
-     * This setting is ignored when <config4:headlessMode> is enabled, unless it’s set to an absolute URL.
+     * This setting is ignored when <config5:headlessMode> is enabled, unless it’s set to an absolute URL.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
      *
      * ::: tip
-     * You might also want to set <config4:invalidUserTokenPath> in case a user clicks on an expired password reset link.
+     * You might also want to set <config5:invalidUserTokenPath> in case a user clicks on an expired password reset link.
      * :::
      *
      * ::: code
@@ -2743,7 +2743,7 @@ class GeneralConfig extends BaseConfig
      * If this is set, Craft will redirect [.well-known/change-password requests](https://w3c.github.io/webappsec-change-password-url/) to this URI.
      *
      * ::: tip
-     * You’ll also need to set [setPasswordPath](config4:setPasswordPath), which determines the URI and template path for the Set Password form
+     * You’ll also need to set [setPasswordPath](config5:setPasswordPath), which determines the URI and template path for the Set Password form
      * where the user resets their password after following the link in the Password Reset email.
      * :::
      *
@@ -3119,7 +3119,7 @@ class GeneralConfig extends BaseConfig
      * `x-craft-live-preview` query string parameter.
      *
      * ::: tip
-     * You can customize the behavior of iFrame Resizer via the <config4:previewIframeResizerOptions> config setting.
+     * You can customize the behavior of iFrame Resizer via the <config5:previewIframeResizerOptions> config setting.
      * :::
      *
      * ::: code
@@ -3139,7 +3139,7 @@ class GeneralConfig extends BaseConfig
     /**
      * @var bool Whether Craft should specify the path using `PATH_INFO` or as a query string parameter when generating URLs.
      *
-     * This setting only takes effect if <config4:omitScriptNameInUrls> is set to `false`.
+     * This setting only takes effect if <config5:omitScriptNameInUrls> is set to `false`.
      *
      * ::: code
      * ```php Static Config
@@ -3261,7 +3261,7 @@ class GeneralConfig extends BaseConfig
     /**
      * @var mixed The URI or URL that Craft should use for email verification links on the front end.
      *
-     * This setting is ignored when <config4:headlessMode> is enabled, unless it’s set to an absolute URL.
+     * This setting is ignored when <config5:headlessMode> is enabled, unless it’s set to an absolute URL.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
      *
@@ -3517,7 +3517,7 @@ class GeneralConfig extends BaseConfig
     /**
      * Whether Craft should allow system and plugin updates in the control panel, and plugin installation from the Plugin Store.
      *
-     * This setting will automatically be disabled if <config4:allowAdminChanges> is disabled.
+     * This setting will automatically be disabled if <config5:allowAdminChanges> is disabled.
      *
      * ```php
      * ->allowUpdates(false)
@@ -3694,7 +3694,7 @@ class GeneralConfig extends BaseConfig
      * It will be determined automatically if left blank.
      *
      * ::: tip
-     * The base control panel URL should **not** include the [control panel trigger word](config4:cpTrigger) (e.g. `/admin`).
+     * The base control panel URL should **not** include the [control panel trigger word](config5:cpTrigger) (e.g. `/admin`).
      * :::
      *
      * ```php
@@ -3893,14 +3893,14 @@ class GeneralConfig extends BaseConfig
      * the front-end website.
      *
      * This can be set to `null` if you have a dedicated hostname for the control panel (e.g. `cms.my-project.tld`), or you are running Craft in
-     * [Headless Mode](config4:headlessMode). If you do that, you will need to ensure that the control panel is being served from its own web root
+     * [Headless Mode](config5:headlessMode). If you do that, you will need to ensure that the control panel is being served from its own web root
      * directory on your server, with an `index.php` file that defines the `CRAFT_CP` PHP constant.
      *
      * ```php
      * define('CRAFT_CP', true);
      * ```
      *
-     * Alternatively, you can set the <config4:baseCpUrl> config setting, but then you will run the risk of losing access to portions of your
+     * Alternatively, you can set the <config5:baseCpUrl> config setting, but then you will run the risk of losing access to portions of your
      * control panel due to URI conflicts with actual folders/files in your main web root.
      *
      * (For example, if you have an `assets/` folder, that would conflict with the `/assets` page in the control panel.)
@@ -3922,7 +3922,7 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * The name of CSRF token used for CSRF validation if <config4:enableCsrfProtection> is set to `true`.
+     * The name of CSRF token used for CSRF validation if <config5:enableCsrfProtection> is set to `true`.
      *
      * ```php
      * ->csrfTokenName('MY_CSRF')
@@ -4015,7 +4015,7 @@ class GeneralConfig extends BaseConfig
      * The default locale the control panel should use for date/number formatting, for users who haven’t set
      * a preferred language or formatting locale.
      *
-     * If this is `null`, the <config4:defaultCpLanguage> config setting will determine which locale is used for date/number formatting by default.
+     * If this is `null`, the <config5:defaultCpLanguage> config setting will determine which locale is used for date/number formatting by default.
      *
      * ```php
      * ->defaultCpLocale('en-US')
@@ -4388,7 +4388,7 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * Whether to use a cookie to persist the CSRF token if <config4:enableCsrfProtection> is enabled. If false, the CSRF token will be
+     * Whether to use a cookie to persist the CSRF token if <config5:enableCsrfProtection> is enabled. If false, the CSRF token will be
      * stored in session under the `csrfTokenName` config setting name. Note that while storing CSRF tokens in session increases security,
      * it requires starting a session for every page that a CSRF token is needed, which may degrade site performance.
      *
@@ -4577,7 +4577,7 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * List of file extensions that will be merged into the <config4:allowedFileExtensions> config setting.
+     * List of file extensions that will be merged into the <config5:allowedFileExtensions> config setting.
      *
      * ```php
      * ->extraAllowedFileExtensions(['mbox', 'xml'])
@@ -4649,7 +4649,7 @@ class GeneralConfig extends BaseConfig
      *
      * ::: tip
      * File extensions listed here won’t immediately be allowed to be uploaded. You will also need to list them with
-     * the <config4:extraAllowedFileExtensions> config setting.
+     * the <config5:extraAllowedFileExtensions> config setting.
      * :::
      *
      * @group Assets
@@ -4814,11 +4814,11 @@ class GeneralConfig extends BaseConfig
      * - Front-end routing will skip checks for element and template requests.
      * - Front-end responses will be JSON-formatted rather than HTML by default.
      * - Twig will be configured to escape unsafe strings for JavaScript/JSON rather than HTML by default for front-end requests.
-     * - The <config4:loginPath>, <config4:logoutPath>, <config4:setPasswordPath>, and <config4:verifyEmailPath> settings will be ignored.
+     * - The <config5:loginPath>, <config5:logoutPath>, <config5:setPasswordPath>, and <config5:verifyEmailPath> settings will be ignored.
      *
      * ::: tip
      * With Headless Mode enabled, users may only set passwords and verify email addresses via the control panel. Be sure to grant “Access the control
-     * panel” permission to all content editors and administrators. You’ll also need to set the <config4:baseCpUrl> config setting if the control
+     * panel” permission to all content editors and administrators. You’ll also need to set the <config5:baseCpUrl> config setting if the control
      * panel is located on a different domain than your front end.
      * :::
      *
@@ -5062,7 +5062,7 @@ class GeneralConfig extends BaseConfig
      *
      * This can be set to `false` to disable front-end login.
      *
-     * Note that this config setting is ignored when <config4:headlessMode> is enabled.
+     * Note that this config setting is ignored when <config5:headlessMode> is enabled.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
      *
@@ -5087,7 +5087,7 @@ class GeneralConfig extends BaseConfig
      *
      * This can be set to `false` to disable front-end logout.
      *
-     * Note that this config setting is ignored when <config4:headlessMode> is enabled.
+     * Note that this config setting is ignored when <config5:headlessMode> is enabled.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
      *
@@ -5365,7 +5365,7 @@ class GeneralConfig extends BaseConfig
      * `?page` | `/news?page=5`
      *
      * ::: tip
-     * If you want to set this to `?p` (e.g. `/news?p=5`), you’ll also need to change your <config4:pathParam> setting which defaults to `p`.
+     * If you want to set this to `?p` (e.g. `/news?p=5`), you’ll also need to change your <config5:pathParam> setting which defaults to `p`.
      * If your server is running Apache, you’ll need to update the redirect code in your `.htaccess` file to match your new `pathParam` value.
      * :::
      *
@@ -5536,7 +5536,7 @@ class GeneralConfig extends BaseConfig
     /**
      * The path users should be redirected to after logging in from the front-end site.
      *
-     * This setting will also come into effect if the user visits the login page (as specified by the <config4:loginPath> config setting) when
+     * This setting will also come into effect if the user visits the login page (as specified by the <config5:loginPath> config setting) when
      * they are already logged in.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
@@ -5579,7 +5579,7 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * Whether the <config4:gqlTypePrefix> config setting should have an impact on `query`, `mutation`, and `subscription` types.
+     * Whether the <config5:gqlTypePrefix> config setting should have an impact on `query`, `mutation`, and `subscription` types.
      *
      * ```php
      * ->prefixGqlRootTypes(false)
@@ -5742,7 +5742,7 @@ class GeneralConfig extends BaseConfig
     /**
      * The amount of time content preview tokens can be used before expiring.
      *
-     * Defaults to <config4:defaultTokenDuration> value.
+     * Defaults to <config5:defaultTokenDuration> value.
      *
      * See [[ConfigHelper::durationInSeconds()]] for a list of supported value types.
      *
@@ -5868,7 +5868,7 @@ class GeneralConfig extends BaseConfig
     /**
      * Whether SVG thumbnails should be rasterized.
      *
-     * This will only work if ImageMagick is installed, and <config4:imageDriver> is set to either `auto` or `imagick`.
+     * This will only work if ImageMagick is installed, and <config5:imageDriver> is set to either `auto` or `imagick`.
      *
      * ```php
      * ->rasterizeSvgThumbs(true)
@@ -6268,12 +6268,12 @@ class GeneralConfig extends BaseConfig
     /**
      * The URI or URL that Craft should use for Set Password forms on the front end.
      *
-     * This setting is ignored when <config4:headlessMode> is enabled, unless it’s set to an absolute URL.
+     * This setting is ignored when <config5:headlessMode> is enabled, unless it’s set to an absolute URL.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
      *
      * ::: tip
-     * You might also want to set <config4:invalidUserTokenPath> in case a user clicks on an expired password reset link.
+     * You might also want to set <config5:invalidUserTokenPath> in case a user clicks on an expired password reset link.
      * :::
      *
      * ```php
@@ -6300,7 +6300,7 @@ class GeneralConfig extends BaseConfig
      * If this is set, Craft will redirect [.well-known/change-password requests](https://w3c.github.io/webappsec-change-password-url/) to this URI.
      *
      * ::: tip
-     * You’ll also need to set [setPasswordPath](config4:setPasswordPath), which determines the URI and template path for the Set Password form
+     * You’ll also need to set [setPasswordPath](config5:setPasswordPath), which determines the URI and template path for the Set Password form
      * where the user resets their password after following the link in the Password Reset email.
      * :::
      *
@@ -6727,7 +6727,7 @@ class GeneralConfig extends BaseConfig
      * `x-craft-live-preview` query string parameter.
      *
      * ::: tip
-     * You can customize the behavior of iFrame Resizer via the <config4:previewIframeResizerOptions> config setting.
+     * You can customize the behavior of iFrame Resizer via the <config5:previewIframeResizerOptions> config setting.
      * :::
      *
      * ```php
@@ -6749,7 +6749,7 @@ class GeneralConfig extends BaseConfig
     /**
      * Whether Craft should specify the path using `PATH_INFO` or as a query string parameter when generating URLs.
      *
-     * This setting only takes effect if <config4:omitScriptNameInUrls> is set to `false`.
+     * This setting only takes effect if <config5:omitScriptNameInUrls> is set to `false`.
      *
      * ```php
      * ->usePathInfo(true)
@@ -6887,7 +6887,7 @@ class GeneralConfig extends BaseConfig
     /**
      * The URI or URL that Craft should use for email verification links on the front end.
      *
-     * This setting is ignored when <config4:headlessMode> is enabled, unless it’s set to an absolute URL.
+     * This setting is ignored when <config5:headlessMode> is enabled, unless it’s set to an absolute URL.
      *
      * See [[ConfigHelper::localizedValue()]] for a list of supported value types.
      *

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -718,7 +718,7 @@ class App
 
     /**
      * Sets PHP’s memory limit to the maximum specified by the
-     * <config4:phpMaxMemoryLimit> config setting, and gives the script an
+     * <config5:phpMaxMemoryLimit> config setting, and gives the script an
      * unlimited amount of time to execute.
      */
     public static function maxPowerCaptain(): void

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -71,7 +71,7 @@ class ElementHelper
      *
      * @param string $str The string
      * @param bool|null $ascii Whether the slug should be converted to ASCII. If null, it will depend on
-     * the <config4:limitAutoSlugsToAscii> config setting value.
+     * the <config5:limitAutoSlugsToAscii> config setting value.
      * @param string|null $language The language to pull ASCII character mappings for, if needed
      * @return string
      * @since 3.5.0

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -125,7 +125,7 @@ class StringHelper extends \yii\helpers\StringHelper
 
     /**
      * Returns ASCII character mappings, merging in any custom defined mappings
-     * from the <config4:customAsciiCharMappings> config setting.
+     * from the <config5:customAsciiCharMappings> config setting.
      *
      * @param bool $flat Whether the mappings should be returned as a flat array (é => e)
      * @param string|null $language Whether to include language-specific mappings (only applied if $flat is true)

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -61,7 +61,7 @@ class Gc extends Component
     /**
      * @var bool whether [[hardDelete()]] should delete *all* soft-deleted rows,
      * rather than just the ones that were deleted long enough ago to be ready
-     * for hard-deletion per the <config4:softDeleteDuration> config setting.
+     * for hard-deletion per the <config5:softDeleteDuration> config setting.
      */
     public bool $deleteAllTrashed = false;
 

--- a/src/services/Images.php
+++ b/src/services/Images.php
@@ -252,7 +252,7 @@ class Images extends Component
      * The code was adapted from http://www.php.net/manual/en/function.imagecreatefromjpeg.php#64155.
      * It will first attempt to do it with available memory. If that fails,
      * Craft will bump the memory to amount defined by the
-     * <config4:phpMaxMemoryLimit> config setting, then try again.
+     * <config5:phpMaxMemoryLimit> config setting, then try again.
      *
      * @param string $filePath The path to the image file.
      * @param bool $toTheMax If set to true, will set the PHP memory to the config setting phpMaxMemoryLimit.

--- a/src/services/ProjectConfig.php
+++ b/src/services/ProjectConfig.php
@@ -280,7 +280,7 @@ class ProjectConfig extends Component
     private array $_configFileList = [];
 
     /**
-     * @var int|null The project config cache duration. If null, the <config4:cacheDuration> config setting will be used.
+     * @var int|null The project config cache duration. If null, the <config5:cacheDuration> config setting will be used.
      * @since 4.5.0
      */
     public ?int $cacheDuration = null;

--- a/src/services/Tokens.php
+++ b/src/services/Tokens.php
@@ -96,7 +96,7 @@ class Tokens extends Component
     }
 
     /**
-     * Creates a new token for previewing content, using the <config4:previewTokenDuration> to determine the duration, if set.
+     * Creates a new token for previewing content, using the <config5:previewTokenDuration> to determine the duration, if set.
      *
      * @param mixed $route Where matching requests should be routed to.
      * @param int|null $usageLimit The maximum number of times this token can be

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -304,7 +304,7 @@ class Users extends Component
      * Returns whether a verification code is valid for the given user.
      *
      * This method first checks if the code has expired past the
-     * <config4:verificationCodeDuration> config setting. If it is still valid,
+     * <config5:verificationCodeDuration> config setting. If it is still valid,
      * then, the checks the validity of the contents of the code.
      *
      * @param User $user The user to check the code for.
@@ -1211,7 +1211,7 @@ class Users extends Component
      * Deletes any pending users that have shown zero sense of urgency and are
      * just taking up space.
      *
-     * This method will check the <config4:purgePendingUsersDuration> config
+     * This method will check the <config5:purgePendingUsersDuration> config
      * setting, and if it is set to a valid duration, it will delete any user
      * accounts that were created that duration ago, and have still not
      * activated their account.

--- a/src/web/Controller.php
+++ b/src/web/Controller.php
@@ -478,7 +478,7 @@ abstract class Controller extends \yii\web\Controller
     /**
      * Throws a 403 error if the current user is not an admin.
      *
-     * @param bool $requireAdminChanges Whether the <config4:allowAdminChanges>
+     * @param bool $requireAdminChanges Whether the <config5:allowAdminChanges>
      * config setting must also be enabled.
      * @throws ForbiddenHttpException if the current user is not an admin
      */

--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -411,8 +411,8 @@ class Request extends \yii\web\Request
      * Returns the segments of the requested path.
      *
      * ::: tip
-     * Note that the segments will not include the [control panel trigger](config4:cpTrigger)
-     * if it’s a control panel request, or the [page trigger](config4:pageTrigger)
+     * Note that the segments will not include the [control panel trigger](config5:cpTrigger)
+     * if it’s a control panel request, or the [page trigger](config5:pageTrigger)
      * or page number if it’s a paginated request.
      * :::
      *
@@ -505,7 +505,7 @@ class Request extends \yii\web\Request
     /**
      * Returns the token submitted with the request, if there is one.
      *
-     * Tokens must be sent either as a query string param named after the <config4:tokenParam> config setting (`token` by
+     * Tokens must be sent either as a query string param named after the <config5:tokenParam> config setting (`token` by
      * default), or an `X-Craft-Token` HTTP header on the request.
      *
      * @return string|null The token, or `null` if there isn’t one.
@@ -561,7 +561,7 @@ class Request extends \yii\web\Request
     /**
      * Returns the site token submitted with the request, if there is one.
      *
-     * Tokens must be sent either as a query string param named after the <config4:siteToken> config setting
+     * Tokens must be sent either as a query string param named after the <config5:siteToken> config setting
      * (`siteToken` by default), or an `X-Craft-Site-Token` HTTP header on the request.
      *
      * @return string|null The token, or `null` if there isn’t one.
@@ -591,7 +591,7 @@ class Request extends \yii\web\Request
      * Returns whether the control panel was requested.
      *
      * The result depends on whether the first segment in the URI matches the
-     * [control panel trigger](config4:cpTrigger).
+     * [control panel trigger](config5:cpTrigger).
      *
      * @return bool Whether the current request should be routed to the control panel.
      */
@@ -628,7 +628,7 @@ class Request extends \yii\web\Request
      *
      * There are several ways that this method could return `true`:
      *
-     * - If the first segment in the Craft path matches the [action trigger](config4:actionTrigger)
+     * - If the first segment in the Craft path matches the [action trigger](config5:actionTrigger)
      * - If there is an `action` param in either the POST data or query string
      * - If the Craft path matches the Login path, the Logout path, or the Set Password path
      *

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -789,8 +789,8 @@ class View extends \yii\web\View
      * - TemplateName/index.twig
      *
      * If this is a front-end request, the actual list of file extensions and
-     * index filenames are configurable via the <config4:defaultTemplateExtensions>
-     * and <config4:indexTemplateFilenames> config settings.
+     * index filenames are configurable via the <config5:defaultTemplateExtensions>
+     * and <config5:indexTemplateFilenames> config settings.
      *
      * For example if you set the following in config/general.php:
      *


### PR DESCRIPTION
@olivierbon found a number of issues in the General config reference—and it turned out it was a more widespread issue that affected class reference, too.

The remaining references to `config4` and `config3` appear to be false-positives in compiled JavaScript.