### PR TITLE
Set no-cache headers for health check endpoint

### DIFF
--- a/src/controllers/AppController.php
+++ b/src/controllers/AppController.php
@@ -103,6 +103,7 @@ class AppController extends Controller
     public function actionHealthCheck(): Response
     {
         // All that matters is the 200 response
+        $this->response->setNoCacheHeaders();
         $this->response->format = Response::FORMAT_RAW;
         $this->response->data = '';
         return $this->response;


### PR DESCRIPTION
### Description

Currently with static caching in use, the health check endpoint response can be cached when using GET and return a 304 response by a client. This occurs on Craft Cloud, but possible also with other static caching solutions i.e. Blitz.

This sets `$this->response->setNoCacheHeaders();` in the action controller to prevent this from happening.

