### PR TITLE
when ordering by value from json col, cast text to char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where tabs within field layout designers weren’t always getting positioned correctly when wrapped. ([#15590](https://github.com/craftcms/cms/issues/15590))
 - Fixed a bug where editable table rows’ action buttons were misaligned for newly-created rows. ([#15602](https://github.com/craftcms/cms/issues/15602))
 - Fixed a bug where relational fields’ element query results weren’t limited to the selected relations if the `id` param was overridden. ([#15570](https://github.com/craftcms/cms/issues/15570))
+- Fixed a bug where ordering element queries by textual custom fields would factor in character marks. ([#15609](https://github.com/craftcms/cms/issues/15609))
 
 ## 5.3.6 - 2024-08-26
 

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -783,14 +783,8 @@ abstract class Field extends SavableComponent implements FieldInterface
         // for mysql, we have to make sure text column type is cast to char, otherwise it won't be sorted correctly
         // see https://github.com/craftcms/cms/issues/15609
         $db = Craft::$app->getDb();
-        if ($db->getIsMysql()) {
-            $castType = match (Db::parseColumnType($dbType)) {
-                Schema::TYPE_TEXT => 'CHAR(255)',
-                default => null,
-            };
-            if ($castType !== null) {
-                $orderBy = "CAST($orderBy AS $castType)";
-            }
+        if ($db->getIsMysql() && Db::parseColumnType($dbType) === Schema::TYPE_TEXT) {
+            $orderBy = "CAST($orderBy AS CHAR(255))";
         }
 
         // The attribute name should match the table attribute name,

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -773,15 +773,31 @@ abstract class Field extends SavableComponent implements FieldInterface
      */
     public function getSortOption(): array
     {
-        if (static::dbType() === null || !isset($this->layoutElement)) {
+        $dbType = static::dbType();
+        if ($dbType === null || !isset($this->layoutElement)) {
             throw new NotSupportedException('getSortOption() not supported by ' . $this->name);
+        }
+
+        $orderBy = $this->getValueSql();
+
+        // for mysql, we have to make sure text column type is cast to char, otherwise it won't be sorted correctly
+        // see https://github.com/craftcms/cms/issues/15609
+        $db = Craft::$app->getDb();
+        if ($db->getIsMysql()) {
+            $castType = match (Db::parseColumnType($dbType)) {
+                Schema::TYPE_TEXT => 'CHAR(255)',
+                default => null,
+            };
+            if ($castType !== null) {
+                $orderBy = "CAST($orderBy AS $castType)";
+            }
         }
 
         // The attribute name should match the table attribute name,
         // per ElementSources::getTableAttributesForFieldLayouts()
         return [
             'label' => Craft::t('site', $this->name),
-            'orderBy' => $this->getValueSql(),
+            'orderBy' => $orderBy,
             'attribute' => isset($this->layoutElement->handle)
                 ? "fieldInstance:{$this->layoutElement->uid}"
                 : "field:$this->uid",


### PR DESCRIPTION
### Description
In MySQL, when ordering by a field that resolves to the default `Schema::TYPE_TEXT`, we need to cast the value to a `CHAR` for the `order by` clause. Otherwise, the sort order will be incorrect.

order by title ascending (before and after this PR):
<img width="655" alt="Screenshot 2024-08-28 at 14 18 45" src="https://github.com/user-attachments/assets/79cb7b3f-8b18-4c2e-a50e-e30d8cfe257a">

order by plain text field ascending (before this PR):
<img width="605" alt="Screenshot 2024-08-28 at 14 18 55" src="https://github.com/user-attachments/assets/a93ff584-2259-4f77-a4ba-2891f1269fee">

order by plain text field ascending (with this PR):
<img width="593" alt="Screenshot 2024-08-28 at 14 19 13" src="https://github.com/user-attachments/assets/02915ec6-ce7b-4c4f-af47-09311c0699d0">


### Related issues
#15609 
