### PR TITLE
Move setting default author and post date from `beforeValidate` to `beforeSave` (v4)

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1873,35 +1873,6 @@ EOD;
 
     /**
      * @inheritdoc
-     */
-    public function beforeValidate(): bool
-    {
-        if (!$this->getAuthorId() && $this->getSection()->type !== Section::TYPE_SINGLE) {
-            $this->setAuthorId(Craft::$app->getUser()->getId());
-        }
-
-        if (
-            !$this->_userPostDate() &&
-            (
-                in_array($this->scenario, [self::SCENARIO_LIVE, self::SCENARIO_DEFAULT]) ||
-                (!$this->getIsDraft() && !$this->getIsRevision())
-            )
-        ) {
-            // Default the post date to the current date/time
-            $this->postDate = new DateTime();
-            // ...without the seconds
-            $this->postDate->setTimestamp($this->postDate->getTimestamp() - ($this->postDate->getTimestamp() % 60));
-            // ...unless an expiry date is set in the past
-            if ($this->expiryDate && $this->postDate >= $this->expiryDate) {
-                $this->postDate = (clone $this->expiryDate)->modify('-1 day');
-            }
-        }
-
-        return parent::beforeValidate();
-    }
-
-    /**
-     * @inheritdoc
      * @throws Exception if reasons
      */
     public function beforeSave(bool $isNew): bool
@@ -1967,9 +1938,40 @@ EOD;
             $this->expiryDate = null;
         }
 
+        $this->maybeSetDefaultAttributes();
+
         $this->updateTitle();
 
         return parent::beforeSave($isNew);
+    }
+
+    /**
+     * Set the default values for attributes if certain conditions are met.
+     *
+     * @return void
+     */
+    private function maybeSetDefaultAttributes(): void
+    {
+        if (!$this->getAuthorId() && $this->getSection()->type !== Section::TYPE_SINGLE) {
+            $this->setAuthorId(Craft::$app->getUser()->getId());
+        }
+
+        if (
+            !$this->_userPostDate() &&
+            (
+                in_array($this->scenario, [self::SCENARIO_LIVE, self::SCENARIO_DEFAULT]) ||
+                (!$this->getIsDraft() && !$this->getIsRevision())
+            )
+        ) {
+            // Default the post date to the current date/time
+            $this->postDate = new DateTime();
+            // ...without the seconds
+            $this->postDate->setTimestamp($this->postDate->getTimestamp() - ($this->postDate->getTimestamp() % 60));
+            // ...unless an expiry date is set in the past
+            if ($this->expiryDate && $this->postDate >= $this->expiryDate) {
+                $this->postDate = (clone $this->expiryDate)->modify('-1 day');
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Moves setting default author and post date attribute values for Entry element from `beforeValidate()` to `beforeSave()` to avoid cases where the validation was not set to trigger for the entry and we end up with an entry without a `postDate` and therefore not being returned via basic entries query (without providing the status param).

I raised a separate PR for v5 (https://github.com/craftcms/cms/pull/16504).


### Related issues
n/a
