### PR TITLE
Address::getCountry() + normalize Country fields to Country models

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -18,10 +18,12 @@
 - The `allowedGraphqlOrigins` config setting is now deprecated. `craft\filters\Cors` should be used instead. ([#15397](https://github.com/craftcms/cms/pull/15397))
 - The `permissionsPolicyHeader` config settings is now deprecated. `craft\filters\Headers` should be used instead. ([#15397](https://github.com/craftcms/cms/pull/15397))
 - `{% cache %}` tags now cache any asset bundles registered within them.
+- Country field values are now set to `CommerceGuys\Addressing\Country\Country` objects. ([#15463](https://github.com/craftcms/cms/pull/15463))
 - Auto-populated section and category group Template settings are now suffixed with `.twig`.
 
 ### Extensibility
 - Added `craft\config\GeneralConfig::addAlias()`. ([#15346](https://github.com/craftcms/cms/pull/15346))
+- Added `craft\elements\Address::getCountry()`. ([#15463](https://github.com/craftcms/cms/pull/15463))
 - Added `craft\elements\Asset::$sanitizeOnUpload`. ([#15430](https://github.com/craftcms/cms/discussions/15430))
 - Added `craft\filters\Cors`. ([#15397](https://github.com/craftcms/cms/pull/15397))
 - Added `craft\filters\Headers`. ([#15397](https://github.com/craftcms/cms/pull/15397))

--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -4,6 +4,7 @@ namespace craft\elements;
 
 use CommerceGuys\Addressing\AddressFormat\AddressField;
 use CommerceGuys\Addressing\AddressInterface;
+use CommerceGuys\Addressing\Country\Country;
 use Craft;
 use craft\base\BlockElementInterface;
 use craft\base\Element;
@@ -405,6 +406,17 @@ class Address extends Element implements AddressInterface, BlockElementInterface
     public function getCountryCode(): string
     {
         return $this->countryCode;
+    }
+
+    /**
+     * Returns a [[Country]] object representing the address’ coutry.
+     *
+     * @return Country
+     * @since 4.11.0
+     */
+    public function getCountry(): Country
+    {
+        return Craft::$app->getAddresses()->getCountryRepository()->get($this->countryCode);
     }
 
     /**


### PR DESCRIPTION
## Description

Adds a `getCountry()` method to address elements, which returns a `CommerceGuys\Addressing\Country\Country` object. And Country field values are now set to a `CommerceGuys\Addressing\Country\Country` object.

`Country` objects have the following methods:

- `getCountryCode()`
- `getName()`
- `getThreeLetterCode()`
- `getNumericalCode()`
- `getCurrencyCode()`
- `getTimezones()`
- `getLocale()`


## Related issues

- #15455