### PR TITLE
store empty entry types props as null in the PC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug where blank user group descriptions weren’t getting omitted from project config data. ([#16272](https://github.com/craftcms/cms/pull/16272))
+- Fixed a bug where some blank user group and entry type values weren’t getting omitted from project config data. ([#16272](https://github.com/craftcms/cms/pull/16272), [#16273](https://github.com/craftcms/cms/pull/16273))
 
 ## 5.5.5 - 2024-12-03
 

--- a/src/models/EntryType.php
+++ b/src/models/EntryType.php
@@ -364,15 +364,15 @@ JS, [
         $config = [
             'name' => $this->name,
             'handle' => $this->handle,
-            'icon' => $this->icon,
+            'icon' => $this->icon ?: null,
             'color' => $this->color?->value,
             'hasTitleField' => $this->hasTitleField,
             'titleTranslationMethod' => $this->titleTranslationMethod,
-            'titleTranslationKeyFormat' => $this->titleTranslationKeyFormat,
-            'titleFormat' => $this->titleFormat,
+            'titleTranslationKeyFormat' => $this->titleTranslationKeyFormat ?: null,
+            'titleFormat' => $this->titleFormat ?: null,
             'showSlugField' => $this->showSlugField,
             'slugTranslationMethod' => $this->slugTranslationMethod,
-            'slugTranslationKeyFormat' => $this->slugTranslationKeyFormat,
+            'slugTranslationKeyFormat' => $this->slugTranslationKeyFormat ?: null,
             'showStatusField' => $this->showStatusField,
         ];
 


### PR DESCRIPTION
### Description
When the project config is generated via save in the control panel, the entry type yaml file has the icon, titleTranslationKeyFormat, titleFormat and slugTranslationKeyFormat saved as an empty string. When the project-config/rebuild command is run, they are stored as null.

The PR ensures that, in both cases, an empty value is stored as null.

(applicable to v5 only; already stores the existing empty values as null in v4)

### Related issues
#16266 
