### PR TITLE
Unset name/handle for srcset size transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where all multi-byte characters were getting stripped out of search indexes. ([#16457](https://github.com/craftcms/cms/issues/16457))
 - Fixed a bug where Color fields weren’t translating color palette labels.
+- Fixed a bug where `craft\elements\Asset::getSrcset()` (and `srcset` method arguments) weren’t producing the correct transform URLs if the asset already had a named transform applied to it. ([#16486](https://github.com/craftcms/cms/issues/16486))
 
 ## 5.6.0.2 - 2025-01-21
 

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -1958,6 +1958,8 @@ JS,[
 
             $sizeTransform = $transform ? $transform->toArray() : [];
 
+            unset($sizeTransform['name'], $sizeTransform['handle']);
+
             if ($unit === 'w') {
                 $sizeTransform['width'] = (int)$value;
             } else {

--- a/src/services/ImageTransforms.php
+++ b/src/services/ImageTransforms.php
@@ -428,6 +428,8 @@ class ImageTransforms extends Component
                         ...$refTransform->toArray(),
                 ]);
 
+                unset($transform->name, $transform->handle);
+
                 if ($sizeUnit === 'w') {
                     $transform->width = (int)$sizeValue;
                 } else {


### PR DESCRIPTION
### Description
https://github.com/craftcms/cms/pull/15646 introduced a bug where transform URLs created by `\craft\elements\Asset::getUrlsBySize` would all be identical (based on the transform handle).

### Related issues
Fixes https://github.com/craftcms/cms/issues/16486
