### PR TITLE
Nested element DX improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -28,9 +28,11 @@
 - Added support for passing aliased field handles into element queries’ `select()`/`addSelect()` methods. ([#15827](https://github.com/craftcms/cms/issues/15827))
 
 ### Extensibility
+- Added `craft\base\NestedElementTrait::saveOwnership()`. ([#15894](https://github.com/craftcms/cms/pull/15894))
 - Added `craft\base\RequestTrait::getIsWebRequest()`. ([#15690](https://github.com/craftcms/cms/pull/15690))
 - Added `craft\console\Controller::output()`. 
 - Added `craft\console\controllers\ResaveController::hasTheFields()`.
+- Added `craft\elements\db\NestedElementQueryTrait`. ([#15894](https://github.com/craftcms/cms/pull/15894))
 - Added `craft\events\ApplyFieldSaveEvent`. ([#15872](https://github.com/craftcms/cms/discussions/15872))
 - Added `craft\events\DefineAddressCountriesEvent`. ([#15711](https://github.com/craftcms/cms/pull/15711))
 - Added `craft\filters\BasicHttpAuthLogin`. ([#15720](https://github.com/craftcms/cms/pull/15720))

--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -11,7 +11,6 @@ use craft\base\Element;
 use craft\base\NameTrait;
 use craft\base\NestedElementInterface;
 use craft\base\NestedElementTrait;
-use craft\db\Query;
 use craft\db\Table;
 use craft\elements\conditions\addresses\AddressCondition;
 use craft\elements\conditions\ElementConditionInterface;
@@ -21,7 +20,6 @@ use craft\fieldlayoutelements\addresses\OrganizationField;
 use craft\fieldlayoutelements\addresses\OrganizationTaxIdField;
 use craft\fieldlayoutelements\BaseNativeField;
 use craft\fieldlayoutelements\FullNameField;
-use craft\helpers\Db;
 use craft\models\FieldLayout;
 use craft\records\Address as AddressRecord;
 use yii\base\InvalidConfigException;
@@ -722,64 +720,10 @@ class Address extends Element implements AddressInterface, NestedElementInterfac
 
         // Capture the dirty attributes from the record
         $dirtyAttributes = array_keys($record->getDirtyAttributes());
-
         $record->save(false);
-
-        $ownerId = $this->getOwnerId();
-        if (isset($this->fieldId) && $ownerId && $this->saveOwnership) {
-            if (!isset($this->sortOrder) && (!$isNew || $this->duplicateOf)) {
-                // figure out if we should proceed this way
-                // if we're dealing with an element that's being duplicated, and it has a draftId
-                // it means we're creating a draft of something
-                // if we're duplicating element via duplicate action - draftId would be empty
-                $elementId = null;
-                if ($this->duplicateOf) {
-                    if ($this->draftId) {
-                        $elementId = $this->duplicateOf->id;
-                    }
-                } else {
-                    // if we're not duplicating - use element's id
-                    $elementId = $this->id;
-                }
-                if ($elementId) {
-                    $this->sortOrder = (new Query())
-                        ->select('sortOrder')
-                        ->from(Table::ELEMENTS_OWNERS)
-                        ->where([
-                            'elementId' => $elementId,
-                            'ownerId' => $ownerId,
-                        ])
-                        ->scalar() ?: null;
-                }
-            }
-            if (!isset($this->sortOrder)) {
-                $max = (new Query())
-                    ->from(['eo' => Table::ELEMENTS_OWNERS])
-                    ->innerJoin(['a' => Table::ADDRESSES], '[[a.id]] = [[eo.elementId]]')
-                    ->where([
-                        'eo.ownerId' => $ownerId,
-                        'a.fieldId' => $this->fieldId,
-                    ])
-                    ->max('[[eo.sortOrder]]');
-                $this->sortOrder = $max ? $max + 1 : 1;
-            }
-            if ($isNew) {
-                Db::insert(Table::ELEMENTS_OWNERS, [
-                    'elementId' => $this->id,
-                    'ownerId' => $ownerId,
-                    'sortOrder' => $this->sortOrder,
-                ]);
-            } else {
-                Db::update(Table::ELEMENTS_OWNERS, [
-                    'sortOrder' => $this->sortOrder,
-                ], [
-                    'elementId' => $this->id,
-                    'ownerId' => $ownerId,
-                ]);
-            }
-        }
-
         $this->setDirtyAttributes($dirtyAttributes);
+
+        $this->saveOwnership($isNew, Table::ADDRESSES);
 
         parent::afterSave($isNew);
     }

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -19,7 +19,6 @@ use craft\behaviors\DraftBehavior;
 use craft\controllers\ElementIndexesController;
 use craft\db\Connection;
 use craft\db\FixedOrderExpression;
-use craft\db\Query;
 use craft\db\Table;
 use craft\elements\actions\Delete;
 use craft\elements\actions\DeleteForSite;
@@ -2518,7 +2517,6 @@ JS;
 
             // Capture the dirty attributes from the record
             $dirtyAttributes = array_keys($record->getDirtyAttributes());
-
             $record->save(false);
 
             // save authors
@@ -2531,60 +2529,9 @@ JS;
                 }
             }
 
-            // ownerId will be null when creating a revision
-            $ownerId = $this->getOwnerId();
-            if (isset($this->fieldId) && $ownerId && $this->saveOwnership) {
-                if (!isset($this->sortOrder) && (!$isNew || $this->duplicateOf)) {
-                    // figure out if we should proceed this way
-                    // if we're dealing with an element that's being duplicated, and it has a draftId
-                    // it means we're creating a draft of something
-                    // if we're duplicating element via duplicate action - draftId would be empty
-                    $elementId = null;
-                    if ($this->duplicateOf) {
-                        if ($this->draftId) {
-                            $elementId = $this->duplicateOf->id;
-                        }
-                    } else {
-                        // if we're not duplicating - use element's id
-                        $elementId = $this->id;
-                    }
-                    if ($elementId) {
-                        $this->sortOrder = (new Query())
-                            ->select('sortOrder')
-                            ->from(Table::ELEMENTS_OWNERS)
-                            ->where([
-                                'elementId' => $elementId,
-                                'ownerId' => $ownerId,
-                            ])
-                            ->scalar() ?: null;
-                    }
-                }
-                if (!isset($this->sortOrder)) {
-                    $max = (new Query())
-                        ->from(['eo' => Table::ELEMENTS_OWNERS])
-                        ->innerJoin(['e' => Table::ENTRIES], '[[e.id]] = [[eo.elementId]]')
-                        ->where([
-                            'eo.ownerId' => $ownerId,
-                            'e.fieldId' => $this->fieldId,
-                        ])
-                        ->max('[[eo.sortOrder]]');
-                    $this->sortOrder = $max ? $max + 1 : 1;
-                }
-                if ($isNew) {
-                    Db::insert(Table::ELEMENTS_OWNERS, [
-                        'elementId' => $this->id,
-                        'ownerId' => $ownerId,
-                        'sortOrder' => $this->sortOrder,
-                    ]);
-                } else {
-                    Db::update(Table::ELEMENTS_OWNERS, [
-                        'sortOrder' => $this->sortOrder,
-                    ], [
-                        'elementId' => $this->id,
-                        'ownerId' => $ownerId,
-                    ]);
-                }
-            }
+            $this->setDirtyAttributes($dirtyAttributes);
+
+            $this->saveOwnership($isNew, Table::ENTRIES);
 
             if ($this->getIsCanonical() && isset($this->sectionId) && $section->type == Section::TYPE_STRUCTURE) {
                 // Has the parent changed?
@@ -2597,8 +2544,6 @@ JS;
                     Craft::$app->getElements()->updateDescendantSlugsAndUris($this, true, true);
                 }
             }
-
-            $this->setDirtyAttributes($dirtyAttributes);
         }
 
         parent::afterSave($isNew);

--- a/src/elements/db/AddressQuery.php
+++ b/src/elements/db/AddressQuery.php
@@ -8,16 +8,10 @@
 namespace craft\elements\db;
 
 use Craft;
-use craft\base\ElementContainerFieldInterface;
-use craft\base\ElementInterface;
-use craft\db\Query;
 use craft\db\QueryAbortedException;
 use craft\db\Table;
 use craft\elements\Address;
-use craft\helpers\ArrayHelper;
 use craft\helpers\Db;
-use yii\base\InvalidArgumentException;
-use yii\base\InvalidConfigException;
 
 /**
  * AddressQuery represents a SELECT SQL statement for categories in a way that is independent of DBMS.
@@ -37,47 +31,9 @@ use yii\base\InvalidConfigException;
  */
 class AddressQuery extends ElementQuery
 {
-    /**
-     * @var mixed The field ID(s) that the resulting addresses must belong to.
-     * @used-by fieldId()
-     * @since 5.0.0
-     */
-    public mixed $fieldId = null;
-
-    /**
-     * @var mixed The primary owner element ID(s) that the resulting addresses must belong to.
-     * @used-by primaryOwner()
-     * @used-by primaryOwnerId()
-     * @since 5.0.0
-     */
-    public mixed $primaryOwnerId = null;
-
-    /**
-     * @var mixed The owner element ID(s) that the resulting addresses must belong to.
-     * @used-by owner()
-     * @used-by ownerId()
-     */
-    public mixed $ownerId = null;
-
-    /**
-     * @var bool|null Whether the owner elements can be drafts.
-     * @used-by allowOwnerDrafts()
-     * @since 5.0.0
-     */
-    public ?bool $allowOwnerDrafts = null;
-
-    /**
-     * @var bool|null Whether the owner elements can be revisions.
-     * @used-by allowOwnerRevisions()
-     * @since 5.0.0
-     */
-    public ?bool $allowOwnerRevisions = null;
-
-    /**
-     * @var ElementInterface|null The owner element specified by [[owner()]].
-     * @used-by owner()
-     */
-    private ?ElementInterface $_owner = null;
+    use NestedElementQueryTrait {
+        cacheTags as nestedTraitCacheTags;
+    }
 
     /**
      * @var mixed The address countryCode(s) that the resulting address must be in.
@@ -907,271 +863,6 @@ class AddressQuery extends ElementQuery
         return $this;
     }
 
-
-    /**
-     * Narrows the query results based on the field the addresses are contained by.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches {elements}…
-     * | - | -
-     * | `'foo'` | in a field with a handle of `foo`.
-     * | `['foo', 'bar']` | in a field with a handle of `foo` or `bar`.
-     * | an [[craft\fields\Addresses]] object | in a field represented by the object.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch {elements} in the Foo field #}
-     * {% set {elements-var} = {twig-method}
-     *   .field('foo')
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch {elements} in the Foo field
-     * ${elements-var} = {php-method}
-     *     ->field('foo')
-     *     ->all();
-     * ```
-     *
-     * @param mixed $value The property value
-     * @return static self reference
-     * @uses $fieldId
-     * @since 5.0.0
-     */
-    public function field(mixed $value): static
-    {
-        if (Db::normalizeParam($value, function($item) {
-            if (is_string($item)) {
-                $item = Craft::$app->getFields()->getFieldByHandle($item);
-            }
-            return $item instanceof ElementContainerFieldInterface ? $item->id : null;
-        })) {
-            $this->fieldId = $value;
-        } else {
-            $this->fieldId = false;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on the field the addresses are contained by, per the fields’ IDs.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches addresses…
-     * | - | -
-     * | `1` | in a field with an ID of 1.
-     * | `'not 1'` | not in a field with an ID of 1.
-     * | `[1, 2]` | in a field with an ID of 1 or 2.
-     * | `['not', 1, 2]` | not in a field with an ID of 1 or 2.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch addresses in the field with an ID of 1 #}
-     * {% set {elements-var} = {twig-method}
-     *   .fieldId(1)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch addresses in the field with an ID of 1
-     * ${elements-var} = {php-method}
-     *     ->fieldId(1)
-     *     ->all();
-     * ```
-     *
-     * @param mixed $value The property value
-     * @return static self reference
-     * @uses $fieldId
-     * @since 5.0.0
-     */
-    public function fieldId(mixed $value): static
-    {
-        $this->fieldId = $value;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on the primary owner element of the addresses, per the owners’ IDs.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches addresses…
-     * | - | -
-     * | `1` | created for an element with an ID of 1.
-     * | `[1, 2]` | created for an element with an ID of 1 or 2.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch addresses created for an element with an ID of 1 #}
-     * {% set {elements-var} = {twig-method}
-     *   .primaryOwnerId(1)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch addresses created for an element with an ID of 1
-     * ${elements-var} = {php-method}
-     *     ->primaryOwnerId(1)
-     *     ->all();
-     * ```
-     *
-     * @param mixed $value The property value
-     * @return static self reference
-     * @uses $primaryOwnerId
-     * @since 5.0.0
-     */
-    public function primaryOwnerId(mixed $value): static
-    {
-        $this->primaryOwnerId = $value;
-        return $this;
-    }
-
-    /**
-     * Sets the [[primaryOwnerId()]] and [[siteId()]] parameters based on a given element.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch addresses created for this entry #}
-     * {% set {elements-var} = {twig-method}
-     *   .primaryOwner(myEntry)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch addresses created for this entry
-     * ${elements-var} = {php-method}
-     *     ->primaryOwner($myEntry)
-     *     ->all();
-     * ```
-     *
-     * @param ElementInterface $primaryOwner The primary owner element
-     * @return static self reference
-     * @uses $primaryOwnerId
-     * @since 5.0.0
-     */
-    public function primaryOwner(ElementInterface $primaryOwner): static
-    {
-        $this->primaryOwnerId = [$primaryOwner->id];
-        $this->siteId = $primaryOwner->siteId;
-        return $this;
-    }
-
-    /**
-     * Sets the [[ownerId()]] parameter based on a given owner element.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch addresses for the current user #}
-     * {% set {elements-var} = {twig-method}
-     *   .owner(currentUser)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch addresses created for the current user
-     * ${elements-var} = {php-method}
-     *     ->owner(Craft::$app->user->identity)
-     *     ->all();
-     * ```
-     *
-     * @param ElementInterface $owner The owner element
-     * @return static self reference
-     * @uses $ownerId
-     */
-    public function owner(ElementInterface $owner): static
-    {
-        $this->ownerId = [$owner->id];
-        $this->_owner = $owner;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on the addresses’ owner elements, per their IDs.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches addresses…
-     * | - | -
-     * | `1` | created for an element with an ID of 1.
-     * | `[1, 2]` | created for an element with an ID of 1 or 2.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch addresses created for an element with an ID of 1 #}
-     * {% set {elements-var} = {twig-method}
-     *   .ownerId(1)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch addresses created for an element with an ID of 1
-     * ${elements-var} = {php-method}
-     *     ->ownerId(1)
-     *     ->all();
-     * ```
-     *
-     * @param int|int[]|null $value The property value
-     * @return static self reference
-     * @uses $ownerId
-     */
-    public function ownerId(array|int|null $value): static
-    {
-        $this->ownerId = $value;
-        $this->_owner = null;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on whether the addresses’ owners are drafts.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches addresses…
-     * | - | -
-     * | `true` | which can belong to a draft.
-     * | `false` | which cannot belong to a draft.
-     *
-     * @param bool|null $value The property value
-     * @return static self reference
-     * @uses $allowOwnerDrafts
-     * @since 5.0.0
-     */
-    public function allowOwnerDrafts(?bool $value = true): static
-    {
-        $this->allowOwnerDrafts = $value;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on whether the addresses’ owners are revisions.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches addresses…
-     * | - | -
-     * | `true` | which can belong to a revision.
-     * | `false` | which cannot belong to a revision.
-     *
-     * @param bool|null $value The property value
-     * @return static self reference
-     * @uses $allowOwnerRevisions
-     * @since 5.0.0
-     */
-    public function allowOwnerRevisions(?bool $value = true): static
-    {
-        $this->allowOwnerRevisions = $value;
-        return $this;
-    }
-
     /**
      * @inheritdoc
      */
@@ -1179,24 +870,6 @@ class AddressQuery extends ElementQuery
     {
         if (!parent::beforePrepare()) {
             return false;
-        }
-
-        if ($this->fieldId === false) {
-            throw new QueryAbortedException();
-        }
-
-        $this->_normalizeFieldId();
-
-        try {
-            $this->primaryOwnerId = $this->_normalizeOwnerId($this->primaryOwnerId);
-        } catch (InvalidArgumentException) {
-            throw new InvalidConfigException('Invalid primaryOwnerId param value');
-        }
-
-        try {
-            $this->ownerId = $this->_normalizeOwnerId($this->ownerId);
-        } catch (InvalidArgumentException) {
-            throw new InvalidConfigException('Invalid ownerId param value');
         }
 
         $this->joinElementTable(Table::ADDRESSES);
@@ -1223,49 +896,13 @@ class AddressQuery extends ElementQuery
             'addresses.longitude',
         ]);
 
+        $this->normalizeNestedElementParams();
+
+        // Only join the elements_owners table if fieldId is specified
         if (!empty($this->fieldId) && (!empty($this->ownerId) || !empty($this->primaryOwnerId))) {
-            // Join in the elements_owners table
-            $ownersCondition = [
-                'and',
-                '[[elements_owners.elementId]] = [[elements.id]]',
-                $this->ownerId ? ['elements_owners.ownerId' => $this->ownerId] : '[[elements_owners.ownerId]] = [[addresses.primaryOwnerId]]',
-            ];
-
-            $this->query
-                ->addSelect([
-                    'elements_owners.ownerId',
-                    'elements_owners.sortOrder',
-                ])
-                ->innerJoin(['elements_owners' => Table::ELEMENTS_OWNERS], $ownersCondition);
-            $this->subQuery->innerJoin(['elements_owners' => Table::ELEMENTS_OWNERS], $ownersCondition);
-
-            $this->subQuery->andWhere(['addresses.fieldId' => $this->fieldId]);
-
-            if ($this->primaryOwnerId) {
-                $this->subQuery->andWhere(['addresses.primaryOwnerId' => $this->primaryOwnerId]);
-            }
-
-            // Ignore revision/draft blocks by default
-            $allowOwnerDrafts = $this->allowOwnerDrafts ?? ($this->id || $this->primaryOwnerId || $this->ownerId);
-            $allowOwnerRevisions = $this->allowOwnerRevisions ?? ($this->id || $this->primaryOwnerId || $this->ownerId);
-
-            if (!$allowOwnerDrafts || !$allowOwnerRevisions) {
-                $this->subQuery->innerJoin(
-                    ['owners' => Table::ELEMENTS],
-                    $this->ownerId ? '[[owners.id]] = [[elements_owners.ownerId]]' : '[[owners.id]] = [[addresses.primaryOwnerId]]'
-                );
-
-                if (!$allowOwnerDrafts) {
-                    $this->subQuery->andWhere(['owners.draftId' => null]);
-                }
-
-                if (!$allowOwnerRevisions) {
-                    $this->subQuery->andWhere(['owners.revisionId' => null]);
-                }
-            }
-
-            $this->defaultOrderBy = ['elements_owners.sortOrder' => SORT_ASC];
+            $this->applyNestedElementParams('addresses.fieldId', 'addresses.primaryOwnerId');
         } elseif (isset($this->primaryOwnerId) || isset($this->ownerId)) {
+            // User addresses don't get rows in the elements_owners table
             if (!$this->primaryOwnerId && !$this->ownerId) {
                 throw new QueryAbortedException();
             }
@@ -1329,83 +966,6 @@ class AddressQuery extends ElementQuery
         }
 
         return true;
-    }
-
-    /**
-     * Normalizes the fieldId param to an array of IDs or null
-     */
-    private function _normalizeFieldId(): void
-    {
-        if (empty($this->fieldId)) {
-            $this->fieldId = is_array($this->fieldId) ? [] : null;
-        } elseif (is_numeric($this->fieldId)) {
-            $this->fieldId = [$this->fieldId];
-        } elseif (!is_array($this->fieldId) || !ArrayHelper::isNumeric($this->fieldId)) {
-            $this->fieldId = (new Query())
-                ->select(['id'])
-                ->from([Table::FIELDS])
-                ->where(Db::parseNumericParam('id', $this->fieldId))
-                ->column();
-        }
-    }
-
-    public function createElement(array $row): ElementInterface
-    {
-        if (isset($this->_owner)) {
-            $row['owner'] = $this->_owner;
-        }
-
-        return parent::createElement($row);
-    }
-
-    /**
-     * Normalizes the primaryOwnerId param to an array of IDs or null
-     *
-     * @param mixed $value
-     * @return int[]|null
-     * @throws InvalidArgumentException
-     */
-    private function _normalizeOwnerId(mixed $value): ?array
-    {
-        if (empty($value)) {
-            return null;
-        }
-        if (is_numeric($value)) {
-            return [$value];
-        }
-        if (!is_array($value) || !ArrayHelper::isNumeric($value)) {
-            throw new InvalidArgumentException();
-        }
-        return $value;
-    }
-
-    /**
-     * @inheritdoc
-     * @since 3.5.0
-     */
-    protected function cacheTags(): array
-    {
-        $tags = [];
-
-        if ($this->fieldId) {
-            foreach ($this->fieldId as $fieldId) {
-                $tags[] = "field:$fieldId";
-            }
-        }
-
-        if ($this->primaryOwnerId) {
-            foreach ($this->primaryOwnerId as $ownerId) {
-                $tags[] = "element::$ownerId";
-            }
-        }
-
-        if ($this->ownerId) {
-            foreach ($this->ownerId as $ownerId) {
-                $tags[] = "element::$ownerId";
-            }
-        }
-
-        return $tags;
     }
 
     /**

--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -8,8 +8,6 @@
 namespace craft\elements\db;
 
 use Craft;
-use craft\base\ElementContainerFieldInterface;
-use craft\base\ElementInterface;
 use craft\db\Query;
 use craft\db\QueryAbortedException;
 use craft\db\Table;
@@ -23,7 +21,6 @@ use craft\models\Section;
 use craft\models\UserGroup;
 use DateTime;
 use Illuminate\Support\Collection;
-use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 
 /**
@@ -55,6 +52,11 @@ use yii\base\InvalidConfigException;
  */
 class EntryQuery extends ElementQuery
 {
+    use NestedElementQueryTrait {
+        __set as nestedTraitSet;
+        cacheTags as nestedTraitCacheTags;
+    }
+
     // General parameters
     // -------------------------------------------------------------------------
 
@@ -90,43 +92,6 @@ class EntryQuery extends ElementQuery
      * @used-by sectionId()
      */
     public mixed $sectionId = null;
-
-    /**
-     * @var mixed The field ID(s) that the resulting entries must belong to.
-     * @used-by fieldId()
-     * @since 5.0.0
-     */
-    public mixed $fieldId = null;
-
-    /**
-     * @var mixed The primary owner element ID(s) that the resulting entries must belong to.
-     * @used-by primaryOwner()
-     * @used-by primaryOwnerId()
-     * @since 5.0.0
-     */
-    public mixed $primaryOwnerId = null;
-
-    /**
-     * @var mixed The owner element ID(s) that the resulting entries must belong to.
-     * @used-by owner()
-     * @used-by ownerId()
-     * @since 5.0.0
-     */
-    public mixed $ownerId = null;
-
-    /**
-     * @var bool|null Whether the owner elements can be drafts.
-     * @used-by allowOwnerDrafts()
-     * @since 5.0.0
-     */
-    public ?bool $allowOwnerDrafts = null;
-
-    /**
-     * @var bool|null Whether the owner elements can be revisions.
-     * @used-by allowOwnerRevisions()
-     * @since 5.0.0
-     */
-    public ?bool $allowOwnerRevisions = null;
 
     /**
      * @var mixed The entry type ID(s) that the resulting entries must have.
@@ -271,15 +236,6 @@ class EntryQuery extends ElementQuery
             case 'section':
                 $this->section($value);
                 break;
-            case 'field':
-                $this->field($value);
-                break;
-            case 'owner':
-                $this->owner($value);
-                break;
-            case 'primaryOwner':
-                $this->primaryOwner($value);
-                break;
             case 'type':
                 $this->type($value);
                 break;
@@ -287,7 +243,7 @@ class EntryQuery extends ElementQuery
                 $this->authorGroup($value);
                 break;
             default:
-                parent::__set($name, $value);
+                $this->nestedTraitSet($name, $value);
         }
     }
 
@@ -434,271 +390,6 @@ class EntryQuery extends ElementQuery
     public function sectionId(mixed $value): static
     {
         $this->sectionId = $value;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on the field the entries are contained by.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches {elements}…
-     * | - | -
-     * | `'foo'` | in a field with a handle of `foo`.
-     * | `['foo', 'bar']` | in a field with a handle of `foo` or `bar`.
-     * | a [[craft\fields\Matrix]] object | in a field represented by the object.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch {elements} in the Foo field #}
-     * {% set {elements-var} = {twig-method}
-     *   .field('foo')
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch {elements} in the Foo field
-     * ${elements-var} = {php-method}
-     *     ->field('foo')
-     *     ->all();
-     * ```
-     *
-     * @param mixed $value The property value
-     * @return static self reference
-     * @uses $fieldId
-     * @since 5.0.0
-     */
-    public function field(mixed $value): static
-    {
-        if (Db::normalizeParam($value, function($item) {
-            if (is_string($item)) {
-                $item = Craft::$app->getFields()->getFieldByHandle($item);
-            }
-            return $item instanceof ElementContainerFieldInterface ? $item->id : null;
-        })) {
-            $this->fieldId = $value;
-        } else {
-            $this->fieldId = false;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on the field the entries are contained by, per the fields’ IDs.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches entries…
-     * | - | -
-     * | `1` | in a field with an ID of 1.
-     * | `'not 1'` | not in a field with an ID of 1.
-     * | `[1, 2]` | in a field with an ID of 1 or 2.
-     * | `['not', 1, 2]` | not in a field with an ID of 1 or 2.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch entries in the field with an ID of 1 #}
-     * {% set {elements-var} = {twig-method}
-     *   .fieldId(1)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch entries in the field with an ID of 1
-     * ${elements-var} = {php-method}
-     *     ->fieldId(1)
-     *     ->all();
-     * ```
-     *
-     * @param mixed $value The property value
-     * @return static self reference
-     * @uses $fieldId
-     * @since 5.0.0
-     */
-    public function fieldId(mixed $value): static
-    {
-        $this->fieldId = $value;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on the primary owner element of the entries, per the owners’ IDs.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches entries…
-     * | - | -
-     * | `1` | created for an element with an ID of 1.
-     * | `[1, 2]` | created for an element with an ID of 1 or 2.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch entries created for an element with an ID of 1 #}
-     * {% set {elements-var} = {twig-method}
-     *   .primaryOwnerId(1)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch entries created for an element with an ID of 1
-     * ${elements-var} = {php-method}
-     *     ->primaryOwnerId(1)
-     *     ->all();
-     * ```
-     *
-     * @param mixed $value The property value
-     * @return static self reference
-     * @uses $primaryOwnerId
-     * @since 5.0.0
-     */
-    public function primaryOwnerId(mixed $value): static
-    {
-        $this->primaryOwnerId = $value;
-        return $this;
-    }
-
-    /**
-     * Sets the [[primaryOwnerId()]] and [[siteId()]] parameters based on a given element.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch entries created for this entry #}
-     * {% set {elements-var} = {twig-method}
-     *   .primaryOwner(myEntry)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch entries created for this entry
-     * ${elements-var} = {php-method}
-     *     ->primaryOwner($myEntry)
-     *     ->all();
-     * ```
-     *
-     * @param ElementInterface $primaryOwner The primary owner element
-     * @return static self reference
-     * @uses $primaryOwnerId
-     * @since 5.0.0
-     */
-    public function primaryOwner(ElementInterface $primaryOwner): static
-    {
-        $this->primaryOwnerId = [$primaryOwner->id];
-        $this->siteId = $primaryOwner->siteId;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on the owner element of the entries, per the owners’ IDs.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches entries…
-     * | - | -
-     * | `1` | created for an element with an ID of 1.
-     * | `[1, 2]` | created for an element with an ID of 1 or 2.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch entries created for an element with an ID of 1 #}
-     * {% set {elements-var} = {twig-method}
-     *   .ownerId(1)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch entries created for an element with an ID of 1
-     * ${elements-var} = {php-method}
-     *     ->ownerId(1)
-     *     ->all();
-     * ```
-     *
-     * @param mixed $value The property value
-     * @return static self reference
-     * @uses $ownerId
-     * @since 5.0.0
-     */
-    public function ownerId(mixed $value): static
-    {
-        $this->ownerId = $value;
-        return $this;
-    }
-
-    /**
-     * Sets the [[ownerId()]] and [[siteId()]] parameters based on a given element.
-     *
-     * ---
-     *
-     * ```twig
-     * {# Fetch entries created for this entry #}
-     * {% set {elements-var} = {twig-method}
-     *   .owner(myEntry)
-     *   .all() %}
-     * ```
-     *
-     * ```php
-     * // Fetch entries created for this entry
-     * ${elements-var} = {php-method}
-     *     ->owner($myEntry)
-     *     ->all();
-     * ```
-     *
-     * @param ElementInterface $owner The owner element
-     * @return static self reference
-     * @uses $ownerId
-     * @since 5.0.0
-     */
-    public function owner(ElementInterface $owner): static
-    {
-        $this->ownerId = [$owner->id];
-        $this->siteId = $owner->siteId;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on whether the entries’ owners are drafts.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches entries…
-     * | - | -
-     * | `true` | which can belong to a draft.
-     * | `false` | which cannot belong to a draft.
-     *
-     * @param bool|null $value The property value
-     * @return static self reference
-     * @uses $allowOwnerDrafts
-     * @since 5.0.0
-     */
-    public function allowOwnerDrafts(?bool $value = true): static
-    {
-        $this->allowOwnerDrafts = $value;
-        return $this;
-    }
-
-    /**
-     * Narrows the query results based on whether the entries’ owners are revisions.
-     *
-     * Possible values include:
-     *
-     * | Value | Fetches entries…
-     * | - | -
-     * | `true` | which can belong to a revision.
-     * | `false` | which cannot belong to a revision.
-     *
-     * @param bool|null $value The property value
-     * @return static self reference
-     * @uses $allowOwnerRevisions
-     * @since 5.0.0
-     */
-    public function allowOwnerRevisions(?bool $value = true): static
-    {
-        $this->allowOwnerRevisions = $value;
         return $this;
     }
 
@@ -1149,29 +840,12 @@ class EntryQuery extends ElementQuery
             return false;
         }
 
-        if ($this->fieldId === false) {
-            throw new QueryAbortedException();
-        }
-
         $this->_normalizeSectionId();
-        $this->_normalizeFieldId();
         $this->_normalizeTypeId();
 
         // See if 'section', 'type', or 'authorGroup' were set to invalid handles
         if ($this->sectionId === [] || $this->typeId === [] || $this->authorGroupId === []) {
             return false;
-        }
-
-        try {
-            $this->primaryOwnerId = $this->_normalizeOwnerId($this->primaryOwnerId);
-        } catch (InvalidArgumentException) {
-            throw new InvalidConfigException('Invalid primaryOwnerId param value');
-        }
-
-        try {
-            $this->ownerId = $this->_normalizeOwnerId($this->ownerId);
-        } catch (InvalidArgumentException) {
-            throw new InvalidConfigException('Invalid ownerId param value');
         }
 
         $this->joinElementTable(Table::ENTRIES);
@@ -1185,53 +859,8 @@ class EntryQuery extends ElementQuery
             'entries.expiryDate',
         ]);
 
-        if (!empty($this->fieldId) || !empty($this->ownerId) || !empty($this->primaryOwnerId)) {
-            // Join in the elements_owners table
-            $ownersCondition = [
-                'and',
-                '[[elements_owners.elementId]] = [[elements.id]]',
-                $this->ownerId ? ['elements_owners.ownerId' => $this->ownerId] : '[[elements_owners.ownerId]] = [[entries.primaryOwnerId]]',
-            ];
-
-            $this->query
-                ->addSelect([
-                    'elements_owners.ownerId',
-                    'elements_owners.sortOrder',
-                ])
-                ->innerJoin(['elements_owners' => Table::ELEMENTS_OWNERS], $ownersCondition);
-            $this->subQuery->innerJoin(['elements_owners' => Table::ELEMENTS_OWNERS], $ownersCondition);
-
-            if ($this->fieldId) {
-                $this->subQuery->andWhere(['entries.fieldId' => $this->fieldId]);
-            }
-
-            if ($this->primaryOwnerId) {
-                $this->subQuery->andWhere(['entries.primaryOwnerId' => $this->primaryOwnerId]);
-            }
-
-            // Ignore revision/draft blocks by default
-            $allowOwnerDrafts = $this->allowOwnerDrafts ?? ($this->id || $this->primaryOwnerId || $this->ownerId);
-            $allowOwnerRevisions = $this->allowOwnerRevisions ?? ($this->id || $this->primaryOwnerId || $this->ownerId);
-
-            if (!$allowOwnerDrafts || !$allowOwnerRevisions) {
-                $this->subQuery->innerJoin(
-                    ['owners' => Table::ELEMENTS],
-                    $this->ownerId ? '[[owners.id]] = [[elements_owners.ownerId]]' : '[[owners.id]] = [[entries.primaryOwnerId]]'
-                );
-
-                if (!$allowOwnerDrafts) {
-                    $this->subQuery->andWhere(['owners.draftId' => null]);
-                }
-
-                if (!$allowOwnerRevisions) {
-                    $this->subQuery->andWhere(['owners.revisionId' => null]);
-                }
-            }
-
-            $this->defaultOrderBy = ['elements_owners.sortOrder' => SORT_ASC];
-        } else {
-            $this->_applySectionIdParam();
-        }
+        $this->_applySectionIdParam();
+        $this->applyNestedElementParams('entries.fieldId', 'entries.primaryOwnerId');
 
         if ($this->postDate) {
             $this->subQuery->andWhere(Db::parseDateParam('entries.postDate', $this->postDate));
@@ -1547,45 +1176,6 @@ class EntryQuery extends ElementQuery
     }
 
     /**
-     * Normalizes the fieldId param to an array of IDs or null
-     */
-    private function _normalizeFieldId(): void
-    {
-        if (empty($this->fieldId)) {
-            $this->fieldId = is_array($this->fieldId) ? [] : null;
-        } elseif (is_numeric($this->fieldId)) {
-            $this->fieldId = [$this->fieldId];
-        } elseif (!is_array($this->fieldId) || !ArrayHelper::isNumeric($this->fieldId)) {
-            $this->fieldId = (new Query())
-                ->select(['id'])
-                ->from([Table::FIELDS])
-                ->where(Db::parseNumericParam('id', $this->fieldId))
-                ->column();
-        }
-    }
-
-    /**
-     * Normalizes the primaryOwnerId param to an array of IDs or null
-     *
-     * @param mixed $value
-     * @return int[]|null
-     * @throws InvalidArgumentException
-     */
-    private function _normalizeOwnerId(mixed $value): ?array
-    {
-        if (empty($value)) {
-            return null;
-        }
-        if (is_numeric($value)) {
-            return [$value];
-        }
-        if (!is_array($value) || !ArrayHelper::isNumeric($value)) {
-            throw new InvalidArgumentException();
-        }
-        return $value;
-    }
-
-    /**
      * Applies the 'ref' param to the query being prepared.
      */
     private function _applyRefParam(): void
@@ -1633,6 +1223,7 @@ class EntryQuery extends ElementQuery
     protected function cacheTags(): array
     {
         $tags = [];
+
         // If the type is set, go with that instead of the section
         if ($this->typeId) {
             foreach ($this->typeId as $typeId) {
@@ -1642,23 +1233,10 @@ class EntryQuery extends ElementQuery
             foreach ($this->sectionId as $sectionId) {
                 $tags[] = "section:$sectionId";
             }
-        } elseif ($this->fieldId) {
-            foreach ($this->fieldId as $fieldId) {
-                $tags[] = "field:$fieldId";
-            }
         }
 
-        if ($this->primaryOwnerId) {
-            foreach ($this->primaryOwnerId as $ownerId) {
-                $tags[] = "element::$ownerId";
-            }
-        }
+        array_push($tags, ...$this->nestedTraitCacheTags());
 
-        if ($this->ownerId) {
-            foreach ($this->ownerId as $ownerId) {
-                $tags[] = "element::$ownerId";
-            }
-        }
         return $tags;
     }
 

--- a/src/elements/db/NestedElementQueryTrait.php
+++ b/src/elements/db/NestedElementQueryTrait.php
@@ -1,0 +1,504 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\elements\db;
+
+use Craft;
+use craft\base\ElementContainerFieldInterface;
+use craft\base\ElementInterface;
+use craft\db\Query;
+use craft\db\QueryAbortedException;
+use craft\db\Table;
+use craft\helpers\ArrayHelper;
+use craft\helpers\Db;
+
+/**
+ * Trait NestedElementQueryTrait
+ *
+ * @mixin ElementQuery
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.5.0
+ */
+trait NestedElementQueryTrait
+{
+    /**
+     * @var mixed The field ID(s) that the resulting {elements} must belong to.
+     * @used-by fieldId()
+     * @since 5.0.0
+     */
+    public mixed $fieldId = null;
+
+    /**
+     * @var mixed The primary owner element ID(s) that the resulting {elements} must belong to.
+     * @used-by primaryOwner()
+     * @used-by primaryOwnerId()
+     * @since 5.0.0
+     */
+    public mixed $primaryOwnerId = null;
+
+    /**
+     * @var mixed The owner element ID(s) that the resulting {elements} must belong to.
+     * @used-by owner()
+     * @used-by ownerId()
+     * @since 5.0.0
+     */
+    public mixed $ownerId = null;
+
+    /**
+     * @var ElementInterface|null The owner element specified by [[owner()]].
+     * @used-by owner()
+     */
+    private ?ElementInterface $_owner = null;
+
+    /**
+     * @var bool|null Whether the owner elements can be drafts.
+     * @used-by allowOwnerDrafts()
+     * @since 5.0.0
+     */
+    public ?bool $allowOwnerDrafts = null;
+
+    /**
+     * @var bool|null Whether the owner elements can be revisions.
+     * @used-by allowOwnerRevisions()
+     * @since 5.0.0
+     */
+    public ?bool $allowOwnerRevisions = null;
+
+    /**
+     * @inheritdoc
+     */
+    public function __set($name, $value)
+    {
+        switch ($name) {
+            case 'field':
+                $this->field($value);
+                break;
+            case 'owner':
+                $this->owner($value);
+                break;
+            case 'primaryOwner':
+                $this->primaryOwner($value);
+                break;
+            default:
+                parent::__set($name, $value);
+        }
+    }
+
+    /**
+     * Narrows the query results based on the field the {elements} are contained by.
+     *
+     * Possible values include:
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `'foo'` | in a field with a handle of `foo`.
+     * | `['foo', 'bar']` | in a field with a handle of `foo` or `bar`.
+     * | a [[craft\fields\Matrix]] object | in a field represented by the object.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch {elements} in the Foo field #}
+     * {% set {elements-var} = {twig-method}
+     *   .field('foo')
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch {elements} in the Foo field
+     * ${elements-var} = {php-method}
+     *     ->field('foo')
+     *     ->all();
+     * ```
+     *
+     * @param mixed $value The property value
+     * @return static self reference
+     * @uses $fieldId
+     * @since 5.0.0
+     */
+    public function field(mixed $value): static
+    {
+        if (Db::normalizeParam($value, function($item) {
+            if (is_string($item)) {
+                $item = Craft::$app->getFields()->getFieldByHandle($item);
+            }
+            return $item instanceof ElementContainerFieldInterface ? $item->id : null;
+        })) {
+            $this->fieldId = $value;
+        } else {
+            $this->fieldId = false;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Narrows the query results based on the field the {elements} are contained by, per the fields’ IDs.
+     *
+     * Possible values include:
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `1` | in a field with an ID of 1.
+     * | `'not 1'` | not in a field with an ID of 1.
+     * | `[1, 2]` | in a field with an ID of 1 or 2.
+     * | `['not', 1, 2]` | not in a field with an ID of 1 or 2.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch {elements} in the field with an ID of 1 #}
+     * {% set {elements-var} = {twig-method}
+     *   .fieldId(1)
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch {elements} in the field with an ID of 1
+     * ${elements-var} = {php-method}
+     *     ->fieldId(1)
+     *     ->all();
+     * ```
+     *
+     * @param mixed $value The property value
+     * @return static self reference
+     * @uses $fieldId
+     * @since 5.0.0
+     */
+    public function fieldId(mixed $value): static
+    {
+        $this->fieldId = $value;
+        return $this;
+    }
+
+    /**
+     * Narrows the query results based on the primary owner element of the {elements}, per the owners’ IDs.
+     *
+     * Possible values include:
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `1` | created for an element with an ID of 1.
+     * | `[1, 2]` | created for an element with an ID of 1 or 2.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch {elements} created for an element with an ID of 1 #}
+     * {% set {elements-var} = {twig-method}
+     *   .primaryOwnerId(1)
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch {elements} created for an element with an ID of 1
+     * ${elements-var} = {php-method}
+     *     ->primaryOwnerId(1)
+     *     ->all();
+     * ```
+     *
+     * @param mixed $value The property value
+     * @return static self reference
+     * @uses $primaryOwnerId
+     * @since 5.0.0
+     */
+    public function primaryOwnerId(mixed $value): static
+    {
+        $this->primaryOwnerId = $value;
+        return $this;
+    }
+
+    /**
+     * Sets the [[primaryOwnerId()]] and [[siteId()]] parameters based on a given element.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch {elements} created for this entry #}
+     * {% set {elements-var} = {twig-method}
+     *   .primaryOwner(myEntry)
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch {elements} created for this entry
+     * ${elements-var} = {php-method}
+     *     ->primaryOwner($myEntry)
+     *     ->all();
+     * ```
+     *
+     * @param ElementInterface $primaryOwner The primary owner element
+     * @return static self reference
+     * @uses $primaryOwnerId
+     * @since 5.0.0
+     */
+    public function primaryOwner(ElementInterface $primaryOwner): static
+    {
+        $this->primaryOwnerId = [$primaryOwner->id];
+        $this->siteId = $primaryOwner->siteId;
+        return $this;
+    }
+
+    /**
+     * Narrows the query results based on the owner element of the {elements}, per the owners’ IDs.
+     *
+     * Possible values include:
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `1` | created for an element with an ID of 1.
+     * | `[1, 2]` | created for an element with an ID of 1 or 2.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch {elements} created for an element with an ID of 1 #}
+     * {% set {elements-var} = {twig-method}
+     *   .ownerId(1)
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch {elements} created for an element with an ID of 1
+     * ${elements-var} = {php-method}
+     *     ->ownerId(1)
+     *     ->all();
+     * ```
+     *
+     * @param mixed $value The property value
+     * @return static self reference
+     * @uses $ownerId
+     * @since 5.0.0
+     */
+    public function ownerId(mixed $value): static
+    {
+        $this->ownerId = $value;
+        $this->_owner = null;
+        return $this;
+    }
+
+    /**
+     * Sets the [[ownerId()]] and [[siteId()]] parameters based on a given element.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch {elements} created for this entry #}
+     * {% set {elements-var} = {twig-method}
+     *   .owner(myEntry)
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch {elements} created for this entry
+     * ${elements-var} = {php-method}
+     *     ->owner($myEntry)
+     *     ->all();
+     * ```
+     *
+     * @param ElementInterface $owner The owner element
+     * @return static self reference
+     * @uses $ownerId
+     * @since 5.0.0
+     */
+    public function owner(ElementInterface $owner): static
+    {
+        $this->ownerId = [$owner->id];
+        $this->siteId = $owner->siteId;
+        $this->_owner = $owner;
+        return $this;
+    }
+
+    /**
+     * Narrows the query results based on whether the {elements}’ owners are drafts.
+     *
+     * Possible values include:
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `true` | which can belong to a draft.
+     * | `false` | which cannot belong to a draft.
+     *
+     * @param bool|null $value The property value
+     * @return static self reference
+     * @uses $allowOwnerDrafts
+     * @since 5.0.0
+     */
+    public function allowOwnerDrafts(?bool $value = true): static
+    {
+        $this->allowOwnerDrafts = $value;
+        return $this;
+    }
+
+    /**
+     * Narrows the query results based on whether the {elements}’ owners are revisions.
+     *
+     * Possible values include:
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `true` | which can belong to a revision.
+     * | `false` | which cannot belong to a revision.
+     *
+     * @param bool|null $value The property value
+     * @return static self reference
+     * @uses $allowOwnerRevisions
+     * @since 5.0.0
+     */
+    public function allowOwnerRevisions(?bool $value = true): static
+    {
+        $this->allowOwnerRevisions = $value;
+        return $this;
+    }
+
+    private function applyNestedElementParams(string $fieldIdColumn, string $primaryOwnerIdColumn): void
+    {
+        $this->normalizeNestedElementParams();
+
+        if ($this->fieldId === false || $this->primaryOwnerId === false || $this->ownerId === false) {
+            throw new QueryAbortedException();
+        }
+
+        if (!empty($this->fieldId) || !empty($this->ownerId) || !empty($this->primaryOwnerId)) {
+            // Join in the elements_owners table
+            $ownersCondition = [
+                'and',
+                '[[elements_owners.elementId]] = [[elements.id]]',
+                $this->ownerId ? ['elements_owners.ownerId' => $this->ownerId] : "[[elements_owners.ownerId]] = [[$primaryOwnerIdColumn]]",
+            ];
+
+            $this->query
+                ->addSelect([
+                    'elements_owners.ownerId',
+                    'elements_owners.sortOrder',
+                ])
+                ->innerJoin(['elements_owners' => Table::ELEMENTS_OWNERS], $ownersCondition);
+            $this->subQuery->innerJoin(['elements_owners' => Table::ELEMENTS_OWNERS], $ownersCondition);
+
+            if ($this->fieldId) {
+                $this->subQuery->andWhere([$fieldIdColumn => $this->fieldId]);
+            }
+
+            if ($this->primaryOwnerId) {
+                $this->subQuery->andWhere([$primaryOwnerIdColumn => $this->primaryOwnerId]);
+            }
+
+            // Ignore revision/draft blocks by default
+            $allowOwnerDrafts = $this->allowOwnerDrafts ?? ($this->id || $this->primaryOwnerId || $this->ownerId);
+            $allowOwnerRevisions = $this->allowOwnerRevisions ?? ($this->id || $this->primaryOwnerId || $this->ownerId);
+
+            if (!$allowOwnerDrafts || !$allowOwnerRevisions) {
+                $this->subQuery->innerJoin(
+                    ['owners' => Table::ELEMENTS],
+                    $this->ownerId ? '[[owners.id]] = [[elements_owners.ownerId]]' : "[[owners.id]] = [[$primaryOwnerIdColumn]]"
+                );
+
+                if (!$allowOwnerDrafts) {
+                    $this->subQuery->andWhere(['owners.draftId' => null]);
+                }
+
+                if (!$allowOwnerRevisions) {
+                    $this->subQuery->andWhere(['owners.revisionId' => null]);
+                }
+            }
+
+            $this->defaultOrderBy = ['elements_owners.sortOrder' => SORT_ASC];
+        }
+    }
+
+    /**
+     * Normalizes the `fieldId`, `primaryOwnerId`, and `ownerId` params.
+     */
+    private function normalizeNestedElementParams(): void
+    {
+        $this->normalizeFieldId();
+        $this->primaryOwnerId = $this->normalizeOwnerId($this->primaryOwnerId);
+        $this->ownerId = $this->normalizeOwnerId($this->ownerId);
+    }
+
+    /**
+     * Normalizes the fieldId param to an array of IDs or null
+     */
+    private function normalizeFieldId(): void
+    {
+        if ($this->fieldId === false) {
+            return;
+        }
+
+        if (empty($this->fieldId)) {
+            $this->fieldId = is_array($this->fieldId) ? [] : null;
+        } elseif (is_numeric($this->fieldId)) {
+            $this->fieldId = [$this->fieldId];
+        } elseif (!is_array($this->fieldId) || !ArrayHelper::isNumeric($this->fieldId)) {
+            $this->fieldId = (new Query())
+                ->select(['id'])
+                ->from([Table::FIELDS])
+                ->where(Db::parseNumericParam('id', $this->fieldId))
+                ->column();
+        }
+    }
+
+    /**
+     * Normalizes the primaryOwnerId param to an array of IDs or null
+     *
+     * @param mixed $value
+     * @return int[]|null|false
+     */
+    private function normalizeOwnerId(mixed $value): array|null|false
+    {
+        if (empty($value)) {
+            return null;
+        }
+        if (is_numeric($value)) {
+            return [$value];
+        }
+        if (!is_array($value) || !ArrayHelper::isNumeric($value)) {
+            return false;
+        }
+        return $value;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createElement(array $row): ElementInterface
+    {
+        if (isset($this->_owner)) {
+            $row['owner'] = $this->_owner;
+        }
+
+        return parent::createElement($row);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function cacheTags(): array
+    {
+        $tags = [];
+
+        if ($this->fieldId) {
+            foreach ($this->fieldId as $fieldId) {
+                $tags[] = "field:$fieldId";
+            }
+        }
+
+        if ($this->primaryOwnerId) {
+            foreach ($this->primaryOwnerId as $ownerId) {
+                $tags[] = "element::$ownerId";
+            }
+        }
+
+        if ($this->ownerId) {
+            foreach ($this->ownerId as $ownerId) {
+                $tags[] = "element::$ownerId";
+            }
+        }
+
+        return $tags;
+    }
+}


### PR DESCRIPTION
### Description

Adds `NestedElementQueryTrait`, which can be added to element query classes to provide `fieldId`, `ownerId`, `primaryOwnerId`, `allowOwnerDrafts`, and `allowOwnerRevisions` params.

```php
class MyElementQuery extends ElementQuery
{
    use NestedElementQueryTrait;

    protected function beforePrepare(): bool
    {
        // ...

        $this->applyNestedElementParams('elementable.fieldId', 'elementtable.primaryOwnerId');
    }
}
```

Also adds `NestedElementTrait::saveOwnership()`, which can be called from elements’ `afterSave()` methods to save their ownership data in the `elements_owners` table.

```php
class MyElement extends Element
{
    public function afterSave(bool $isNew): void
    {
        // ...

        $this->saveOwnership($isNew, '{{%elementtable}}');
    }
}
```

### Related issues

- #15882