### PR TITLE
set secureHeaders property to prevent IP spoofing

### DIFF
--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -69,6 +69,18 @@ class Request extends \yii\web\Request
     ];
 
     /**
+     * @inheritdoc
+     */
+    public $secureHeaders = [
+        'Client-IP',
+        'X-Forwarded-For',
+        'X-Forwarded',
+        'X-Cluster-Client-IP',
+        'Forwarded-For',
+        'Forwarded',
+    ];
+
+    /**
      * @var int The highest page number that Craft should accept.
      * @since 3.1.14
      */


### PR DESCRIPTION
### Description
In the `craft\web\Request` class the `$ipHeaders` property overwrites the default values set in the `\yii\web\Request` class. However the `$secureHeaders` property is not updated accordingly with the same headers.

This oversight allows users to spoof their IP addresses. For instance, if someone sets a spoofed `Forwarded-For` header to a random IP address, the method `Craft::$app->getRequest()->getUserIP()` will return this spoofed IP address instead of the user's real IP. This happens because the `Forwarded-For` header is not in the `$secureHeaders` property, making it vulnerable to manipulation.

Tested with Craft version **4.8.7**

### Related issues

