### PR TITLE
Money fields' condition rules change input values with certain formatting locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where `craft\helpers\Db::supportsTimeZones()` could return `false` on databases that supported time zone conversion. ([#15592](https://github.com/craftcms/cms/issues/15592))
 - Fixed a bug where tabs within field layout designers weren’t always getting positioned correctly when wrapped. ([#15590](https://github.com/craftcms/cms/issues/15590))
 - Fixed a bug where editable table rows’ action buttons were misaligned for newly-created rows. ([#15602](https://github.com/craftcms/cms/issues/15602))
+- Fixed a bug where Money fields’ condition rules could display incorrect values based on a user’s formatting locale.
 
 ## 5.3.6 - 2024-08-26
 

--- a/src/fields/conditions/MoneyFieldConditionRule.php
+++ b/src/fields/conditions/MoneyFieldConditionRule.php
@@ -69,6 +69,10 @@ class MoneyFieldConditionRule extends BaseNumberConditionRule implements FieldCo
         }
 
         if ($this->operator === self::OPERATOR_BETWEEN) {
+            /** @var Money $field */
+            $field = $this->field();
+            $maxValue = is_numeric($this->maxValue) ? MoneyHelper::toNumber(MoneyHelper::toMoney(['value' => $this->maxValue, 'currency' => $field->currency])) : $this->maxValue;
+
             return Html::tag('div',
                 Html::hiddenLabel(Craft::t('app', 'Min Value'), 'min') .
                 // Min value (value) input
@@ -78,7 +82,7 @@ class MoneyFieldConditionRule extends BaseNumberConditionRule implements FieldCo
                 // Max value input
                 Cp::moneyInputHtml(array_merge(
                     $this->inputOptions(),
-                    ['id' => 'maxValue', 'name' => 'maxValue', 'value' => $this->maxValue]
+                    ['id' => 'maxValue', 'name' => 'maxValue', 'value' => $maxValue]
                 )) .
                 Html::tag('span', Craft::t('app', 'The values are matched inclusively.'), ['class' => 'info']),
                 ['class' => 'flex flex-center']
@@ -100,11 +104,13 @@ class MoneyFieldConditionRule extends BaseNumberConditionRule implements FieldCo
             $defaultValue = MoneyHelper::toNumber(new MoneyLibrary($field->defaultValue, new Currency($field->currency)));
         }
 
+        $value = is_numeric($this->value) ? MoneyHelper::toNumber(MoneyHelper::toMoney(['value' => $this->value, 'currency' => $field->currency])) : $this->value;
+
         return [
             'type' => 'text',
             'id' => 'value',
             'name' => 'value',
-            'value' => $this->value,
+            'value' => $value,
             'autocomplete' => false,
             'currency' => $field->currency,
             'currencyLabel' => $field->currencyLabel(),


### PR DESCRIPTION
### Description
Steps to reproduce:

- Add a money field to an entry type used by a section
- Set your formatting locale to something that reverses the `,` and `.` usage (e.g. French)
- Go to the element index for that section
- Add the condition rule for the money field
- Type `10` in that rule value and hit apply
- refresh the page

The value will have now changed to something different to what was entered (and stored in the DB)
