### PR TITLE
Ensure DefineAssetUrlEvent is passed transform when parsing refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an error that could occur when setting `relatedTo*` GraphQL arguments to `null`. ([#16433](https://github.com/craftcms/cms/issues/16433))
 - Fixed a bug where old structure data wasn’t getting soft-deleted when a section was assigned a new structure UUID when applying project config changes. ([#16450](https://github.com/craftcms/cms/issues/16450))
+- Fixed a bug where `craft\events\DefineAssetUrlEvent::$transform` wasn’t always defined for assets’ `EVENT_BEFORE_DEFINE_URL` and `EVENT_DEFINE_URL` events. ([#16464](https://github.com/craftcms/cms/pull/16464))
 
 ## 4.13.10 - 2025-01-14
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1924,6 +1924,8 @@ JS;
             return null;
         }
 
+        $transform = $transform ?? $this->_transform;
+
         // Give plugins/modules a chance to provide a custom URL
         $event = new DefineAssetUrlEvent([
             'transform' => $transform,
@@ -1961,7 +1963,6 @@ JS;
         }
 
         $volume = $this->getVolume();
-        $transform = $transform ?? $this->_transform;
 
         if (
             $transform && (


### PR DESCRIPTION
### Description
`\craft\services\Elements::_getRefTokenReplacement` coerces and an asset to a URL string via `\craft\elements\Asset::__toString`, which relies on any transform existing at `\craft\elements\Asset::$_transform` to get the correct transformed URL.

However, when the `DefineAssetUrlEvent` event is triggered and passed a transform, `\craft\elements\Asset::$_transform` is ignored.

Something using `DefineAssetUrlEvent` may then return the wrong URL, as receives a `null` transform when `\craft\elements\Asset::$_transform` is actually set.

This can end up interfering with `HtmlField`'s Asset transform URL parsing, as it expects values to be identical for correct substitution when parsing refs, but they may not be.

### Related issues
https://github.com/craftcms/ckeditor/issues/336
