### PR TITLE
Bugfix/16094 removing draft data for nested entry

### DIFF
--- a/src/controllers/NestedElementsController.php
+++ b/src/controllers/NestedElementsController.php
@@ -84,6 +84,7 @@ class NestedElementsController extends Controller
         if ($this->nestedElements instanceof ElementQueryInterface) {
             $oldSortOrders = (clone $this->nestedElements)
                 ->status(null)
+                ->drafts(null)
                 ->asArray()
                 ->select(['id', 'sortOrder'])
                 ->pairs();

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -770,7 +770,8 @@ JS, [
                         }
                     } elseif (
                         $element->getIsUnpublishedDraft() &&
-                        $element->getPrimaryOwnerId() === $owner->id
+                        $element->getPrimaryOwnerId() === $owner->id &&
+                        !$owner->getIsDraft()
                     ) {
                         Craft::$app->getDrafts()->removeDraftData($element);
                     }


### PR DESCRIPTION
### Description
When saving nested elements, and the element is an unpublished draft, only drop the draft data if the owner isn’t a draft, too.

When reordering nested elements, take drafts into consideration, too.


### Related issues
#16094 
