### PR TITLE
Relation field improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,7 +1,7 @@
 # Release Notes for Craft CMS 5.3 (WIP)
 
 ### Content Management
-- Added the “Link” field type, which replaces “URL”, and can store URLs, `mailto` and `tel` URIs, and entry/asset/category references. ([#15251](https://github.com/craftcms/cms/pull/15251))
+- Added the “Link” field type, which replaces “URL”, and can store URLs, `mailto` and `tel` URIs, and entry/asset/category relations. ([#15251](https://github.com/craftcms/cms/pull/15251), [#15400](https://github.com/craftcms/cms/pull/15400))
 - Entry and category conditions now have a “Has Descendants” rule. ([#15276](https://github.com/craftcms/cms/discussions/15276))
 - “Replace file” actions now display success notices on complete. ([#15217](https://github.com/craftcms/cms/issues/15217))
 - Double-clicking on folders within asset indexes and folder selection modals now navigates the index/modal into the folder. ([#15238](https://github.com/craftcms/cms/discussions/15238))
@@ -18,6 +18,8 @@
 - Improved the focus ring styling for dark buttons. ([#15364](https://github.com/craftcms/cms/pull/15364))
 
 ### Administration
+- Relation fields are now multi-instance. ([#15400](https://github.com/craftcms/cms/pull/15400))
+- Relation fields now have Translation Method settings with all the usual options, replacing “Manage relations on a per-site basis” settings. ([#15400](https://github.com/craftcms/cms/pull/15400))
 - Icon fields now have an “Include Pro icons” setting, which determines whether Font Awesome Pro icon should be selectable. ([#15242](https://github.com/craftcms/cms/issues/15242))
 - New sites’ Base URL settings now default to an environment variable name based on the site name. ([#15347](https://github.com/craftcms/cms/pull/15347))
 - Craft now warns against using the `@web` alias for URL settings, regardless of whether it was explicitly defined. ([#15347](https://github.com/craftcms/cms/pull/15347))
@@ -32,6 +34,9 @@
 - Added `craft\base\ElementInterface::addInvalidNestedElementIds()`.
 - Added `craft\base\ElementInterface::getInvalidNestedElementIds()`.
 - Added `craft\base\FieldLayoutComponent::EVENT_DEFINE_SHOW_IN_FORM`. ([#15260](https://github.com/craftcms/cms/issues/15260))
+- Added `craft\base\FieldLayoutElement::$dateAdded`.
+- Added `craft\base\RelationFieldInterface`. ([#15400](https://github.com/craftcms/cms/pull/15400))
+- Added `craft\base\RelationFieldTrait`. ([#15400](https://github.com/craftcms/cms/pull/15400))
 - Added `craft\config\GeneralConfig::addAlias()`. ([#15346](https://github.com/craftcms/cms/pull/15346))
 - Added `craft\events\DefineShowFieldLayoutComponentInFormEvent`. ([#15260](https://github.com/craftcms/cms/issues/15260))
 - Added `craft\fields\Link`.
@@ -44,7 +49,10 @@
 - Added `craft\fields\linktypes\Email`.
 - Added `craft\fields\linktypes\Phone`.
 - Added `craft\fields\linktypes\Url`.
+- `craft\helpers\DateTimeHelper::toIso8601()` now has a `$setToUtc` argument.
+- Deprecated `craft\fields\BaseRelationField::$localizeRelations`.
 - Deprecated `craft\fields\Url`, which is now an alias for `craft\fields\Link`.
+- Deprecated `craft\services\Relations`.
 - Deprecated `craft\web\assets\elementresizedetector\ElementResizeDetectorAsset`.
 - Added `Craft.EnvVarGenerator`.
 - Added `Craft.endsWith()`.

--- a/src/base/ApplicationTrait.php
+++ b/src/base/ApplicationTrait.php
@@ -170,7 +170,7 @@ use yii\web\ServerErrorHttpException;
  * @property-read Plugins $plugins The plugins service
  * @property-read ProjectConfig $projectConfig The project config service
  * @property-read Queue|QueueInterface $queue The job queue
- * @property-read Relations $relations The relations service
+ * @property-read Relations $relations The relations service (deprecated)
  * @property-read Revisions $revisions The revisions service
  * @property-read Routes $routes The routes service
  * @property-read Search $search The search service
@@ -1343,6 +1343,7 @@ trait ApplicationTrait
      * Returns the relations service.
      *
      * @return Relations The relations service
+     * @deprecated in 5.3.0
      */
     public function getRelations(): Relations
     {

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -13,6 +13,7 @@ use craft\behaviors\CustomFieldBehavior;
 use craft\behaviors\DraftBehavior;
 use craft\behaviors\RevisionBehavior;
 use craft\db\CoalesceColumnsExpression;
+use craft\db\Command;
 use craft\db\Connection;
 use craft\db\Query;
 use craft\db\Table;
@@ -5808,6 +5809,9 @@ JS,
      */
     public function afterSave(bool $isNew): void
     {
+        // Update the element’s relation data
+        $this->updateRelations();
+
         // Tell the fields about it
         foreach ($this->fieldLayoutFields() as $field) {
             $field->afterElementSave($this, $isNew);
@@ -5821,6 +5825,149 @@ JS,
         }
     }
 
+    private function updateRelations(): void
+    {
+        if (!$this->hasFieldLayout()) {
+            return;
+        }
+
+        $fields = $this->relationalFields();
+
+        /** @var int[] $skipFieldIds */
+        $skipFieldIds = [];
+        /** @var array<int,int|null> $sourceSiteIds */
+        $sourceSiteIds = [];
+        /** @var array<int,array<int,int>> $relationData */
+        $relationData = [];
+
+        foreach ($fields as $fieldId => $instances) {
+            $localizeRelations = $instances[0]->localizeRelations();
+            $include = false;
+
+            foreach ($instances as $field) {
+                // Skip if nothing changed, or the element is just propagating and we're not localizing relations
+                if (
+                    ($this->duplicateOf || $this->isFieldDirty($field->handle) || $field->forceUpdateRelations($this)) &&
+                    (!$this->propagating || $localizeRelations)
+                ) {
+                    $include = true;
+                    break;
+                }
+            }
+
+            if ($include) {
+                // Create target ID => sort order mappings for the field
+                foreach ($instances as $field) {
+                    $sourceSiteIds[$field->id] = $localizeRelations ? $this->siteId : null;
+                    $relationData[$field->id] ??= [];
+                    foreach ($field->getRelationTargetIds($this) as $targetId) {
+                        if (!isset($relationData[$field->id][$targetId])) {
+                            $relationData[$field->id][$targetId] = count($relationData[$field->id]) + 1;
+                        }
+                    }
+                }
+            } else {
+                $skipFieldIds[] = $fieldId;
+            }
+        }
+
+        // Get the old relations
+        $db = Craft::$app->getDb();
+        $query = (new Query())
+            ->select(['id', 'fieldId', 'sourceSiteId', 'targetId', 'sortOrder'])
+            ->from([Table::RELATIONS])
+            ->where(['sourceId' => $this->id])
+            ->andWhere(['or', ['sourceSiteId' => null], ['sourceSiteId' => $this->siteId]]);
+        if (!empty(($skipFieldIds))) {
+            // Exclude the skipped fields rather than listing included fields,
+            // so we also get any relations for fields that aren't part of the layout
+            // (https://github.com/craftcms/cms/issues/13956)
+            $query->andWhere(['not', ['fieldId' => $skipFieldIds]]);
+        }
+        $oldRelations = $query->all($db);
+
+        /** @var Command[] $updateCommands */
+        $updateCommands = [];
+        $deleteIds = [];
+
+        foreach ($oldRelations as $relation) {
+            [$relationId, $fieldId, $oldSourceSiteId, $targetId, $oldSortOrder] = [
+                $relation['id'],
+                $relation['fieldId'],
+                $relation['sourceSiteId'],
+                $relation['targetId'],
+                $relation['sortOrder'],
+            ];
+
+            // Does this relation still exist?
+            if (isset($relationData[$fieldId][$targetId])) {
+                // Anything to update?
+                if ($oldSourceSiteId != $sourceSiteIds[$fieldId] || $oldSortOrder != $relationData[$fieldId][$targetId]) {
+                    $updateCommands[] = $db->createCommand()->update(Table::RELATIONS, [
+                        'sourceSiteId' => $sourceSiteIds[$fieldId],
+                        'sortOrder' => $relationData[$fieldId][$targetId],
+                    ], ['id' => $relationId]);
+                }
+
+                // Avoid re-inserting it
+                unset($relationData[$fieldId][$targetId]);
+                if (empty($relationData[$fieldId])) {
+                    unset($relationData[$fieldId]);
+                }
+            } else {
+                $deleteIds[] = $relationId;
+            }
+        }
+
+        if (empty($updateCommands) && empty($deleteIds) && empty($relationData)) {
+            // Nothing to do here
+            return;
+        }
+
+        $db->transaction(function() use ($updateCommands, $deleteIds, $relationData, $sourceSiteIds, $db) {
+            foreach ($updateCommands as $command) {
+                $command->execute();
+            }
+
+            // Add the new ones
+            if (!empty($relationData)) {
+                $values = [];
+                foreach ($relationData as $fieldId => $targetIds) {
+                    foreach ($targetIds as $targetId => $sortOrder) {
+                        $values[] = [
+                            $fieldId,
+                            $this->id,
+                            $sourceSiteIds[$fieldId],
+                            $targetId,
+                            $sortOrder,
+                        ];
+                    }
+                }
+                Db::batchInsert(Table::RELATIONS, ['fieldId', 'sourceId', 'sourceSiteId', 'targetId', 'sortOrder'], $values, $db);
+            }
+
+            if (!empty($deleteIds)) {
+                Db::delete(Table::RELATIONS, [
+                    'id' => $deleteIds,
+                ], [], $db);
+            }
+        });
+    }
+
+    /**
+     * @return array<int,RelationalFieldInterface[]>
+     */
+    private function relationalFields(): array
+    {
+        $fields = [];
+        foreach ($this->fieldLayoutFields() as $field) {
+            if ($field instanceof RelationalFieldInterface) {
+                $fields[$field->id][] = $field;
+            }
+        }
+        return $fields;
+    }
+
     /**
      * @inheritdoc
      */
@@ -5829,11 +5976,6 @@ JS,
         // Tell the fields about it
         foreach ($this->fieldLayoutFields() as $field) {
             $field->afterElementPropagate($this, $isNew);
-        }
-
-        // Delete relations that don’t belong to a relational field on the element's field layout
-        if (!ElementHelper::isDraftOrRevision($this)) {
-            Craft::$app->getRelations()->deleteLeftoverRelations($this);
         }
 
         // Fire an 'afterPropagate' event
@@ -5902,9 +6044,22 @@ JS,
      */
     public function afterDeleteForSite(): void
     {
+        // Delete any site-specific relation data
+        $this->deleteSiteRelations();
+
         // Tell the fields about it
         foreach ($this->fieldLayoutFields() as $field) {
             $field->afterElementDeleteForSite($this);
+        }
+    }
+
+    private function deleteSiteRelations(): void
+    {
+        if ($this->hasFieldLayout()) {
+            Db::delete(Table::RELATIONS, [
+                'sourceSiteId' => $this->siteId,
+                'sourceId' => $this->id,
+            ]);
         }
     }
 

--- a/src/base/FieldLayoutElement.php
+++ b/src/base/FieldLayoutElement.php
@@ -8,6 +8,7 @@
 namespace craft\base;
 
 use craft\models\FieldLayout;
+use DateTime;
 
 /**
  * FieldLayoutElement is the base class for classes representing field layout elements in terms of objects.
@@ -22,6 +23,12 @@ abstract class FieldLayoutElement extends FieldLayoutComponent
      * @var int The width (%) of the field
      */
     public int $width = 100;
+
+    /**
+     * @var DateTime|null The date that the element was added to the field layout.
+     * @since 5.3.0
+     */
+    public ?DateTime $dateAdded = null;
 
     /**
      * @inheritdoc

--- a/src/base/Model.php
+++ b/src/base/Model.php
@@ -192,6 +192,10 @@ abstract class Model extends \yii\base\Model implements ModelInterface
             $attributes[] = 'dateCreated';
         }
 
+        if (property_exists($this, 'dateAdded')) {
+            $attributes[] = 'dateAdded';
+        }
+
         if (property_exists($this, 'dateUpdated')) {
             $attributes[] = 'dateUpdated';
         }
@@ -245,8 +249,9 @@ abstract class Model extends \yii\base\Model implements ModelInterface
         // Have all DateTime attributes converted to ISO-8601 strings
         foreach ($datetimeAttributes as $attribute) {
             $fields[$attribute] = function($model, $attribute) {
-                if (!empty($model->$attribute)) {
-                    return DateTimeHelper::toIso8601($model->$attribute);
+                $date = $model->$attribute;
+                if ($date) {
+                    return DateTimeHelper::toIso8601($date, true);
                 }
 
                 return $model->$attribute;

--- a/src/base/RelationalFieldInterface.php
+++ b/src/base/RelationalFieldInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\base;
+
+/**
+ * RelationalFieldInterface defines the common interface to be implemented by field classes
+ * which can store relation data.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.3.0
+ */
+interface RelationalFieldInterface extends FieldInterface
+{
+    /**
+     * Returns whether relations stored for the field should include the source element’s site ID.
+     *
+     * Note that this must be consistent across all instances of the same field.
+     *
+     * @return bool
+     */
+    public function localizeRelations(): bool;
+
+    /**
+     * Returns whether relations should be updated for the field.
+     *
+     * @param ElementInterface $element
+     * @return bool
+     */
+    public function forceUpdateRelations(ElementInterface $element): bool;
+
+    /**
+     * Returns the related element IDs for this field.
+     *
+     * @param ElementInterface $element
+     * @return int[]
+     */
+    public function getRelationTargetIds(ElementInterface $element): array;
+}

--- a/src/base/RelationalFieldTrait.php
+++ b/src/base/RelationalFieldTrait.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\base;
+
+/**
+ * RelationalFieldTrait provides a base implementation for [[RelationalFieldInterface]].
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.3.0
+ */
+trait RelationalFieldTrait
+{
+    public function localizeRelations(): bool
+    {
+        return true;
+    }
+
+    public function forceUpdateRelations(ElementInterface $element): bool
+    {
+        return false;
+    }
+}

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -29,6 +29,7 @@ use craft\elements\ElementCollection;
 use craft\errors\SiteNotFoundException;
 use craft\events\CancelableEvent;
 use craft\events\ElementCriteriaEvent;
+use craft\fieldlayoutelements\CustomField;
 use craft\fields\conditions\RelationalFieldConditionRule;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
@@ -41,9 +42,11 @@ use craft\services\Elements;
 use craft\services\ElementSources;
 use DateTime;
 use GraphQL\Type\Definition\Type;
+use Illuminate\Support\Collection;
 use yii\base\Event;
 use yii\base\InvalidConfigException;
 use yii\db\Expression;
+use yii\db\Schema;
 use yii\validators\NumberValidator;
 
 /**
@@ -64,17 +67,6 @@ abstract class BaseRelationField extends Field implements
     public const EVENT_DEFINE_SELECTION_CRITERIA = 'defineSelectionCriteria';
 
     private static bool $validatingRelatedElements = false;
-
-    /**
-     * @inheritdoc
-     */
-    public static function supportedTranslationMethods(): array
-    {
-        // Don't ever automatically propagate values to other sites.
-        return [
-            self::TRANSLATION_METHOD_SITE,
-        ];
-    }
 
     /**
      * Returns the element class associated with this field type.
@@ -107,7 +99,7 @@ abstract class BaseRelationField extends Field implements
      */
     public static function dbType(): array|string|null
     {
-        return null;
+        return Schema::TYPE_JSON;
     }
 
     /**
@@ -273,6 +265,7 @@ abstract class BaseRelationField extends Field implements
 
     /**
      * @var bool Whether each site should get its own unique set of relations
+     * @deprecated in 5.3.0
      */
     public bool $localizeRelations = false;
 
@@ -374,6 +367,12 @@ abstract class BaseRelationField extends Field implements
             unset($config['sources']);
         }
 
+        if (isset($config['localizeRelations'])) {
+            $config['translationMethod'] = $config['localizeRelations'] ? self::TRANSLATION_METHOD_SITE : self::TRANSLATION_METHOD_NONE;
+        } else {
+            $config['localizeRelations'] = ($config['translationMethod'] ?? self::TRANSLATION_METHOD_NONE) !== self::TRANSLATION_METHOD_NONE;
+        }
+
         parent::__construct($config);
     }
 
@@ -443,7 +442,6 @@ abstract class BaseRelationField extends Field implements
     {
         $attributes = parent::settingsAttributes();
         $attributes[] = 'allowSelfRelations';
-        $attributes[] = 'localizeRelations';
         $attributes[] = 'maxRelations';
         $attributes[] = 'minRelations';
         $attributes[] = 'selectionLabel';
@@ -658,12 +656,14 @@ JS, [
         $query = $class::find()
             ->siteId($this->targetSiteId($element));
 
-        // $value will be an array of element IDs if there was a validation error or we're loading a draft/version.
         if (is_array($value)) {
             $query
                 ->id(array_values(array_filter($value)))
                 ->fixedOrder();
-        } elseif ($value !== '' && $element && $element->id) {
+        } elseif ($value === null && $element?->id && $this->isFirstInstance($element)) {
+            // If $value is null, the element + field haven’t been saved since updatid to Craft 5.3+,
+            // or since the field was added to the field layout. So only actually look at the `relations` table
+            // if this is the first instance of the field that was ever added to the field layout.
             if (!$this->allowMultipleSources && $this->source) {
                 $source = ElementHelper::findSource($class, $this->source, ElementSources::CONTEXT_FIELD);
 
@@ -752,6 +752,21 @@ JS, [
         return $query;
     }
 
+    private function isFirstInstance(?Elementinterface $element): bool
+    {
+        if ($this->layoutElement?->uid === null) {
+            return false;
+        }
+
+        /** @var CustomField|null $first */
+        $first = Collection::make($element?->getFieldLayout()?->getCustomFieldElements())
+            ->filter(fn(CustomField $layoutElement) => $layoutElement->getField()->id === $this->id)
+            ->sortBy(fn(CustomField $layoutElement) => $layoutElement->dateAdded)
+            ->first();
+
+        return $this->layoutElement->uid === $first?->uid;
+    }
+
     /**
      * @inheritdoc
      */
@@ -759,7 +774,7 @@ JS, [
     {
         /** @var ElementQueryInterface|ElementCollection $value */
         if ($value instanceof ElementCollection) {
-            return $value->map(fn(ElementInterface $element) => $element->id)->all();
+            return $value->ids()->all();
         }
 
         return $this->_all($value, $element)->ids();

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -661,7 +661,7 @@ JS, [
                 ->id(array_values(array_filter($value)))
                 ->fixedOrder();
         } elseif ($value === null && $element?->id && $this->isFirstInstance($element)) {
-            // If $value is null, the element + field haven’t been saved since updatid to Craft 5.3+,
+            // If $value is null, the element + field haven’t been saved since updating to Craft 5.3+,
             // or since the field was added to the field layout. So only actually look at the `relations` table
             // if this is the first instance of the field that was ever added to the field layout.
             if (!$this->allowMultipleSources && $this->source) {

--- a/src/fields/Link.php
+++ b/src/fields/Link.php
@@ -13,6 +13,7 @@ use craft\base\Event;
 use craft\base\Field;
 use craft\base\InlineEditableFieldInterface;
 use craft\base\RelationalFieldInterface;
+use craft\base\RelationalFieldTrait;
 use craft\events\RegisterComponentTypesEvent;
 use craft\fields\conditions\TextFieldConditionRule;
 use craft\fields\data\LinkData;
@@ -40,6 +41,8 @@ use yii\db\Schema;
  */
 class Link extends Field implements InlineEditableFieldInterface, RelationalFieldInterface
 {
+    use RelationalFieldTrait;
+
     /**
      * @event DefineLinkOptionsEvent The event that is triggered when registering the link types for Link fields.
      * @see types()
@@ -478,22 +481,6 @@ JS;
         }
         $value = Html::encode((string)$value);
         return "<a href=\"$value\" target=\"_blank\">$value</a>";
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function localizeRelations(): bool
-    {
-        return true;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function forceUpdateRelations(ElementInterface $element): bool
-    {
-        return false;
     }
 
     /**

--- a/src/fields/Link.php
+++ b/src/fields/Link.php
@@ -12,6 +12,7 @@ use craft\base\ElementInterface;
 use craft\base\Event;
 use craft\base\Field;
 use craft\base\InlineEditableFieldInterface;
+use craft\base\RelationalFieldInterface;
 use craft\events\RegisterComponentTypesEvent;
 use craft\fields\conditions\TextFieldConditionRule;
 use craft\fields\data\LinkData;
@@ -37,7 +38,7 @@ use yii\db\Schema;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 5.3.0
  */
-class Link extends Field implements InlineEditableFieldInterface
+class Link extends Field implements InlineEditableFieldInterface, RelationalFieldInterface
 {
     /**
      * @event DefineLinkOptionsEvent The event that is triggered when registering the link types for Link fields.
@@ -477,5 +478,36 @@ JS;
         }
         $value = Html::encode((string)$value);
         return "<a href=\"$value\" target=\"_blank\">$value</a>";
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function localizeRelations(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function forceUpdateRelations(ElementInterface $element): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRelationTargetIds(ElementInterface $element): array
+    {
+        $targetIds = [];
+        /** @var LinkData|null $value */
+        $value = $element->getFieldValue($this->handle);
+        $element = $value?->getElement();
+        if ($element) {
+            $targetIds[] = $element->id;
+        }
+        return $targetIds;
     }
 }

--- a/src/helpers/DateTimeHelper.php
+++ b/src/helpers/DateTimeHelper.php
@@ -287,17 +287,25 @@ class DateTimeHelper
      * Converts a date to an ISO-8601 string.
      *
      * @param mixed $date The date, in any format that [[toDateTime()]] supports.
+     * @param bool $setToUtc Whether the resulting string should be set to UTC.
      * @return string|false The date formatted as an ISO-8601 string, or `false` if $date was not a valid date
      */
-    public static function toIso8601(mixed $date): string|false
+    public static function toIso8601(mixed $date, bool $setToUtc = false): string|false
     {
-        $date = static::toDateTime($date);
-
-        if ($date !== false) {
-            return $date->format(DateTime::ATOM);
+        if ($date instanceof DateTime && $setToUtc) {
+            $date = clone $date;
+        } else {
+            $date = static::toDateTime($date);
+            if (!$date) {
+                return false;
+            }
         }
 
-        return false;
+        if ($setToUtc) {
+            $date->setTimezone(new DateTimeZone('UTC'));
+        }
+
+        return $date->format(DateTime::ATOM);
     }
 
     /**

--- a/src/models/FieldLayoutTab.php
+++ b/src/models/FieldLayoutTab.php
@@ -217,9 +217,9 @@ class FieldLayoutTab extends FieldLayoutComponent
             }
             $elementConfig = ['type' => get_class($layoutElement)] + $layoutElement->toArray();
             if (!isset($elementConfig['dateAdded'])) {
-                // Default `dateAdded` to a minute ago for GET requests, so there’s no chance that an element that
-                // predated 5.3 would get the same timestamp as a newly-added element, if the layout was saved within
-                // a minute of being edited, after updating to Craft 5.3+.
+                // Default `dateAdded` to a minute ago, so there’s no chance that an element that predated 5.3 would get
+                // the same timestamp as a newly-added element, if the layout was saved within a minute of being edited,
+                // after updating to Craft 5.3+.
                 $elementConfig['dateAdded'] = DateTimeHelper::toIso8601((new DateTime())->modify('-1 minute'));
             }
             $elementConfigs[] = $elementConfig;

--- a/src/models/FieldLayoutTab.php
+++ b/src/models/FieldLayoutTab.php
@@ -16,9 +16,11 @@ use craft\fieldlayoutelements\BaseField;
 use craft\fieldlayoutelements\CustomField;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
+use craft\helpers\DateTimeHelper;
 use craft\helpers\Html;
 use craft\helpers\Json;
 use craft\helpers\StringHelper;
+use DateTime;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 
@@ -213,7 +215,14 @@ class FieldLayoutTab extends FieldLayoutComponent
             if (!isset($layoutElement->uid)) {
                 $layoutElement->uid = StringHelper::UUID();
             }
-            $elementConfigs[] = ['type' => get_class($layoutElement)] + $layoutElement->toArray();
+            $elementConfig = ['type' => get_class($layoutElement)] + $layoutElement->toArray();
+            if (!isset($elementConfig['dateAdded'])) {
+                // Default `dateAdded` to a minute ago for GET requests, so there’s no chance that an element that
+                // predated 5.3 would get the same timestamp as a newly-added element, if the layout was saved within
+                // a minute of being edited, after updating to Craft 5.3+.
+                $elementConfig['dateAdded'] = DateTimeHelper::toIso8601((new DateTime())->modify('-1 minute'));
+            }
+            $elementConfigs[] = $elementConfig;
         }
         return $elementConfigs;
     }

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -63,6 +63,7 @@ use craft\models\FieldLayout;
 use craft\models\FieldLayoutTab;
 use craft\records\Field as FieldRecord;
 use craft\records\FieldLayout as FieldLayoutRecord;
+use DateTime;
 use Throwable;
 use yii\base\Component;
 use yii\base\Exception;
@@ -1049,7 +1050,16 @@ class Fields extends Component
     {
         $paramPrefix = $namespace ? rtrim($namespace, '.') . '.' : '';
         $config = Json::decode(Craft::$app->getRequest()->getBodyParam($paramPrefix . 'fieldLayout'));
-        return $this->createLayout($config);
+        $layout = $this->createLayout($config);
+
+        // Make sure all the elements have a dateAdded value set
+        foreach ($layout->getTabs() as $tab) {
+            foreach ($tab->getElements() as $layoutElement) {
+                $layoutElement->dateAdded ??= new DateTime();
+            }
+        }
+
+        return $layout;
     }
 
     /**

--- a/src/services/Relations.php
+++ b/src/services/Relations.php
@@ -25,6 +25,7 @@ use yii\base\Component;
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
+ * @deprecated in 5.3.0
  */
 class Relations extends Component
 {

--- a/src/templates/_components/fieldtypes/elementfieldsettings.twig
+++ b/src/templates/_components/fieldtypes/elementfieldsettings.twig
@@ -150,15 +150,6 @@
                 {% block targetSiteField %}
                     {{ field.getTargetSiteFieldHtml()|raw }}
                 {% endblock %}
-
-                {% block localizeRelationsField %}
-                    {{ forms.lightswitchField({
-                        label: 'Manage relations on a per-site basis'|t('app'),
-                        id: 'localize-relations',
-                        name: 'localizeRelations',
-                        on: field.localizeRelations
-                    }) }}
-                {% endblock %}
             {% endif %}
 
         </div>

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -910,7 +910,6 @@ return [
     'Make sure you’ve followed the <a href="{url}" target="_blank">Environment Setup</a> instructions before applying project config YAML changes.' => 'Make sure you’ve followed the <a href="{url}" target="_blank">Environment Setup</a> instructions before applying project config YAML changes.',
     'Make this the primary site' => 'Make this the primary site',
     'Manage categories' => 'Manage categories',
-    'Manage relations on a per-site basis' => 'Manage relations on a per-site basis',
     'Manage your Craft Console account' => 'Manage your Craft Console account',
     'Manipulated SVG image rasterizing is unreliable. See \\craft\\services\\Images::loadImage()' => 'Manipulated SVG image rasterizing is unreliable. See \\craft\\services\\Images::loadImage()',
     'Matrix field' => 'Matrix field',


### PR DESCRIPTION
### Description

Several improvements for relations in Craft:

- Relation fields are now multi-instance.
- Relation fields now get all the normal Translation Method options. (Existing fields will be set to either “Not translatable” or “Translate for each site”, depending on their previous “Manage relations on a per-site basis” setting.)
- Link fields now store relations when an element is selected—so they now get factored in by `relatedTo` element query params—and the framework is in place for other field types (e.g. CKEditor) to start storing relations as well.

Field types which should store relations (in addition to their normal field data) must implement `RelationalFieldInterface`, and optionally import `RelationalFieldTrait`.

```php
use craft\base\Field;
use craft\base\RelationalFieldInterface;
use craft\base\RelationalFieldTrait;

class MyFieldType extends Field implements RelationalFieldInterface
{
    use RelationalFieldTrait;

    public function getRelationTargetIds(ElementInterface $element): array
    {
        $value = $element->getFieldValue($this->handle);
        return $this->scrapeRelationIdsFromValue($value);
    }

    private function scrapeRelationIdsFromValue(mixed $value): array
    {
        // ...
    }
}
```

### Related issues

- #8497
- #8539
- #11934
- #14728
- #14929