### PR TITLE
ElementQuery `andId` param and method

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -240,6 +240,12 @@ class ElementQuery extends Query implements ElementQueryInterface
     public mixed $id = null;
 
     /**
+     * @var mixed The element ID(s). Prefix IDs with `'not '` to exclude them.
+     * @used-by andId()
+     */
+    public mixed $andId = null;
+
+    /**
      * @var mixed The element UID(s). Prefix UIDs with `'not '` to exclude them.
      * @used-by uid()
      */
@@ -846,7 +852,25 @@ class ElementQuery extends Query implements ElementQueryInterface
      */
     public function id($value): static
     {
+        if ($this->id !== null) {
+            return $this->andId($value);
+        }
+
         $this->id = $value;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     * @uses $andId
+     */
+    public function andId($value): static
+    {
+        if (!$this->id) {
+            return $this->id($value);
+        }
+
+        $this->andId[] = $value;
         return $this;
     }
 
@@ -1575,6 +1599,12 @@ class ElementQuery extends Query implements ElementQueryInterface
 
         if ($this->id) {
             $this->subQuery->andWhere(Db::parseNumericParam('elements.id', $this->id));
+        }
+
+        if ($this->andId) {
+            foreach ($this->andId as $id) {
+                $this->subQuery->andWhere(Db::parseNumericParam('elements.id', $id));
+            }
         }
 
         if ($this->uid) {

--- a/src/elements/db/ElementQueryInterface.php
+++ b/src/elements/db/ElementQueryInterface.php
@@ -426,6 +426,45 @@ interface ElementQueryInterface extends QueryInterface, Arrayable
     public function id(mixed $value): static;
 
     /**
+     * Narrows the query results based on the {elements}’ IDs.
+     *
+     * Possible values include:
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `1` | with an ID of 1.
+     * | `'not 1'` | not with an ID of 1.
+     * | `[1, 2]` | with an ID of 1 or 2.
+     * | `['not', 1, 2]` | not with an ID of 1 or 2.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch the {element} by its ID #}
+     * {% set {element-var} = {twig-method}
+     *   .id(1)
+     *   .one() %}
+     * ```
+     *
+     * ```php
+     * // Fetch the {element} by its ID
+     * ${element-var} = {php-method}
+     *     ->id(1)
+     *     ->one();
+     * ```
+     *
+     * ---
+     *
+     * ::: tip
+     * This can be combined with [[fixedOrder()]] if you want the results to be returned in a specific order.
+     * :::
+     *
+     * @param mixed $value The property value
+     * @return static self reference
+     */
+    public function andId(mixed $value): static;
+
+    /**
      * Narrows the query results based on the {elements}’ UIDs.
      *
      * ---


### PR DESCRIPTION
### Description
Adds `andId` method and parameter to the `ElementQuery`. It will be used if the `id` parameter is already set. 

(I’ve not added it to the GraphQL. In GQL, querying a relation field with the `id` param works as expected, even post version 5.3.0)

### Related issues
#15570
