### PR TITLE
Import map improvements

### DIFF
--- a/src/events/RegisterJsImportEvent.php
+++ b/src/events/RegisterJsImportEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace craft\events;
+
+use craft\base\Event;
+
+class RegisterJsImportEvent extends Event
+{
+    /**
+     * @var array import entries to be added to the import map.
+     */
+    public array $imports = [];
+}

--- a/src/templates/_layouts/base.twig
+++ b/src/templates/_layouts/base.twig
@@ -33,6 +33,12 @@
     <meta name="referrer" content="origin-when-cross-origin">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    {% if craft.app.view.importMap | length %}
+        <script type="importmap">
+            {"imports": {{ craft.app.view.importMap()|json_encode|raw }} }
+        </script>
+    {% endif %}
+
     {% set hasCustomIcon = false %}
     {% for tag in craft.app.config.general.cpHeadTags %}
         {{ tag(tag[0], tag[1]) }}

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -113,6 +113,18 @@ class View extends \yii\web\View
     /**
      * @event RegisterJsImportEvent The event that is triggered when building a JavaScript import map
      * @since 5.7.0
+     *
+     * ```php
+     * Event::on(
+     *    View::class,
+     *    View::EVENT_REGISTER_JS_IMPORT_MAP,
+     *    function(RegisterJsImportEvent $event) {
+     *        $view = $event->sender;
+     *
+     *        $bundle = $view->assetManager->getBundle(CkeditorPluginAsset::class);
+     *        $event->imports[$bundle->namespace] = $view->getAssetManager()->getAssetUrl($bundle, 'index.js');
+     *   }
+     * );
      */
     public const EVENT_REGISTER_JS_IMPORT_MAP = 'registerImportMap';
 

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\ElementInterface;
 use craft\events\AssetBundleEvent;
 use craft\events\CreateTwigEvent;
+use craft\events\RegisterJsImportEvent;
 use craft\events\RegisterTemplateRootsEvent;
 use craft\events\TemplateEvent;
 use craft\helpers\App;
@@ -108,6 +109,12 @@ class View extends \yii\web\View
      * @since 4.5.0
      */
     public const EVENT_AFTER_REGISTER_ASSET_BUNDLE = 'afterRegisterAssetBundle';
+
+    /**
+     * @event RegisterJsImportEvent The event that is triggered when building a JavaScript import map
+     * @since 5.7.0
+     */
+    public const EVENT_REGISTER_JS_IMPORT_MAP = 'registerImportMap';
 
     /**
      * @const TEMPLATE_MODE_CP
@@ -1492,9 +1499,9 @@ class View extends \yii\web\View
      * Registers a JavaScript import map entry to be injected into the final page response.
      *
      * @param string $key The module specifier.
-     * @param string $value  The URL or path to the resource the key will resolve to.
+     * @param string $value The URL or path to the resource the key will resolve to.
      * @since 5.6.0
-    */
+     */
     public function registerJsImport(string $key, string $value): void
     {
         $this->_jsImports[$key] = $value;
@@ -2214,9 +2221,6 @@ JS;
             $lines[] = '<title>' . Html::encode($this->title) . '</title>';
         }
 
-        if (!empty($this->_jsImports)) {
-            $lines[] = '<script type="importmap">{"imports": ' . Json::encode($this->_jsImports) . '}</script>';
-        }
         if (!empty($this->_scripts[self::POS_HEAD])) {
             $lines[] = implode("\n", $this->_scripts[self::POS_HEAD]);
         }
@@ -2336,6 +2340,24 @@ JS;
         }
 
         return $bundle;
+    }
+
+    /**
+     * Returns a key => values array of JavaScript imports
+     *
+     * @return array
+     */
+    public function getImportMap(): array
+    {
+        $imports = $this->_jsImports;
+
+        if ($this->hasEventHandlers(self::EVENT_REGISTER_JS_IMPORT_MAP)) {
+            $event = new RegisterJsImportEvent(['imports' => $imports]);
+            $this->trigger(self::EVENT_REGISTER_JS_IMPORT_MAP, $event);
+            $imports = $event->imports;
+        }
+
+        return $imports;
     }
 
     /**


### PR DESCRIPTION
Our [initial implementation](https://github.com/craftcms/cms/pull/16414) doesn't work so well with slideouts attempting to us the feature. In that scenario, when the slideout is loaded, it's corresponding `importmap` will be returned as a part of `headHtml` and injected into the page. Unfortunately, that map won't be parsed and any imports referencing it will fail.

Instead, we need something a bit more global. This PR is a first draft at that. We now have a `View::getImportMap()` method that will collect all imports registered via a `View::EVENT_REGISTER_JS_IMPORT_MAP` event and return the array.

## Open questions
- Can we make this process any nicer?
- Should this method be on the `View` or would `AssetManager` be more appropriate?
- Should we include a twig function for outputting the import map? 