### PR TITLE
value can be null too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where element index result counts weren’t getting updated when the element list was refreshed but pagination was preserved. ([#15367](https://github.com/craftcms/cms/issues/15367))
+- Fixed a PHP error that occurred when making a field layout component conditional on a Time or CKEditor field. ([craftcms/ckeditor#267](https://github.com/craftcms/ckeditor/issues/267))
 
 ## 4.10.6 - 2024-07-16
 

--- a/src/fields/conditions/EmptyFieldConditionRule.php
+++ b/src/fields/conditions/EmptyFieldConditionRule.php
@@ -50,11 +50,11 @@ class EmptyFieldConditionRule extends BaseConditionRule implements FieldConditio
      */
     protected function matchFieldValue($value): bool
     {
-        /** @var ElementQueryInterface|Collection $value */
+        /** @var ElementQueryInterface|Collection|null $value */
         if ($value instanceof ElementQueryInterface) {
             $isEmpty = !$value->exists();
         } else {
-            $isEmpty = $value->isEmpty();
+            $isEmpty = $value === null ? true : $value->isEmpty();
         }
 
         if ($this->operator === self::OPERATOR_EMPTY) {

--- a/src/fields/conditions/EmptyFieldConditionRule.php
+++ b/src/fields/conditions/EmptyFieldConditionRule.php
@@ -3,9 +3,10 @@
 namespace craft\fields\conditions;
 
 use craft\base\conditions\BaseConditionRule;
-use craft\elements\db\ElementQueryInterface;
-use Illuminate\Support\Collection;
+use craft\base\ElementInterface;
+use craft\errors\InvalidFieldException;
 use yii\base\InvalidConfigException;
+use yii\base\NotSupportedException;
 
 /**
  * Empty/not-empty field condition rule.
@@ -36,6 +37,34 @@ class EmptyFieldConditionRule extends BaseConditionRule implements FieldConditio
     /**
      * @inheritdoc
      */
+    public function matchElement(ElementInterface $element): bool
+    {
+        try {
+            $field = $this->field();
+        } catch (InvalidConfigException) {
+            // The field doesn't exist
+            return true;
+        }
+
+        try {
+            $value = $element->getFieldValue($field->handle);
+        } catch (InvalidFieldException) {
+            // The field doesn't belong to the element's field layout
+            return false;
+        }
+
+        $isEmpty = $this->field()->isValueEmpty($value, $element);
+
+        if ($this->operator === self::OPERATOR_EMPTY) {
+            return $isEmpty;
+        }
+
+        return !$isEmpty;
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function elementQueryParam(): int|string|null
     {
         return match ($this->operator) {
@@ -50,17 +79,6 @@ class EmptyFieldConditionRule extends BaseConditionRule implements FieldConditio
      */
     protected function matchFieldValue($value): bool
     {
-        /** @var ElementQueryInterface|Collection|null $value */
-        if ($value instanceof ElementQueryInterface) {
-            $isEmpty = !$value->exists();
-        } else {
-            $isEmpty = $value === null ? true : $value->isEmpty();
-        }
-
-        if ($this->operator === self::OPERATOR_EMPTY) {
-            return $isEmpty;
-        }
-
-        return !$isEmpty;
+        throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
### Description
The `$value` passed to `EmptyFieldConditionRule->matchFieldValue()` can also be `null`. This will be the case for an empty CKEditor or Redactor field, for example.

Related PR: https://github.com/craftcms/html-field/pull/14.


### Related issues
[#267](https://github.com/craftcms/ckeditor/issues/267)
