### PR TITLE
Fixed a bug where `craft\helpers\Db::supportsTimeZones()` could return incorrect timezone information on some environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fixed a SQL error that occurred when running the `db/convert-charset` command if there were any custom database views or sequences. ([#15598](https://github.com/craftcms/cms/issues/15598))
-- Fixed a bug where `craft\helpers\Db::supportsTimeZones()` could return incorrect timezone information on some environments.  ([#15592](https://github.com/craftcms/cms/issues/15592))
+- Fixed a bug where `craft\helpers\Db::supportsTimeZones()` could return `false` on databases that supported time zone conversion. ([#15592](https://github.com/craftcms/cms/issues/15592))
 
 ## 4.11.5 - 2024-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where `craft\helpers\Db::supportsTimeZones()` could return incorrect timezone information on some environments.  ([#15592](https://github.com/craftcms/cms/issues/15592))
+
 ## 4.11.5 - 2024-08-26
 
 - Fixed a bug where it wasn’t possible to override named transforms in GraphQL queries. ([#15572](https://github.com/craftcms/cms/issues/15572))

--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -1470,7 +1470,7 @@ class Db
             return true;
         }
 
-        $result = $db->createCommand("SELECT CONVERT_TZ('2007-03-11 2:00:00','US/Eastern','US/Central') AS time1")->queryScalar();
+        $result = $db->createCommand("SELECT CONVERT_TZ('2007-03-11 02:00:00','America/Los_Angeles','America/New_York') AS time1")->queryScalar();
         return (bool)$result;
     }
 


### PR DESCRIPTION
https://github.com/craftcms/cms/issues/15592

Can be merged into 5.x