### PR TITLE
remove `structureelements` rows for regular drafts

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -2145,24 +2145,6 @@ EOD;
 
         if ($section->type == Section::TYPE_STRUCTURE && $section->structureId == $structureId) {
             Craft::$app->getElements()->updateElementSlugAndUri($this, true, true, true);
-
-            // If this is the canonical entry, update its drafts
-            if ($this->getIsCanonical()) {
-                /** @var self[] $drafts */
-                $drafts = self::find()
-                    ->draftOf($this)
-                    ->status(null)
-                    ->site('*')
-                    ->unique()
-                    ->all();
-                $structuresService = Craft::$app->getStructures();
-                $lastElement = $this;
-
-                foreach ($drafts as $draft) {
-                    $structuresService->moveAfter($section->structureId, $draft, $lastElement);
-                    $lastElement = $draft;
-                }
-            }
         }
 
         parent::afterMoveInStructure($structureId);

--- a/src/services/Drafts.php
+++ b/src/services/Drafts.php
@@ -305,11 +305,6 @@ class Drafts extends Component
                     'revisionNotes' => $draftNotes ?: Craft::t('app', 'Applied “{name}”', ['name' => $draft->draftName]),
                 ]);
 
-                // Move the new canonical element after the draft?
-                if ($draft->structureId && $draft->root) {
-                    Craft::$app->getStructures()->moveAfter($draft->structureId, $newCanonical, $draft);
-                }
-
                 // Now delete the draft
                 $elementsService->deleteElement($draft, true);
             } else {


### PR DESCRIPTION
### Description
While working on https://github.com/craftcms/cms/issues/15949 I noticed the following behaviour:

replication steps:
- have a structure with at least 2 live entries in it
- one of them has a draft (regular, not provisional)
- the `structureelements` table only references the canonical IDs of those two entries;
- move the entry that has the draft in structure (before or after the other entry)
- now, the `structureelements` table has rows for the canonical ID of those two entries and a row for the draft

When you do the above, the draft has its position saved as after its canonical entry. If the canonical moves, the draft’s position is aligned as just after the canonical every time. You cannot change the position of just that draft and save those changes. The draft will always follow its canonical.

The code removed in this PR was originally added in June 2021 via https://github.com/craftcms/cms/commit/1ccba2c9f9706919b1afed7c94a687279bc7e34e.

We then de-structured drafts and revisions via https://github.com/craftcms/cms/pull/10040 in November 2021.

The removed code doesn’t look to be needed anymore, and it causes an issue in v5 when moving entries between sections. (I can adjust moving entries between sections differently if this PR ends up not being approved.)
