### PR TITLE
when applying PC, soft delete old structure if w're saving a new one now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed an error that could occur when setting `relatedTo*` GraphQL arguments to `null`. ([#16433](https://github.com/craftcms/cms/issues/16433))
+- Fixed a bug where old structure data wasn’t getting soft-deleted when a section was assigned a new structure UUID when applying project config changes. ([#16450](https://github.com/craftcms/cms/issues/16450))
 
 ## 4.13.10 - 2025-01-14
 

--- a/src/services/Sections.php
+++ b/src/services/Sections.php
@@ -604,12 +604,26 @@ class Sections extends Component
             $propagationMethodChanged = $sectionRecord->propagationMethod != $sectionRecord->getOldAttribute('propagationMethod');
 
             if ($data['type'] === Section::TYPE_STRUCTURE) {
+                $structuresService = Craft::$app->getStructures();
+
                 // Save the structure
                 $structureUid = $data['structure']['uid'];
-                $structure = Craft::$app->getStructures()->getStructureByUid($structureUid, true) ?? new Structure(['uid' => $structureUid]);
+                $structure = $structuresService->getStructureByUid($structureUid, true) ?? new Structure(['uid' => $structureUid]);
                 $isNewStructure = empty($structure->id);
                 $structure->maxLevels = $data['structure']['maxLevels'];
-                Craft::$app->getStructures()->saveStructure($structure);
+
+                // check if we need to soft-delete an old structure
+                // see https://github.com/craftcms/cms/issues/16450
+                if (
+                    $isNewStructure &&
+                    $event->oldValue['type'] === Section::TYPE_STRUCTURE &&
+                    $event->oldValue['structure']['uid'] !== $structureUid &&
+                    $sectionRecord->structureId
+                ) {
+                    $structuresService->deleteStructureById($sectionRecord->structureId);
+                }
+
+                $structuresService->saveStructure($structure);
                 $sectionRecord->structureId = $structure->id;
             } else {
                 if ($sectionRecord->structureId) {


### PR DESCRIPTION
### Description
When applying project config changes, and the section’s old and new type is a structure but with a different uid, ensure we soft delete the old structure.


### Related issues
#16450 
