### PR TITLE
check if options passed to `resave/all` are supported by subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an error that could occur if an invalid folder ID was passed to `craft\services\Assets::deleteFoldersByIds()`. ([#16147](https://github.com/craftcms/cms/pull/16147))
 - Fixed a SQL error that occurred when creating a new Single section. ([#16145](https://github.com/craftcms/cms/issues/16145))
+- Fixed an error that occurred when running the `resave/all` command, if any of the options passed weren’t supported by other `resave/*` commands. ([#16148](https://github.com/craftcms/cms/pull/16148))
 - Fixed an RCE vulnerability.
 
 ## 5.5.1.1 - 2024-11-18

--- a/src/console/controllers/ResaveController.php
+++ b/src/console/controllers/ResaveController.php
@@ -386,11 +386,11 @@ class ResaveController extends Controller
         $proceed = true;
         // ask for confirmation
         if ($this->interactive && !empty($actionsToSkip)) {
-            $this->output('Following commands, don’t support all the provided parameters:', Console::FG_YELLOW);
+            $this->output('Following commands, don’t support all the provided options:', Console::FG_YELLOW);
             foreach ($actionsToSkip as $id) {
                 $invalidParams = array_map(
                     fn($param) => '--' . StringHelper::toKebabCase($param),
-                    $this->getUnsupportedParams($id, $params)
+                    $this->getUnsupportedOptions($id, $params)
                 );
                 $count = count($invalidParams);
                 $invalidParams = implode(', ', $invalidParams);
@@ -871,7 +871,7 @@ class ResaveController extends Controller
      * @param array $params
      * @return array
      */
-    private function getUnsupportedParams(string $actionId, array $params): array
+    private function getUnsupportedOptions(string $actionId, array $params): array
     {
         $unsupportedParams = [];
         $options = $this->options($actionId);


### PR DESCRIPTION
### Description
The `resave/all` command now checks if the options it’s being run with (like `--with-fields`) are supported by each command it’s supposed to call. If not (and the command is run interactively), ask a user to confirm if they wish to proceed, and if so (or the command isn’t run interactively), run it for the actions that support all the options.

<img width="657" alt="Screenshot 2024-11-19 at 11 57 47" src="https://github.com/user-attachments/assets/9fcb12ae-3754-4082-bd32-8514f998e2ee">


### Related issues
[cms-1348](https://linear.app/craftcms/issue/CMS-1348/resaveall-to-check-if-provided-options-are-supported)
