### PR TITLE
Default card view attributes

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -59,9 +59,12 @@
 
 ### Extensibility
 - Added `craft\base\Element::EVENT_REGISTER_CARD_ATTRIBUTES`.
+- Added `craft\base\Element::EVENT_REGISTER_DEFAULT_CARD_ATTRIBUTES`.
 - Added `craft\base\Element::defineCardAttributes()`.
+- Added `craft\base\Element::defineDefaultCardAttributes()`.
 - Added `craft\base\ElementInterface::attributePreviewHtml()`.
 - Added `craft\base\ElementInterface::cardAttributes()`.
+- Added `craft\base\ElementInterface::defaultCardAttributes()`.
 - Added `craft\base\ElementInterface::indexViewModes()`.
 - Added `craft\base\NestedElementTrait::saveOwnership()`. ([#15894](https://github.com/craftcms/cms/pull/15894))
 - Added `craft\base\PreviewableFieldInterface::previewPlaceholderHtml()`.
@@ -73,6 +76,7 @@
 - Added `craft\events\ApplyFieldSaveEvent`. ([#15872](https://github.com/craftcms/cms/discussions/15872))
 - Added `craft\events\DefineAddressCountriesEvent`. ([#15711](https://github.com/craftcms/cms/pull/15711))
 - Added `craft\events\RegisterElementCardAttributesEvent`.
+- Added `craft\events\RegisterElementDefaultCardAttributesEvent`.
 - Added `craft\fieldlayoutelements\Template::$templateMode`. ([#15932](https://github.com/craftcms/cms/pull/15932))
 - Added `craft\fields\data\LinkData::$target`.
 - Added `craft\fields\data\LinkData::setLabel()`.

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -50,6 +50,7 @@ use craft\events\ElementStructureEvent;
 use craft\events\ModelEvent;
 use craft\events\RegisterElementActionsEvent;
 use craft\events\RegisterElementCardAttributesEvent;
+use craft\events\RegisterElementDefaultCardAttributesEvent;
 use craft\events\RegisterElementDefaultTableAttributesEvent;
 use craft\events\RegisterElementExportersEvent;
 use craft\events\RegisterElementFieldLayoutsEvent;
@@ -284,6 +285,12 @@ abstract class Element extends Component implements ElementInterface
      * @since 5.5.0
      */
     public const EVENT_REGISTER_CARD_ATTRIBUTES = 'registerCardAttributes';
+
+    /**
+     * @event RegisterElementCardAttributesEvent The event that is triggered when registering the card attributes for the element type.
+     * @since 5.5.0
+     */
+    public const EVENT_REGISTER_DEFAULT_CARD_ATTRIBUTES = 'registerDefaultCardAttributes';
 
     /**
      * @event DefineEagerLoadingMapEvent The event that is triggered when defining an eager-loading map.
@@ -1592,6 +1599,38 @@ abstract class Element extends Component implements ElementInterface
             'link', 'uri' => $attribute['placeholder'],
             default => ElementHelper::attributeHtml($attribute['placeholder'] ?? $attribute['label']),
         };
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function defaultCardAttributes(): array
+    {
+        $cardAttributes = static::defineDefaultCardAttributes();
+
+        // Fire a 'registerDefaultCardAttributes' event
+        if (Event::hasHandlers(static::class, self::EVENT_REGISTER_DEFAULT_CARD_ATTRIBUTES)) {
+            $event = new RegisterElementDefaultCardAttributesEvent([
+                'cardAttributes' => $cardAttributes,
+            ]);
+            Event::trigger(static::class, self::EVENT_REGISTER_DEFAULT_CARD_ATTRIBUTES, $event);
+            return $event->cardAttributes;
+        }
+
+        return $cardAttributes;
+    }
+
+    /**
+     * Returns the list of card attribute keys that should be shown by default.
+     *
+     * @return string[] The card attributes.
+     * @see defaultCardAttributes()
+     * @see cardAttributes()
+     * @since 5.5.0
+     */
+    protected static function defineDefaultCardAttributes(): array
+    {
+        return [];
     }
 
     // Methods for customizing element queries

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -541,6 +541,17 @@ interface ElementInterface extends
     public static function cardAttributes(): array;
 
     /**
+     * Returns the list of card attribute keys that should be shown by default, if the field layout hasn't been customised.
+     *
+     * This method should return an array where each element in the array maps to one of the keys of the array returned
+     * by [[cardAttributes()]].
+     *
+     * @return string[] The card attribute keys
+     * @since 5.5.0
+     */
+    public static function defaultCardAttributes(): array;
+
+    /**
      * Return HTML for the attribute in the card preview.
      *
      * @param array $attribute

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -694,14 +694,6 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
     /**
      * @inheritdoc
      */
-    protected static function defineDefaultCardAttributes(): array
-    {
-        return ['type'];
-    }
-
-    /**
-     * @inheritdoc
-     */
     public static function attributePreviewHtml(array $attribute): mixed
     {
         return match ($attribute['value']) {

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -694,6 +694,14 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
     /**
      * @inheritdoc
      */
+    protected static function defineDefaultCardAttributes(): array
+    {
+        return ['type'];
+    }
+
+    /**
+     * @inheritdoc
+     */
     public static function attributePreviewHtml(array $attribute): mixed
     {
         return match ($attribute['value']) {

--- a/src/events/RegisterElementDefaultCardAttributesEvent.php
+++ b/src/events/RegisterElementDefaultCardAttributesEvent.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use yii\base\Event;
+
+/**
+ * RegisterElementDefaultCardAttributesEvent class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.5.0
+ */
+class RegisterElementDefaultCardAttributesEvent extends Event
+{
+    /**
+     * @var string[] List of registered default card attributes for the element type.
+     */
+    public array $cardAttributes = [];
+}

--- a/src/models/FieldLayout.php
+++ b/src/models/FieldLayout.php
@@ -264,7 +264,11 @@ class FieldLayout extends Model
         }
 
         if (!isset($this->_cardView)) {
-            $this->setCardView([]);
+            if (!$this->type) {
+                $this->setCardView([]);
+            } else {
+                $this->setCardView($this->type::defaultCardAttributes());
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Add the ability for elements to define the default card attributes for a given element type. The defaults will be used if no customisation of the field layout’s card view has taken place. Once you save a field layout (and so you’ve customised the card view in the layout’s config) the config will be used. If you were to change the defaults later on, they won’t affect the field layouts you’ve already saved and specified your own card view selection (even if that selection is empty). There’s also a corresponding event that allows you to tweak the default values further.

- added `src/events/RegisterElementDefaultCardAttributesEvent`
- added `src/base/ElementInterface::defaultCardAttributes()`

### Related PR
https://github.com/craftcms/cms/pull/15283
