### PR TITLE
Fixed #15572 GQL not allowing overriding named transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a bug where Craft couldn’t be installed with existing project config files, if any plugins specified their schema version via `composer.json`. ([#15559](https://github.com/craftcms/cms/issues/15559))
 - Fixed a bug where Money fields’ min, max, and default values weren’t being set to the correct currency. ([#15565](https://github.com/craftcms/cms/issues/15565), [#15566](https://github.com/craftcms/cms/pull/15566))
 - Fixed a bug where PHP-originated Craft Console API requests weren’t timing out if the API was down. ([#15571](https://github.com/craftcms/cms/pull/15571))
+- Fixed a bug where it wasn’t possible to override named transforms in GraphQL queries. ([#15572](https://github.com/craftcms/cms/issues/15572))
 
 ## 4.11.3 - 2024-08-13
 

--- a/src/helpers/Gql.php
+++ b/src/helpers/Gql.php
@@ -400,15 +400,13 @@ class Gql
     {
         unset($arguments['immediately']);
 
-        if (!empty($arguments['handle'])) {
-            $transform = $arguments['handle'];
-        } elseif (!empty($arguments['transform'])) {
-            $transform = $arguments['transform'];
-        } else {
-            $transform = $arguments;
+        // Remap handle to transform to work with image transform normalization
+        if (isset($arguments['handle'])) {
+            $arguments['transform'] = $arguments['handle'];
+            unset($arguments['handle']);
         }
 
-        return $transform;
+        return $arguments;
     }
 
     /**

--- a/tests/unit/gql/ElementFieldResolverTest.php
+++ b/tests/unit/gql/ElementFieldResolverTest.php
@@ -447,8 +447,9 @@ class ElementFieldResolverTest extends TestCase
             [['width' => 200, 'height' => 200], ['width' => 200, 'height' => 200]],
             [['width' => 400, 'height' => 200], ['width' => 400, 'height' => 200]],
             [['width' => 200, 'height' => 500], ['width' => 200, 'height' => 500]],
-            [['width' => 200, 'height' => 200, 'handle' => 'testHandle'], ['handle' => 'testHandle']],
-            [['width' => 200, 'height' => 200, 'transform' => 'testHandle2'], ['handle' => 'testHandle2']],
+            // Overriding named transforms
+            [['width' => 200, 'height' => 200, 'handle' => 'testHandle'], ['handle' => null, 'width' => 200, 'height' => 200]],
+            [['width' => 200, 'height' => 200, 'transform' => 'testHandle2'], ['handle' => null, 'width' => 200, 'height' => 200]],
         ];
     }
 }


### PR DESCRIPTION
### Description
Image transforms in GQL queries were not allowing argument overriding. As described [in the docs](https://craftcms.com/docs/5.x/development/image-transforms.html)

Updated the `Gql::parseTransformArguments()` method to stop dumping of other arguments and prep them correctly for later being passed through `ImageTransforms::normalizeTransform()`


### Related issues
#15572 
