### PR TITLE
relatedViaField & relatedViaSite

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -3,6 +3,15 @@
 ### Content Management
 - Asset chips and cards no longer include the “Replace file” action. ([#15498](https://github.com/craftcms/cms/issues/15498))
 
+### Development
+- `relatedToAssets`, `relatedToCategories`, `relatedToEntries`, `relatedToTags`, and `relatedToUsers` GraphQL arguments now support passing `relatedViaField` and `relatedViaSite` keys to their criteria objects. ([#15508](https://github.com/craftcms/cms/pull/15508))
+
 ### Extensibility
+- Added `craft\gql\arguments\RelationCriteria`.
+- Added `craft\gql\types\input\criteria\AssetRelation`.
+- Added `craft\gql\types\input\criteria\CategoryRelation`.
+- Added `craft\gql\types\input\criteria\EntryRelation`.
+- Added `craft\gql\types\input\criteria\TagRelation`.
+- Added `craft\gql\types\input\criteria\UserRelation`.
 - `craft\services\Elements::saveContent()`’ now saves dirty fields’ content even if `$saveContent` is `false`. ([#15393](https://github.com/craftcms/cms/pull/15393))
 - Element action menu items returned by `craft\base\Element::safeActionMenuItems()` and `destructiveActionMenuItems()` can now include a `showInChips` key to explicitly opt into/out of being shown within element chips and cards.

--- a/src/gql/arguments/RelationCriteria.php
+++ b/src/gql/arguments/RelationCriteria.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\gql\arguments;
+
+use craft\gql\base\Arguments;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Class RelationCriteria
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.4.0
+ */
+class RelationCriteria extends Arguments
+{
+    /**
+     * @inheritdoc
+     */
+    public static function getArguments(): array
+    {
+        return [
+            'relatedViaField' => [
+                'name' => 'relatedViaField',
+                'type' => Type::listOf(Type::string()),
+                'description' => 'Narrows the relations based on the field they were created in.',
+            ],
+            'relatedViaSite' => [
+                'name' => 'relatedViaSite',
+                'type' => Type::listOf(Type::string()),
+                'description' => 'Narrows the relations based on the site they were created in.',
+            ],
+        ];
+    }
+}

--- a/src/gql/base/ElementArguments.php
+++ b/src/gql/base/ElementArguments.php
@@ -7,11 +7,11 @@
 
 namespace craft\gql\base;
 
-use craft\gql\types\input\criteria\Asset;
-use craft\gql\types\input\criteria\Category;
-use craft\gql\types\input\criteria\Entry;
-use craft\gql\types\input\criteria\Tag;
-use craft\gql\types\input\criteria\User;
+use craft\gql\types\input\criteria\AssetRelation;
+use craft\gql\types\input\criteria\CategoryRelation;
+use craft\gql\types\input\criteria\EntryRelation;
+use craft\gql\types\input\criteria\TagRelation;
+use craft\gql\types\input\criteria\UserRelation;
 use craft\gql\types\QueryArgument;
 use craft\helpers\Gql;
 use GraphQL\Type\Definition\Type;
@@ -77,27 +77,27 @@ abstract class ElementArguments extends Arguments
             ],
             'relatedToAssets' => [
                 'name' => 'relatedToAssets',
-                'type' => Type::listOf(Asset::getType()),
+                'type' => fn() => Type::listOf(AssetRelation::getType()),
                 'description' => 'Narrows the query results to elements that relate to an asset list defined with this argument.',
             ],
             'relatedToEntries' => [
                 'name' => 'relatedToEntries',
-                'type' => Type::listOf(Entry::getType()),
+                'type' => fn() => Type::listOf(EntryRelation::getType()),
                 'description' => 'Narrows the query results to elements that relate to an entry list defined with this argument.',
             ],
             'relatedToUsers' => [
                 'name' => 'relatedToUsers',
-                'type' => Type::listOf(User::getType()),
+                'type' => fn() => Type::listOf(UserRelation::getType()),
                 'description' => 'Narrows the query results to elements that relate to a use list defined with this argument.',
             ],
             'relatedToCategories' => [
                 'name' => 'relatedToCategories',
-                'type' => Type::listOf(Category::getType()),
+                'type' => fn() => Type::listOf(CategoryRelation::getType()),
                 'description' => 'Narrows the query results to elements that relate to a category list defined with this argument.',
             ],
             'relatedToTags' => [
                 'name' => 'relatedToTags',
-                'type' => Type::listOf(Tag::getType()),
+                'type' => fn() => Type::listOf(TagRelation::getType()),
                 'description' => 'Narrows the query results to elements that relate to a tag list defined with this argument.',
             ],
             'relatedToAll' => [

--- a/src/gql/base/RelationArgumentHandler.php
+++ b/src/gql/base/RelationArgumentHandler.php
@@ -37,7 +37,6 @@ abstract class RelationArgumentHandler extends ArgumentHandler
         $idSets = [];
 
         foreach ($criteriaList as $criteria) {
-            unset($criteria['relatedViaField'], $criteria['relatedViaSite']);
             /** @var ElementQuery $elementQuery */
             $elementQuery = Craft::configure(Craft::$app->getElements()->createElementQuery($elementType), $criteria);
             $idSets[] = $elementQuery->ids();

--- a/src/gql/base/RelationArgumentHandler.php
+++ b/src/gql/base/RelationArgumentHandler.php
@@ -37,6 +37,7 @@ abstract class RelationArgumentHandler extends ArgumentHandler
         $idSets = [];
 
         foreach ($criteriaList as $criteria) {
+            unset($criteria['relatedViaField'], $criteria['relatedViaSite']);
             /** @var ElementQuery $elementQuery */
             $elementQuery = Craft::configure(Craft::$app->getElements()->createElementQuery($elementType), $criteria);
             $idSets[] = $elementQuery->ids();
@@ -55,6 +56,16 @@ abstract class RelationArgumentHandler extends ArgumentHandler
         }
 
         $argumentValue = $argumentList[$this->argumentName];
+
+        // Extract relatedViaField and relatedViaSite values
+        $relationParams = [];
+        foreach ($argumentValue as &$value) {
+            $relationParams[] = [
+                'field' => ArrayHelper::remove($value, 'relatedViaField'),
+                'site' => ArrayHelper::remove($value, 'relatedViaSite'),
+            ];
+        }
+
         $hash = md5(serialize($argumentValue));
 
         // See if we have done something exactly like this already.
@@ -76,7 +87,8 @@ abstract class RelationArgumentHandler extends ArgumentHandler
         }
 
         foreach ($idSets as $idSet) {
-            $relatedTo[] = ['element' => $idSet];
+            $relationParams = array_shift($relationParams) ?? [];
+            $relatedTo[] = ['element' => $idSet] + $relationParams;
         }
 
         $argumentList['relatedTo'] = $relatedTo;

--- a/src/gql/types/input/criteria/AssetRelation.php
+++ b/src/gql/types/input/criteria/AssetRelation.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\gql\types\input\criteria;
+
+use craft\gql\arguments\elements\Asset as AssetArguments;
+use craft\gql\arguments\RelationCriteria;
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\InputObjectType;
+
+/**
+ * Class AssetRelation
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.4.0
+ */
+class AssetRelation extends InputObjectType
+{
+    /**
+     * @return mixed
+     */
+    public static function getType(): mixed
+    {
+        $typeName = 'AssetRelationCriteriaInput';
+
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
+            'name' => $typeName,
+            'fields' => fn() => AssetArguments::getArguments() + RelationCriteria::getArguments(),
+        ]));
+    }
+}

--- a/src/gql/types/input/criteria/CategoryRelation.php
+++ b/src/gql/types/input/criteria/CategoryRelation.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\gql\types\input\criteria;
+
+use craft\gql\arguments\elements\Category as CategoryArguments;
+use craft\gql\arguments\RelationCriteria;
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\InputObjectType;
+
+/**
+ * Class CategoryRelation
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.4.0
+ */
+class CategoryRelation extends InputObjectType
+{
+    /**
+     * @return mixed
+     */
+    public static function getType(): mixed
+    {
+        $typeName = 'CategoryRelationCriteriaInput';
+
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
+            'name' => $typeName,
+            'fields' => fn() => CategoryArguments::getArguments() + RelationCriteria::getArguments(),
+        ]));
+    }
+}

