### PR TITLE
store empty user group description as null in the PC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where blank user group descriptions weren’t getting omitted from project config data. ([#16272](https://github.com/craftcms/cms/pull/16272))
+
 ## 4.13.5 - 2024-12-03
 
 - Fixed a bug where asset, category, and entry sources defined by the `EVENT_REGISTER_SOURCES` event didn’t have any custom fields available to them, unless the `EVENT_REGISTER_FIELD_LAYOUTS` event was also used to define the available field layouts for the event-defined source. ([#16256](https://github.com/craftcms/cms/discussions/16256))

--- a/src/models/UserGroup.php
+++ b/src/models/UserGroup.php
@@ -124,7 +124,7 @@ class UserGroup extends Model
         $config = [
             'name' => $this->name,
             'handle' => $this->handle,
-            'description' => $this->description,
+            'description' => $this->description ?: null,
         ];
 
         if ($withPermissions && $this->id) {


### PR DESCRIPTION
### Description
When the project config is generated via save in the control panel, the user group yaml file has the description saved as an empty string. When the `project-config/rebuild` command is run, it is stored as `null`.

The PR ensures that in both cases, an empty description is stored as `null`.

(applicable to v4 and v5)

### Related issues
#16266 
