### PR TITLE
Generate transforms by the specified index from Assets Controller

### DIFF
--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -1107,6 +1107,7 @@ class AssetsController extends Controller
     public function actionGenerateTransform(?int $transformId = null): Response
     {
         try {
+            $transformIndexModel = null;
             // If a transform ID was not passed in, see if a file ID and handle were.
             if ($transformId) {
                 $transformer = Craft::createObject(ImageTransformer::class);
@@ -1134,7 +1135,7 @@ class AssetsController extends Controller
             throw new NotFoundHttpException();
         }
 
-        $url = $transformer->getTransformUrl($asset, $transform, true);
+        $url = $transformer->getTransformUrl($asset, $transform, true, $transformIndexModel);
 
         if ($this->request->getAcceptsJson()) {
             return $this->asJson(['url' => $url]);

--- a/src/imagetransforms/ImageTransformer.php
+++ b/src/imagetransforms/ImageTransformer.php
@@ -75,7 +75,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface, E
     /**
      * @inheritdoc
      */
-    public function getTransformUrl(Asset $asset, ImageTransform $imageTransform, bool $immediately): string
+    public function getTransformUrl(Asset $asset, ImageTransform $imageTransform, bool $immediately, ?ImageTransformIndex $imageTransformIndex = null): string
     {
         $fs = $asset->getVolume()->getTransformFs();
         $mimeType = $asset->getMimeType();
@@ -93,7 +93,7 @@ class ImageTransformer extends Component implements ImageTransformerInterface, E
             throw new NotSupportedException('SVG files shouldn’t be transformed.');
         }
 
-        $index = $this->getTransformIndex($asset, $imageTransform);
+        $index = $imageTransformIndex ?? $this->getTransformIndex($asset, $imageTransform);
         $uri = str_replace('\\', '/', $this->getTransformBasePath($asset)) . $this->getTransformUri($asset, $index);
 
         // If it's a local filesystem, make sure `fileExists` is accurate


### PR DESCRIPTION
### Description

**TL;DR:** When passing a transform index ID to `/actions/assets/generate-transforms`, the action should generate that exact index.

**Full Story:** We launched a site running 4.10.4 and somehow ended up with duplicate rows in our `imagetransformindex` table. Our template eager loaded transforms, and it yields the second row from the table (id: 21) for a particular transform. When the Assets Controller went to generate the transform by ID, it actually queries the `imagetransformindex` table based on the attributes of the transform, which would yield the first row (id: 20) and not the actual row requested (id: 21). This would yield an ever-growing queue of image transformations that would never flip the `fileExists` to 1 on id 21.

I recognize this solution deals with symptoms and not the root problem, but at least it prevents the queue from infinitely pushing image transforms jobs. I believe this fix is also applicable for 5.x.

We did have multiple processes in our supervisor config, so that was probably the root cause of the duplicate rows. I used these queries to diagnose and clean up the table:

```sql
SELECT 
  assetId,
  format,
  transformString, 
  COUNT(*) as duplicate_count
FROM 
  craft_imagetransformindex
GROUP BY 
  assetId, format, transformString
HAVING 
  COUNT(*) > 1;


DELETE FROM craft_imagetransformindex
WHERE id NOT IN (
  SELECT id FROM (
    SELECT MIN(id) as id
    FROM craft_imagetransformindex
    GROUP BY assetId, format, transformString
  ) as subquery
);

```

### Related issues

https://github.com/craftcms/cms/issues/12453

