### PR TITLE
`_deleteOrphanedFkRows` wrap column name in quotes

### DIFF
--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -556,7 +556,7 @@ SQL;
                         } else {
                             $sql = <<<SQL
 DELETE FROM $table->name t
-WHERE t.$fkColumn IS NOT NULL
+WHERE t."$fkColumn" IS NOT NULL
 AND NOT EXISTS (
     SELECT * FROM $refTable
     WHERE "$pkColumn" = t."$fkColumn"


### PR DESCRIPTION
### Description
In the new `Gc->_deleteOrphanedFkRows()` method, the column name needs to be wrapped in quotes for PostgreSQL.


### Related issues
n/a
