### PR TITLE
Craft 4 Backport: ensure the db connection is closed

### DIFF
--- a/src/test/Craft.php
+++ b/src/test/Craft.php
@@ -164,6 +164,9 @@ class Craft extends Yii2
 
         parent::_before($test);
 
+        // transaction events are registered now, so it's ok to open the connection
+        \Craft::$app->db->open();
+
         // If full mock, create the mock app and don't perform to any further actions
         if ($this->_getConfig('fullMock') === true) {
             /** @var ConsoleApplication|WebApplication|MockObject $mockApp */

--- a/src/test/CraftConnector.php
+++ b/src/test/CraftConnector.php
@@ -122,4 +122,20 @@ class CraftConnector extends Yii2
         Db::reset();
         Session::reset();
     }
+
+    /**
+     * Closes the db connection after initializing Craft. The Yii2 module will
+     * try to initialize transaction listeners before each test. If we don't
+     * close the connection first, those listeners will never get picked up.
+     * We'll open the connection after all of the transaction listeners are
+     * registered.
+     *
+     * @inheritDoc
+     */
+    public function startApp(\yii\log\Logger $logger = null): void
+    {
+        parent::startApp($logger);
+
+        \Craft::$app->db->close();
+    }
 }


### PR DESCRIPTION
Backporting commit 4097887 from the 5.x branch.

Bug Ticket:
- https://github.com/craftcms/cms/issues/16546

### Description

I work on a Craft 4 site with a large test suite that often runs into these `Too Many Connections` errors. 

My workaround has been to split my tests up into smaller groups. But it looks like [this commit from the Craft 5 branch](https://github.com/craftcms/cms/commit/40978874f80929181de2986395e71974413f6802) resolves my issue. 

Is there any chance that we can backport this into Craft 4? It would really help me get our test suite and Codeception upgrade in order before switching to Craft 5 in the coming months. 

![CleanShot 2025-01-27 at 11 03 05@2x](https://github.com/user-attachments/assets/63fb732c-1dc4-4a48-89b1-a03488068566)