### PR TITLE
tweak to hard delete structures not linked to revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Updated Twig to 3.14. ([#15704](https://github.com/craftcms/cms/issues/15704))
+- Fixed a bug where soft-deleted structures weren’t getting hard-deleted via garbage collection. ([#15705](https://github.com/craftcms/cms/pull/15705))
 - Fixed an RCE vulnerability.
 
 ## 4.12.1 - 2024-09-06

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -609,6 +609,7 @@ SQL;
             ->leftJoin(['r' => $revisionsTable], '[[r.canonicalId]] = coalesce([[e.canonicalId]],[[e.id]])')
             ->where([
                 'and',
+                ['not', ['se.elementId' => null]],
                 $this->_hardDeleteCondition('s'),
                 [
                     'r.canonicalId' => null,
@@ -624,7 +625,7 @@ SQL;
             if ($this->db->getIsMysql()) {
                 $sql = <<<SQL
 DELETE [[s]].* FROM $structuresTable [[s]]
-WHERE [[s.id]] NOT IN ($ids)
+WHERE [[s.id]] IN ($ids)
 AND $conditionSql
 SQL;
             } else {
@@ -633,7 +634,7 @@ DELETE FROM $structuresTable
 USING $structuresTable [[s]]
 WHERE 
     $structuresTable.[[id]] = [[s.id]] AND 
-    [[s.id]] NOT IN ($ids) AND
+    [[s.id]] IN ($ids) AND
     $conditionSql
 SQL;
             }


### PR DESCRIPTION
### Description
The changes made as part of #14995 are a bit too strict, causing soft-deleted section structures to never get removed, even if they have no revisions linked to them.


### Related issues

