### PR TITLE
Phone link normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a JavaScript error that occurred on the Plugins index page, if there were any missing plugins associated with the Craft CMS license and no plugins were Composer-installed yet.
 - Fixed a bug where custom fields would stay visible within Field Layout Designer field libraries when they didn’t match the search criteria, if they had previously been dragged. ([#16277](https://github.com/craftcms/cms/issues/16277))
 - Fixed a bug where new, unsaved nested addresses and entries could cause validation errors when saving the owner element. ([#16282](https://github.com/craftcms/cms/issues/16282))
+- Fixed a bug where spaces in phone number values within Link fields were getting replaced with `+` characters rather than `-`. ([#16300](https://github.com/craftcms/cms/issues/16300))
 
 ## 5.5.5 - 2024-12-03
 

--- a/src/fields/Link.php
+++ b/src/fields/Link.php
@@ -434,7 +434,7 @@ class Link extends Field implements InlineEditableFieldInterface, RelationalFiel
                 $linkType = Component::createComponent($type, BaseLinkType::class);
             }
 
-            $value = $linkType->normalizeValue(str_replace(' ', '+', $value));
+            $value = $linkType->normalizeValue($value);
         } else {
             if (!$value) {
                 return null;

--- a/src/fields/linktypes/BaseTextLinkType.php
+++ b/src/fields/linktypes/BaseTextLinkType.php
@@ -42,6 +42,8 @@ abstract class BaseTextLinkType extends BaseLinkType
 
     public function normalizeValue(string $value): string
     {
+        $value = str_replace(' ', '+', $value);
+
         if ($this->supports($value)) {
             return $value;
         }


### PR DESCRIPTION
### Description
Moved replacing spaces with plus signs from `Link->normalizeValue()` to `BaseTextLinkType->normalizeValue()` so that link type normalisation can do its job first.

### Related issues
#16300 
