### PR TITLE
update improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -2,6 +2,7 @@
 
 ### Administration
 - Added `pc/*` commands as an alias of `project-config/*`.
+- Added the `--except`, `--minor-only`, and `--patch-only` options to the `update` command. ([#15829](https://github.com/craftcms/cms/pull/15829))
 
 ### Extensibility
 - Added `craft\base\RequestTrait::getIsWebRequest()`. ([#15690](https://github.com/craftcms/cms/pull/15690))

--- a/src/console/controllers/UpdateController.php
+++ b/src/console/controllers/UpdateController.php
@@ -8,6 +8,7 @@
 namespace craft\console\controllers;
 
 use Composer\IO\BufferIO;
+use Composer\Semver\VersionParser;
 use Craft;
 use craft\console\Controller;
 use craft\elements\User;
@@ -53,6 +54,24 @@ class UpdateController extends Controller
     public bool $withExpired = false;
 
     /**
+     * @var bool Whether only minor updates should be applied.
+     * @since 4.13.0
+     */
+    public bool $minorOnly = false;
+
+    /**
+     * @var bool Whether only patch updates should be applied.
+     * @since 4.13.0
+     */
+    public bool $patchOnly = false;
+
+    /**
+     * @var string[] Plugin handles to exclude
+     * @since 4.13.0
+     */
+    public array $except = [];
+
+    /**
      * @var bool Force the update if allowUpdates is disabled
      */
     public bool $force = false;
@@ -76,6 +95,9 @@ class UpdateController extends Controller
 
         if ($actionID === 'update') {
             $options[] = 'withExpired';
+            $options[] = 'minorOnly';
+            $options[] = 'patchOnly';
+            $options[] = 'except';
             $options[] = 'force';
             $options[] = 'backup';
             $options[] = 'migrate';
@@ -252,7 +274,24 @@ class UpdateController extends Controller
      */
     private function _getRequirements(string ...$handles): array
     {
-        $maxVersions = [];
+        $constraints = [];
+        $pluginsService = Craft::$app->getPlugins();
+
+        if ($this->minorOnly || $this->patchOnly) {
+            foreach ($pluginsService->getAllPlugins() as $plugin) {
+                // don't update dev versions
+                $version = $plugin->getVersion();
+                if (VersionParser::parseStability($version) === 'dev') {
+                    continue;
+                }
+
+                $constraint = $this->_constraint($version);
+                if ($constraint !== null) {
+                    $constraints[$plugin->id] = $constraint;
+                }
+            }
+        }
+
         if ($handles !== ['all']) {
             // Look for any specific versions that were requested
             foreach ($handles as $handle) {
@@ -261,23 +300,28 @@ class UpdateController extends Controller
                     if ($handle === 'craft') {
                         $handle = 'cms';
                     }
-                    $maxVersions[$handle] = $to;
+                    $constraints[$handle] = $to;
                 }
             }
         }
 
-        $updates = $this->_getUpdates($maxVersions);
-        $pluginsService = Craft::$app->getPlugins();
+        $updates = $this->_getUpdates($constraints);
         $info = [];
         $requirements = [];
 
         if ($handles === ['all']) {
-            if (($latest = $updates->cms->getLatest()) !== null) {
+            if (
+                !in_array('craft', $this->except) &&
+                ($latest = $updates->cms->getLatest()) !== null
+            ) {
                 $this->_updateRequirements($requirements, $info, 'craft', Craft::$app->version, $latest->version, 'craftcms/cms', $updates->cms);
             }
 
             foreach ($updates->plugins as $pluginHandle => $pluginUpdate) {
-                if (($latest = $pluginUpdate->getLatest()) !== null) {
+                if (
+                    !in_array($pluginHandle, $this->except) &&
+                    ($latest = $pluginUpdate->getLatest()) !== null
+                ) {
                     try {
                         $pluginInfo = $pluginsService->getPluginInfo($pluginHandle);
                     } catch (InvalidPluginException) {
@@ -332,6 +376,25 @@ class UpdateController extends Controller
         }
 
         return $requirements;
+    }
+
+    private function _constraint(string $version): ?string
+    {
+        if ($this->minorOnly) {
+            // 1.5.7.0 => ^1.5.7.0
+            return "^$version";
+        }
+
+        if ($this->patchOnly) {
+            // 1.5.7.0 => ~1.5.7
+            $version = (new VersionParser())->normalize($version);
+            $parts = explode('.', $version);
+            if (count($parts) === 4) {
+                return sprintf('~%s.%s.%s', ...array_slice($parts, 0, 3));
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -591,13 +654,13 @@ class UpdateController extends Controller
     /**
      * Returns the available updates.
      *
-     * @param string[] $maxVersions
+     * @param string[] $constraints
      * @return Updates
      */
-    private function _getUpdates(array $maxVersions = []): Updates
+    private function _getUpdates(array $constraints = []): Updates
     {
         $this->stdout('Fetching available updates ... ', Console::FG_YELLOW);
-        $updateData = Craft::$app->getApi()->getUpdates($maxVersions);
+        $updateData = Craft::$app->getApi()->getUpdates($constraints);
         $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
         return new UpdatesModel($updateData);
     }

--- a/src/console/controllers/UpdateController.php
+++ b/src/console/controllers/UpdateController.php
@@ -278,6 +278,11 @@ class UpdateController extends Controller
         $pluginsService = Craft::$app->getPlugins();
 
         if ($this->minorOnly || $this->patchOnly) {
+            $cmsConstraint = $this->_constraint(Craft::$app->getVersion());
+            if ($cmsConstraint !== null) {
+                $constraints['cms'] = $cmsConstraint;
+            }
+
             foreach ($pluginsService->getAllPlugins() as $plugin) {
                 // don't update dev versions
                 $version = $plugin->getVersion();
@@ -285,9 +290,9 @@ class UpdateController extends Controller
                     continue;
                 }
 
-                $constraint = $this->_constraint($version);
-                if ($constraint !== null) {
-                    $constraints[$plugin->id] = $constraint;
+                $pluginConstraint = $this->_constraint($version);
+                if ($pluginConstraint !== null) {
+                    $constraints[$plugin->id] = $pluginConstraint;
                 }
             }
         }


### PR DESCRIPTION
### Description

Adds new options to the `update` command:

```sh
php craft update all --except craft,ckeditor
php craft update all --minor-only
php craft update all --patch-only
```

`--minor-only` will prevent plugins from being updated beyond their current major version (e.g. `5.x`).

`--patch-only` will prevent Craft/plugins from being updated beyond their current minor version (e.g. `5.4.x`).

### Related issues

- #15795