### PR TITLE
wrap League's Uri instantiation in try catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed an error that could occur when duplicating an element with an Assets field that had a dynamic subpath. ([#16214](https://github.com/craftcms/cms/issues/16214))
 - Fixed a bug where element slideouts had Save buttons even if the user didn’t have permission to save the element. ([#16205](https://github.com/craftcms/cms/pull/16205))
 - Fixed a bug where pagination wasn’t working properly on the Entry Types index page when searching. ([#16204](https://github.com/craftcms/cms/issues/16204))
+- Fixed an error that could occur when saving an element with an invalid Link field value. ([#16212](https://github.com/craftcms/cms/issues/16212))
 
 ## 5.5.3 - 2024-11-22
 

--- a/src/fields/linktypes/Url.php
+++ b/src/fields/linktypes/Url.php
@@ -76,8 +76,13 @@ class Url extends BaseTextLinkType
 
     public function validateValue(string $value, ?string &$error = null): bool
     {
-        // Leveraging Uri package to convert domains to punycode
-        return parent::validateValue(Uri::new($value), $error);
+        try {
+            // Leveraging Uri package to convert domains to punycode
+            $value = Uri::new($value);
+            return parent::validateValue($value, $error);
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     protected function pattern(): string


### PR DESCRIPTION
### Description
When validating the URL Link, wrap the League’s `Uri` instantiation in a try-catch so that a completely invalid link returns a validation error and not an exception.


### Related issues
#16212
