### PR TITLE
Adding requireUtilityEnabled and apply

### DIFF
--- a/src/controllers/SystemMessagesController.php
+++ b/src/controllers/SystemMessagesController.php
@@ -37,6 +37,9 @@ class SystemMessagesController extends Controller
         // Make sure they have access to the System Messages utility
         $this->requirePermission('utility:system-messages');
 
+        // Make sure utility is enabled
+        $this->requireUtilityEnabled('system-messages');
+
         return true;
     }
 

--- a/src/controllers/UtilitiesController.php
+++ b/src/controllers/UtilitiesController.php
@@ -220,6 +220,7 @@ class UtilitiesController extends Controller
     public function actionDbBackupPerformAction(): ?Response
     {
         $this->requirePermission('utility:db-backup');
+        $this->requireUtilityEnabled('db-backup');
 
         try {
             $backupPath = Craft::$app->getDb()->backup();
@@ -253,6 +254,7 @@ class UtilitiesController extends Controller
     public function actionFindAndReplacePerformAction(): Response
     {
         $this->requirePermission('utility:find-replace');
+        $this->requireUtilityEnabled('find-replace');
 
         $params = $this->request->getRequiredBodyParam('params');
 

--- a/src/web/Controller.php
+++ b/src/web/Controller.php
@@ -512,6 +512,20 @@ abstract class Controller extends \yii\web\Controller
     }
 
     /**
+     * Checks whether the certain utilities are disabled, and ends the request with a 403 error if they are.
+     *
+     * @param string $utilityString The name of the utility.
+     * @throws ForbiddenHttpException if the utility is disabled.
+     */
+    public function requireUtilityEnabled(string $utilityString): void
+    {
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
+        if (in_array($utilityString, $generalConfig->disabledUtilities)) {
+            throw new ForbiddenHttpException('Utility disabled');
+        }
+    }
+
+    /**
      * Checks whether the current user can perform a given action, and ends the request with a 403 error if they don’t.
      *
      * @param string $action The name of the action to check.


### PR DESCRIPTION
### Description
#### Overview
Adds a verification for backend functions that checks whether these functions are allowed to be available via the `disabledUtilities` flags.


#### Why
As part of a security review, I came across the sensitivity of powerful utility backend functions. I advised my customer to deactivate these functionalities for his particularly security-critical application.  
The development team applied the following configuration:

```PHP
    ->allowAdminChanges(false)
    ->disabledUtilities(['db-backup','find-replace','system-messages'])
```

Unfortunately, this only hid the UI and the backend functions remained available. An XSS attack that targets these functionalities can cause **considerable damage**. E.g. the extraction of confidential information such as environment variables via the system-messages function.


### Related issues
GHSA-cw6g-qmjq-6w2w
