### PR TITLE
Fixed `ElementCondition::$elementType` being reset in `__construct()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Fixed styling issues with Template field layout UI elements’ selector labels.
 - Fixed a validation error that could occur when saving a relational field, if the “Maintain hierarchy” setting had been enabled but was no longer applicable. ([#15666](https://github.com/craftcms/cms/issues/15666))
 - Fixed an information disclosure vulnerability.
-- Fixed a bug where element conditions could have their `$elementType` property reset.
 
 ## 4.12.0 - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed styling issues with Template field layout UI elements’ selector labels.
 - Fixed a validation error that could occur when saving a relational field, if the “Maintain hierarchy” setting had been enabled but was no longer applicable. ([#15666](https://github.com/craftcms/cms/issues/15666))
 - Fixed an information disclosure vulnerability.
+- Fixed a bug where element conditions could have their `$elementType` property reset.
 
 ## 4.12.0 - 2024-09-03
 

--- a/src/elements/conditions/ElementCondition.php
+++ b/src/elements/conditions/ElementCondition.php
@@ -73,7 +73,10 @@ class ElementCondition extends BaseCondition implements ElementConditionInterfac
             throw new InvalidConfigException("Invalid element type: $elementType");
         }
 
-        $this->elementType = $elementType;
+        if ($elementType !== null) {
+            $this->elementType = $elementType;
+        }
+
         parent::__construct($config);
     }
 


### PR DESCRIPTION
### Description
If you create an element-based condition builder and set the `$elementType` property in the class this can be "reset" (set to `null` on instantiation.

For example, if I wanted to create a custom address condition I might create the following class:

```php
class MyAddressCondition extends AddressCondition
{ 
    public ?string $elementType = Address::class;
}
```

And then instantiate it with `Craft::$app->getConditions()->createCondition(MyAddressCondtion::class);`. I would get all the condition rules but I wouldn't get any of the custom fields. The change in this PR fixes that issue by only setting the `$elementType` property in the constructor if there is something to set it to. Otherwise it will leave it alone.

This is also an issue for custom element types e.g. :

```php
class MyElementCondition extends ElementCondtion
{ 
    public ?string $elementType = MyElement::class;
}

// then instantiate it

Craft::$app->getConditions()->createCondition(MyElementCondition::class);
```

If I had custom field layouts/field they wouldn't show in the condition rules.

Although not included in this PR, we could update the elements conditions to add the `$elementType`'s e.h in `AddressCondtion` class add  `public ?string $elementType = Address::class;` so it is there by default. It would stop us from [needing to pass in the element class on creation](https://github.com/craftcms/cms/blob/4.x/src/elements/Address.php#L104).