### PR TITLE
`applyFieldSave` needs to get the most up-to-date field before assigning old settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed an error that could occur when duplicating an element with an Assets field that had a dynamic subpath. ([#16214](https://github.com/craftcms/cms/issues/16214))
 - Reduced the likelihood of a deadlock error occurring when updating search indexes. ([#15221](https://github.com/craftcms/cms/issues/15221))
 - Fixed a bug where renaming asset folders could move them to the webroot on Windows. ([#16215](https://github.com/craftcms/cms/issues/16215))
+- Fixed a bug where Matrix fields’ content tables weren’t getting renamed properly when applying project config changes. ([#16227](https://github.com/craftcms/cms/issues/16227))
 
 ## 4.13.3 - 2024-11-22
 

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -1677,6 +1677,13 @@ class Fields extends Component
             $field ??= $this->getFieldById($fieldRecord->id);
             $field->id = $fieldRecord->id;
         } else {
+            // if it's not a control panel save request, get the field again
+            // so that it has the new settings
+            // https://github.com/craftcms/cms/issues/16227
+            if (!isset($this->_savingFields[$fieldUid])) {
+                $field = $this->getFieldById($fieldRecord->id);
+            }
+
             // Save the old field handle and settings on the model in case the field type needs to do something with it.
             $field->oldHandle = $fieldRecord->getOldHandle();
             $field->oldSettings = is_string($oldSettings) ? Json::decode($oldSettings) : null;


### PR DESCRIPTION
### Description
When the field save is not coming from the control panel, we need to ensure that we have the most up-to-date field before assigning old settings.

Without this, the handle and settings will still be set to the old values, causing issues when e.g. a matrix table name needs to be changed.


### Related issues
#16227 
