### PR TITLE
Fixed bug where element would disappear in a condition rule on reload.

### DIFF
--- a/src/base/conditions/BaseElementSelectConditionRule.php
+++ b/src/base/conditions/BaseElementSelectConditionRule.php
@@ -152,6 +152,7 @@ abstract class BaseElementSelectConditionRule extends BaseConditionRule
         /** @phpstan-var class-string<ElementInterface>|ElementInterface $elementType */
         $elementType = $this->elementType();
         return $elementType::find()
+            ->site('*')
             ->id($elementId)
             ->status(null)
             ->one();


### PR DESCRIPTION
### Description

When making a condition rule that uses `BaseElementSelectConditionRule` (like the "Related To" rule) the element would not show up after page reload. This is due to the element query looking for the `$sitesService->getCurrentSite()->id` by default.

Fixed by changing the query to look for all sites. This also mimics the rule’s matching logic, which only matches on element ID.


https://github.com/user-attachments/assets/f4861457-1a9b-45b5-a662-34a5d1ce53a1


### Related Issue

https://github.com/craftcms/commerce/issues/3739
