### PR TITLE
Better user creation workflow

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -8,6 +8,8 @@
 - Matrix fields now show validation errors when nested entries don’t validate. ([#15161](https://github.com/craftcms/cms/issues/15161), [#15165](https://github.com/craftcms/cms/pull/15165))
 - Matrix fields set to inline-editable blocks view now support selecting all blocks by pressing <kbd>Command</kbd>/<kbd>Ctrl</kbd> + <kbd>A</kbd> when a checkbox is focused. ([#15326](https://github.com/craftcms/cms/issues/15326))
 - Users’ Permissions, Preferences, and Password & Verification screens now have “Save and continue editing” actions, as well as support for <kbd>Command</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd> keyboard shortcuts.
+- User profile screens now have a “Create and set permissions” button for new users, if the current user has access to edit user permissions. ([#15356](https://github.com/craftcms/cms/pull/15356))
+- User permission screens now have a “Save and send activation email” button for inactive users, if the current user has the “Administrate users” permission. ([#15356](https://github.com/craftcms/cms/pull/15356))
 
 ### Accessibility
 - Improved the accessibility of two-step verification setup. ([#15229](https://github.com/craftcms/cms/pull/15229))

--- a/src/controllers/EditUserTrait.php
+++ b/src/controllers/EditUserTrait.php
@@ -84,7 +84,6 @@ trait EditUserTrait
 
         $screens = [
             self::SCREEN_PROFILE => ['label' => Craft::t('app', 'Profile')],
-            self::SCREEN_ADDRESSES => ['label' => Craft::t('app', 'Addresses')],
         ];
 
         if (
@@ -101,6 +100,8 @@ trait EditUserTrait
         if ($user->getIsCurrent()) {
             $screens[self::SCREEN_PREFERENCES] = ['label' => Craft::t('app', 'Preferences')];
         }
+
+        $screens[self::SCREEN_ADDRESSES] = ['label' => Craft::t('app', 'Addresses')];
 
         // Fire a 'defineEditScreens' event
         if (Event::hasHandlers(UsersController::class, UsersController::EVENT_DEFINE_EDIT_SCREENS)) {

--- a/src/controllers/EditUserTrait.php
+++ b/src/controllers/EditUserTrait.php
@@ -86,14 +86,7 @@ trait EditUserTrait
             self::SCREEN_PROFILE => ['label' => Craft::t('app', 'Profile')],
         ];
 
-        if (
-            Craft::$app->edition->value >= CmsEdition::Team->value &&
-            (
-                (Craft::$app->edition === CmsEdition::Team && $currentUser->admin) ||
-                (Craft::$app->edition === CmsEdition::Pro && $currentUser->can('assignUserPermissions')) ||
-                $currentUser->canAssignUserGroups()
-            )
-        ) {
+        if ($this->showPermissionsScreen()) {
             $screens[self::SCREEN_PERMISSIONS] = ['label' => Craft::t('app', 'Permissions')];
         }
 
@@ -187,6 +180,19 @@ trait EditUserTrait
         }
 
         return $response;
+    }
+
+    private function showPermissionsScreen(): bool
+    {
+        $currentUser = static::currentUser();
+        return (
+            Craft::$app->edition->value >= CmsEdition::Team->value &&
+            (
+                (Craft::$app->edition === CmsEdition::Team && $currentUser->admin) ||
+                (Craft::$app->edition === CmsEdition::Pro && $currentUser->can('assignUserPermissions')) ||
+                $currentUser->canAssignUserGroups()
+            )
+        );
     }
 
     private function editUserScreenUrl(User $user, string $screen): string

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -1015,6 +1015,12 @@ class UsersController extends Controller
             'element' => $element,
         ]);
 
+        if ($element->getIsUnpublishedDraft() && $this->showPermissionsScreen()) {
+            $this->response
+                ->submitButtonLabel(Craft::t('app', 'Create and set permissions'))
+                ->redirectUrl($this->editUserScreenUrl($element, self::SCREEN_PERMISSIONS));
+        }
+
         return $this->asEditUserScreen($element, self::SCREEN_PROFILE);
     }
 

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -1333,6 +1333,7 @@ return [
     'Savable' => 'Savable',
     'Save and add another' => 'Save and add another',
     'Save and continue editing' => 'Save and continue editing',
+    'Save and send activation email' => 'Save and send activation email',
     'Save as a new asset' => 'Save as a new asset',
     'Save as a new {type}' => 'Save as a new {type}',
     'Save assets uploaded by other users' => 'Save assets uploaded by other users',

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -443,6 +443,7 @@ return [
     'Create a one-time password.' => 'Create a one-time password.',
     'Create and add another' => 'Create and add another',
     'Create and continue editing' => 'Create and continue editing',
+    'Create and set permissions' => 'Create and set permissions',
     'Create assets in the “{volume}” volume' => 'Create assets in the “{volume}” volume',
     'Create entries in the “{section}” section' => 'Create entries in the “{section}” section',
     'Create entries in the “{section}” {type} field' => 'Create entries in the “{section}” {type} field',


### PR DESCRIPTION
### Description

Makes a couple improvements to the user creation workflow to address issues in #15079:

- When editing the profile info for a new user, the “Create user” button is now replaced with “Create and set permissions”. Pressing it will take you to the Permissions screen, rather than back to the Users index. (The <kbd>Command</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd> shortcut still keeps you on the current page.)

- When editing the permissions for an inactive user, a new “Save and send activation email” button is displayed to the left of the primary Save button.

End result is that it’s now possible to create a new user, set their profile info, then permissions, then save + send an activation email, all in one linear workflow.

(Both changes only take effect if the current user has adequate permissions.)

### Related issues

- #15079