### PR TITLE
Add `@phpstan-var` to `mode` enum on ImageTransform model

### DIFF
--- a/src/models/ImageTransform.php
+++ b/src/models/ImageTransform.php
@@ -68,7 +68,8 @@ class ImageTransform extends Model
     public ?DateTime $parameterChangeTime = null;
 
     /**
-     * @var string 'crop'|'fit'|'stretch'|'letterbox' Mode
+     * @var string Mode
+     * @phpstan-var 'crop'|'fit'|'stretch'|'letterbox'
      */
     public string $mode = 'crop';
 


### PR DESCRIPTION
### Description

In the commit https://github.com/craftcms/cms/commit/1203286775e19657cef661349dfbd58f772c76bc, several `@phpstan-var` declarations were added for enums. However, the declaration for the `mode` property on the ImageTransform model was omitted. PHPStan flagged this as an issue while I was working on a plugin, but adding the missing declaration resolves the problem.

