### PR TITLE
allow changing the template render mode for Template fieldlayoutelement

### DIFF
--- a/src/fieldlayoutelements/Template.php
+++ b/src/fieldlayoutelements/Template.php
@@ -28,6 +28,11 @@ class Template extends BaseUiElement
     public string $template = '';
 
     /**
+     * @var string The template render mode
+     */
+    public string $templateMode = View::TEMPLATE_MODE_SITE;
+
+    /**
      * @inheritdoc
      */
     protected function selectorLabel(): string
@@ -100,7 +105,7 @@ class Template extends BaseUiElement
             $content = trim(Craft::$app->getView()->renderTemplate($this->template, [
                 'element' => $element,
                 'static' => $static,
-            ], View::TEMPLATE_MODE_SITE));
+            ], $this->templateMode));
         } catch (Throwable $e) {
             return $this->_error($e->getMessage(), 'error');
         }


### PR DESCRIPTION
### Description
Allow changing the template render mode when using `\craft\fieldlayoutelements\Template`.


### Related issues
https://github.com/craftcms/cms/issues/15926#issuecomment-2426231890
