### PR TITLE
Fixed a MySQL error that would occur if you ran `php craft db/convert-charset` with custom views defined in the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a MySQL error that would occur if you ran `php craft db/convert-charset` with custom views defined in the database. ([#15598](https://github.com/craftcms/cms/issues/15598))
+
 ## 4.11.5 - 2024-08-26
 
 - Fixed a bug where it wasn’t possible to override named transforms in GraphQL queries. ([#15572](https://github.com/craftcms/cms/issues/15572))

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -375,6 +375,13 @@ class DbController extends Controller
 
         $schema = $db->getSchema();
         $tableNames = $schema->getTableNames();
+        $dbName= Craft::$app->getConfig()->getDb()->database;
+
+        // See if there are any views to skip from this command.
+        $views = $db->createCommand("SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_SCHEMA = '" . $dbName . "' AND TABLE_TYPE = 'VIEW'")->queryColumn();
+
+        // Remove any views from the list of tables
+        $tableNames = array_diff($tableNames, $views);
 
         if (empty($tableNames)) {
             $this->stderr('Could not find any database tables.' . PHP_EOL, Console::FG_RED);


### PR DESCRIPTION
Issue https://github.com/craftcms/cms/issues/15598

Yii2's `getTableNames()` returns all views, in addition to tables, so we have to do filtering on our end.

Can be merged into 5.x.