### PR TITLE
get country code for matching country label

### DIFF
--- a/src/fields/Country.php
+++ b/src/fields/Country.php
@@ -119,6 +119,11 @@ class Country extends Field implements InlineEditableFieldInterface, MergeableFi
         if (!$value) {
             return '';
         }
+
+        if ($value instanceof CountryModel) {
+            $value = $value->getCountryCode();
+        }
+
         $list = Craft::$app->getAddresses()->getCountryRepository()->getList(Craft::$app->language);
         return $list[$value] ?? $value;
     }


### PR DESCRIPTION
### Description
If a `$value` passed to `getPreviewHtml()` is an instance of the `CountryModel`, get the country code before trying to match it to the list of all countries. 


### Related issues
#15583 
