### PR TITLE
Editing owner entry when it's new for site (and still a provisional draft)

### DIFF
--- a/src/base/NestedElementTrait.php
+++ b/src/base/NestedElementTrait.php
@@ -154,8 +154,9 @@ trait NestedElementTrait
                 return null;
             }
 
-            $this->_primaryOwner = Craft::$app->getElements()->getElementById($primaryOwnerId, null, $this->siteId, [
+            $this->_primaryOwner = Craft::$app->getElements()->getElementById($primaryOwnerId, null, null, [
                 'trashed' => null,
+                'preferSites' => [$this->siteId],
             ]) ?? false;
             if (!$this->_primaryOwner) {
                 throw new InvalidConfigException("Invalid owner ID: $primaryOwnerId");


### PR DESCRIPTION
### Description
Follow up to #15898. 
After changes in https://github.com/craftcms/cms/commit/bc047295cb58775301fcd710ee567a4a7a788f16, switching to a newly enabled site causes an invalid owner ID exception and prevents a user from viewing the entry for a new site without fully saving first.


### Related issues

