### PR TITLE
Use the primary site URL as the base CP URL for CLI requests

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -17,6 +17,7 @@
 ### Extensibility
 - Added `craft\config\GeneralConfig::addAlias()`. ([#15346](https://github.com/craftcms/cms/pull/15346))
 - Added `Craft.EnvVarGenerator`.
+- `craft\helpers\UrlHelper::cpUrl()` now returns URLs based on the primary site’s base URL (if it has one), for console requests if the `baseCpUrl` config setting isn’t set, and the `@web` alias wasn’t explicitly defined. ([#15374](https://github.com/craftcms/cms/issues/15374))
 - Deprecated `craft\web\assets\elementresizedetector\ElementResizeDetectorAsset`.
 
 ### System


### PR DESCRIPTION
### Description

Follow up on 8e69802d89556d4432002fed3754404a4e8e0252, but this time for control panel URLs.

### Related issues

- #15374