### PR TITLE
entries table is aliased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a SQL error that occurred when creating a new Single section. ([#16145](https://github.com/craftcms/cms/issues/16145))
+
 ## 5.5.1.1 - 2024-11-18
 
 - Fixed a PHP error. ([#16142](https://github.com/craftcms/cms/issues/16142))

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -43,7 +43,6 @@ use craft\models\Site;
 use craft\models\Structure;
 use craft\queue\jobs\ApplyNewPropagationMethod;
 use craft\queue\jobs\ResaveElements;
-use craft\records\Entry as EntryRecord;
 use craft\records\EntryType as EntryTypeRecord;
 use craft\records\Section as SectionRecord;
 use craft\records\Section_SiteSettings as Section_SiteSettingsRecord;
@@ -979,7 +978,7 @@ class Entries extends Component
         if ($entry === null) {
             $entry = $baseEntryQuery
                 ->trashed(null)
-                ->where([EntryRecord::tableName() . '.[[deletedWithEntryType]]' => 1])
+                ->where(['entries.deletedWithEntryType' => 1])
                 ->one();
 
             if ($entry !== null) {

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -978,7 +978,7 @@ class Entries extends Component
         if ($entry === null) {
             $entry = $baseEntryQuery
                 ->trashed(null)
-                ->where(['entries.deletedWithEntryType' => 1])
+                ->where(['entries.deletedWithEntryType' => true])
                 ->one();
 
             if ($entry !== null) {


### PR DESCRIPTION
### Description
Fixes an issue where `_ensureSingleEntry` method wasn’t calling the entries table by its alias.


### Related issues
#16145 
