### PR TITLE
fix: prevent db/backup from exporting triggeres twice

### DIFF
--- a/src/db/mysql/Schema.php
+++ b/src/db/mysql/Schema.php
@@ -227,6 +227,7 @@ class Schema extends \yii\db\mysql\Schema
 
         $schemaDump = (clone $baseCommand)
             ->addArg('--no-data')
+            ->addArg('--skip-triggers')
             ->addArg('--result-file=', '{file}')
             ->addArg('{database}');
 


### PR DESCRIPTION
### Description

If plugins include triggers in their tables, using `craft db/backup` exports them twice, leading into importing problems since triggers have to be imported after the data to prevent their execution. 
