### PR TITLE
UsersController Docblock, Dead Code

### DIFF
--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -183,9 +183,6 @@ class UsersController extends Controller
      */
     public function beforeAction($action): bool
     {
-        if ($action->id === 'login-modal') {
-//            sleep(1);
-        }
         // Don't enable CSRF validation for login requests if the user is already logged-in.
         // (Guards against double-clicking a Login button.)
         if ($action->id === 'login' && !Craft::$app->getUser()->getIsGuest()) {

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -98,6 +98,7 @@ class UsersController extends Controller
      *             ->one();
      *     }
      * );
+     * ```
      *
      * @since 4.2.0
      */


### PR DESCRIPTION
A fenced code block for `EVENT_DEFINE_CONTENT_SUMMARY` was swallowing a bunch of stuff in the docs!

Also removes a dead `if` statement in `beforeAction()`.