### PR TITLE
disable2fa config setting

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -70,10 +70,12 @@
 - It’s now possible to reference custom field handles in element queries’ `where` params. ([#16318](https://github.com/craftcms/cms/pull/16318))
 - Number fields’ scalar values now return an integer if Decimals is set to `0`, and a number formatted with the correct decimal points when using MySQL. ([16369](https://github.com/craftcms/cms/issues/16369))
 - Added support for specifying the current site via an `X-Craft-Site` header set to a site ID or handle. ([#16367](https://github.com/craftcms/cms/pull/16367))
+- Added the `disable2fa` config setting. ([#16426](https://github.com/craftcms/cms/pull/16426))
 - Added support for defining redirects from `config/redirects.php`. ([#16355](https://github.com/craftcms/cms/pull/16355))
 - Deprecated the `ucfirst` Twig filter. `capitalize` should be used instead.
 
 ### Extensibility
+- Added `craft\attributes\EnvName`.
 - Added `craft\base\ConfigurableComponentInterface::getReadOnlySettingsHtml()`. ([#16265](https://github.com/craftcms/cms/pull/16265))
 - Added `craft\base\CrossSiteCopyableFieldInterface`. ([#14056](https://github.com/craftcms/cms/pull/14056))
 - Added `craft\base\Element::EVENT_DEFINE_ALT_ACTIONS`. ([#16294](https://github.com/craftcms/cms/pull/16294))
@@ -135,6 +137,7 @@
 - `GuzzleHttp\Client` is now instantiated via `Craft::createObject()`. ([#16366](https://github.com/craftcms/cms/pull/16366))
 - `craft\elements\NestedElementManager::getIndexHtml()` now supports passing `defaultSort` in the `$config` array. ([#16236](https://github.com/craftcms/cms/discussions/16236))
 - `craft\elements\conditions\entries\MatrixFieldConditionRule` is now an alias of `FieldConditionRule`.
+- `craft\helpers\App::envConfig()` now checks for a `craft\attributes\EnvName` attribute on public properties, which can be used to override the environment variable name (sans prefix) that is associated with the property.
 - `craft\helpers\Cp::elementIndexHtml()` now supports passing `defaultSort` in the `$config` array, when `sources` is `null`. ([#16236](https://github.com/craftcms/cms/discussions/16236))
 - `craft\helpers\Cp::fieldHtml()` now supports passing an `actionMenuItems` array in the config. ([#16415](https://github.com/craftcms/cms/pull/16415))
 - `craft\helpers\DateTimeHelper::humanDuration()` now has a `$language` argument. ([#16332](https://github.com/craftcms/cms/pull/16332))

--- a/src/attributes/EnvName.php
+++ b/src/attributes/EnvName.php
@@ -20,5 +20,6 @@ class EnvName
 {
     public function __construct(
         public readonly string $name,
-    ) {}
+    ) {
+    }
 }

--- a/src/attributes/EnvName.php
+++ b/src/attributes/EnvName.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\attributes;
+
+use Attribute;
+
+/**
+ * Attribute EnvName
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.6.0
+ */
+#[Attribute]
+class EnvName
+{
+    public function __construct(
+        public readonly string $name,
+    ) {}
+}

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -9,6 +9,7 @@ namespace craft\config;
 
 use Closure;
 use Craft;
+use craft\attributes\EnvName;
 use craft\helpers\ConfigHelper;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Localization;
@@ -943,6 +944,24 @@ class GeneralConfig extends BaseConfig
      * @group System
      */
     public bool $devMode = false;
+
+    /**
+     * @var bool Whether two-step verification features should be disabled.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->disable2fa()
+     * ```
+     * ```shell Environment Override
+     * CRAFT_DISABLE_2FA=true
+     * ```
+     * :::
+     *
+     * @group Users
+     * @since 5.6.0
+     */
+    #[EnvName('DISABLE_2FA')]
+    public bool $disable2fa = false;
 
     /**
      * @var string[]|string|null Array of plugin handles that should be disabled, regardless of what the project config says.
@@ -4313,6 +4332,30 @@ class GeneralConfig extends BaseConfig
     public function devMode(bool $value = true): self
     {
         $this->devMode = $value;
+        return $this;
+    }
+
+    /**
+     * Whether two-step verification features should be disabled.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->disable2fa()
+     * ```
+     * ```shell Environment Override
+     * CRAFT_DISABLE_2FA=true
+     * ```
+     * :::
+     *
+     * @group Users
+     * @param bool $value
+     * @return self
+     * @see $disable2fa
+     * @since 5.6.0
+     */
+    public function disable2fa(bool $value = true): self
+    {
+        $this->disable2fa = $value;
         return $this;
     }
 

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -9,6 +9,7 @@ namespace craft\helpers;
 
 use Closure;
 use Craft;
+use craft\attributes\EnvName;
 use craft\behaviors\SessionBehavior;
 use craft\cache\FileCache;
 use craft\config\DbConfig;
@@ -160,12 +161,23 @@ class App
                 continue;
             }
 
-            $propName = $prop->getName();
-            $envName = $envPrefix . strtoupper(StringHelper::toSnakeCase($propName));
-            $envValue = static::env($envName);
+            $envName = null;
+
+            foreach ($prop->getAttributes(EnvName::class) as $attribute) {
+                /** @var EnvName $envName */
+                $envName = $attribute->newInstance();
+                $envName = $envName->name;
+                break;
+            }
+
+            if (!$envName) {
+                $envName = strtoupper(StringHelper::toSnakeCase($prop->getName()));
+            }
+
+            $envValue = static::env(sprintf('%s%s', $envPrefix, $envName));
 
             if ($envValue !== null) {
-                $envConfig[$propName] = $envValue;
+                $envConfig[$prop->getName()] = $envValue;
             }
         }
 

--- a/src/web/Application.php
+++ b/src/web/Application.php
@@ -294,10 +294,12 @@ class Application extends \yii\web\Application
 
                 if (!$userSession->getIsGuest()) {
                     // See if the user is expected to have 2FA enabled
-                    $auth = $this->getAuth();
-                    $user = $userSession->getIdentity();
-                    if ($auth->is2faRequired($user) && !$auth->hasActiveMethod($user)) {
-                        return $this->runAction('users/setup-2fa');
+                    if (!$generalConfig->disable2fa) {
+                        $auth = $this->getAuth();
+                        $user = $userSession->getIdentity();
+                        if ($auth->is2faRequired($user) && !$auth->hasActiveMethod($user)) {
+                            return $this->runAction('users/setup-2fa');
+                        }
                     }
 
                     if ($isCpRequest && !$this->getCanTestEditions()) {


### PR DESCRIPTION
### Description

Adds a new `disable2fa` setting, which can be used to disable two-step verification for the current environment. Useful when working with a production database backup on a local dev environment where 2FA isn’t important.

### Related issues

- #16389