### PR TITLE
Eager-load fields based on fields actually present in query

### DIFF
--- a/src/base/EagerLoadingFieldInterface.php
+++ b/src/base/EagerLoadingFieldInterface.php
@@ -13,7 +13,7 @@ namespace craft\base;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
-interface EagerLoadingFieldInterface
+interface EagerLoadingFieldInterface extends FieldInterface
 {
     /**
      * Returns an array that maps source-to-target element IDs based on this custom field.

--- a/src/base/GqlInlineFragmentFieldInterface.php
+++ b/src/base/GqlInlineFragmentFieldInterface.php
@@ -13,7 +13,7 @@ namespace craft\base;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.3.0
  */
-interface GqlInlineFragmentFieldInterface
+interface GqlInlineFragmentFieldInterface extends FieldInterface
 {
     /**
      * Returns a GraphQL fragment by its GraphQL fragment name.

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -132,6 +132,7 @@ class ElementQuery extends Query implements ElementQueryInterface
 
     /**
      * @var FieldInterface[]|null The fields that may be involved in this query.
+     * @todo make this private in v6
      */
     public ?array $customFields = null;
 
@@ -1436,6 +1437,19 @@ class ElementQuery extends Query implements ElementQueryInterface
 
     // Query preparation/execution
     // -------------------------------------------------------------------------
+
+    /**
+     * Returns the custom fields that may be involved in this query.
+     *
+     * @since 5.5.0
+     */
+    public function getCustomFields(): array
+    {
+        if (!isset($this->customFields)) {
+            $this->customFields = $this->customFields();
+        }
+        return $this->customFields;
+    }
 
     /**
      * @inheritdoc


### PR DESCRIPTION
Refactors how we resolve GraphQL field names to custom fields, so the fields in the element query are referenced rather than the global list of fields. That way any handle overrides can be accounted for.