### PR TITLE
Fallback element partial templates

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,1 +1,5 @@
 # Release notes for Craft CMS 5.6 (WIP)
+
+### Development
+
+- Added support for fallback element partial templates, e.g. `_partials/entry.twig` as opposed to `_partials/entry/typeHandle.twig`. ([#16125](https://github.com/craftcms/cms/pull/16125))

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -13,6 +13,7 @@ use craft\base\ElementActionInterface;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\NestedElementInterface;
+use craft\config\GeneralConfig;
 use craft\db\Query;
 use craft\db\Table;
 use craft\errors\OperationAbortedException;
@@ -22,7 +23,6 @@ use craft\services\ElementSources;
 use craft\web\View;
 use DateTime;
 use Throwable;
-use Twig\Error\LoaderError as TwigLoaderError;
 use Twig\Markup;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
@@ -996,31 +996,35 @@ class ElementHelper
     {
         $view = Craft::$app->getView();
         $generalConfig = Craft::$app->getConfig()->getGeneral();
-        $output = [];
+        $output = array_map(fn(ElementInterface $element) => self::renderElement($element, $variables, $view, $generalConfig), $elements);
+        return new Markup(implode("\n", $output), Craft::$app->charset);
+    }
 
-        foreach ($elements as $element) {
-            $refHandle = $element::refHandle();
-            if ($refHandle === null) {
-                throw new NotSupportedException(sprintf('Element type “%s” doesn’t define a reference handle, so it doesn’t support partial templates.', $element::displayName()));
-            }
-            $providerHandle = $element->getFieldLayout()?->provider?->getHandle();
-            if ($providerHandle === null) {
-                throw new InvalidConfigException(sprintf('Element “%s” doesn’t have a field layout provider that defines a handle, so it can’t be rendered with a partial template.', $element));
-            }
-            $template = sprintf('%s/%s/%s', $generalConfig->partialTemplatesPath, $refHandle, $providerHandle);
-            $variables[$refHandle] = $element;
-            try {
-                $output[] = $view->renderTemplate($template, $variables, View::TEMPLATE_MODE_SITE);
-            } catch (TwigLoaderError $error) {
-                if ($error->getSourceContext() !== null) {
-                    throw $error;
-                }
-                // fallback to the string representation of the element
-                $output[] = Html::tag('p', Html::encode((string)$element));
+    private static function renderElement(ElementInterface $element, array $variables, View $view, GeneralConfig $generalConfig): string
+    {
+        $refHandle = $element::refHandle();
+        if ($refHandle === null) {
+            throw new NotSupportedException(sprintf('Element type “%s” doesn’t define a reference handle, so it doesn’t support partial templates.', $element::displayName()));
+        }
+
+        $variables[$refHandle] = $element;
+        $templates = [
+            sprintf('%s/%s', $generalConfig->partialTemplatesPath, $refHandle),
+        ];
+
+        $providerHandle = $element->getFieldLayout()?->provider?->getHandle();
+        if ($providerHandle !== null) {
+            array_unshift($templates, sprintf('%s/%s/%s', $generalConfig->partialTemplatesPath, $refHandle, $providerHandle));
+        }
+
+        foreach ($templates as $template) {
+            if ($view->doesTemplateExist($template, View::TEMPLATE_MODE_SITE)) {
+                return $view->renderTemplate($template, $variables, View::TEMPLATE_MODE_SITE);
             }
         }
 
-        return new Markup(implode("\n", $output), Craft::$app->charset);
+        // fallback to the string representation of the element
+        return Html::tag('p', Html::encode((string)$element));
     }
 
     /**


### PR DESCRIPTION
### Description

Adds support for defining fallback element partial templates, e.g. `_partials/entry.twig`.

The fallback template will be used if a more specific template based on the field layout provider handle (e.g. the entry type handle) doesn’t exist.

Also makes it possible to define partial templates for element types that don’t have field layout providers, like users and addresses.