### PR TITLE
Fixes check for primary key name in Postgres

### DIFF
--- a/src/migrations/m231013_185640_changedfields_amend_primary_key.php
+++ b/src/migrations/m231013_185640_changedfields_amend_primary_key.php
@@ -19,7 +19,7 @@ class m231013_185640_changedfields_amend_primary_key extends Migration
             $this->dropPrimaryKey('elementId', Table::CHANGEDFIELDS);
             $this->addPrimaryKey('layoutUid', Table::CHANGEDFIELDS, ['elementId', 'siteId', 'fieldId', 'layoutElementUid']);
         } else {
-            $pkName = $this->db->getSchema()->getRawTableName(Table::CHANGEDFIELDS) . '_pkey';
+            $pkName = $this->db->getSchema()->getTablePrimaryKey(Table::CHANGEDFIELDS)->name;
 
             $this->dropPrimaryKey($pkName, Table::CHANGEDFIELDS);
             $this->addPrimaryKey($pkName, Table::CHANGEDFIELDS, ['elementId', 'siteId', 'fieldId', 'layoutElementUid']);


### PR DESCRIPTION
### Description

Hey! I’m running into an issue where this migration can’t be run on a Postgres database, because the primary key can’t be found.

```sh
*** applying m231013_185640_changedfields_amend_primary_key
    > drop primary key changedfields_pkey ...Exception: SQLSTATE[42704]: Undefined object: 7 ERROR:  constraint "changedfields_pkey" of relation "changedfields" does not exist
The SQL being executed was: ALTER TABLE "changedfields" DROP CONSTRAINT "changedfields_pkey" (/var/www/html/vendor/yiisoft/yii2/db/Schema.php:676)
#0 /var/www/html/vendor/yiisoft/yii2/db/Command.php(1325): yii\db\Schema->convertException(Object(PDOException), 'ALTER TABLE "ch...')
#1 /var/www/html/vendor/yiisoft/yii2/db/Command.php(1120): yii\db\Command->internalExecute('ALTER TABLE "ch...')
#2 /var/www/html/vendor/yiisoft/yii2/db/Migration.php(460): yii\db\Command->execute()
#3 /var/www/html/vendor/craftcms/cms/src/migrations/m231013_185640_changedfields_amend_primary_key.php(24): yii\db\Migration->dropPrimaryKey('changedfields_p...', '{{%changedfield...')
#4 /var/www/html/vendor/craftcms/cms/src/db/Migration.php(50): craft\migrations\m231013_185640_changedfields_amend_primary_key->safeUp()
#5 /var/www/html/vendor/yiisoft/yii2/console/controllers/BaseMigrateController.php(758): craft\db\Migration->up()
#6 /var/www/html/vendor/craftcms/cms/src/console/controllers/MigrateController.php(382): yii\console\controllers\BaseMigrateController->migrateUp('m231013_185640_...')
#7 [internal function]: craft\console\controllers\MigrateController->actionAll()
#8 /var/www/html/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)
#9 /var/www/html/vendor/yiisoft/yii2/base/Controller.php(178): yii\base\InlineAction->runWithParams(Array)
#10 /var/www/html/vendor/yiisoft/yii2/console/Controller.php(180): yii\base\Controller->runAction('all', Array)
#11 /var/www/html/vendor/craftcms/cms/src/console/controllers/MigrateController.php(195): yii\console\Controller->runAction('all', Array)
#12 /var/www/html/vendor/yiisoft/yii2/base/Module.php(552): craft\console\controllers\MigrateController->runAction('all', Array)
#13 /var/www/html/vendor/yiisoft/yii2/console/Application.php(180): yii\base\Module->runAction('migrate/all', Array)
#14 /var/www/html/vendor/craftcms/cms/src/console/Application.php(91): yii\console\Application->runAction('migrate/all', Array)
#15 /var/www/html/vendor/yiisoft/yii2/console/Application.php(147): craft\console\Application->runAction('migrate/all', Array)
#16 /var/www/html/vendor/craftcms/cms/src/console/Application.php(122): yii\console\Application->handleRequest(Object(craft\console\Request))
#17 /var/www/html/vendor/yiisoft/yii2/base/Application.php(384): craft\console\Application->handleRequest(Object(craft\console\Request))
#18 /var/www/html/craft(13): yii\base\Application->run()
#19 {main}
*** failed to apply m231013_185640_changedfields_amend_primary_key (time: 0.001s)
```

This PR is a bit of guess, but I’m wondering if this PR is another valid way to get the key? The database I’m using started life as a Craft 2 project in MySQL, and at some point went through [this migration process](https://craftcms.stackexchange.com/a/35816) to Postgres, so it’s possible this is a project-specific issue.

In any case, the constraint had an entirely different name in this DB, and once I made this change the migration ran successfully.
