### PR TITLE
find dynamic folder by canonical of duplicateOf element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where the `utils/delete-empty-volume-folders` command was deleting folders that had no assets directly, but had subfolders. ([#16388](https://github.com/craftcms/cms/issues/16388))
 - Fixed a bug where some Matrix blocks weren’t getting propagated to newly-added sites of their owners, if any blocks had been modified. ([#16640](https://github.com/craftcms/cms/issues/16640))
 - Fixed an error that could occur when deleting a draft.
+- Fixed an error that could occur when saving a Structure section entry, if it had an Assets field with a dynamic subpath that referenced `level`. ([#16661](https://github.com/craftcms/cms/pull/16661))
 - Fixed a potential phishing attack vector.
 
 ## 4.14.4 - 2025-02-04

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -946,7 +946,7 @@ class Assets extends BaseRelationField
             // Prepare the path by parsing tokens and normalizing slashes.
             try {
                 if ($element?->duplicateOf) {
-                    $element = $element->duplicateOf;
+                    $element = $element->duplicateOf->getCanonical();
                 }
                 $renderedSubpath = Craft::$app->getView()->renderObjectTemplate($subpath, $element);
             } catch (InvalidConfigException|RuntimeError $e) {


### PR DESCRIPTION
### Description
When saving an asset with dynamic location, we need to use the canonical of the `duplicateOf` element.

**Steps to reproduce:**
- on a clean v4 installation
- create a local filesystem and a volume that uses it
- create an assets field with “Restrict assets to a single location” checked; “Asset Location” set to `{level == 1 ? slug : parent.slug}`
- create a structure section with an entry type containing that assets field
- create an entry in that structure (level 1); use the “Upload files” button to upload an asset - at this point, everything works as expected
- fully save the entry and observe an “Invalid subpath” exception being thrown



### Related issues
https://github.com/craftcms/cms/pull/16220

Thanks for reporting, @olivierbon!
