### PR TITLE
Link type no longer allowed

### DIFF
--- a/src/fields/Link.php
+++ b/src/fields/Link.php
@@ -327,6 +327,14 @@ class Link extends Field implements InlineEditableFieldInterface, RelationalFiel
             }
 
             $typeId = $this->resolveType($value);
+
+            // if typeId is no longer allowed by the field
+            // don't freak out and return an empty value
+            // @see https://github.com/craftcms/cms/issues/15542
+            if (!isset($linkTypes[$typeId])) {
+                return null;
+            }
+
             $linkType = $linkTypes[$typeId];
         }
 


### PR DESCRIPTION
### Description
When trying to edit an element with a Link field in the Control Panel and the link type is no longer allowed by the field, set the normalised value to `null` instead of throwing an error.

### Related issues
#15542 
