### PR TITLE
allow aliasing of custom fields in element queries when using asArray

### DIFF
--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -3089,6 +3089,17 @@ class ElementQuery extends Query implements ElementQueryInterface
                     }
                 }
 
+                // allow aliasing of custom fields, but only when using asArray
+                // https://github.com/craftcms/cms/issues/15827
+                if (
+                    $this->asArray &&
+                    $alias !== $column &&
+                    isset($this->_columnMap[$column]) &&
+                    !empty(ArrayHelper::firstWhere($this->customFields, 'handle', $column))
+                ) {
+                    $column = $this->_columnMap[$column];
+                }
+
                 $select[$alias] = $column;
             }
         }


### PR DESCRIPTION
### Description
Allow aliasing of custom fields in element queries (when using in conjunction with `asArray`).

Example code to test with:
```
$myEntry = Entry::find()
    ->section('blog')
    ->select(['t' => 'title', 'pt' => 'plainText'])
    ->asArray()
    ->one();
```

This was easier to achieve in v4, though it still required extra work. In v5, that’s harder (though certainly not impossible). Tested against v4 and v5, and with overwritten field handles too.
Feel free to discard it if there’s a reason I didn’t think of why this shouldn’t be implemented.

### Related issues
#15827 
