### PR TITLE
get trashed elements too, so that delete permanently works as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Fixed styling issues with classic Live Preview. ([#15640](https://github.com/craftcms/cms/issues/15640))
 - Fixed a bug where fields were bleeding out of the content pane on smaller viewports.
 - Fixed a bug where Link fields didn’t allow URLs with TLDs longer than six characters.
+- Fixed a bug where hard-deleting an element wasn’t hard-deleting any nested elements as well. ([#15645](https://github.com/craftcms/cms/pull/15645))
+- Fixed a bug where it wasn’t possible to hard-delete nested elements from embedded element index views. ([#15645](https://github.com/craftcms/cms/pull/15645))
 
 ## 5.3.6 - 2024-08-26
 

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -1236,6 +1236,7 @@ JS, [
             $elementsService = Craft::$app->getElements();
             $query = $this->nestedElementQuery($owner)
                 ->status(null)
+                ->trashed(null)
                 ->siteId($siteId);
             $query->{$this->ownerIdParam} = null;
             $query->{$this->primaryOwnerIdParam} = $owner->id;

--- a/src/elements/actions/Delete.php
+++ b/src/elements/actions/Delete.php
@@ -231,8 +231,8 @@ JS, [static::class]);
         Elements $elementsService,
         array &$deleteOwnership,
     ): void {
-        // If the element primarily belongs to a different element, just delete the ownership
-        if ($element instanceof NestedElementInterface) {
+        // If the element primarily belongs to a different element, (and we're not hard deleting) just delete the ownership
+        if (!$this->hard && $element instanceof NestedElementInterface) {
             $ownerId = $element->getOwnerId();
             if ($ownerId && $element->getPrimaryOwnerId() !== $ownerId) {
                 $deleteOwnership[$ownerId][] = $element->id;


### PR DESCRIPTION
### Description
Currently, when you soft delete an owner element, its nested elements get (correctly) marked as soft deleted, too. If you then go to view the trashed elements and decide to permanently delete that soft-deleted element, its nested ones won’t get hard deleted. 

This PR ensures that the nested element manager‘s `deleteNestedElements()` method also gets the trashed nested elements. This way, if the owner is hard deleted, the nested elements are too.

Also, you can now hard-delete nested elements via the “Delete permanently” action from the nested element index (previously, it was still attempting to delete the ownership). Hard deletion of nested elements this was is irreversible.

<img width="1774" alt="Screenshot 2024-09-03 at 16 29 18" src="https://github.com/user-attachments/assets/f9468977-466b-4a72-a1e6-e486103eda17">


### Related issues
n/a
