### PR TITLE
prevent infinitely calling `processIndexSession` when `assetindexdata` is empty

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -20,6 +20,7 @@
 - Added `craft\helpers\Image::EXIF_IFD0_ROTATE_180_MIRRORED`.
 - Added `craft\helpers\Image::EXIF_IFD0_ROTATE_270_MIRRORED`.
 - Added `craft\helpers\Image::EXIF_IFD0_ROTATE_90_MIRRORED`.
+- Added `craft\models\AssetIndexingSession::$forceStop`. ([#16435](https://github.com/craftcms/cms/pull/16435))
 - `GuzzleHttp\Client` is now instantiated via `Craft::createObject()`. ([#16366](https://github.com/craftcms/cms/pull/16366))
 - `craft\helpers\DateTimeHelper::humanDuration()` now has a `$language` argument. ([#16332](https://github.com/craftcms/cms/pull/16332))
 
@@ -31,4 +32,5 @@
 - Fixed a bug where `craft\config\GeneralConfig::safeMode()` set Safe Mode to `false` by default.
 - Fixed a bug where Craft wasn’t auto-rotating or flipping images uploaded with a mirrored EXIF orientation.
 - Fixed a bug where elements weren’t getting returned in a consistent order when `orderBy` was set to `RAND(X)` across varying `limit` param values. ([#16432](https://github.com/craftcms/cms/issues/16432))
+- Fixed a bug where asset indexing could get stuck in an infinite loop if the index data was deleted. ([#16435](https://github.com/craftcms/cms/pull/16435))
 - Updated Twig to 3.15. ([#16207](https://github.com/craftcms/cms/discussions/16207))

--- a/src/controllers/AssetIndexesController.php
+++ b/src/controllers/AssetIndexesController.php
@@ -151,6 +151,14 @@ class AssetIndexesController extends Controller
         if (!$indexingSession->actionRequired) {
             $indexingSession = $assetIndexer->processIndexSession($indexingSession);
 
+            if ($indexingSession->forceStop) {
+                $assetIndexer->stopIndexingSession($indexingSession);
+                return $this->asFailure(data: [
+                    'stop' => $sessionId,
+                    'message' => Craft::t('app', 'There was an issue indexing assets.'),
+                ]);
+            }
+
             // If action is now required, we just processed the last entry
             // To save a round-trip, just pull the session review data
             if ($indexingSession->actionRequired) {

--- a/src/controllers/AssetIndexesController.php
+++ b/src/controllers/AssetIndexesController.php
@@ -155,7 +155,7 @@ class AssetIndexesController extends Controller
                 $assetIndexer->stopIndexingSession($indexingSession);
                 return $this->asFailure(data: [
                     'stop' => $sessionId,
-                    'message' => Craft::t('app', 'There was an issue indexing assets.'),
+                    'message' => Craft::t('app', 'There was a problem indexing assets.'),
                 ]);
             }
 

--- a/src/models/AssetIndexingSession.php
+++ b/src/models/AssetIndexingSession.php
@@ -86,4 +86,10 @@ class AssetIndexingSession extends Model
      * @since 4.4.0
      */
     public bool $processIfRootEmpty = false;
+
+    /**
+     * @var bool Whether we should stop processing the session because there was a problem.
+     * @since 4.14.0
+     */
+    public bool $forceStop = false;
 }

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -1533,6 +1533,7 @@ return [
     'There was a problem activating the user.' => 'There was a problem activating the user.',
     'There was a problem deactivating the user.' => 'There was a problem deactivating the user.',
     'There was a problem impersonating this user.' => 'There was a problem impersonating this user.',
+    'There was a problem indexing assets.' => 'There was a problem indexing assets.',
     'There was a problem saving your message.' => 'There was a problem saving your message.',
     'There was a problem sending the password reset email.' => 'There was a problem sending the password reset email.',
     'There was a problem with uploading the file.' => 'There was a problem with uploading the file.',


### PR DESCRIPTION
### Description
If you’re in the middle of indexing assets and you e.g. clear all caches via `./craft clear-caches/all`, it’ll delete the contents of the `assetindexdata` table and will cause the indexing job to go into an infinite loop where `processIndexSession()` is constantly called with the indexing session stuck on the last item it was able to process, unable to progress.

When this happens, it’s also very hard to discard that indexing session via the UI as the row with the session’s data and the discard button is replaced each time the response from the `processIndexSession()` is received.

Solution:
When we’re not able to get the next item to process, check if there’s any data in the `assetindexdata` table at all, and if not, log a warning, stop the indexing session and return a failure.


### Related issues
might be related to https://github.com/craftcms/cms/issues/16023

