### PR TITLE
Ensure essential validation attributes are always validated

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2512,6 +2512,7 @@ abstract class Element extends Component implements ElementInterface
             $fieldLayout = $this->getFieldLayout()
         ) {
             $scenario = $this->getScenario();
+            $scenarios = $this->scenarios();
             $layoutElements = $fieldLayout->getVisibleCustomFieldElements($this);
 
             foreach ($layoutElements as $layoutElement) {
@@ -2533,7 +2534,13 @@ abstract class Element extends Component implements ElementInterface
                     $validator = $this->_normalizeFieldValidator($attribute, $rule, $field, $isEmpty);
                     if (
                         in_array($scenario, $validator->on) ||
-                        (empty($validator->on) && !in_array($scenario, $validator->except))
+                        (
+                            (
+                                $scenario !== self::SCENARIO_ESSENTIALS && !empty($scenarios[self::SCENARIO_ESSENTIALS]) ||
+                                empty($validator->on)
+                            ) &&
+                            !in_array($scenario, $validator->except)
+                        )
                     ) {
                         $validator->validateAttributes($this);
                     }

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2470,6 +2470,29 @@ abstract class Element extends Component implements ElementInterface
     /**
      * @inheritdoc
      */
+    public function activeAttributes(): array
+    {
+        $scenario = $this->getScenario();
+        $scenarios = $this->scenarios();
+        $attributes = array_values($scenarios[$scenario] ?? []);
+
+        // if this is a custom scenario, ensure that all essential attributes are included
+        if ($scenario !== self::SCENARIO_ESSENTIALS && !empty($scenarios[self::SCENARIO_ESSENTIALS])) {
+            $attributes = array_merge($attributes, $scenarios[self::SCENARIO_ESSENTIALS]);
+        }
+
+        foreach ($attributes as $i => $attribute) {
+            if (strncmp($attribute, '!', 1) === 0) {
+                $attributes[$i] = substr($attribute, 1);
+            }
+        }
+
+        return array_values(array_unique($attributes));
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function validate($attributeNames = null, $clearErrors = true)
     {
         $this->_attributeNames = $attributeNames ? array_flip((array)$attributeNames) : null;

--- a/tests/unit/elements/UserElementTest.php
+++ b/tests/unit/elements/UserElementTest.php
@@ -100,7 +100,7 @@ class UserElementTest extends TestCase
 
         $activated = Craft::$app->getUsers()->activateUser($user);
         self::assertFalse($activated);
-        self::assertFalse($user->hasErrors('fullName'));
+        self::assertTrue($user->hasErrors('fullName'));
         self::assertTrue($user->hasErrors('username'));
         self::assertTrue($user->hasErrors('email'));
 


### PR DESCRIPTION
Ensures that any validation rules that have `'on' => [Element::SCENARIO_ESSENTIALS]` will always be validated, for all other validation scenarios.