--- a/src/gql/types/input/criteria/EntryRelation.php
+++ b/src/gql/types/input/criteria/EntryRelation.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\gql\types\input\criteria;
+
+use craft\gql\arguments\elements\Entry as EntryArguments;
+use craft\gql\arguments\RelationCriteria;
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\InputObjectType;
+
+/**
+ * Class EntryRelation
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.4.0
+ */
+class EntryRelation extends InputObjectType
+{
+    /**
+     * @return mixed
+     */
+    public static function getType(): mixed
+    {
+        $typeName = 'EntryRelationCriteriaInput';
+
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
+            'name' => $typeName,
+            'fields' => fn() => EntryArguments::getArguments() + RelationCriteria::getArguments(),
+        ]));
+    }
+}

--- a/src/gql/types/input/criteria/TagRelation.php
+++ b/src/gql/types/input/criteria/TagRelation.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\gql\types\input\criteria;
+
+use craft\gql\arguments\elements\Tag as TagArguments;
+use craft\gql\arguments\RelationCriteria;
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\InputObjectType;
+
+/**
+ * Class TagRelation
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.4.0
+ */
+class TagRelation extends InputObjectType
+{
+    /**
+     * @return mixed
+     */
+    public static function getType(): mixed
+    {
+        $typeName = 'TagRelationCriteriaInput';
+
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
+            'name' => $typeName,
+            'fields' => fn() => TagArguments::getArguments() + RelationCriteria::getArguments(),
+        ]));
+    }
+}

--- a/src/gql/types/input/criteria/UserRelation.php
+++ b/src/gql/types/input/criteria/UserRelation.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\gql\types\input\criteria;
+
+use craft\gql\arguments\elements\User as UserArguments;
+use craft\gql\arguments\RelationCriteria;
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\InputObjectType;
+
+/**
+ * Class UserRelation
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.4.0
+ */
+class UserRelation extends InputObjectType
+{
+    /**
+     * @return mixed
+     */
+    public static function getType(): mixed
+    {
+        $typeName = 'UserRelationCriteriaInput';
+
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
+            'name' => $typeName,
+            'fields' => fn() => UserArguments::getArguments() + RelationCriteria::getArguments(),
+        ]));
+    }
+}


### PR DESCRIPTION
Adds support for `relatedViaField` and `relatedViaSite` params on the criteria objects that are passed to `relatedToAssets`, `relatedToCategories`, `relatedToEntries`, `relatedToTags`, and `relatedToUsers` GraphQL arguments.

```graphql
query {
  entries(relatedToEntries: {
    section: "services",
    relatedViaField: "servicesPerformed",
    relatedViaSite: "en"
  }) {
    title
  }
}
```