### PR TITLE
Column is `primaryOwnerId` not `ownerId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed a bug where relational fields’ element query results weren’t limited to the selected relations if the `id` param was overridden. ([#15570](https://github.com/craftcms/cms/issues/15570))
 - Fixed a bug where ordering element queries by textual custom fields would factor in character marks. ([#15609](https://github.com/craftcms/cms/issues/15609))
 - Fixed a bug where Money fields’ condition rules could display incorrect values based on a user’s formatting locale.
+- Fixed an error that occurred when eager-loading user addresses. ([#15629](https://github.com/craftcms/cms/pull/15629))
 
 ## 5.3.6 - 2024-08-26
 

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -506,11 +506,11 @@ class User extends Element implements IdentityInterface
         if ($handle == 'addresses') {
             $map = (new Query())
                 ->select([
-                    'source' => 'ownerId',
+                    'source' => 'primaryOwnerId',
                     'target' => 'id',
                 ])
                 ->from([Table::ADDRESSES])
-                ->where(['ownerId' => $sourceElementIds])
+                ->where(['primaryOwnerId' => $sourceElementIds])
                 ->all();
 
             return [


### PR DESCRIPTION
Running a GraphQL query of

```graphql
query {
  users {
    addresses {
      id
    }
  }
}
```

Will throw an error from the `User::eagerLoadingMap` because the `addresses` table column is `primaryOwnerId` and not `ownerId`