### PR TITLE
Search index queue

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -7,8 +7,13 @@
 - Global nav items and breadcrumbs can now have `aria-label` attributes via an `ariaLabel` property.
 - Added `craft\base\ElementInterface::getSerializedFieldValuesForDb()`.
 - Added `craft\base\FieldInterface::serializeValueForDb()`.
+- Added `craft\db\Table::SEARCHINDEXQUEUE_FIELDS`.
+- Added `craft\db\Table::SEARCHINDEXQUEUE`.
+- Added `craft\services\Search::indexElementIfQueued()`.
+- Added `craft\services\Search::queueIndexElement()`.
 
 ### System
 - The `changedattributes` and `changedfields` tables are now cleaned up during garbage collection. ([#16531](https://github.com/craftcms/cms/pull/16531))
 - The `resourcepaths` table is now truncated when clearing control panel resources, via the Caches utility or the `clear-caches/cp-resources` command. ([#16514](https://github.com/craftcms/cms/issues/16514))
 - Date values for custom fields are now represented as ISO-8601 date strings (with time zones) within element exports. ([#16629](https://github.com/craftcms/cms/pull/16629))
+- “Updating search indexes” queue jobs no longer do anything if search indexes were already updated for the element since the job was created. ([#16644](https://github.com/craftcms/cms/pull/16644))

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '4.14.4',
-    'schemaVersion' => '4.5.3.0',
+    'schemaVersion' => '4.15.0.0',
     'minVersionRequired' => '3.7.11',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/db/Table.php
+++ b/src/db/Table.php
@@ -97,4 +97,8 @@ abstract class Table
     public const VOLUMES = '{{%volumes}}';
     public const WIDGETS = '{{%widgets}}';
     public const SEARCHINDEX = '{{%searchindex}}';
+    /** @since 4.15.0 */
+    public const SEARCHINDEXQUEUE = '{{%searchindexqueue}}';
+    /** @since 4.15.0 */
+    public const SEARCHINDEXQUEUE_FIELDS = '{{%searchindexqueue_fields}}';
 }

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -939,7 +939,7 @@ JS, [
      */
     public function afterSave(bool $isNew): void
     {
-        // If the propagation method just changed, resave all the Matrix blocks
+        // If the propagation method just changed, resave all the elements
         if (isset($this->oldSettings)) {
             $oldLocalizeRelations = (bool)($this->oldSettings['localizeRelations'] ?? false);
             if ($this->localizeRelations !== $oldLocalizeRelations) {

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -574,6 +574,17 @@ class Install extends Migration
             'dateUpdated' => $this->dateTime()->notNull(),
             'uid' => $this->uid(),
         ]);
+        $this->createTable(Table::SEARCHINDEXQUEUE, [
+            'id' => $this->primaryKey(),
+            'elementId' => $this->integer()->notNull(),
+            'siteId' => $this->integer()->notNull(),
+            'reserved' => $this->boolean()->notNull()->defaultValue(false),
+        ]);
+        $this->createTable(Table::SEARCHINDEXQUEUE_FIELDS, [
+            'jobId' => $this->integer()->notNull(),
+            'fieldHandle' => $this->string()->notNull(),
+            'PRIMARY KEY([[jobId]], [[fieldHandle]])',
+        ]);
         $this->createTable(Table::SECTIONS, [
             'id' => $this->primaryKey(),
             'structureId' => $this->integer(),
@@ -896,6 +907,8 @@ class Install extends Migration
         $this->createIndex(null, Table::RELATIONS, ['targetId'], false);
         $this->createIndex(null, Table::RELATIONS, ['sourceSiteId'], false);
         $this->createIndex(null, Table::REVISIONS, ['canonicalId', 'num'], true);
+        $this->createIndex(null, Table::SEARCHINDEXQUEUE, ['elementId', 'siteId', 'reserved'], false);
+        $this->createIndex(null, Table::SEARCHINDEXQUEUE_FIELDS, ['jobId', 'fieldHandle'], true);
         $this->createIndex(null, Table::SECTIONS, ['handle'], false);
         $this->createIndex(null, Table::SECTIONS, ['name'], false);
         $this->createIndex(null, Table::SECTIONS, ['structureId'], false);
@@ -1064,6 +1077,8 @@ class Install extends Migration
         $this->addForeignKey(null, Table::RELATIONS, ['sourceSiteId'], Table::SITES, ['id'], 'CASCADE', 'CASCADE');
         $this->addForeignKey(null, Table::REVISIONS, ['creatorId'], Table::USERS, ['id'], 'SET NULL', null);
         $this->addForeignKey(null, Table::REVISIONS, ['canonicalId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, Table::SEARCHINDEXQUEUE, 'elementId', Table::ELEMENTS, 'id', 'CASCADE', null);
+        $this->addForeignKey(null, Table::SEARCHINDEXQUEUE_FIELDS, 'jobId', Table::SEARCHINDEXQUEUE, 'id', 'CASCADE', null);
         $this->addForeignKey(null, Table::SECTIONS, ['structureId'], Table::STRUCTURES, ['id'], 'SET NULL', null);
         $this->addForeignKey(null, Table::SECTIONS_SITES, ['siteId'], Table::SITES, ['id'], 'CASCADE', 'CASCADE');
         $this->addForeignKey(null, Table::SECTIONS_SITES, ['sectionId'], Table::SECTIONS, ['id'], 'CASCADE', null);

--- a/src/migrations/m250206_135036_search_index_queue.php
+++ b/src/migrations/m250206_135036_search_index_queue.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m250206_135036_search_index_queue migration.
+ */
+class m250206_135036_search_index_queue extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->safeDown();
+        $this->createTable(Table::SEARCHINDEXQUEUE, [
+            'id' => $this->primaryKey(),
+            'elementId' => $this->integer()->notNull(),
+            'siteId' => $this->integer()->notNull(),
+            'reserved' => $this->boolean()->notNull()->defaultValue(false),
+        ]);
+        $this->createTable(Table::SEARCHINDEXQUEUE_FIELDS, [
+            'jobId' => $this->integer()->notNull(),
+            'fieldHandle' => $this->string()->notNull(),
+            'PRIMARY KEY([[jobId]], [[fieldHandle]])',
+        ]);
+        $this->createIndex(null, Table::SEARCHINDEXQUEUE, ['elementId', 'siteId', 'reserved'], false);
+        $this->createIndex(null, Table::SEARCHINDEXQUEUE_FIELDS, ['jobId', 'fieldHandle'], true);
+        $this->addForeignKey(null, Table::SEARCHINDEXQUEUE, 'elementId', Table::ELEMENTS, 'id', 'CASCADE', null);
+        $this->addForeignKey(null, Table::SEARCHINDEXQUEUE_FIELDS, 'jobId', Table::SEARCHINDEXQUEUE, 'id', 'CASCADE', null);
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->dropTableIfExists(Table::SEARCHINDEXQUEUE_FIELDS);
+        $this->dropTableIfExists(Table::SEARCHINDEXQUEUE);
+        return true;
+    }
+}

--- a/src/queue/jobs/UpdateSearchIndex.php
+++ b/src/queue/jobs/UpdateSearchIndex.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\ElementInterface;
 use craft\i18n\Translation;
 use craft\queue\BaseJob;
+use yii\base\InvalidConfigException;
 
 /**
  * UpdateSearchIndex job
@@ -42,10 +43,26 @@ class UpdateSearchIndex extends BaseJob
     public ?array $fieldHandles = null;
 
     /**
+     * @var bool Whether to check if the element’s search indexes are queued to be updated before proceeding.
+     * @since 4.15.0
+     */
+    public bool $queued = false;
+
+    /**
      * @inheritdoc
      */
     public function execute($queue): void
     {
+        $searchService = Craft::$app->getSearch();
+
+        if ($this->queued) {
+            if (!is_int($this->elementId) || !is_int($this->siteId)) {
+                throw new InvalidConfigException('`elementId` and `siteId` must be an integer when `queued` is true.');
+            }
+            $searchService->indexElementIfQueued($this->elementId, $this->siteId, $this->elementType);
+            return;
+        }
+
         $elements = $this->elementType::find()
             ->drafts(null)
             ->provisionalDrafts(null)
@@ -54,7 +71,6 @@ class UpdateSearchIndex extends BaseJob
             ->status(null)
             ->all();
         $total = count($elements);
-        $searchService = Craft::$app->getSearch();
 
         foreach ($elements as $i => $element) {
             $this->setProgress($queue, ($i + 1) / $total);

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -57,7 +57,6 @@ use craft\i18n\Translation;
 use craft\models\ElementActivity;
 use craft\queue\jobs\FindAndReplace;
 use craft\queue\jobs\UpdateElementSlugsAndUris;
-use craft\queue\jobs\UpdateSearchIndex;
 use craft\records\Element as ElementRecord;
 use craft\records\Element_SiteSettings as Element_SiteSettingsRecord;
 use craft\records\StructureElement as StructureElementRecord;
@@ -3564,12 +3563,7 @@ class Elements extends Component
                     if (Craft::$app->getRequest()->getIsConsoleRequest()) {
                         Craft::$app->getSearch()->indexElementAttributes($element, $searchableDirtyFields);
                     } else {
-                        Queue::push(new UpdateSearchIndex([
-                            'elementType' => get_class($element),
-                            'elementId' => $element->id,
-                            'siteId' => $element->siteId,
-                            'fieldHandles' => $searchableDirtyFields,
-                        ]), 2048);
+                        Craft::$app->getSearch()->queueIndexElement($element, $searchableDirtyFields);
                     }
                 }
             }

--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -18,16 +18,20 @@ use craft\elements\db\ElementQuery;
 use craft\events\IndexKeywordsEvent;
 use craft\events\SearchEvent;
 use craft\helpers\ArrayHelper;
+use craft\helpers\Component as ComponentHelper;
 use craft\helpers\Db;
 use craft\helpers\ElementHelper;
+use craft\helpers\Queue;
 use craft\helpers\Search as SearchHelper;
 use craft\helpers\StringHelper;
+use craft\queue\jobs\UpdateSearchIndex;
 use craft\search\SearchQuery;
 use craft\search\SearchQueryTerm;
 use craft\search\SearchQueryTermGroup;
 use Throwable;
 use yii\base\Component;
-use yii\db\Exception;
+use yii\base\Exception;
+use yii\db\Exception as DbException;
 use yii\db\Expression;
 use yii\db\Schema;
 
@@ -195,6 +199,157 @@ class Search extends Component
         $mutex->release($lockKey);
 
         return true;
+    }
+
+    /**
+     * Queues up an element to be indexed.
+     *
+     * @param ElementInterface $element
+     * @param string[] $fieldHandles
+     * @since 4.15.0
+     */
+    public function queueIndexElement(ElementInterface $element, array $fieldHandles): void
+    {
+        $this->createOrUpdateIndexJob($element, $fieldHandles);
+
+        Queue::push(new UpdateSearchIndex([
+            'elementType' => get_class($element),
+            'elementId' => $element->id,
+            'siteId' => $element->siteId,
+            'queued' => true,
+        ]), 2048);
+    }
+
+    private function createOrUpdateIndexJob(ElementInterface $element, array $fieldHandles): void
+    {
+        $jobId = $this->pendingIndexJobId($element->id, $element->siteId);
+
+        if ($jobId) {
+            if (empty($fieldHandles)) {
+                // nothing more to do
+                return;
+            }
+
+            // get a lock on the job and make sure it still exists && is pending
+            $mutex = Craft::$app->getMutex();
+            $lockName = "searchqueue:$jobId";
+
+            if ($mutex->acquire($lockName)) {
+                try {
+                    if ($this->isIndexJobPending($jobId)) {
+                        foreach ($fieldHandles as $fieldHandle) {
+                            Db::upsert(Table::SEARCHINDEXQUEUE_FIELDS, [
+                                'jobId' => $jobId,
+                                'fieldHandle' => $fieldHandle,
+                            ]);
+                        }
+                        return;
+                    }
+                } finally {
+                    $mutex->release($lockName);
+                }
+            }
+        }
+
+        $db = Craft::$app->getDb();
+        $db->transaction(function() use ($element, $fieldHandles, $db) {
+            Db::insert(Table::SEARCHINDEXQUEUE, [
+                'elementId' => $element->id,
+                'siteId' => $element->siteId,
+            ], $db);
+            $jobId = $db->getLastInsertID(Table::SEARCHINDEXQUEUE);
+            $fieldData = array_map(fn(string $fieldHandle) => [$jobId, $fieldHandle], $fieldHandles);
+            Db::batchInsert(Table::SEARCHINDEXQUEUE_FIELDS, ['jobId', 'fieldHandle'], $fieldData, $db);
+        });
+    }
+
+    /**
+     * Indexes the attributes of a given element, only if it’s queued.
+     *
+     * @param int $elementId
+     * @param int $siteId
+     * @param class-string<ElementInterface>|null $elementType
+     * @since 4.15.0
+     */
+    public function indexElementIfQueued(int $elementId, int $siteId, ?string $elementType = null): void
+    {
+        $jobId = $this->pendingIndexJobId($elementId, $siteId);
+
+        if (!$jobId) {
+            // no pending jobs
+            return;
+        }
+
+        // get a lock on the job and then mark it as reserved,
+        // so there's no chance another process reserves it/modifies it, overlapping with this one
+        $mutex = Craft::$app->getMutex();
+        $lockName = "searchqueue:$jobId";
+        if (!$mutex->acquire($lockName, 5)) {
+            throw new Exception("Unable to acquire a mutex lock for search queue job $jobId");
+        }
+
+        try {
+            if (!Db::update(Table::SEARCHINDEXQUEUE, ['reserved' => true], ['id' => $jobId])) {
+                // another process must be handling the same job
+                return;
+            }
+        } finally {
+            $mutex->release($lockName);
+        }
+
+        try {
+            // Figure out which fields need to be updated for the element
+            $fieldHandles = (new Query())
+                ->select(['fieldHandle'])
+                ->from(Table::SEARCHINDEXQUEUE_FIELDS)
+                ->where(['jobId' => $jobId])
+                ->column();
+
+            $elementType ??= Craft::$app->getElements()->getElementTypeById($elementId);
+
+            if ($elementType && ComponentHelper::validateComponentClass($elementType, ElementInterface::class)) {
+                $element = $elementType::find()
+                    ->drafts(null)
+                    ->provisionalDrafts(null)
+                    ->id($elementId)
+                    ->siteId($siteId)
+                    ->status(null)
+                    ->one();
+
+                if ($elementId) {
+                    $this->indexElementAttributes($element, $fieldHandles);
+                }
+            }
+
+            Db::delete(Table::SEARCHINDEXQUEUE, ['id' => $jobId]);
+        } catch (Throwable $e) {
+            Db::update(Table::SEARCHINDEXQUEUE, ['reserved' => false], ['id' => $jobId]);
+            throw $e;
+        }
+    }
+
+    private function pendingIndexJobId(int $elementId, int $siteId): ?int
+    {
+        return (new Query())
+            ->select('id')
+            ->from(Table::SEARCHINDEXQUEUE)
+            ->where([
+                'elementId' => $elementId,
+                'siteId' => $siteId,
+                'reserved' => false,
+            ])
+            ->scalar();
+    }
+
+    private function isIndexJobPending(int $jobId): bool
+    {
+        $job = (new Query())
+            ->select('reserved')
+            ->from(Table::SEARCHINDEXQUEUE)
+            ->where(['id' => $jobId])
+            ->one();
+
+        return $job && !$job['reserved'];
     }
 
     /**
@@ -488,7 +643,7 @@ SQL;
             try {
                 Db::insert(Table::SEARCHINDEX, $columns);
                 return;
-            } catch (Exception $e) {
+            } catch (DbException $e) {
                 if (str_contains($e->getPrevious()?->getMessage(), 'deadlock')) {
                     // A gap lock was probably hit. Try again in one second
                     // https://github.com/craftcms/cms/issues/15221


### PR DESCRIPTION
### Description

Adds a new search index queue, which keeps track of elements/fields that need to be indexed.

When an element is saved, the new `craft\services\Search::queueIndexElement()` method will check if there is an existing job in the search queue for the given element/site, and if so, it will just update that job’s list of modified field handles. If not, it will create a new job.

When `UpdateSearchIndex` jobs are executed, the element will only actually be indexed if there’s a pending job in the search index queue. Otherwise it will bail immediately.

### Related issues

- #9801