### PR TITLE
isNewForSite should be false when reverting to a revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a validation error that could occur when saving a relational field, if the “Maintain hierarchy” setting had been enabled but was no longer applicable. ([#15666](https://github.com/craftcms/cms/issues/15666))
 - Fixed a bug where formatted addresses weren’t using the application locale consistently. ([#15668](https://github.com/craftcms/cms/issues/15668))
 - Fixed a bug where Tip and Warning field layout UI elements would display in field layouts even if they had no content. ([#15681](https://github.com/craftcms/cms/issues/15681))
+- Fixed an error that could occur when reverting an element’s content from a revision, if the element had been added to additional sites since the time the revision was created. ([#15679](https://github.com/craftcms/cms/issues/15679))
 - Fixed an information disclosure vulnerability.
 
 ## 4.12.0 - 2024-09-03

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3668,7 +3668,10 @@ class Elements extends Component
             $siteElement->siteSettingsId = null;
             $siteElement->contentId = null;
             $siteElement->setEnabledForSite($siteInfo['enabledByDefault']);
-            $siteElement->isNewForSite = true;
+            // set isNewForSite to true unless it's a duplicate of a revision
+            // in which case we're reverting to a revision
+            // see https://github.com/craftcms/cms/issues/15679 for details
+            $siteElement->isNewForSite = !(($siteElement->duplicateOf !== null && $siteElement->duplicateOf->getIsRevision()));
 
             // Keep track of this new site ID
             $element->newSiteIds[] = $siteInfo['siteId'];

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3668,10 +3668,11 @@ class Elements extends Component
             $siteElement->siteSettingsId = null;
             $siteElement->contentId = null;
             $siteElement->setEnabledForSite($siteInfo['enabledByDefault']);
-            // set isNewForSite to true unless it's a duplicate of a revision
-            // in which case we're reverting to a revision
-            // see https://github.com/craftcms/cms/issues/15679 for details
-            $siteElement->isNewForSite = !(($siteElement->duplicateOf !== null && $siteElement->duplicateOf->getIsRevision()));
+            // set isNewForSite to true unless we're reverting content from a revision
+            // in which case, it's possible that the canonical element exists for the site already,
+            // but didn't back when the revision was created.
+            // (see https://github.com/craftcms/cms/issues/15679)
+            $siteElement->isNewForSite = !$siteElement->duplicateOf?->getIsRevision();
 
             // Keep track of this new site ID
             $element->newSiteIds[] = $siteInfo['siteId'];


### PR DESCRIPTION
### Description
When reverting to a revision, if revision didn’t exist for the site we’re propagating to, we can’t arbitrarily set `isNewForSite` to `true` because that can cause an integrity constraint error in certain cases (see the issue for details). If we’re duplicating a revision, `isNewForSite` should to be `false`.


### Related issues
#15679 
