### PR TITLE
when getting element by uid check for unpublished draft too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where field conditions weren’t taking effect within Matrix fields set to inline-editable blocks mode, if the owner element didn’t support drafts. ([#16315](https://github.com/craftcms/cms/pull/16315))
+
 ## 5.5.6.1 - 2024-12-11
 
 - Fixed a bug where Tags fields had “Replace” actions. ([#16310](https://github.com/craftcms/cms/issues/16310))

--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -2351,19 +2351,28 @@ JS, [
         }
 
         if ($elementUid) {
-            $withDrafts = false;
-            if (!Craft::$app->getConfig()->getGeneral()->autosaveDrafts) {
-                $withDrafts = null;
+            $element = $this->_elementQuery($elementType)
+                ->uid($elementUid)
+                ->siteId($siteId)
+                ->preferSites($preferSites)
+                ->unique()
+                ->status(null)
+                ->one();
+
+            if ($element) {
+                return $element;
             }
+
+            // check for an unpublished draft if we got this far
+            // (e.g. newly added matrix "block" or where autosaveDrafts is off)
+            // https://github.com/craftcms/cms/issues/15985
             return $this->_elementQuery($elementType)
                 ->uid($elementUid)
                 ->siteId($siteId)
                 ->preferSites($preferSites)
-                // when autosaveDrafts is off, we need search among drafts too
-                // https://github.com/craftcms/cms/issues/15985
-                ->drafts($withDrafts)
                 ->unique()
                 ->status(null)
+                ->draftOf(false)
                 ->one();
         }
 


### PR DESCRIPTION
### Description
Follow up to https://github.com/craftcms/cms/pull/15994. 

The 400 error could still occur when adding an entry to a matrix field in inline-editable blocks view mode if the owner element didn’t support drafts (regardless of the `autosaveDrafts` setting).

thanks, @nfourtythree, for pointing that out!

### Related issues
n/a;
