### PR TITLE
Add note about `async` option available in `csrfInput()`

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1040,7 +1040,7 @@ class GeneralConfig extends BaseConfig
 
 
     /**
-     * @var bool Whether CSRF values should be injected via JavaScript for greater cache-ability.
+     * @var bool Whether CSRF values should be injected via JavaScript for greater cache-ability. This setting can be overridden by passing an `async` option into the `csrfInput()` function.
      *
      *  ::: code
      *  ```php Static Config


### PR DESCRIPTION
This PR adds a note about the option to override the [`asyncCsrfInputs`](https://craftcms.com/docs/5.x/reference/config/general.html#asynccsrfinputs) by passing an `async` option into `csrfInput()` function (added in [5.1.0](https://github.com/craftcms/cms/blob/5.x/CHANGELOG.md#510---2024-04-30)) .