### PR TITLE
merging entry types and ensuring singles - ensure the type is actually unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where the control panel could display a notice about the Craft CMS license belonging to a different domain, even when accessing the control panel from the correct domain. ([#16396](https://github.com/craftcms/cms/issues/16396))
 - Fixed a bug where field layout elements’ action menus could have an empty action group.
+- Fixed a bug where Single section entries could be duplicated after running the `entry-types/merge` command. ([#16394](https://github.com/craftcms/cms/issues/16394))
 
 ## 5.5.9 - 2025-01-06
 

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -966,7 +966,9 @@ class Entries extends Component
         // if we didn't find any, try without the typeId,
         // in case that changed to something completely new
         if ($entry === null) {
-            $entry = $baseEntryQuery->one();
+            $entry = $baseEntryQuery
+                ->typeId(null)
+                ->one();
 
             if ($entry !== null) {
                 $entry->setTypeId($entryTypeIds[0]);
@@ -977,6 +979,7 @@ class Entries extends Component
         // try without the typeId with trashed where they were deleted with entry type
         if ($entry === null) {
             $entry = $baseEntryQuery
+                ->typeId(null)
                 ->trashed(null)
                 ->where(['entries.deletedWithEntryType' => true])
                 ->one();


### PR DESCRIPTION
### Description
Follow up to https://github.com/craftcms/cms/pull/16102. 

When ensuring a single type entry exists, if we don’t find any of the given type, unset the type before querying further.


### Related issues
#16394
