### PR TITLE
(fix) Hide phpinfo utility is not available

### DIFF
--- a/src/services/Utilities.php
+++ b/src/services/Utilities.php
@@ -69,7 +69,7 @@ class Utilities extends Component
         $utilityTypes = [
             UpdatesUtility::class,
             SystemReport::class,
-            ProjectConfigUtility::class
+            ProjectConfigUtility::class,
         ];
 
         if (PhpInfo::isAvailable()) {

--- a/src/services/Utilities.php
+++ b/src/services/Utilities.php
@@ -69,9 +69,12 @@ class Utilities extends Component
         $utilityTypes = [
             UpdatesUtility::class,
             SystemReport::class,
-            ProjectConfigUtility::class,
-            PhpInfo::class,
+            ProjectConfigUtility::class
         ];
+
+        if (PhpInfo::isAvailable()) {
+            $utilityTypes[] = PhpInfo::class;
+        }
 
         if (Craft::$app->edition->value >= CmsEdition::Pro->value) {
             $utilityTypes[] = SystemMessagesUtility::class;

--- a/src/utilities/PhpInfo.php
+++ b/src/utilities/PhpInfo.php
@@ -53,6 +53,16 @@ class PhpInfo extends Utility
     }
 
     /**
+     * Returns whether the utility is available.
+     * @since 5.6.0
+     * @return bool
+     */
+    public static function isAvailable(): bool
+    {
+        return \function_exists('phpinfo');
+    }
+
+    /**
      * Parses and returns the PHP info.
      *
      * @return array


### PR DESCRIPTION
This simple PR prevents the cp from displaying a page that we know would error out.

On production systems, phpinfo should be disabled anyways.

Let me know if you need me to change anything.

Thanks!
