### PR TITLE
Bugfix card designer thumbnails

### DIFF
--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -2598,7 +2598,7 @@ JS, [
             ]);
 
         // get thumb placeholder
-        if ($showThumb) {
+        if ($showThumb ?? $fieldLayout->getThumbField() !== null) {
             $previewThumb = Html::tag('div',
                 Html::tag('div', Cp::iconSvg('image'), ['class' => 'cp-icon']),
                 ['class' => 'cvd-thumbnail']


### PR DESCRIPTION
Fixes an issue where card preview thumbnails would disappear when editing. 

**Before**


https://github.com/user-attachments/assets/d1bd9f89-f480-4c6d-8db9-a1a434cdee28

**After**

https://github.com/user-attachments/assets/6738b908-826e-493e-8287-3c049bd4ff2f

