### PR TITLE
`env` commands

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -6,6 +6,7 @@
 - Double-clicking on folders within asset indexes and folder selection modals now navigates the index/modal into the folder. ([#15238](https://github.com/craftcms/cms/discussions/15238))
 
 ### Administration
+- Added the `env`, `env/set`, and `env/remove` commands. ([#15431](https://github.com/craftcms/cms/pull/15431))
 - New sites’ Base URL settings now default to an environment variable name based on the site name. ([#15347](https://github.com/craftcms/cms/pull/15347))
 - Craft now warns against using the `@web` alias for URL settings, regardless of whether it was explicitly defined. ([#15347](https://github.com/craftcms/cms/pull/15347))
 
@@ -22,6 +23,7 @@
 - Added `craft\filters\Headers`. ([#15397](https://github.com/craftcms/cms/pull/15397))
 - Added `Craft.EnvVarGenerator`.
 - `craft\helpers\UrlHelper::cpUrl()` now returns URLs based on the primary site’s base URL (if it has one), for console requests if the `baseCpUrl` config setting isn’t set, and the `@web` alias wasn’t explicitly defined. ([#15374](https://github.com/craftcms/cms/issues/15374))
+- `craft\services\Config::setDotEnvVar()` now accepts `false` for its `value` argument, which removes the environment variable from the `.env` file.
 - Deprecated `craft\web\assets\elementresizedetector\ElementResizeDetectorAsset`.
 
 ### System

--- a/src/console/controllers/EnvController.php
+++ b/src/console/controllers/EnvController.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\console\controllers;
+
+use Craft;
+use craft\console\Controller;
+use craft\helpers\App;
+use craft\helpers\Console;
+use yii\base\Exception;
+use yii\console\ExitCode;
+
+/**
+ * Sets or removes environment variables in the `.env` file.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.11.0
+ */
+class EnvController extends Controller
+{
+    /**
+     * @inheritdoc
+     */
+    public $defaultAction = 'show';
+
+    /**
+     * Displays the value of an environment variable, or sets its value if $name contains `=`.
+     *
+     *     php craft env CRAFT_DEV_MODE
+     *     php craft env CRAFT_DEV_MODE=true
+     *
+     * @param string $name
+     * @return int
+     */
+    public function actionShow(string $name): int
+    {
+        if (str_contains($name, '=')) {
+            [$name, $value] = explode('=', $name, 2);
+            return $this->runAction('set', [$name, $value]);
+        }
+
+        $value = App::env($name);
+        $dump = Craft::dump($value, return: true);
+        $this->stdout(trim($dump) . "\n");
+        return ExitCode::OK;
+    }
+
+    /**
+     * Sets an environment variable in the `.env` file.
+     *
+     *     php craft env/set CRAFT_DEV_MODE true
+     *
+     * @param string $name
+     * @param string $value
+     * @return int
+     */
+    public function actionSet(string $name, string $value = ''): int
+    {
+        if (str_contains($name, '=')) {
+            [$name, $value] = explode('=', $name, 2);
+        }
+
+        try {
+            Craft::$app->getConfig()->setDotEnvVar(trim($name), trim($value));
+        } catch (Exception $e) {
+            $this->stderr($e->getMessage() . "\n", Console::FG_RED);
+            return ExitCode::UNSPECIFIED_ERROR;
+        }
+
+        $dump = Craft::dump(App::env($name), return: true);
+        $this->stdout(sprintf("%s %s.\n", $this->markdownToAnsi("`$name` is now"), trim($dump)));
+        return ExitCode::OK;
+    }
+
+    /**
+     * Removes an environment variable from the `.env` file.
+     *
+     *     php craft env/remove CRAFT_DEV_MODE
+     *
+     * @param string $name
+     * @return int
+     */
+    public function actionRemove(string $name): int
+    {
+        try {
+            Craft::$app->getConfig()->setDotEnvVar($name, false);
+        } catch (Exception $e) {
+            $this->stderr($e->getMessage() . "\n", Console::FG_RED);
+            return ExitCode::UNSPECIFIED_ERROR;
+        }
+
+        $this->stdout($this->markdownToAnsi("`$name` has been removed.") . "\n");
+        return ExitCode::OK;
+    }
+}

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -499,7 +499,7 @@ class Gql extends Component
                 $event->result = $cachedResult;
             } else {
                 $isIntrospectionQuery = GqlHelper::isIntrospectionQuery($event->query);
-                $schemaDef = $this->getSchemaDef($schema, true);
+                $schemaDef = $this->getSchemaDef($schema, $debugMode || $isIntrospectionQuery);
                 $elementsService = Craft::$app->getElements();
                 $elementsService->startCollectingCacheInfo();
 


### PR DESCRIPTION
### Description

Adds `env`, `env/set`, and `env/remove` commands, for managing environment variables in the `.env` file.

`env` can output the current value of an environment variable (as returned by `craft\helpers\App::env()` – so possibly normalized to a boolean or integer), or it can act as a shortcut for `env/set` if an equal sign is included in the `name` parameter.

<img src="https://github.com/user-attachments/assets/c40ad95f-e671-4b55-83ad-d4a9cf7a40f2" width="399" height="223" alt="Example env command output">
