### PR TITLE
Don’t preload defined Twig globals when preloading singles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a PHP error. ([#14635](https://github.com/craftcms/cms/issues/14635))
 - Fixed a PHP error that could occur when running Codeception tests. ([#15445](https://github.com/craftcms/cms/issues/15445))
+- Fixed a bug where `deleteAsset`, `deleteCategory`, `deleteEntry`, and `deleteTag` GraphQL mutations were returning `null` rather than `true` or `false`. ([#15465](https://github.com/craftcms/cms/issues/15465))
 
 ## 4.10.7 - 2024-07-29
 

--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -113,9 +113,10 @@ class Asset extends ElementMutationResolver
      * @param array $arguments
      * @param mixed $context
      * @param ResolveInfo $resolveInfo
+     * @return bool
      * @throws Throwable if reasons.
      */
-    public function deleteAsset(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): void
+    public function deleteAsset(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): bool
     {
         $assetId = $arguments['id'];
 
@@ -124,13 +125,13 @@ class Asset extends ElementMutationResolver
         $asset = $elementService->getElementById($assetId, AssetElement::class);
 
         if (!$asset) {
-            return;
+            return false;
         }
 
         $volumeUid = Db::uidById(Table::VOLUMES, $asset->getVolumeId());
         $this->requireSchemaAction('volumes.' . $volumeUid, 'delete');
 
-        $elementService->deleteElementById($assetId);
+        return $elementService->deleteElementById($assetId);
     }
 
     /**

--- a/src/gql/resolvers/mutations/Category.php
+++ b/src/gql/resolvers/mutations/Category.php
@@ -84,9 +84,10 @@ class Category extends ElementMutationResolver
      * @param array $arguments
      * @param mixed $context
      * @param ResolveInfo $resolveInfo
+     * @return bool
      * @throws Throwable if reasons.
      */
-    public function deleteCategory(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): void
+    public function deleteCategory(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): bool
     {
         $categoryId = $arguments['id'];
 
@@ -94,12 +95,12 @@ class Category extends ElementMutationResolver
         $category = $elementService->getElementById($categoryId, CategoryElement::class);
 
         if (!$category) {
-            return;
+            return false;
         }
 
         $categoryGroupUid = Db::uidById(Table::CATEGORYGROUPS, $category->groupId);
         $this->requireSchemaAction('categorygroups.' . $categoryGroupUid, 'delete');
 
-        $elementService->deleteElementById($categoryId);
+        return $elementService->deleteElementById($categoryId);
     }
 }

--- a/src/gql/resolvers/mutations/Entry.php
+++ b/src/gql/resolvers/mutations/Entry.php
@@ -107,9 +107,10 @@ class Entry extends ElementMutationResolver
      * @param array $arguments
      * @param mixed $context
      * @param ResolveInfo $resolveInfo
+     * @return bool
      * @throws Throwable if reasons.
      */
-    public function deleteEntry(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): void
+    public function deleteEntry(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): bool
     {
         $entryId = $arguments['id'];
         $siteId = $arguments['siteId'] ?? null;
@@ -119,13 +120,13 @@ class Entry extends ElementMutationResolver
         $entry = $elementService->getElementById($entryId, EntryElement::class, $siteId);
 
         if (!$entry) {
-            return;
+            return false;
         }
 
         $entryTypeUid = Db::uidById(Table::ENTRYTYPES, $entry->getTypeId());
         $this->requireSchemaAction('entrytypes.' . $entryTypeUid, 'delete');
 
-        $elementService->deleteElementById($entryId);
+        return $elementService->deleteElementById($entryId);
     }
 
     /**

--- a/src/gql/resolvers/mutations/Tag.php
+++ b/src/gql/resolvers/mutations/Tag.php
@@ -78,9 +78,10 @@ class Tag extends ElementMutationResolver
      * @param array $arguments
      * @param mixed $context
      * @param ResolveInfo $resolveInfo
+     * @return bool
      * @throws Throwable if reasons.
      */
-    public function deleteTag(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): void
+    public function deleteTag(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): bool
     {
         $tagId = $arguments['id'];
 
@@ -88,12 +89,12 @@ class Tag extends ElementMutationResolver
         $tag = $elementService->getElementById($tagId, TagElement::class);
 
         if (!$tag) {
-            return;
+            return false;
         }
 
         $tagGroupUid = Db::uidById(Table::TAGGROUPS, $tag->groupId);
         $this->requireSchemaAction('taggroups.' . $tagGroupUid, 'delete');
 
-        $elementService->deleteElementById($tagId);
+        return $elementService->deleteElementById($tagId);
     }
 }

--- a/src/helpers/Template.php
+++ b/src/helpers/Template.php
@@ -396,6 +396,12 @@ class Template
      */
     public static function preloadSingles(array $handles): void
     {
-        self::$_fallbacks += Craft::$app->getEntries()->getSingleEntriesByHandle($handles);
+        // Ignore handles that are defined Twig globals
+        $globals = Craft::$app->view->getTwig()->getGlobals();
+        $handles = array_diff($handles, array_keys($globals));
+
+        if (!empty($handles)) {
+            self::$_fallbacks += Craft::$app->getEntries()->getSingleEntriesByHandle($handles);
+        }
     }
 }


### PR DESCRIPTION
This PR ignores handles that are defined Twig globals when preloading singles as fallback values. Without this, `Craft::$app->getEntries()->getSingleEntriesByHandle()` is unnecessarily called on values such as `craft`, `currentSite`, `currentUser`, etc. This is a micro optimisation but feels like a better way of loading fallbacks.

If merged, this should be carried over to the 5.x branch as well.