### PR TITLE
filter out mappings that have empty targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed an error that could occur when eager-loading nested elements’ owners, if any of the queried elements didn’t have an owner ID. ([#16570](https://github.com/craftcms/cms/issues/16570), [#16572](https://github.com/craftcms/cms/issues/16572), [#16576](https://github.com/craftcms/cms/issues/16576))
+
 ## 5.6.2 - 2024-01-28
 
 - The Login page now displays the Login Page Logo above the login form, rather than within the header. ([#16564](https://github.com/craftcms/cms/pull/16564))

--- a/src/base/NestedElementTrait.php
+++ b/src/base/NestedElementTrait.php
@@ -45,13 +45,16 @@ trait NestedElementTrait
 
                 return [
                     'elementType' => $ownerType,
-                    'map' => array_map(fn(NestedElementInterface $element) => [
-                        'source' => $element->id,
-                        'target' => match ($handle) {
+                    'map' => array_filter(array_map(function(NestedElementInterface $element) use ($handle) {
+                        $ownerId = match ($handle) {
                             'owner' => $element->getOwnerId(),
                             'primaryOwner' => $element->getPrimaryOwnerId(),
-                        },
-                    ], $sourceElements),
+                        };
+                        return $ownerId ? [
+                            'source' => $element->id,
+                            'target' => $ownerId,
+                        ] : null;
+                    }, $sourceElements)),
                     'criteria' => [
                         'status' => null,
                     ],

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3235,8 +3235,10 @@ class Elements extends Component
                     $targetElementIdsBySourceIds = [];
 
                     foreach ($map['map'] as $mapping) {
-                        $uniqueTargetElementIds[$mapping['target']] = true;
-                        $targetElementIdsBySourceIds[$mapping['source']][$mapping['target']] = true;
+                        if (!empty($mapping['target'])) {
+                            $uniqueTargetElementIds[$mapping['target']] = true;
+                            $targetElementIdsBySourceIds[$mapping['source']][$mapping['target']] = true;
+                        }
                     }
 
                     // Get the target elements


### PR DESCRIPTION
### Description
When eager loading owner/primary owner, filter out any empty target IDs (because we can't query by those).


### Related issues
#16570 
#16572 
#16576 
