### PR TITLE
support read-only settings when plugin only implements settingsHtml()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a `cp.login.alternative-login-methods` hook to the system login template.
 - Fixed a bug where Color fields’ custom color inputs were including presets based on the color palette.
 - Fixed a bug where nested Matrix entries weren’t getting assigned a post date if they were created while saving the owner element with a custom validation scenario. ([#16504](https://github.com/craftcms/cms/pull/16504))
+- Fixed a bug where plugin settings pages weren’t displaying a read-only notice and had Save buttons, when `allowAdminChanges` was `false`. ([#16509](https://github.com/craftcms/cms/pull/16509))
 
 ## 5.6.1 - 2025-01-22
 

--- a/src/base/Plugin.php
+++ b/src/base/Plugin.php
@@ -247,6 +247,7 @@ class Plugin extends Module implements PluginInterface
         return $controller->renderTemplate('settings/plugins/_settings.twig', [
             'plugin' => $this,
             'settingsHtml' => $settingsHtml,
+            'readOnly' => $readOnly,
         ]);
     }
 

--- a/src/templates/settings/plugins/_settings.twig
+++ b/src/templates/settings/plugins/_settings.twig
@@ -3,7 +3,8 @@
 {% extends "_layouts/cp" %}
 {% set title = plugin.name %}
 {% set docTitle = title ~ ' - ' ~ "Plugins"|t('app') %}
-{% set fullPageForm = true %}
+{% set readOnly = readOnly ?? false %}
+{% set fullPageForm = not readOnly %}
 
 {% set crumbs = [
     { label: "Settings"|t('app'), url: url('settings') },
@@ -19,10 +20,15 @@
     },
 ] %}
 
+{% if readOnly %}
+    {% set contentNotice = readOnlyNotice() %}
+{% endif %}
 
 {% block content %}
-    {{ actionInput('plugins/save-plugin-settings') }}
-    {{ hiddenInput('pluginHandle', plugin.handle) }}
-    {{ redirectInput('settings') }}
+    {% if not readOnly %}
+        {{ actionInput('plugins/save-plugin-settings') }}
+        {{ hiddenInput('pluginHandle', plugin.handle) }}
+        {{ redirectInput('settings') }}
+    {% endif %}
     {{ settingsHtml|raw }}
 {% endblock %}


### PR DESCRIPTION
### Description
Add an easy way for plugins that only implement `settingsHtml()` (like described in the first example [here](https://craftcms.com/docs/5.x/extend/plugin-settings.html#settings-pages)) to support read-only settings.


### Related issues
n/a
