### PR TITLE
support querying when link field data is of the old dbType

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -235,6 +235,8 @@ abstract class Field extends SavableComponent implements FieldInterface, Iconic,
             return false;
         }
 
+        $valueSql = static::adjustValueSql($instances, $valueSql);
+
         if (is_array($value) && isset($value['value'])) {
             $caseInsensitive = $value['caseInsensitive'] ?? false;
             $value = $value['value'];
@@ -250,13 +252,14 @@ abstract class Field extends SavableComponent implements FieldInterface, Iconic,
      *
      * @param static[] $instances
      * @param string|null $key The data key to fetch, if this field stores multiple values
+     * @param bool $includeJsonPath
      * @return string|null
      * @since 5.0.0
      */
-    protected static function valueSql(array $instances, string $key = null): ?string
+    protected static function valueSql(array $instances, string $key = null, bool $includeJsonPath = true): ?string
     {
         $valuesSql = array_filter(
-            array_map(fn(self $field) => $field->getValueSql($key), $instances),
+            array_map(fn(self $field) => $field->getValueSql($key, $includeJsonPath), $instances),
             fn(?string $valueSql) => $valueSql !== null,
         );
 
@@ -269,6 +272,18 @@ abstract class Field extends SavableComponent implements FieldInterface, Iconic,
         }
 
         return sprintf('COALESCE(%s)', implode(',', $valuesSql));
+    }
+
+    /**
+     * Gives fields a chance to adjust the value SQL.
+     *
+     * @param array $instances
+     * @param string $valueSql
+     * @return string|null
+     */
+    protected static function adjustValueSql(array $instances, string $valueSql): null|string
+    {
+        return $valueSql;
     }
 
     /**
@@ -954,18 +969,18 @@ JS, [
     /**
      * @inheritdoc
      */
-    public function getValueSql(?string $key = null): ?string
+    public function getValueSql(?string $key = null, bool $includeJsonPath = true): ?string
     {
         if (!isset($this->layoutElement)) {
             return null;
         }
 
         $cacheKey = $key ?? '*';
-        $this->_valueSql[$cacheKey] ??= $this->_valueSql($key) ?? false;
+        $this->_valueSql[$cacheKey] ??= $this->_valueSql($key, $includeJsonPath) ?? false;
         return $this->_valueSql[$cacheKey] ?: null;
     }
 
-    private function _valueSql(?string $key): ?string
+    private function _valueSql(?string $key, bool $includeJsonPath = true): ?string
     {
         $dbType = static::dbType();
 
@@ -982,7 +997,9 @@ JS, [
         if (is_array($dbType)) {
             // Get the primary value by default
             $key ??= array_key_first($dbType);
-            $jsonPath[] = $key;
+            if ($includeJsonPath) {
+                $jsonPath[] = $key;
+            }
             $dbType = $dbType[$key];
         }
 

--- a/src/base/FieldInterface.php
+++ b/src/base/FieldInterface.php
@@ -452,10 +452,11 @@ interface FieldInterface extends SavableComponentInterface, Chippable, Grippable
      * Returns a SQL expression which extracts the field’s value from the `elements_sites.content` column.
      *
      * @param string|null $key The data key to fetch, if this field stores multiple values
+     * @param bool $includeJsonPath
      * @return string|null
      * @since 5.0.0
      */
-    public function getValueSql(?string $key = null): ?string;
+    public function getValueSql(?string $key = null, bool $includeJsonPath = true): ?string;
 
     /**
      * Modifies an element index query.

--- a/src/fields/Link.php
+++ b/src/fields/Link.php
@@ -692,4 +692,14 @@ JS;
         }
         return $targetIds;
     }
+
+    /**
+     * @inheritdoc
+     */
+    protected static function adjustValueSql(array $instances, string $valueSql): null|string
+    {
+        $oldValueSql = static::valueSql($instances, 'value', false);
+
+        return sprintf('COALESCE(%s, %s)', $valueSql, $oldValueSql);
+    }
 }


### PR DESCRIPTION
### Description
The issue occurs because the field `dbType` changed. The normalisation of the field’s value handles it when it comes to content retrieval, but querying based on `Field::getValueSql()` doesn’t work unless you resave the elements that contain the Link field so their content is stored as the new array structure.

Changes in this PR:
- When getting the query condition, give field types a way of manipulating the value SQL.
- Allow an extra parameter to be passed to `valueSql`, `getValueSql` and `_valueSql` so that the path to the nested parameters can be excluded.

Another way to fix this would be to write a migration that resaved all elements that use the Link field.



### Related issues
#16113
