### PR TITLE
when duplicating find dynamic folder by duplicateOf element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed an error that could occur when duplicating an element with an Assets field that had a dynamic subpath. ([#16214](https://github.com/craftcms/cms/issues/16214))
+
 ## 4.13.3 - 2024-11-22
 
 - Element indexes now sort by ID by default, for sources that don’t define a default sort option.

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -945,6 +945,9 @@ class Assets extends BaseRelationField
         if ($isDynamic) {
             // Prepare the path by parsing tokens and normalizing slashes.
             try {
+                if ($element?->duplicateOf) {
+                    $element = $element->duplicateOf;
+                }
                 $renderedSubpath = Craft::$app->getView()->renderObjectTemplate($subpath, $element);
             } catch (InvalidConfigException|RuntimeError $e) {
                 throw new InvalidSubpathException($subpath, null, 0, $e);


### PR DESCRIPTION
### Description
When duplicating an element that contains an Assets field with a dynamic subpath, ensure we use the original element (one that’s being duplicated) to find the destination folder (as, by that time, the new duplicate might not yet have all the required characteristics). 


### Related issues
#16214 
