### PR TITLE
don't factor in owner when getting nested entry's canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed a JavaScript error that could occur when reordering structured elements within an embedded element index. ([#16103](https://github.com/craftcms/cms/issues/16103))
 - Fixed a bug where changes to nested entries/addresses in card view were getting published immediately on save, if the parent element was a draft.
 - Fixed a bug where element cards could bleed out of their containers. ([#16112](https://github.com/craftcms/cms/issues/16112))
+- Fixed a bug where nested entries could get deleted when restoring revisions. ([#16116](https://github.com/craftcms/cms/issues/16116))
 
 ## 5.5.0.1 - 2024-11-13
 

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -3048,8 +3048,7 @@ abstract class Element extends Component implements ElementInterface
 
             if ($this instanceof NestedElementInterface && $query instanceof NestedElementQueryInterface) {
                 $query
-                    ->fieldId($this->getField()?->id)
-                    ->ownerId($this->getOwnerId());
+                    ->fieldId($this->getField()?->id);
             }
 
             $this->$prop = $query->one();


### PR DESCRIPTION
### Description
The nested element’s derivative was returned as a canonical of that element. This led to the actual canonical being marked as soft-deleted when the owner element was saved. Then, when the time came to revert the owner entry to the revision referencing the true canonical of the nested element, that nested element was not returned as it was marked as soft-deleted. (This started happening in `5.4.9`.)


### Related issues
#16116
