### PR TITLE
ColorData::$label

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,1 +1,4 @@
 # Release Notes for Craft CMS 5.7 (WIP)
+
+### Extensibility
+- Added `craft\fields\data\ColorData::$label`. ([#16492](https://github.com/craftcms/cms/pull/16492))

--- a/src/fields/Color.php
+++ b/src/fields/Color.php
@@ -293,7 +293,15 @@ class Color extends Field implements InlineEditableFieldInterface, MergeableFiel
         }
 
         $value = ColorValidator::normalizeColor($value);
-        return new ColorData($value);
+        $value = new ColorData($value);
+
+        // set the label on the value too?
+        $option = Arr::first($this->palette, fn(array $color) => $color['color'] === $value->getHex());
+        if (isset($option['label']) && $option['label'] !== '') {
+            $value->label = $option['label'];
+        }
+
+        return $value;
     }
 
     /**

--- a/src/fields/data/ColorData.php
+++ b/src/fields/data/ColorData.php
@@ -29,6 +29,12 @@ use yii\base\BaseObject;
 class ColorData extends BaseObject implements Serializable
 {
     /**
+     * @var string|null The human-facing label for the color.
+     * @since 5.7.0
+     */
+    public ?string $label = null;
+
+    /**
      * @var string The color’s hex value
      */
     private string $_hex;


### PR DESCRIPTION
### Description

Adds a `label` property to Color field data, to expose the user-facing color labels.

```twig
{% if entry.myColorField %}
  Color: {{ entry.myColorField.label }}
{% endif %}
```

### Related issues

- #14488