### PR TITLE
Add HTML5 audio and video player to getPreviewHtml()

### DIFF
--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2749,6 +2749,32 @@ JS,[
                 ($userSession->getId() == $this->uploaderId || $userSession->checkPermission("editPeerImages:$volume->uid"))
             );
 
+            switch ($this->kind) {
+                case Asset::KIND_VIDEO:
+                    $previewInner =
+                        Html::tag('video', null, [
+                            'class' => 'preview-thumb',
+                            'src' => $this->url,
+                            'controls' => true,
+                            'preload' => 'metadata',
+                        ]);
+                    break;
+                case Asset::KIND_AUDIO:
+                    $previewInner =
+                        Html::tag('audio', null, [
+                            'class' => 'preview-thumb',
+                            'src' => $this->url,
+                            'controls' => true,
+                            'preload' => 'metadata',
+                        ]);
+                    break;
+                default:
+                    $previewInner =
+                        Html::tag('div', $this->getPreviewThumbImg(350, 190), [
+                            'class' => 'preview-thumb',
+                        ]);
+            }
+            
             $previewThumbHtml =
                 Html::beginTag('div', [
                     'id' => 'thumb-container',
@@ -2758,9 +2784,7 @@ JS,[
                         $this->hasCheckeredThumb() ? 'checkered' : null,
                     ]),
                 ]) .
-                Html::tag('div', $this->getPreviewThumbImg(350, 190), [
-                    'class' => 'preview-thumb',
-                ]) .
+                $previewInner .
                 Html::endTag('div'); // .preview-thumb-container
 
             if ($previewable || $editable) {

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -2752,7 +2752,7 @@ JS,[
             switch ($this->kind) {
                 case Asset::KIND_VIDEO:
                     $previewInner =
-                        Html::tag('video', null, [
+                        Html::tag('video', '', [
                             'class' => 'preview-thumb',
                             'src' => $this->url,
                             'controls' => true,
@@ -2761,7 +2761,7 @@ JS,[
                     break;
                 case Asset::KIND_AUDIO:
                     $previewInner =
-                        Html::tag('audio', null, [
+                        Html::tag('audio', '', [
                             'class' => 'preview-thumb',
                             'src' => $this->url,
                             'controls' => true,


### PR DESCRIPTION
Replaces the generic thumbnail for audio and video files in the sidebar of an assets edit page with an HTML5 audio or video player.