### PR TITLE
check if typeId exist in the config types not top level config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where Link fields weren’t retaining their link type-specific settings. ([#15491](https://github.com/craftcms/cms/issues/15491))
+
 ## 5.3.0.3 - 2024-08-06
 
 - Fixed a PHP error that could occur when editing Addresses fields set to the element index view mode. ([#15486](https://github.com/craftcms/cms/issues/15486))

--- a/src/fields/Link.php
+++ b/src/fields/Link.php
@@ -196,7 +196,7 @@ class Link extends Field implements InlineEditableFieldInterface, RelationalFiel
         if (isset($config['types'], $config['typeSettings'])) {
             // Filter out any unneeded type settings
             foreach (array_keys($config['typeSettings']) as $typeId) {
-                if (!in_array($typeId, $config)) {
+                if (!in_array($typeId, $config['types'])) {
                     unset($config['typeSettings'][$typeId]);
                 }
             }


### PR DESCRIPTION
### Description
When cleaning up link type settings, check if `$typeId` exists in the `$config['types']`, not the top level `$config`.


### Related issues
#15491 
