### PR TITLE
when propagating an element, cross-site validate if we’re changing the status to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where changes to custom fields within Matrix blocks weren’t getting merged into existing drafts for the same owner element. ([#16519](https://github.com/craftcms/cms/issues/16519))
 - Fixed a bug where native fields (e.g. Title) were showing changed statuses when viewing revisions, if they had been updated since the time the revision was created.
 - Fixed a bug where eager-loading element queries could create an excessive amount of cache invalidation tags.
+- Fixed a bug where it was possible to enable elements for new sites with validation errors. ([#16505](https://github.com/craftcms/cms/issues/16505))
 
 ## 4.14.1 - 2025-01-22
 

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3282,8 +3282,13 @@ class Elements extends Component
 
         // Validate
         if ($runValidation) {
-            // If we're propagating, only validate changed custom fields
-            if ($element->propagating) {
+            // If we're propagating, only validate changed custom fields,
+            // unless we're enabling this element
+            if ($element->propagating && !(
+                $element->isProvisionalDraft &&
+                $element->getEnabledForSite() &&
+                !$element->getCanonical()->getEnabledForSite())
+            ) {
                 $names = array_map(
                     fn(string $handle) => "field:$handle",
                     array_unique(array_merge($dirtyFields, $element->getModifiedFields()))

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3285,7 +3285,8 @@ class Elements extends Component
             // If we're propagating, only validate changed custom fields,
             // unless we're enabling this element
             if ($element->propagating && !(
-                $element->isProvisionalDraft &&
+                $element->getIsDerivative() &&
+                $element->getIsDraft() &&
                 $element->getEnabledForSite() &&
                 !$element->getCanonical()->getEnabledForSite())
             ) {


### PR DESCRIPTION
### Description
When propagating an element to a site, we only run cross-site validation on the changed custom fields (https://github.com/craftcms/cms/discussions/13675). However, when the site status changes to enabled, we should make an exception and cross-site validate everything.

### Related issues
#16505 


#### steps to reproduce:

- have at least two sites
- have a section enabled for both; the propagation method can be left as “all”, but then the default status should be ’disabled'
- the section needs an entry type with at least one required custom field (plain text will suffice) that is set to be translatable for each site
- on `siteA`, create a new entry in that section, fill out only the title and fully save
- fill out the plain text field, enable the entry only for `siteA` & fully save
- now edit the entry for `siteA` again, toggle `siteB` to be enabled and fully save
- before this PR: the entry saves and is enabled on `siteB` now despite not having the plain text field filled out
- after this PR: the cross-site validation kicks in and lets you know that you should fill out the required fields before enabling the entry for `siteB`