### PR TITLE
Change jQuery UI version to 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.11.4 - 2024-08-21
 
-- Updated jQuery UI to 1.13.3. ([#15558](https://github.com/craftcms/cms/issues/15558))
+- Updated jQuery UI to 1.14.0. ([#15558](https://github.com/craftcms/cms/issues/15558))
 - Fixed a bug where `craft\helpers\App::env()` and `normalizeValue()` could return incorrect results for values that looked like floats. ([#15533](https://github.com/craftcms/cms/issues/15533))
 - Fixed a bug where the `users/set-password` action wasn’t respecting `redirect` params. ([#15538](https://github.com/craftcms/cms/issues/15538))
 - Fixed a bug where the “Default Values” Table field setting wasn’t escaping column headings. ([#15552](https://github.com/craftcms/cms/issues/15552))


### PR DESCRIPTION
It looks like jQuery UI was updated to 1.14.0, at least according to the license file updates in https://github.com/craftcms/cms/commit/3a608f42e9293805b93fd7553973c52d5dcf08ea#diff-5770088c40ad4be0fff29516b741b027fc5ef6a75d7d6728d7417033ca072295

Note: if merged, this should be carried over to the 5.x branch, too.