### PR TITLE
Prune unneeded entry fields from the GraphQL schema

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -60,6 +60,7 @@
 - Added `craft\elements\User::getAffiliatedSite()`.
 - Added `craft\elements\conditions\entries\FieldConditionRule`.
 - Added `craft\events\DefineAltActionsEvent`.
+- Added `craft\fields\BaseRelationField::gqlFieldArguments()`.
 - Added `craft\fields\Color::$allowCustomColors`. ([#16249](https://github.com/craftcms/cms/pull/16249))
 - Added `craft\fields\Color::$palette`. ([#16249](https://github.com/craftcms/cms/pull/16249))
 - Added `craft\fields\Color::getDefaultColor()`. ([#16249](https://github.com/craftcms/cms/pull/16249))
@@ -78,6 +79,7 @@
 - Added `craft\mail\Mailer::$siteOverrides`.
 - Added `craft\models\MailSettings::$siteOverrides`.
 - Added `craft\services\Elements::canSaveCanonical()`.
+- Added `craft\services\Gql::getFieldLayoutArguments()`.
 - Added `craft\web\View::setTwig()`.
 - `craft\elements\NestedElementManager::getIndexHtml()` now supports passing `defaultSort` in the `$config` array. ([#16236](https://github.com/craftcms/cms/discussions/16236))
 - `craft\elements\conditions\entries\MatrixFieldConditionRule` is now an alias of `FieldConditionRule`.
@@ -95,5 +97,6 @@
 - Craft now keeps track of which site users registered from. When sending an email from the control panel, the current site is now set to the user’s affiliated site, if known. ([#16174](https://github.com/craftcms/cms/pull/16174))
 - Database rows with foreign keys referencing nonexistent rows are now deleted via garbage collection.
 - Pages which contain image transform generation URLs now set no-cache headers. ([#16195](https://github.com/craftcms/cms/discussions/16195))
+- Reduced the size of GraphQL introspection schemas. ([#16326](https://github.com/craftcms/cms/pull/16326))
 - Updated Twig to 3.15. ([#16207](https://github.com/craftcms/cms/discussions/16207))
 - Fixed a bug where embedded element index filter HUDs were including condition rules for fields that weren’t applicable to the nested elements. ([#16289](https://github.com/craftcms/cms/discussions/16289))

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -1057,6 +1057,33 @@ JS, [
         ];
     }
 
+    /**
+     * Returns the custom field arguments for the selected source(s).
+     *
+     * @return array
+     * @since 5.6.0
+     */
+    protected function gqlFieldArguments(): array
+    {
+        $elementSourcesService = Craft::$app->getElementSources();
+        $gqlService = Craft::$app->getGql();
+        $fieldLayouts = [];
+        $arguments = [];
+
+        foreach ((array)$this->getInputSources() as $source) {
+            $sourceFieldLayouts = $elementSourcesService->getFieldLayoutsForSource(static::elementType(), $source);
+            foreach ($sourceFieldLayouts as $fieldLayout) {
+                $fieldLayouts[$fieldLayout->uid] = $fieldLayout;
+            }
+        }
+
+        foreach ($fieldLayouts as $fieldLayout) {
+            $arguments += $gqlService->getFieldLayoutArguments($fieldLayout);
+        }
+
+        return $arguments;
+    }
+
     // Events
     // -------------------------------------------------------------------------
 

--- a/src/fields/Entries.php
+++ b/src/fields/Entries.php
@@ -89,7 +89,10 @@ class Entries extends BaseRelationField
         return [
             'name' => $this->handle,
             'type' => Type::nonNull(Type::listOf(EntryInterface::getType())),
-            'args' => EntryArguments::getArguments(),
+            'args' => [
+                ...EntryArguments::getArguments(),
+                ...$this->gqlFieldArguments(),
+            ],
             'resolve' => EntryResolver::class . '::resolve',
             'complexity' => GqlHelper::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
         ];

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1202,10 +1202,17 @@ JS;
         $typeArray = EntryTypeGenerator::generateTypes($this);
         $typeName = $this->handle . '_MatrixField';
 
+        $arguments = EntryArguments::getArguments();
+        $gqlService = Craft::$app->getGql();
+
+        foreach ($this->getEntryTypes() as $entryType) {
+            $arguments += $gqlService->getFieldLayoutArguments($entryType->getFieldLayout());
+        }
+
         return [
             'name' => $this->handle,
             'type' => Type::nonNull(Type::listOf(Gql::getUnionType($typeName, $typeArray))),
-            'args' => EntryArguments::getArguments(),
+            'args' => $arguments,
             'resolve' => EntryResolver::class . '::resolve',
             'complexity' => Gql::eagerLoadComplexity(),
         ];

--- a/src/gql/arguments/elements/Entry.php
+++ b/src/gql/arguments/elements/Entry.php
@@ -27,7 +27,7 @@ class Entry extends StructureElementArguments
      */
     public static function getArguments(): array
     {
-        return array_merge(parent::getArguments(), self::getContentArguments(), [
+        return array_merge(parent::getArguments(), [
             'editable' => [
                 'name' => 'editable',
                 'type' => Type::boolean(),

--- a/src/gql/interfaces/elements/Entry.php
+++ b/src/gql/interfaces/elements/Entry.php
@@ -15,6 +15,7 @@ use craft\gql\interfaces\Structure;
 use craft\gql\types\DateTime;
 use craft\gql\types\generators\EntryType;
 use craft\helpers\Gql;
+use craft\models\Section;
 use craft\services\Gql as GqlService;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\Type;
@@ -69,7 +70,23 @@ class Entry extends Structure
      */
     public static function getFieldDefinitions(): array
     {
-        return Craft::$app->getGql()->prepareFieldDefinitions(array_merge(parent::getFieldDefinitions(), static::getDraftFieldDefinitions(), self::getConditionalFields(), [
+        $gqlService = Craft::$app->getGql();
+        $entryArguments = EntryArguments::getArguments();
+        $allFieldArguments = EntryArguments::getContentArguments();
+        $sectionFieldArguments = [...$entryArguments];
+        $structureSectionFieldArguments = [...$entryArguments];
+
+        foreach (Gql::getSchemaContainedSections() as $section) {
+            foreach ($section->getEntryTypes() as $entryType) {
+                $entryTypeArguments = $gqlService->getFieldLayoutArguments($entryType->getFieldLayout());
+                $sectionFieldArguments += $entryTypeArguments;
+                if ($section->type === Section::TYPE_STRUCTURE) {
+                    $structureSectionFieldArguments += $entryTypeArguments;
+                }
+            }
+        }
+
+        return Craft::$app->getGql()->prepareFieldDefinitions(array_merge(parent::getFieldDefinitions(), static::getDraftFieldDefinitions(), self::getConditionalFields($sectionFieldArguments), [
             'canonicalId' => [
                 'name' => 'canonicalId',
                 'type' => Type::int(),
@@ -147,28 +164,28 @@ class Entry extends Structure
             ],
             'children' => [
                 'name' => 'children',
-                'args' => EntryArguments::getArguments(),
+                'args' => $structureSectionFieldArguments,
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(static::getType()))),
                 'description' => 'The entry’s children, if the section is a structure. Accepts the same arguments as the `entries` query.',
                 'complexity' => Gql::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
             ],
             'descendants' => [
                 'name' => 'descendants',
-                'args' => EntryArguments::getArguments(),
+                'args' => $structureSectionFieldArguments,
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(static::getType()))),
                 'description' => 'The entry’s descendants, if the section is a structure. Accepts the same arguments as the `entries` query.',
                 'complexity' => Gql::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
             ],
             'parent' => [
                 'name' => 'parent',
-                'args' => EntryArguments::getArguments(),
+                'args' => $structureSectionFieldArguments,
                 'type' => EntryInterface::getType(),
                 'description' => 'The entry’s parent, if the section is a structure.',
                 'complexity' => Gql::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
             ],
             'ancestors' => [
                 'name' => 'ancestors',
-                'args' => EntryArguments::getArguments(),
+                'args' => $structureSectionFieldArguments,
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(static::getType()))),
                 'description' => 'The entry’s ancestors, if the section is a structure. Accepts the same arguments as the `entries` query.',
                 'complexity' => Gql::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
@@ -180,7 +197,10 @@ class Entry extends Structure
             ],
             'localized' => [
                 'name' => 'localized',
-                'args' => EntryArguments::getArguments(),
+                'args' => [
+                    ...$entryArguments,
+                    ...$allFieldArguments,
+                ],
                 'type' => Type::nonNull(Type::listOf(Type::nonNull(static::getType()))),
                 'description' => 'The same element in other locales.',
                 'complexity' => Gql::eagerLoadComplexity(),
@@ -188,7 +208,10 @@ class Entry extends Structure
             'prev' => [
                 'name' => 'prev',
                 'type' => self::getType(),
-                'args' => EntryArguments::getArguments(),
+                'args' => [
+                    ...$entryArguments,
+                    ...$allFieldArguments,
+                ],
                 'description' => 'Returns the previous element relative to this one, from a given set of criteria.',
                 'complexity' => function($childrenComplexity, $args) {
                     return $childrenComplexity + GqlService::GRAPHQL_COMPLEXITY_NPLUS1 * (int)!empty($args);
@@ -197,7 +220,10 @@ class Entry extends Structure
             'next' => [
                 'name' => 'next',
                 'type' => self::getType(),
-                'args' => EntryArguments::getArguments(),
+                'args' => [
+                    ...$entryArguments,
+                    ...$allFieldArguments,
+                ],
                 'description' => 'Returns the next element relative to this one, from a given set of criteria.',
                 'complexity' => function($childrenComplexity, $args) {
                     return $childrenComplexity + GqlService::GRAPHQL_COMPLEXITY_NPLUS1 * (int)!empty($args);
@@ -214,7 +240,7 @@ class Entry extends Structure
     /**
      * @inheritdoc
      */
-    protected static function getConditionalFields(): array
+    private static function getConditionalFields(array $sectionFieldArguments): array
     {
         $fields = [];
         if (Gql::canQueryUsers()) {
@@ -254,7 +280,7 @@ class Entry extends Structure
                 ],
                 'drafts' => [
                     'name' => 'drafts',
-                    'args' => EntryArguments::getArguments(),
+                    'args' => $sectionFieldArguments,
                     'type' => Type::listOf(EntryInterface::getType()),
                     'description' => 'The drafts for the entry.',
                     'complexity' => Gql::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
@@ -278,7 +304,7 @@ class Entry extends Structure
                 ],
                 'revisions' => [
                     'name' => 'revisions',
-                    'args' => EntryArguments::getArguments(),
+                    'args' => $sectionFieldArguments,
                     'type' => Type::listOf(EntryInterface::getType()),
                     'description' => 'The revisions for the entry.',
                     'complexity' => Gql::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),

--- a/src/gql/queries/Entry.php
+++ b/src/gql/queries/Entry.php
@@ -7,6 +7,7 @@
 
 namespace craft\gql\queries;
 
+use Craft;
 use craft\gql\arguments\elements\Entry as EntryArguments;
 use craft\gql\base\Query;
 use craft\gql\GqlEntityRegistry;
@@ -50,21 +51,30 @@ class Entry extends Query
         return [
             'entries' => [
                 'type' => Type::listOf(EntryInterface::getType()),
-                'args' => EntryArguments::getArguments(),
+                'args' => [
+                    ...EntryArguments::getArguments(),
+                    ...EntryArguments::getContentArguments(),
+                ],
                 'resolve' => EntryResolver::class . '::resolve',
                 'description' => 'This query is used to query for entries.',
                 'complexity' => GqlHelper::relatedArgumentComplexity(),
             ],
             'entryCount' => [
                 'type' => Type::nonNull(Type::int()),
-                'args' => EntryArguments::getArguments(),
+                'args' => [
+                    ...EntryArguments::getArguments(),
+                    ...EntryArguments::getContentArguments(),
+                ],
                 'resolve' => EntryResolver::class . '::resolveCount',
                 'description' => 'This query is used to return the number of entries.',
                 'complexity' => GqlHelper::singleQueryComplexity(),
             ],
             'entry' => [
                 'type' => EntryInterface::getType(),
-                'args' => EntryArguments::getArguments(),
+                'args' => [
+                    ...EntryArguments::getArguments(),
+                    ...EntryArguments::getContentArguments(),
+                ],
                 'resolve' => EntryResolver::class . '::resolveOne',
                 'description' => 'This query is used to query for a single entry.',
                 'complexity' => GqlHelper::singleQueryComplexity(),
@@ -84,6 +94,7 @@ class Entry extends Query
     private static function sectionLevelFields(array $entryTypeGqlTypes): array
     {
         $gqlTypes = [];
+        $gqlService = Craft::$app->getGql();
 
         foreach (GqlHelper::getSchemaContainedSections() as $section) {
             $typeName = "{$section->handle}SectionEntriesQuery";
@@ -103,8 +114,9 @@ class Entry extends Query
                     continue;
                 }
 
-                // Unset unusable arguments
                 $arguments = EntryArguments::getArguments();
+
+                // Unset unusable arguments
                 unset(
                     $arguments['section'],
                     $arguments['sectionId'],
@@ -112,6 +124,10 @@ class Entry extends Query
                     $arguments['fieldId'],
                     $arguments['ownerId'],
                 );
+
+                foreach ($section->getEntryTypes() as $entryType) {
+                    $arguments += $gqlService->getFieldLayoutArguments($entryType->getFieldLayout());
+                }
 
                 // Create the section query field
                 $sectionQueryType = [
@@ -141,6 +157,7 @@ class Entry extends Query
     private static function nestedEntryFieldLevelFields(array $entryTypeGqlTypes): array
     {
         $gqlTypes = [];
+        $gqlService = Craft::$app->getGql();
 
         foreach (GqlHelper::getSchemaContainedNestedEntryFields() as $field) {
             $typeName = "{$field->handle}NestedEntriesQuery";
@@ -148,20 +165,23 @@ class Entry extends Query
 
             if (!$fieldQueryType) {
                 $entryTypesInField = [];
+                $entryTypeGqlTypesInField = [];
 
                 // Loop through the entry types and create further queries
                 foreach ($field->getFieldLayoutProviders() as $provider) {
                     if ($provider instanceof EntryType && isset($entryTypeGqlTypes[$provider->id])) {
-                        $entryTypesInField[] = $entryTypeGqlTypes[$provider->id];
+                        $entryTypesInField[] = $provider;
+                        $entryTypeGqlTypesInField[] = $entryTypeGqlTypes[$provider->id];
                     }
                 }
 
-                if (empty($entryTypesInField)) {
+                if (empty($entryTypeGqlTypesInField)) {
                     continue;
                 }
 
-                // Unset unusable arguments
                 $arguments = EntryArguments::getArguments();
+
+                // Unset unusable arguments
                 unset(
                     $arguments['section'],
                     $arguments['sectionId'],
@@ -169,12 +189,16 @@ class Entry extends Query
                     $arguments['fieldId'],
                 );
 
+                foreach ($entryTypesInField as $entryType) {
+                    $arguments += $gqlService->getFieldLayoutArguments($entryType->getFieldLayout());
+                }
+
                 // Create the query field
                 $fieldQueryType = [
                     'name' => "{$field->handle}FieldEntries",
                     'args' => $arguments,
                     'description' => sprintf('Entries within the “%s” %s field.', $field->name, $field::displayName()),
-                    'type' => Type::listOf(GqlHelper::getUnionType("{$field->handle}FieldEntryUnion", $entryTypesInField)),
+                    'type' => Type::listOf(GqlHelper::getUnionType("{$field->handle}FieldEntryUnion", $entryTypeGqlTypesInField)),
                     // Enforce the section argument and set the source to `null`, to enforce a new element query.
                     'resolve' => fn($source, array $arguments, $context, ResolveInfo $resolveInfo) =>
                     EntryResolver::resolve(null, $arguments + ['field' => $field->handle], $context, $resolveInfo),

--- a/src/gql/types/input/criteria/Entry.php
+++ b/src/gql/types/input/criteria/Entry.php
@@ -28,7 +28,10 @@ class Entry extends InputObjectType
 
         return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
-            'fields' => fn() => EntryArguments::getArguments(),
+            'fields' => fn() => [
+                ...EntryArguments::getArguments(),
+                ...EntryArguments::getContentArguments(),
+            ],
         ]));
     }
 }

--- a/src/gql/types/input/criteria/EntryRelation.php
+++ b/src/gql/types/input/criteria/EntryRelation.php
@@ -29,7 +29,11 @@ class EntryRelation extends InputObjectType
 
         return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
             'name' => $typeName,
-            'fields' => fn() => EntryArguments::getArguments() + RelationCriteria::getArguments(),
+            'fields' => fn() => [
+                ...EntryArguments::getArguments(),
+                ...EntryArguments::getContentArguments(),
+                ...RelationCriteria::getArguments(),
+            ],
         ]));
     }
 }

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -338,6 +338,12 @@ class Gql extends Component
     private array $_contentArguments = [];
 
     /**
+     * @var array Custom field arguments by field layout UUID
+     * @see getFieldLayoutArguments()
+     */
+    private array $_fieldArguments = [];
+
+    /**
      * @var TypeManager|null GQL type manager
      */
     private ?TypeManager $_typeManager = null;
@@ -1167,6 +1173,29 @@ class Gql extends Component
             $this->_contentArguments[$elementType] = $setter();
         }
         return $this->_contentArguments[$elementType];
+    }
+
+    /**
+     * Returns arguments for fields in the given field layout.
+     *
+     * @param FieldLayout $fieldLayout
+     * @return array
+     * @since 5.6.0
+     */
+    public function getFieldLayoutArguments(FieldLayout $fieldLayout): array
+    {
+        if (!isset($fieldLayout->type)) {
+            throw new InvalidArgumentException('Field layout is missing its element type.');
+        }
+
+        if (!isset($this->_fieldArguments[$fieldLayout->uid])) {
+            $this->_fieldArguments[$fieldLayout->uid] = $this->defineContentArgumentsForFields(
+                $fieldLayout->type,
+                $fieldLayout->getCustomFields(),
+            );
+        }
+
+        return $this->_fieldArguments[$fieldLayout->uid];
     }
 
     /**


### PR DESCRIPTION
### Description

Removes unneeded entry fields from the GraphQL schema where possible, to reduce the size of the introspection schema.

### Related issues

- #15068
- #16316