### PR TITLE
Delete pointless change data via GC

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,1 +1,4 @@
 # Release Notes for Craft CMS 4.15 (WIP)
+
+### System
+- The `changedattributes` and `changedfields` tables are now cleaned up during garbage collection. ([#16531](https://github.com/craftcms/cms/pull/16531))

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -153,6 +153,7 @@ class Gc extends Component
         $this->_deleteOrphanedRelations();
         $this->_deleteOrphanedStructureElements();
         $this->_deleteOrphanedFkRows();
+        $this->_deletePointlessChangeData();
 
         $this->_hardDeleteStructures();
 
@@ -571,6 +572,37 @@ SQL;
         $this->db->createCommand($qb->checkIntegrity())->execute();
 
         $this->_stdout("done\n", Console::FG_GREEN);
+    }
+
+    private function _deletePointlessChangeData(): void
+    {
+        $db = Craft::$app->getDb();
+        $schema = $db->getSchema();
+
+        foreach ([Table::CHANGEDATTRIBUTES, Table::CHANGEDFIELDS] as $table) {
+            $this->_stdout(sprintf('    > deleting pointless rows in the %s table ... ', $schema->getRawTableName($table)));
+
+            // fetch any rows in the table for canonical elements that don't have any drafts
+            $query = (new Query())
+                ->select('t.elementId')
+                ->from(['t' => $table])
+                ->innerJoin(['e' => Table::ELEMENTS], '[[e.id]] = [[t.elementId]]')
+                ->leftJoin(['d' => Table::ELEMENTS], [
+                    'and',
+                    ['not', ['d.draftId' => null]],
+                    '[[d.canonicalId]] = [[e.id]]',
+                ])
+                ->where(['e.canonicalId' => null])
+                ->andWhere(['d.id' => null])
+                ->groupBy('t.elementId');
+
+            foreach (Db::batch($query) as $batch) {
+                $elementIds = array_column($batch, 'elementId');
+                Db::delete($table, ['elementId' => $elementIds]);
+            }
+
+            $this->_stdout("done\n", Console::FG_GREEN);
+        }
     }
 
     /**


### PR DESCRIPTION
### Description

Deletes rows in the `changedattributes` and `changedfields` tables for any elements that are A) canonical and B) don’t have any drafts.

### Related issues

- #16507