### PR TITLE
only validate visible fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a SQL error that occurred when running the `db/convert-charset` command if there were any custom database views or sequences. ([#15598](https://github.com/craftcms/cms/issues/15598))
 - Fixed a bug where `craft\helpers\Db::supportsTimeZones()` could return `false` on databases that supported time zone conversion. ([#15592](https://github.com/craftcms/cms/issues/15592))
+- Fixed a bug where Assets fields were validating settings that weren’t applicable depending on the “Restrict assets to a single location” setting. ([#15545](https://github.com/craftcms/cms/issues/15545))
 
 ## 4.11.5 - 2024-08-26
 

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -242,11 +242,23 @@ class Assets extends BaseRelationField
             [
                 'sources',
                 'defaultUploadLocationSource',
-                'restrictedLocationSource',
                 'defaultUploadLocationSubpath',
+            ],
+            'validateNotTempVolume',
+            'when' => function(self $field): bool {
+                return (bool)$field->restrictLocation === false;
+            },
+        ];
+
+        $rules[] = [
+            [
+                'restrictedLocationSource',
                 'restrictedLocationSubpath',
             ],
             'validateNotTempVolume',
+            'when' => function(self $field): bool {
+                return (bool)$field->restrictLocation;
+            },
         ];
 
         $rules[] = [['previewMode'], 'in', 'range' => [self::PREVIEW_MODE_FULL, self::PREVIEW_MODE_THUMBS], 'skipOnEmpty' => false];

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -245,9 +245,7 @@ class Assets extends BaseRelationField
                 'defaultUploadLocationSubpath',
             ],
             'validateNotTempVolume',
-            'when' => function(self $field): bool {
-                return (bool)$field->restrictLocation === false;
-            },
+            'when' => fn() => !$this->restrictLocation,
         ];
 
         $rules[] = [
@@ -256,9 +254,7 @@ class Assets extends BaseRelationField
                 'restrictedLocationSubpath',
             ],
             'validateNotTempVolume',
-            'when' => function(self $field): bool {
-                return (bool)$field->restrictLocation;
-            },
+            'when' => fn() => $this->restrictLocation,
         ];
 
         $rules[] = [['previewMode'], 'in', 'range' => [self::PREVIEW_MODE_FULL, self::PREVIEW_MODE_THUMBS], 'skipOnEmpty' => false];


### PR DESCRIPTION
### Description
When validating the Assets field to ensure that you haven’t selected the `tempUploadsLocation` volume as a source, default uploads location, or restricted location, only validate the fields the user can see.

(only applicable for v4)

### Related issues
#15545
