### PR TITLE
refactor: make test integration compatible with newer versions of `codeception/module-yii2`

### DIFF
--- a/src/test/CraftConnector.php
+++ b/src/test/CraftConnector.php
@@ -130,11 +130,20 @@ class CraftConnector extends Yii2
      * We'll open the connection after all of the transaction listeners are
      * registered.
      *
+     * Method has nullable param to support `codeception/module-yii2` both in
+     * the < 1.1.6 and >= 1.1.6 versions. The method signature is now compliant
+     * with the `parent` for both branches.
+     *
+     * @param null|\yii\log\Logger $logger
+     *
      * @inheritDoc
      */
-    public function startApp(): void
+    public function startApp(?\yii\log\Logger $logger = null): void
     {
-        parent::startApp();
+        // Pass through all method arguments as to support
+        // `codeception/module-yii2` < 1.1.6 AND >= 1.1.6 versions, whilst
+        // also keeping PHPStan satisfied for both versions.
+        parent::startApp(...func_get_args());
 
         \Craft::$app->db->close();
     }


### PR DESCRIPTION
### Description
Only extend method signature. Pass-through all method arguments to parent. This satisfies both version ranges of `codeception/module-yii2` <= 1.1.5 && >= 1.1.6. 

Using Codeception 5 requires newer Yii2 module. Testing documentation does not restrain Codeception version to 4.x. So making the code work like this seems pragmatic.

### Related issues
https://github.com/craftcms/cms/issues/16577
