### PR TITLE
App type-based configs

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -59,17 +59,18 @@ $environment = App::cliOption('--env', true)
 // -----------------------------------------------------------------------------
 
 $configService = new Config();
+$configService->appType = $appType;
 $configService->env = $environment;
 $configService->configDir = $configPath;
 $configService->appDefaultsDir = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'defaults';
-$generalConfig = $configService->getConfigFromFile('general');
+$generalConfig = $configService->getGeneral();
 
 // Validation
 // -----------------------------------------------------------------------------
 
 $createFolder = function($path) use ($generalConfig) {
     if (!is_dir($path)) {
-        FileHelper::createDirectory($path, $generalConfig['defaultDirMode'] ?? 0775);
+        FileHelper::createDirectory($path, $generalConfig->defaultDirMode ?? 0775);
     }
 };
 
@@ -160,7 +161,7 @@ error_reporting($errorLevel);
 // Determine if Craft is running in Dev Mode
 // -----------------------------------------------------------------------------
 
-$devMode = App::env('CRAFT_DEV_MODE') ?? $generalConfig['devMode'] ?? false;
+$devMode = App::env('CRAFT_DEV_MODE') ?? $generalConfig->devMode;
 
 if ($devMode) {
     ini_set('display_errors', '1');
@@ -215,12 +216,9 @@ if ($webRoot) {
 }
 
 // Set any custom aliases
-$customAliases = $generalConfig['aliases'] ?? $generalConfig['environmentVariables'] ?? null;
-if (is_array($customAliases)) {
-    foreach ($customAliases as $name => $value) {
-        if (is_string($value)) {
-            Craft::setAlias($name, $value);
-        }
+foreach ($generalConfig->aliases as $name => $value) {
+    if (is_string($value)) {
+        Craft::setAlias($name, $value);
     }
 }
 
@@ -244,7 +242,7 @@ $localConfig = ArrayHelper::merge(
     $configService->getConfigFromFile("app.{$appType}")
 );
 
-$safeMode = App::env('CRAFT_SAFE_MODE') ?? $generalConfig['safeMode'] ?? false;
+$safeMode = App::env('CRAFT_SAFE_MODE') ?? $generalConfig->safeMode;
 
 if ($safeMode) {
     ArrayHelper::remove($localConfig, 'bootstrap');

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -145,7 +145,7 @@ class GeneralConfig extends BaseConfig
     public bool $addTrailingSlashesToUrls = false;
 
     /**
-     * @var array Any custom Yii [aliases](https://www.yiiframework.com/doc/guide/2.0/en/concept-aliases) that should be defined for every request.
+     * @var array<string,string|null> Any custom Yii [aliases](https://www.yiiframework.com/doc/guide/2.0/en/concept-aliases) that should be defined for every request.
      *
      * ```php Static Config
      * ->aliases([
@@ -3386,14 +3386,40 @@ class GeneralConfig extends BaseConfig
      * ```
      *
      * @group Environment
-     * @param array $value
+     * @param array<string,string|null> $value
      * @return self
      * @see $aliases
      * @since 4.2.0
      */
     public function aliases(array $value): self
     {
-        $this->aliases = $value;
+        $this->aliases = [];
+        foreach ($value as $name => $path) {
+            $this->addAlias($name, $path);
+        }
+        return $this;
+    }
+
+    /**
+     * Adds a custom Yii [alias](https://www.yiiframework.com/doc/guide/2.0/en/concept-aliases) that should be defined for every request.
+     *
+     * ```php
+     * ->addAlias('@webroot', '/var/www/')
+     * ```
+     *
+     * @group Environment
+     * @param string $name
+     * @param string|null $path
+     * @return self
+     * @see $aliases
+     * @since 4.2.0
+     */
+    public function addAlias(string $name, ?string $path): self
+    {
+        if (!str_starts_with($name, '@')) {
+            $name = "@$name";
+        }
+        $this->aliases[$name] = $path;
         return $this;
     }
 

--- a/src/services/Config.php
+++ b/src/services/Config.php
@@ -43,6 +43,11 @@ class Config extends Component
     public const CATEGORY_GENERAL = 'general';
 
     /**
+     * @var string The application type (`web` or `console`).
+     */
+    public string $appType;
+
+    /**
      * @var string|null The environment ID Craft is currently running in.
      *
      * ---
@@ -94,21 +99,27 @@ class Config extends Component
     public function getConfigSettings(string $category): object
     {
         if (!isset($this->_configSettings[$category])) {
-            $this->_configSettings[$category] = $this->_createConfigObj($category);
+            $config = $this->_createConfigObj($category, $category, null);
+
+            if (isset($this->appType)) {
+                // See if an application type-specific config exists (general.web.php / general.console.php)
+                /** @var GeneralConfig|DbConfig $config */
+                $config = $this->_createConfigObj($category, "$category.$this->appType", $config);
+            }
+
+            $this->_configSettings[$category] = $config;
         }
 
         return $this->_configSettings[$category];
     }
 
-    /**
-     * Creates a new config object.
-     *
-     * @param string $category The config category
-     * @return object
-     */
-    private function _createConfigObj(string $category): object
+    private function _createConfigObj(string $category, string $filename, ?BaseConfig $existingConfig): object
     {
-        $config = $this->getConfigFromFile($category);
+        $config = $this->getConfigFromFile($filename);
+
+        if ($existingConfig && empty($config)) {
+            return $existingConfig;
+        }
 
         switch ($category) {
             case self::CATEGORY_CUSTOM:
@@ -123,6 +134,10 @@ class Config extends Component
                 break;
             default:
                 throw new InvalidArgumentException("Invalid config category: $category");
+        }
+
+        if (is_callable($config)) {
+            $config = $config($existingConfig ?? $configClass::create());
         }
 
         // Get any environment value overrides
@@ -148,12 +163,18 @@ class Config extends Component
         }
 
         $loadingConfig = $this->_loadingConfigFile;
-        $this->_loadingConfigFile = $category;
+        $this->_loadingConfigFile = $filename;
 
         $config = array_merge($config, $envConfig);
         Typecast::properties($configClass, $config);
-        /** @var BaseObject $config */
-        $config = new $configClass($config);
+
+        if ($existingConfig !== null) {
+            Craft::configure($existingConfig, $config);
+            $config = $existingConfig;
+        } else {
+            /** @var BaseObject $config */
+            $config = new $configClass($config);
+        }
 
         $this->_loadingConfigFile = $loadingConfig;
         return $config;
@@ -244,9 +265,9 @@ class Config extends Component
      * ```
      *
      * @param string $filename
-     * @return array|BaseConfig
+     * @return array|callable|BaseConfig
      */
-    public function getConfigFromFile(string $filename): array|BaseConfig
+    public function getConfigFromFile(string $filename): array|callable|BaseConfig
     {
         $path = $this->getConfigFilePath($filename);
 
@@ -263,11 +284,11 @@ class Config extends Component
         return $config;
     }
 
-    private function _configFromFileInternal(string $path): array|BaseConfig
+    private function _configFromFileInternal(string $path): array|callable|BaseConfig
     {
         $config = @include $path;
 
-        if ($config instanceof BaseConfig) {
+        if ($config instanceof BaseConfig || is_callable($config)) {
             return $config;
         }
 


### PR DESCRIPTION
Adds support for app type-based configs, for `general` and `db` (e.g. `general.web.php`/`general.console.php`).

In addition to returning an array or new `GeneralConfig`/`DbConfig` object, `general` and `db` config files can now return a callable which accepts an existing config object, so it’s possible for app type-based configs to use the fluent syntax on the same config object created by the original config file (`general.php`/`db.php`):

```php
// config/general.php

return GeneralConfig::create()
    ->aliases([
        '@webroot' => dirname(__DIR__) . '/web',
    ])
    // ...
;

// or

return fn(GeneralConfig $config) => $config
    ->aliases([
        '@webroot' => dirname(__DIR__) . '/web',
    ])
    // ...
;
```

```php
// config/general.console.php

return fn(GeneralConfig $config) => $config
    ->addAlias('@web', craft\helpers\App::env('CLI_WEB_URL'))
    // ...
;
```