### PR TITLE
Casting of number field in pgsql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where Number fields weren’t getting sorted properly in PostgreSQL. ([#15828](https://github.com/craftcms/cms/issues/15828))
 - Fixed a potential phishing attack vector.
 
 ## 5.6.5.1 - 2025-02-04

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -1050,6 +1050,7 @@ JS, [
         if ($db->getIsPgsql()) {
             $castType = match (Db::parseColumnType($dbType)) {
                 Schema::TYPE_DECIMAL => 'DECIMAL',
+                Schema::TYPE_INTEGER => 'INTEGER',
                 default => null,
             };
         }


### PR DESCRIPTION
### Description
Since https://github.com/craftcms/cms/commit/5eeb785f9dc1055207cf4ae514ec91d2b5482783, the Number field db type can also be an integer. We need to take that into consideration when casting.


### Related issues
#15828 
