### PR TITLE
Deferred event handling for bulk ops

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -17,11 +17,14 @@
 - Editable tables now support `icon` columns.
 - Added `craft\base\ElementInterface::getSerializedFieldValuesForDb()`.
 - Added `craft\base\FieldInterface::serializeValueForDb()`.
+- Added `craft\db\Table::BULKOPEVENTS`.
 - Added `craft\db\Table::SEARCHINDEXQUEUE_FIELDS`.
 - Added `craft\db\Table::SEARCHINDEXQUEUE`.
+- Added `craft\events\BulkOpEvent::defer()`. ([#16655](https://github.com/craftcms/cms/pull/16655))
 - Added `craft\fields\BaseOptionsField::$optionColors`, which can be set to `true` by subclasses to enable the “Color” setting for field options. ([#16645](https://github.com/craftcms/cms/pull/16645))
 - Added `craft\fields\BaseOptionsField::$optionIcons`, which can be set to `true` by subclasses to enable the “Icon” setting for field options. ([#16645](https://github.com/craftcms/cms/pull/16645))
 - Added `craft\fields\data\ColorData::$label`. ([#16492](https://github.com/craftcms/cms/pull/16492))
+- Added `craft\services\Elements::getBulkOpKeys()`.
 - Added `craft\services\Search::indexElementIfQueued()`.
 - Added `craft\services\Search::queueIndexElement()`.
 - Added `Craft.ui.createIconPicker()`.

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '5.6.5.1',
-    'schemaVersion' => '5.7.0.0',
+    'schemaVersion' => '5.7.0.1',
     'minVersionRequired' => '4.5.0',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/db/Table.php
+++ b/src/db/Table.php
@@ -26,6 +26,8 @@ abstract class Table
     public const ASSETS_SITES = '{{%assets_sites}}';
     /** @since 5.0 */
     public const AUTHENTICATOR = '{{%authenticator}}';
+    /** @since 5.7.0 */
+    public const BULKOPEVENTS = '{{%bulkopevents}}';
     /** @since 3.4.14 */
     public const CACHE = '{{%cache}}';
     public const CATEGORIES = '{{%categories}}';

--- a/src/events/BulkOpEvent.php
+++ b/src/events/BulkOpEvent.php
@@ -7,6 +7,16 @@
 
 namespace craft\events;
 
+use Craft;
+use craft\db\Query;
+use craft\db\Table;
+use craft\helpers\ArrayHelper;
+use craft\helpers\DateTimeHelper;
+use craft\helpers\Db;
+use craft\services\Elements;
+use yii\base\Application;
+use yii\base\Event;
+
 /**
  * Bulk operation event class.
  *
@@ -15,6 +25,104 @@ namespace craft\events;
  */
 class BulkOpEvent extends ElementQueryEvent
 {
+    private static array $handlers;
+    private static array $triggers;
+
+    /**
+     * Listens to a class-level event, but defers calling the handler until after a bulk operation
+     * is completed, and only if the event was triggered during the bulk operation.
+     *
+     * ```php
+     * BulkOpEvent::deferredOn(ActiveRecord::class, ActiveRecord::EVENT_AFTER_INSERT, function ($event) {
+     *     Yii::trace(get_class($event->sender) . ' is inserted.');
+     * });
+     * ```
+     *
+     * The handler will be invoked for EVERY successful ActiveRecord insertion.
+     *
+     * Since 2.0.14 you can specify either class name or event name as a wildcard pattern:
+     *
+     * ```php
+     * Event::on('app\models\db\*', '*Insert', function ($event) {
+     *     Yii::trace(get_class($event->sender) . ' is inserted.');
+     * });
+     * ```
+     *
+     * @param string $class the fully qualified class name to which the event handler needs to attach.
+     * @param string $name the event name.
+     * @param callable $handler the event handler.
+     * @param mixed $data the data to be passed to the event handler when the event is triggered.
+     * When the event handler is invoked, this data can be accessed via [[\yii\base\Event::data]].
+     * @since 5.7.0
+     */
+    public static function defer(
+        string $class,
+        string $name,
+        callable $handler,
+        mixed $data = null,
+    ): void {
+        if (!isset(self::$handlers)) {
+            self::$handlers = [];
+            self::$triggers = [];
+
+            Event::on(Elements::class, Elements::EVENT_AFTER_BULK_OP, function(self $event) {
+                $triggers = ArrayHelper::remove(self::$triggers, $event->key, []);
+                $db = Craft::$app->getElements()->bulkOpDb;
+
+                // see if any events were fired for the same bulk op key from previous requests
+                $storedTriggers = (new Query())
+                    ->select(['senderClass', 'eventName'])
+                    ->from(Table::BULKOPEVENTS)
+                    ->where(['key' => $event->key])
+                    ->all($db);
+                if (!empty($storedTriggers)) {
+                    Db::delete(Table::BULKOPEVENTS, ['key' => $event->key], db: $db);
+                    foreach ($storedTriggers as $trigger) {
+                        $triggers[$trigger['senderClass']][$trigger['eventName']] = true;
+                    }
+                }
+
+                foreach ($triggers as $class => $eventNames) {
+                    foreach (array_keys($eventNames) as $eventName) {
+                        $handlers = self::$handlers[$class][$eventName] ?? [];
+                        foreach ($handlers as [$handler, $data]) {
+                            $event->data = $data;
+                            call_user_func($handler, $event);
+                        }
+                    }
+                }
+            }, append: false);
+
+            Craft::$app->on(Application::EVENT_AFTER_REQUEST, function() {
+                // keep track of any event triggers that haven’t been handled yet
+                if (!empty(self::$triggers)) {
+                    $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
+                    $db = Craft::$app->getElements()->bulkOpDb;
+                    foreach (self::$triggers as $key => $triggers) {
+                        foreach ($triggers as $class => $eventNames) {
+                            foreach (array_keys($eventNames) as $eventName) {
+                                Db::upsert(Table::BULKOPEVENTS, [
+                                    'key' => $key,
+                                    'senderClass' => $class,
+                                    'eventName' => $eventName,
+                                    'timestamp' => $timestamp,
+                                ], db: $db);
+                            }
+                        }
+                    }
+                }
+            }, append: false);
+        }
+
+        self::$handlers[$class][$name][] = [$handler, $data];
+
+        static::on($class, $name, function() use ($class, $name) {
+            foreach (Craft::$app->getElements()->getBulkOpKeys() as $key) {
+                self::$triggers[$key][$class][$name] = true;
+            }
+        }, append: false);
+    }
+
     /**
      * @var string The bulk operation key.
      */

--- a/src/events/BulkOpEvent.php
+++ b/src/events/BulkOpEvent.php
@@ -38,16 +38,6 @@ class BulkOpEvent extends ElementQueryEvent
      * });
      * ```
      *
-     * The handler will be invoked for EVERY successful ActiveRecord insertion.
-     *
-     * Since 2.0.14 you can specify either class name or event name as a wildcard pattern:
-     *
-     * ```php
-     * Event::on('app\models\db\*', '*Insert', function ($event) {
-     *     Yii::trace(get_class($event->sender) . ' is inserted.');
-     * });
-     * ```
-     *
      * @param string $class the fully qualified class name to which the event handler needs to attach.
      * @param string $name the event name.
      * @param callable $handler the event handler.

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -237,6 +237,13 @@ class Install extends Migration
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
         ]);
+        $this->createTable(Table::BULKOPEVENTS, [
+            'key' => $this->char(10)->notNull(),
+            'senderClass' => $this->string()->notNull(),
+            'eventName' => $this->string()->notNull(),
+            'timestamp' => $this->dateTime()->notNull(),
+            'PRIMARY KEY([[key]], [[senderClass]], [[eventName]])',
+        ]);
         $this->createTable(Table::CATEGORIES, [
             'id' => $this->integer()->notNull(),
             'groupId' => $this->integer()->notNull(),
@@ -853,6 +860,7 @@ class Install extends Migration
         $this->createIndex(null, Table::ASSETS, ['filename', 'folderId'], false);
         $this->createIndex(null, Table::ASSETS, ['folderId'], false);
         $this->createIndex(null, Table::ASSETS, ['volumeId'], false);
+        $this->createIndex(null, Table::BULKOPEVENTS, ['timestamp'], false);
         $this->createIndex(null, Table::CATEGORIES, ['groupId'], false);
         $this->createIndex(null, Table::CATEGORYGROUPS, ['name'], false);
         $this->createIndex(null, Table::CATEGORYGROUPS, ['handle'], false);

--- a/src/migrations/m250207_172349_bulkop_events.php
+++ b/src/migrations/m250207_172349_bulkop_events.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m250207_172349_bulkop_events migration.
+ */
+class m250207_172349_bulkop_events extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->safeDown();
+        $this->createTable(Table::BULKOPEVENTS, [
+            'key' => $this->char(10)->notNull(),
+            'senderClass' => $this->string()->notNull(),
+            'eventName' => $this->string()->notNull(),
+            'timestamp' => $this->dateTime()->notNull(),
+            'PRIMARY KEY([[key]], [[senderClass]], [[eventName]])',
+        ]);
+        $this->createIndex(null, Table::BULKOPEVENTS, ['timestamp'], false);
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->dropTableIfExists(Table::BULKOPEVENTS);
+        return true;
+    }
+}

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1111,6 +1111,17 @@ class Elements extends Component
     private array $bulkKeys = [];
 
     /**
+     * Returns the active bulk op keys.
+     *
+     * @return string[]
+     * @since 5.7.0
+     */
+    public function getBulkOpKeys(): array
+    {
+        return array_keys($this->bulkKeys);
+    }
+
+    /**
      * Begins tracking element saves and deletes as part of a bulk operation, identified by a unique key.
      *
      * @return string The bulk operation key

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -111,7 +111,7 @@ class Gc extends Component
         $this->_deleteStaleSessions();
         $this->_deleteStaleAnnouncements();
         $this->_deleteStaleElementActivity();
-        $this->_deleteStaleBulkElementOps();
+        $this->_deleteStaleBulkOpData();
 
         // elements should always go first
         $this->hardDeleteElements();
@@ -434,12 +434,15 @@ class Gc extends Component
     }
 
     /**
-     * Deletes any stale bulk element operation records.
+     * Deletes any stale bulk operation data.
      */
-    private function _deleteStaleBulkElementOps(): void
+    private function _deleteStaleBulkOpData(): void
     {
-        $this->_stdout('    > deleting stale bulk element operation records ... ');
-        Db::delete(Table::ELEMENTS_BULKOPS, ['<', 'timestamp', Db::prepareDateForDb(new DateTime('2 weeks ago'))]);
+        $this->_stdout('    > deleting stale bulk operation data ... ');
+        $condition = ['<', 'timestamp', Db::prepareDateForDb(new DateTime('2 weeks ago'))];
+        foreach ([Table::BULKOPEVENTS, Table::ELEMENTS_BULKOPS] as $table) {
+            Db::delete($table, $condition);
+        }
         $this->_stdout("done\n", Console::FG_GREEN);
     }
 


### PR DESCRIPTION
Introduces a new `craft\events\BulkOpEvent::defer()` method, which can be used in place of `Event::on()` when you want to track whether an event occurs during a [bulk operation](https://craftcms.com/docs/5.x/extend/events.html#bulk-operations), and handle it after the bulk operation is complete.

```php
use craft\elements\Entry;
use craft\events\BulkOpEvent;
use craft\helpers\Db;

BulkOpEvent::defer(
    Entry::class,
    Entry::EVENT_AFTER_SAVE,
    function (BulkOpEvent $event) {
        // Fetch all the entries that were affected
        $entries = Entry::find()->inBulkOp($event->key)->status(null);
        foreach (Db::each($entries) as $entry) {
            // ...
        }
    },
);
```

The event handler is passed the same `BulkOpEvent` object you’d get if you were listening to `craft\services\Elements::EVENT_AFTER_BULK_OP`. (The event may have occurred on a previous request, so there’s no way to keep track of the specific event objects that were fired.)