### PR TITLE
When normalising relation field value, respect the empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where field layout elements’ action menus could have an empty action group.
 - Fixed a bug where Single section entries could be duplicated after running the `entry-types/merge` command. ([#16394](https://github.com/craftcms/cms/issues/16394))
 - Fixed a styling bug with the system message modal. ([#16410](https://github.com/craftcms/cms/issues/16410))
+- Fixed a bug where relational fields could eager-load elements from a different instance of the same field, if one of the instances had no relations. ([#16191](https://github.com/craftcms/cms/issues/16191))
 
 ## 5.5.9 - 2025-01-06
 

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -674,7 +674,11 @@ JS, [
                     ->andWhere(['elements.id' => $value])
                     ->orderBy([new FixedOrderExpression('elements.id', $value, Craft::$app->getDb())]);
             } else {
-                $query->andWhere('0 = 1');
+                // if the value here is an empty array, the target ids are already stored
+                // in the elements_sites.content column, as an empty array;
+                // meaning the content was saved since v5.3.0 and the field is supposed to be empty;
+                // see https://github.com/craftcms/cms/issues/16191
+                $query->andWhere(['elements.id' => []]);
             }
         } elseif ($value === null && $element?->id && $this->isFirstInstance($element)) {
             // If $value is null, the element + field haven’t been saved since updating to Craft 5.3+,

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -669,16 +669,9 @@ JS, [
 
         if (is_array($value)) {
             $value = array_values(array_filter($value));
+            $query->andWhere(['elements.id' => $value]);
             if (!empty($value)) {
-                $query
-                    ->andWhere(['elements.id' => $value])
-                    ->orderBy([new FixedOrderExpression('elements.id', $value, Craft::$app->getDb())]);
-            } else {
-                // if the value here is an empty array, the target ids are already stored
-                // in the elements_sites.content column, as an empty array;
-                // meaning the content was saved since v5.3.0 and the field is supposed to be empty;
-                // see https://github.com/craftcms/cms/issues/16191
-                $query->andWhere(['elements.id' => []]);
+                $query->orderBy([new FixedOrderExpression('elements.id', $value, Craft::$app->getDb())]);
             }
         } elseif ($value === null && $element?->id && $this->isFirstInstance($element)) {
             // If $value is null, the element + field haven’t been saved since updating to Craft 5.3+,


### PR DESCRIPTION
### Description
Issue:  
- have entry type has two instances of the same relation field, and the second instance has a changed handle
- create an entry of that type, leave the first instance of the field empty, and fill the second with at least one value (related element)
- query the entry and use lazy eager loading (`.eagerly()`) to get content of both field instances
- notice that the first instance is incorrectly populated with the content of the second instance

Solution:
When normalising the relation field value and the value passed to the method is an empty array, it means that the target IDs are already stored in the `elements_sites.content` column but as an empty array (the field is empty). Having a value there, even if it’s an empty array, means that the content was saved since v5.3.0, and the field is supposed to be empty.

Passing an empty array to the query means that the `getEagerLoadingMap()` method sees the value as an array, which means it then doesn’t attempt to check if the field is the first instance and incorrectly assign the content of the other instance of this field from the relations table.


### Related issues
#16191 


----- 
#### Detailed replication steps

- create a `blog` channel with an entry type (it doesn’t have to have any fields; just the title will suffice)
- create a `relatedEntries` Entries field, which has sources set to the `blog` channel
- create a `collection` channel with an entry type that has the `relatedEntries` field in it added twice; the second instance should have the handle changed to `moreRelatedEntries`
- create at least one `blog` entry
- create at least one entry in the `collection` channel; leave the `relatedEntries` field empty; add a `blog` entry to the `moreRelatedEntries` field; 
- the template for the `collection` channel should contain the following code:
```
<h1>{{ entry.title }}</h1>

{% set relatedEntries = entry.relatedEntries.eagerly().all() %}
<p>relatedEntries:</p>
<ul>
    {% for item in relatedEntries %}
        <li>{{ item.title }}</li>
    {% endfor %}
</ul>
{% set moreRelatedEntries = entry.moreRelatedEntries.eagerly().all() %}
<p>moreRelatedEntries:</p>
<ul>
    {% for item in moreRelatedEntries %}
        <li>{{ item.title }}</li>
    {% endfor %}
</ul>
```

- the collection entry added to the `moreRelatedEntries` shows up in both the `moreRelatedEntries` and `relatedEntries` field

- if you only add an entry to the `relatedEntries`, it will only show for that field, and the `moreRelatedEntries` will be empty - as expected
- if you add entries to both `relatedEntries` and `moreRelatedEntries` fields, the contents of both will show as expected
- if you swap the order of the `relatedEntries` and `moreRelatedEntries` fields and then, in the collection entry, fill out only the `relatedEntries` field, leaving the `moreRelatedEntries` field empty, the `moreRelatedEntries` will incorrectly load the content of the `relatedEntries` field