### PR TITLE
if user can't save element, show the element editor as static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where element slideouts had Save buttons even if the user didn’t have permission to save the element. ([#16205](https://github.com/craftcms/cms/pull/16205))
+
 ## 5.5.3 - 2024-11-22
 
 - Element indexes now sort by ID by default, for sources that don’t define a default sort option.

--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -445,7 +445,7 @@ class ElementsController extends Controller
                         'visibleLayoutElements' => $form ? $form->getVisibleElements() : [],
                         'updatedTimestamp' => $element->dateUpdated?->getTimestamp(),
                         'canonicalUpdatedTimestamp' => $canonical->dateUpdated?->getTimestamp(),
-                        'isStatic' => $isRevision,
+                        'isStatic' => $isRevision || !$canSave,
                     ]
                 )
             );


### PR DESCRIPTION
### Description
If a user has permission to view other users’ entries (but not save them), if you open such entries in a slideout, the cancel and save buttons will show. Clicking the save button triggers an internal server error notification and the entry is not saved (rightly so).

This PR checks if the user can save an element, and, if not, sets the `isStatic` property to `true` so that the element editor slideout can show the correct button(s) in the footer.

Before:
<img width="1349" alt="Screenshot 2024-11-25 at 13 05 43" src="https://github.com/user-attachments/assets/2d076de7-8d7a-4987-a564-a3e894e34cbd">

After:
<img width="1350" alt="Screenshot 2024-11-25 at 13 05 27" src="https://github.com/user-attachments/assets/682420e8-1996-46d6-980f-86ef31f872ae">


### Related issues
n/a
