### PR TITLE
improve how we get parents for subdivision fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where it wasn’t possible to override named transforms in GraphQL queries. ([#15572](https://github.com/craftcms/cms/issues/15572))
+- Fixed a bug where address subdivision fields could be incorrectly labelled and/or populated with the wrong options. ([#15551](https://github.com/craftcms/cms/issues/15551), [#15584](https://github.com/craftcms/cms/pull/15584))
 
 ## 4.11.4 - 2024-08-21
 

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -1398,7 +1398,7 @@ JS, [
      *
      * For the dependentLocality:
      *      - as above but taking locality into consideration too; e.g. China has all 3 levels of subdivisions and has lists for all 3 of them
-     *          (China => Hoilongjiang Sheng > Gegang Shi > Dongshan Qu)
+     *          (China => Heilongjiang Sheng > Hegang Shi > Dongshan Qu)
      *
      * @param Address $address
      * @param array $visibleFields

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -7,6 +7,7 @@
 
 namespace craft\helpers;
 
+use CommerceGuys\Addressing\Subdivision\SubdivisionRepository as BaseSubdivisionRepository;
 use Craft;
 use craft\base\Element;
 use craft\base\ElementInterface;
@@ -1301,6 +1302,8 @@ JS, [
                 $addressesService->getUsedSubdivisionFields($address->countryCode),
             )) + $requiredFields;
 
+        $parents = self::_getSubdivisionParents($address, $visibleFields);
+
         return
             static::textFieldHtml([
                 'status' => $address->getAttributeStatus('addressLine1'),
@@ -1337,7 +1340,7 @@ JS, [
                 $belongsToCurrentUser ? 'address-level2' : 'off',
                 isset($visibleFields['locality']),
                 isset($requiredFields['locality']),
-                [$address->countryCode, $address->administrativeArea],
+                $parents['locality'],
                 true,
             ) .
             self::_subdivisionField(
@@ -1346,7 +1349,7 @@ JS, [
                 $belongsToCurrentUser ? 'address-level3' : 'off',
                 isset($visibleFields['dependentLocality']),
                 isset($requiredFields['dependentLocality']),
-                [$address->countryCode, $address->administrativeArea, $address->locality],
+                $parents['dependentLocality'],
                 false,
             ) .
             static::textFieldHtml([
@@ -1376,6 +1379,49 @@ JS, [
                 'required' => isset($requiredFields['sortingCode']),
                 'errors' => $address->getErrors('sortingCode'),
             ]);
+    }
+
+    /**
+     * Get parents array that needs to be passed to the subdivision repository getList() method to get the list of subdivisions back.
+     *
+     * For the administrativeArea, the parent is always just the country code.
+     *
+     * For the locality:
+     *      - it could be just the country code
+     *          - for countries that don't use administrativeArea field; that's the case with Andorra
+     *      - it could be the country code and the administrative area code
+     *          - for countries that use both administrative areas and localities; e.g. Chile (Chile => Araucania > Carahue)
+     *          - the administrative area can be passed as null too;
+     *              this will be triggered for the United Kingdom (GB), where you can conditionally turn on administrativeArea;
+     *              in the case of GB, not passing null as the second value would result
+     *              in the administrativeAreas list being returned for the locality field (https://github.com/craftcms/cms/issues/15551);
+     *
+     * For the dependentLocality:
+     *      - as above but taking locality into consideration too; e.g. China has all 3 levels of subdivisions and has lists for all 3 of them
+     *          (China => Hoilongjiang Sheng > Gegang Shi > Dongshan Qu)
+     *
+     * @param Address $address
+     * @param array $visibleFields
+     * @return array
+     */
+    private static function _getSubdivisionParents(Address $address, array $visibleFields): array
+    {
+        $baseSubdivisionRepository = new BaseSubdivisionRepository();
+
+        $localityParents = [$address->countryCode];
+        $administrativeAreas = $baseSubdivisionRepository->getList([$address->countryCode]);
+
+        if (array_key_exists('administrativeArea', $visibleFields) || empty($administrativeAreas)) {
+            $localityParents[] = $address->administrativeArea;
+        }
+
+        $dependentLocalityParents = $localityParents;
+        $localities = $baseSubdivisionRepository->getList($localityParents);
+        if (array_key_exists('locality', $visibleFields) || empty($localities)) {
+            $dependentLocalityParents[] = $address->locality;
+        }
+
+        return ['locality' => $localityParents, 'dependentLocality' => $dependentLocalityParents];
     }
 
     private static function _subdivisionField(


### PR DESCRIPTION
### Description
**Background:**
When getting a list of options for subdivision fields, you need to pass an array of parents to the `SubdivisionRepository->getList()` method. Passing `null` is meaningful here.

**Problem:**
With the current way of getting the parents array, wrong data will be returned in certain cases. For example:
- no list will be returned for Andorra’s locality field, but there should be (v4 and v5)
- if you haven’t opted into using counties (administrative areas) for the UK, a list of counties will still be returned and incorrectly used for the locality (city) field (in v5 only; in v4, locality will be a plain text field).

**Solution:**
Check both the visibility of the parent fields as well as the original list of options for the parent field when determining if the field value should be included in the parents array.

Tested against v4 and v5.

Test examples:
- Andorra should have a dropdown list under the “City” field
- United Kingdom without counties (default):
    - v4: “Post Town” should be a plain text field
    - v5: “City” should be a plain text field
- United Kingdom with added counties (`'administrativeArea'` field added via `Addresses::EVENT_DEFINE_USED_FIELDS`):
    - v4: “Province” (label might be renamed, but that’s the default) should be a dropdown list of counties, “Post Town” should be a plain text field
    - v5: “Province” (label might be renamed, but that’s the default) should be a dropdown list of counties, “City” should be a plain text field
- Chile should have a dropdown list under the “Region” and “City” fields (e.g. Region: Araucania; City: Carahue
- China should have a dropdown list under the “Province”, “City” and “District” fields (e.g. Province: Heilongjiang Sheng, City: Hegang Shi, District: Dongshan Qu)

### Related issues
#15551 
