### PR TITLE
don't cache preview requests either

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where it wasn’t possible to override named transforms in GraphQL queries. ([#15572](https://github.com/craftcms/cms/issues/15572))
 - Fixed a bug where address subdivision fields could be incorrectly labelled and/or populated with the wrong options. ([#15551](https://github.com/craftcms/cms/issues/15551), [#15584](https://github.com/craftcms/cms/pull/15584))
 - Fixed a bug where Country fields were displaying the selected country code within element index tables, rather than the country name.
+- Fixed a bug where `{% cache %}` tags were caching content for Live Preview requests. ([#15586](https://github.com/craftcms/cms/issues/15586))
 
 ## 4.11.4 - 2024-08-21
 

--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -368,7 +368,7 @@ class TemplateCaches extends Component
             } else {
                 // Don't enable template caches for tokenized requests
                 $request = Craft::$app->getRequest();
-                if ($request->getHadToken()) {
+                if ($request->getIsPreview() || $request->getHadToken()) {
                     $this->_enabled = $this->_enabledGlobally = false;
                 } else {
                     $this->_enabled = !$request->getIsConsoleRequest();

--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -366,7 +366,7 @@ class TemplateCaches extends Component
             if (!Craft::$app->getConfig()->getGeneral()->enableTemplateCaching) {
                 $this->_enabled = $this->_enabledGlobally = false;
             } else {
-                // Don't enable template caches for tokenized requests
+                // Don't enable template caches for Live Preview/tokenized requests
                 $request = Craft::$app->getRequest();
                 if ($request->getIsPreview() || $request->getHadToken()) {
                     $this->_enabled = $this->_enabledGlobally = false;


### PR DESCRIPTION
### Description
Don’t enable template caching in a preview mode, either.

At the moment, a request with an invalid or expired token would still return `true` from the `getHadToken()` method, which means such a request wouldn’t be cached. The PR ensures that the template caching is also not enabled for a live preview request that doesn’t have a token (which is what will happen if you open preview mode on an entry that has no changes).

### Related issues
#15586 
