### PR TITLE
Widget Title setting for Quick Post widgets

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -3,6 +3,7 @@
 ### Content Management
 - It’s now possible to copy custom field values from other sites. ([#14056](https://github.com/craftcms/cms/pull/14056))
 - “Related To”, “Not Related To”, “Author”, and relational field condition rules now allow multiple elements to be specified. ([#16121](https://github.com/craftcms/cms/discussions/16121))
+- Added the “Widget Title” setting to Quick Post widgets. ([#16429](https://github.com/craftcms/cms/pull/16429))
 - Improved the styling of inline code fragments. ([#16141](https://github.com/craftcms/cms/pull/16141))
 - Improved the styling of attribute previews in card view. ([#16324](https://github.com/craftcms/cms/pull/16324))
 - Added the “Affiliated Site” user condition rule. ([#16174](https://github.com/craftcms/cms/pull/16174))

--- a/src/templates/_components/widgets/QuickPost/settings.twig
+++ b/src/templates/_components/widgets/QuickPost/settings.twig
@@ -1,7 +1,6 @@
 {% import "_includes/forms" as forms %}
 
 {% if sections %}
-
     {% if craft.app.getIsMultiSite() %}
         {% set editableSites = craft.app.sites.getEditableSites() %}
 
@@ -24,8 +23,8 @@
     {% endif %}
 
     {% set sectionOptions = [] %}
-    {% for section in sections %}
-        {% set sectionOptions = sectionOptions|merge([{ label: section.name|t('site'), value: section.id }]) %}
+    {% for s in sections %}
+        {% set sectionOptions = sectionOptions|merge([{ label: s.name|t('site'), value: s.id }]) %}
     {% endfor %}
     {{ forms.selectField({
         label: "Section"|t('app'),
@@ -33,39 +32,36 @@
         id: 'section',
         name: 'section',
         options: sectionOptions,
-        value: sectionId,
+        value: section.id ?? null,
         toggle: true,
         targetPrefix: 'section'
     }) }}
 
-    {% for section in sections %}
-        {% set showSection = ((not sectionId and loop.first) or sectionId == section.id) %}
-        <div id="section{{ section.id }}"{% if not showSection %} class="hidden"{% endif %}>
+    {% for s in sections %}
+        {% set showSection = ((not section and loop.first) or (section.id ?? null) == s.id) %}
+        <div id="section{{ s.id }}"{% if not showSection %} class="hidden"{% endif %}>
 
             {% set entryTypeOptions = [] %}
-            {% for entryType in section.getEntryTypes() %}
-                {% set entryTypeOptions = entryTypeOptions|merge([{ label: entryType.name|t('site'), value: entryType.id }]) %}
+            {% for et in s.getEntryTypes() %}
+                {% set entryTypeOptions = entryTypeOptions|merge([{ label: et.name|t('site'), value: et.id }]) %}
             {% endfor %}
 
             {% if entryTypeOptions|length == 1 %}
-                {{ hiddenInput("sections[#{section.id}][entryType]", entryTypeId) }}
+                {{ hiddenInput("sections[#{s.id}][entryType]", entryType.id ?? null) }}
             {% else %}
                 {{ forms.selectField({
                     label: "Entry Type"|t('app'),
                     instructions: "Which type of entries do you want to create?"|t('app'),
                     id: 'entryType',
-                    name: 'sections['~section.id~'][entryType]',
+                    name: 'sections['~s.id~'][entryType]',
                     options: entryTypeOptions,
-                    value: entryTypeId,
+                    value: entryType.id ?? null,
                     toggle: true,
-                    targetPrefix: 'section'~section.id~'-type'
+                    targetPrefix: 'section'~s.id~'-type'
                 }) }}
             {% endif %}
         </div>
     {% endfor %}
-
 {% else %}
-
     <p>{{ "No sections are available."|t('app') }}</p>
-
 {% endif %}

--- a/src/templates/_components/widgets/QuickPost/settings.twig
+++ b/src/templates/_components/widgets/QuickPost/settings.twig
@@ -62,6 +62,27 @@
             {% endif %}
         </div>
     {% endfor %}
+    {{ forms.textField({
+        label: 'Widget Title'|t('app'),
+        id: 'custom-title',
+        name: 'customTitle',
+        value: widget.customTitle,
+        placeholder: 'Create a new {section} entry'|t('app', {
+            section: (section ?? sections|first).getUiLabel(),
+        }),
+    }) }}
 {% else %}
     <p>{{ "No sections are available."|t('app') }}</p>
 {% endif %}
+
+{% js %}
+  (() => {
+    const $sectionSelect = $('#{{ 'section'|namespaceInputId }}');
+    const $titleInput = $('#{{ 'custom-title'|namespaceInputId }}');
+    $sectionSelect.on('change', () => {
+      $titleInput.attr('placeholder', Craft.t('app', 'Create a new {section} entry', {
+        section: $sectionSelect.find(`option[value="${$sectionSelect.val()}"]`).text(),
+      }));
+    });
+  })();
+{% endjs %}

--- a/src/widgets/QuickPost.php
+++ b/src/widgets/QuickPost.php
@@ -56,6 +56,12 @@ class QuickPost extends Widget
     public ?int $entryType = null;
 
     /**
+     * @var string|null The custom widget title.
+     * @since 5.6.0
+     */
+    public ?string $customTitle = null;
+
+    /**
      * @var Section|false
      * @see section()
      */
@@ -82,6 +88,10 @@ class QuickPost extends Widget
             }
 
             unset($config['sections']);
+        }
+
+        if (isset($config['customTitle']) && $config['customTitle'] === '') {
+            unset($config['customTitle']);
         }
 
         unset($config['fields']);
@@ -130,6 +140,10 @@ class QuickPost extends Widget
      */
     public function getTitle(): ?string
     {
+        if (isset($this->customTitle)) {
+            return Craft::t('site', $this->customTitle);
+        }
+
         $entryType = $this->entryType();
         if (!$entryType) {
             return static::displayName();

--- a/src/widgets/QuickPost.php
+++ b/src/widgets/QuickPost.php
@@ -120,8 +120,8 @@ class QuickPost extends Widget
             'sections' => $sections,
             'widget' => $this,
             'siteId' => $this->siteId,
-            'sectionId' => $this->section()?->id,
-            'entryTypeId' => $this->entryType()?->id,
+            'section' => $this->section(),
+            'entryType' => $this->entryType(),
         ]);
     }
 


### PR DESCRIPTION
### Description

Adds a “Widget Title” setting to Quick Post widgets, which can be used to override the default title (“Create a new ‘[Section Name]’ entry”).

<img src="https://github.com/user-attachments/assets/b3f67034-878d-4a63-bfaa-8a1cc4d482ee" width="419" height="426" alt="A Quick Post widget’s settings, showing that there’s a new Widget Title setting at the bottom.">

### Related issues

- #16420