### PR TITLE
ensure field is set last on the layout element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Auto-generated handles, slugs, etc. now update immediately when the source input is changed. ([#15754](https://github.com/craftcms/cms/issues/15754))
 - Fixed a bug where Table fields’ Default Values table could lose existing rows if they only consisted of Dropdown columns without configured options.
+- Fixed a bug where custom fields’ `required` properties were always `false`. ([#15752](https://github.com/craftcms/cms/issues/15752))
 
 ## 4.12.3 - 2024-09-14
 

--- a/src/fieldlayoutelements/CustomField.php
+++ b/src/fieldlayoutelements/CustomField.php
@@ -37,9 +37,8 @@ class CustomField extends BaseField
     {
         // ensure we set the field last, so it has access to other properties that need to be set first
         // see https://github.com/craftcms/cms/issues/15752
-        if (isset($config['fieldUid'])) {
-            $fieldUid = $config['fieldUid'];
-            unset($config['fieldUid']);
+        $fieldUid = ArrayHelper::remove($config, 'fieldUid');
+        if ($fieldUid) {
             $config['fieldUid'] = $fieldUid;
         }
 

--- a/src/fieldlayoutelements/CustomField.php
+++ b/src/fieldlayoutelements/CustomField.php
@@ -35,8 +35,16 @@ class CustomField extends BaseField
      */
     public function __construct(?FieldInterface $field = null, $config = [])
     {
-        $this->_field = $field;
+        // ensure we set the field last, so it has access to other properties that need to be set first
+        // see https://github.com/craftcms/cms/issues/15752
+        if (isset($config['fieldUid'])) {
+            $fieldUid = $config['fieldUid'];
+            unset($config['fieldUid']);
+            $config['fieldUid'] = $fieldUid;
+        }
+
         parent::__construct($config);
+        $this->_field = $field;
     }
 
     /**


### PR DESCRIPTION
### Description
When constructing a layout element, ensure that the field is set last, so that it has access to all the other properties that it might need (e.g. layout element’s required parameter value).


### Related issues
#15752 
