### PR TITLE
check if layout type class still exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed an error that prevented custom fields from loading on the Settings → Fields.
+
 ## 5.5.0 - 2024-11-12
 
 ### Content Management

--- a/src/models/FieldLayout.php
+++ b/src/models/FieldLayout.php
@@ -264,10 +264,10 @@ class FieldLayout extends Model
         }
 
         if (!isset($this->_cardView)) {
-            if (!$this->type) {
-                $this->setCardView([]);
-            } else {
+            if ($this->type && class_exists($this->type)) {
                 $this->setCardView($this->type::defaultCardAttributes());
+            } else {
+                $this->setCardView([]);
             }
         }
     }


### PR DESCRIPTION
### Description
When initialising a field layout, check if its type class still exists before trying to get the default card attributes.


### Related issues
#16095 
