### PR TITLE
Remove address label translatable icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Updated Twig to 3.14. ([#15704](https://github.com/craftcms/cms/issues/15704))
+- Fixed a bug where address’ Label fields were being marked as translatable. ([#15702](https://github.com/craftcms/cms/pull/15702))
 - Fixed an RCE vulnerability.
 
 ## 5.4.2 - 2024-09-06

--- a/src/fieldlayoutelements/addresses/LabelField.php
+++ b/src/fieldlayoutelements/addresses/LabelField.php
@@ -22,6 +22,11 @@ class LabelField extends TitleField
     /**
      * @inheritdoc
      */
+    public bool $translatable = false;
+
+    /**
+     * @inheritdoc
+     */
     public function defaultLabel(?ElementInterface $element = null, bool $static = false): ?string
     {
         return Craft::t('app', 'Label');


### PR DESCRIPTION
### Description
Address label field is not translatable, so it shouldn't have the translatable icon showing next to it.


### Related issues
#15682
