### PR TITLE
Small `StringHelper::toHandle` improvements

### DIFF
--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -1805,7 +1805,7 @@ class StringHelper extends \yii\helpers\StringHelper
         $handle = static::stripHtml($str);
 
         // Remove inner-word punctuation
-        $handle = preg_replace('/[\'"‘’“”\[\]\(\)\{\}:]/', '', $handle);
+        $handle = preg_replace('/[!,\'"‘’“”\[\]\(\)\{\}\/\\:]/', '', $handle);
 
         // Make it lowercase
         $handle = static::toLowerCase($handle);


### PR DESCRIPTION
### Description

Now also replaces `!`, `,`, `/` & `\` as these are all invalid characters in handles.