### PR TITLE
handling of relatedTo<XYZ> arguments in eager loading plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed an error that could occur when setting `relatedTo*` GraphQL arguments to `null`. ([#16433](https://github.com/craftcms/cms/issues/16433))
+
 ## 4.13.10 - 2025-01-14
 
 - Fixed a bug where the control panel could display a notice about the Craft CMS license belonging to a different domain, even when accessing the control panel from the correct domain. ([#16396](https://github.com/craftcms/cms/issues/16396))

--- a/src/gql/ArgumentManager.php
+++ b/src/gql/ArgumentManager.php
@@ -12,6 +12,7 @@ use craft\base\Component;
 use craft\errors\GqlException;
 use craft\events\RegisterGqlArgumentHandlersEvent;
 use craft\gql\base\ArgumentHandlerInterface;
+use craft\gql\base\RelationArgumentHandler;
 use craft\gql\handlers\RelatedAssets;
 use craft\gql\handlers\RelatedCategories;
 use craft\gql\handlers\RelatedEntries;
@@ -153,6 +154,15 @@ class ArgumentManager extends Component
         foreach ($this->_argumentHandlers as $argumentName => $handler) {
             if (!empty($arguments[$argumentName]) && $handler instanceof ArgumentHandlerInterface) {
                 $arguments = $handler->handleArgumentCollection($arguments);
+            }
+            // if it's one of the relatedToXYZ arguments,
+            // if the value is empty/null unset that arg so that it doesn't go into the criteria
+            if (
+                array_key_exists($argumentName, $arguments) &&
+                empty($arguments[$argumentName]) &&
+                $handler instanceof RelationArgumentHandler
+            ) {
+                unset($arguments[$argumentName]);
             }
         }
 


### PR DESCRIPTION
### Description
When querying elements via GraphQL and using one of the “special” `relatedTo` arguments (e.g. `relatedToEntries`, `relatedToCategories` etc.) with an empty value, if that argument is used for elements that would get eager loaded via a plan (e.g. getting children or ancestors), the argument name was making it into the query criteria causing an error (e.g. `Setting unknown property: craft\\elements\\db\\EntryQuery::relatedToEntries"`).


### Related issues
#16433
