### PR TITLE
Add ability for nested element's to specify their owner's element type

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -4,7 +4,7 @@
 - Improved the accessibility of Checkboxes and Radio Buttons fields that allow custom options. ([#16080](https://github.com/craftcms/cms/pull/16080))
 
 ### Development
-- Added the ability to specify a nested element’s owner element type.
+- Added the ability to specify a nested element’s owner element type. ([#16133](https://github.com/craftcms/cms/pull/16133))
 - Added support for fallback element partial templates, e.g. `_partials/entry.twig` as opposed to `_partials/entry/typeHandle.twig`. ([#16125](https://github.com/craftcms/cms/pull/16125))
 
 ### Extensibility

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -4,4 +4,8 @@
 - Improved the accessibility of Checkboxes and Radio Buttons fields that allow custom options. ([#16080](https://github.com/craftcms/cms/pull/16080))
 
 ### Development
+- Added the ability to specify a nested element’s owner element type.
 - Added support for fallback element partial templates, e.g. `_partials/entry.twig` as opposed to `_partials/entry/typeHandle.twig`. ([#16125](https://github.com/craftcms/cms/pull/16125))
+
+### Extensibility
+- Added `craft\base\NestedElementTrait::$ownerElementType`.

--- a/src/base/NestedElementTrait.php
+++ b/src/base/NestedElementTrait.php
@@ -30,6 +30,12 @@ use yii\base\InvalidConfigException;
 trait NestedElementTrait
 {
     /**
+     * @var string|null The owner element type. Used if the nested element is only every owner by one type of element.
+     * @since 5.6.0
+     */
+    public ?string $ownerElementType = null;
+
+    /**
      * @inheritdoc
      */
     public static function eagerLoadingMap(array $sourceElements, string $handle): array|null|false
@@ -154,7 +160,7 @@ trait NestedElementTrait
                 return null;
             }
 
-            $this->_primaryOwner = Craft::$app->getElements()->getElementById($primaryOwnerId, null, $this->siteId, [
+            $this->_primaryOwner = Craft::$app->getElements()->getElementById($primaryOwnerId, $this->ownerElementType, $this->siteId, [
                 'trashed' => null,
             ]) ?? false;
             if (!$this->_primaryOwner) {
@@ -206,7 +212,7 @@ trait NestedElementTrait
                 return $this->getPrimaryOwner();
             }
 
-            $this->_owner = Craft::$app->getElements()->getElementById($ownerId, null, $this->siteId, [
+            $this->_owner = Craft::$app->getElements()->getElementById($ownerId, $this->ownerElementType, $this->siteId, [
                 'trashed' => null,
             ]) ?? false;
             if (!$this->_owner) {
@@ -306,7 +312,7 @@ trait NestedElementTrait
         if (!$this->saveOwnership || !isset($this->fieldId)) {
             return;
         }
-        
+
         $ownerId = $this->getOwnerId();
         if (!$ownerId) {
             return;


### PR DESCRIPTION
### Description
In the `NestedElementTrait` the implementations of `getOwner()` and `getPrimaryOwner()` have a call to `Elements::getElementById()` currently this is hard-coded to pass `null` to the element type. This makes sense as there is no knowledge in this class of what the owner's element type would be.

Unfortunately, in certain scenarios this can cause an n+1 query issue with many duplicated (get element type) queries.

This PR adds the `$ownerElementType` property to trait. This property is useful for those instances where the nested element already knows what its owner's element type is. This is applicable in the case of variants in Craft Commerce.

In Commerce the `getOwner()` and `getPrimary()` methods from the trait [have been overridden](https://github.com/craftcms/commerce/blob/5.x/src/elements/Variant.php#L525-L576) so that the element type can be specified (this greatly improved performance). With this PR this code can be removed and replaced with an implementation of the new property:

```php
public ?string $ownerElementType = Product::class;
```

There was consideration to note adding the property but instead add an argument to both the `getOwner()` and `getPrimaryOwner()` methods as this could make things more flexible. But this felt like more of a change and greater scope for it to be a breaking change (based on developers who may have implemented/overridden the methods already).

