### PR TITLE
if username is empty and useEmailAsUsername is true - use email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a bug where `deleteAsset`, `deleteCategory`, `deleteEntry`, and `deleteTag` GraphQL mutations were returning `null` rather than `true` or `false`. ([#15465](https://github.com/craftcms/cms/issues/15465))
 - Fixed a styling issue. ([#15473](https://github.com/craftcms/cms/issues/15473))
 - Fixed a bug where `exists()` element queries weren’t working if `distinct`, `groupBy`, `having,` or `union` params were set on them during query preparation. ([#15001](https://github.com/craftcms/cms/issues/15001), [#15223](https://github.com/craftcms/cms/pull/15223))
+- Fixed a bug where users’ `username` properties weren’t getting set if `useEmailAsUsername` was enabled. ([#15475](https://github.com/craftcms/cms/issues/15475))
 
 ## 4.10.7 - 2024-07-29
 

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -754,6 +754,10 @@ class User extends Element implements IdentityInterface
             $this->email = StringHelper::idnToUtf8Email($this->email);
         }
 
+        if (empty($this->username) && Craft::$app->getConfig()->getGeneral()->useEmailAsUsername) {
+            $this->username = $this->email;
+        }
+
         $this->normalizeNames();
     }
 


### PR DESCRIPTION
### Description
As per the issue, when `useEmailAsUsername` is `true`, if the `username` is empty, the link to the user’s profile in the Control Panel dropdown is blank. This affects both v4 and v5, but it’s more prevalent in v5 because saving a user via the Control Panel no longer goes via `users/save-user` (which ensured the username column was filled with the email address on save). Instead, it goes through the standard `elements/save`.

I opted for setting the username property to the user’s email if the username is empty and `useEmailAsUsername` is `true`. That way, the profile link shows the email, calling `user.username` in twig also returns the email, and the username column in the DB is updated on save as it was in v4.


### Related issues
#15475 
