### PR TITLE
Use addSelect in beforePrepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where it wasn’t possible to render element partial templates for assets, categories, or tags. ([#15426](https://github.com/craftcms/cms/issues/15426))
 - Fixed an error that could occur when deleting a nested element, if its owner wasn’t saved for the same site. ([#15290](https://github.com/craftcms/cms/issues/15290))
 - Fixed a PHP error that could occur when running Codeception tests. ([#15445](https://github.com/craftcms/cms/issues/15445))
+- Fixed a bug where columns added to element queries via `EVENT_BEFORE_PREPARE` were getting overridden for all core element types except entries. ([#15446](https://github.com/craftcms/cms/pull/15446))
 
 ## 5.2.9 - 2024-07-29
 

--- a/src/elements/db/AddressQuery.php
+++ b/src/elements/db/AddressQuery.php
@@ -1201,7 +1201,7 @@ class AddressQuery extends ElementQuery
 
         $this->joinElementTable(Table::ADDRESSES);
 
-        $this->query->select([
+        $this->query->addSelect([
             'addresses.id',
             'addresses.fieldId',
             'addresses.primaryOwnerId',

--- a/src/elements/db/AssetQuery.php
+++ b/src/elements/db/AssetQuery.php
@@ -904,7 +904,7 @@ class AssetQuery extends ElementQuery
         $this->subQuery->innerJoin(['volumeFolders' => Table::VOLUMEFOLDERS], '[[volumeFolders.id]] = [[assets.folderId]]');
         $this->query->innerJoin(['volumeFolders' => Table::VOLUMEFOLDERS], '[[volumeFolders.id]] = [[assets.folderId]]');
 
-        $this->query->select([
+        $this->query->addSelect([
             'assets.volumeId',
             'assets.folderId',
             'assets.uploaderId',

--- a/src/elements/db/CategoryQuery.php
+++ b/src/elements/db/CategoryQuery.php
@@ -208,7 +208,7 @@ class CategoryQuery extends ElementQuery
 
         $this->joinElementTable(Table::CATEGORIES);
 
-        $this->query->select([
+        $this->query->addSelect([
             'categories.groupId',
         ]);
 

--- a/src/elements/db/GlobalSetQuery.php
+++ b/src/elements/db/GlobalSetQuery.php
@@ -114,7 +114,7 @@ class GlobalSetQuery extends ElementQuery
 
         $this->joinElementTable(Table::GLOBALSETS);
 
-        $this->query->select([
+        $this->query->addSelect([
             'globalsets.name',
             'globalsets.handle',
             'globalsets.sortOrder',

--- a/src/elements/db/TagQuery.php
+++ b/src/elements/db/TagQuery.php
@@ -182,7 +182,7 @@ class TagQuery extends ElementQuery
 
         $this->joinElementTable(Table::TAGS);
 
-        $this->query->select([
+        $this->query->addSelect([
             'tags.groupId',
         ]);
 

--- a/src/elements/db/UserQuery.php
+++ b/src/elements/db/UserQuery.php
@@ -827,7 +827,7 @@ class UserQuery extends ElementQuery
 
         $this->joinElementTable(Table::USERS);
 
-        $this->query->select([
+        $this->query->addSelect([
             'users.photoId',
             'users.pending',
             'users.locked',


### PR DESCRIPTION
### Description
In Craft 5, the `\craft\elements\db\ElementQuery::EVENT_BEFORE_PREPARE` event is triggered at the beginning the `beforePrepare` method, whereas in Craft 4, it was triggered at the end.

Because of this, code adding a select via `\craft\elements\db\ElementQuery::$query->addSelect()` would work in Craft 4, but would be overwritten in Craft 5, in all element types except entries (which was already adding its select via addSelect).

This PR follows the behavior of EntryQuery with all other entry types, and defines its selects with `addSelect` to prevent inadvertent overwriting of selects set by `\craft\elements\db\ElementQuery::EVENT_BEFORE_PREPARE`.

FWIW, I didn't have an issue with [Commerce queries](https://github.com/craftcms/commerce/blob/5.x/src/elements/db/OrderQuery.php#L1517), because those still fire the event at the end of the method.