### PR TITLE
deleting nested inline editable matrix blocks and updating field layout

### DIFF
--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -2443,13 +2443,29 @@ JS, [
             // check for an unpublished draft if we got this far
             // (e.g. newly added matrix "block" or where autosaveDrafts is off)
             // https://github.com/craftcms/cms/issues/15985
-            return $this->_elementQuery($elementType)
+            $element = $this->_elementQuery($elementType)
                 ->uid($elementUid)
                 ->siteId($siteId)
                 ->preferSites($preferSites)
                 ->unique()
                 ->status(null)
                 ->draftOf(false)
+                ->one();
+
+            if ($element) {
+                return $element;
+            }
+
+            // check for trashed items too;
+            // e.g. you just deleted a block and the update-field-layout kicks in with the uids that were just deleted
+            // https://github.com/craftcms/cms/issues/16540
+            return $this->_elementQuery($elementType)
+                ->uid($elementUid)
+                ->siteId($siteId)
+                ->preferSites($preferSites)
+                ->unique()
+                ->status(null)
+                ->trashed(null)
                 ->one();
         }
 


### PR DESCRIPTION
### Description
Steps to reproduce:
- create a matrix field (`innerMatrix`) with at least one field in it; view mode: inline-editable blocks;
- create a second matrix field (`outerMatrix`) that contains the `innerMatrix` field; view mode: inline-editable blocks;
- create a section with an entry type that contains the `outerMatrix` field
- create an entry in that section (it can be fully saved)
- edit that entry and add at least one `outerMatrix` entry; in that entry create at least one `innerMatrix` entry
- delete the `outerMatrix` entry
- observe a 400 error from the `elements/update-field-layout` action about the element id being invalid

This happens because the entries are marked as deleted but their UIDs are passed to the `elements/update-field-layout` action. Since they’re already deleted, they cannot be found and the error is triggered.

Solution:
As a last resort, check for trashed elements (by uid) too.


### Related issues
#16540
