### PR TITLE
respect selected transform position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fixed a bug where some Matrix blocks weren’t getting propagated to newly-added sites of their owners, if any blocks had been modified. ([#16640](https://github.com/craftcms/cms/issues/16640))
 - Fixed an error that could occur when deleting a draft.
 - Fixed an error that could occur when saving a Structure section entry, if it had an Assets field with a dynamic subpath that referenced `level`. ([#16661](https://github.com/craftcms/cms/pull/16661))
+- Fixed a bug where “Fit” image transforms were showing the “Default Focal Point” setting. ([#16665](https://github.com/craftcms/cms/pull/16665))
+- Fixed a bug where the “Image Position” setting wasn’t saving for “Letterbox” image transforms. ([#16648](https://github.com/craftcms/cms/issues/16648))
 - Fixed a potential phishing attack vector.
 
 ## 4.14.4 - 2025-02-04

--- a/src/templates/settings/assets/transforms/_settings.twig
+++ b/src/templates/settings/assets/transforms/_settings.twig
@@ -17,6 +17,9 @@
   },
 ] %}
 
+{% set defaultPositionLabel = "Default Focal Point"|t('app') %}
+{% set letterboxPositionLabel = "Image Position"|t('app') %}
+
 {% import '_includes/forms.twig' as forms %}
 
 
@@ -86,9 +89,10 @@
             }) }}
         </div>
 
-        <div id="letterbox-position-container"{% if transform.mode != 'letterbox' %} class="hidden"{% endif %}>
+        <div id="position-container"{% if transform.mode not in ['crop', 'letterbox'] %} class="hidden"{% endif %}>
+            {% set positionLabel = transform.mode == 'letterbox' ? letterboxPositionLabel : defaultPositionLabel %}
             {{ forms.selectField({
-                label: "Image Position"|t('app'),
+                label: positionLabel,
                 id: 'position',
                 name: 'position',
                 options: {
@@ -102,27 +106,7 @@
                     'bottom-center': "Bottom-Center"|t('app'),
                     'bottom-right': "Bottom-Right"|t('app')
                 },
-                value: transform.mode != 'letterbox' ? transform.position : 'center-center'
-            }) }}
-        </div>
-
-        <div id="position-container"{% if transform.mode in ['stretch', 'letterbox'] %} class="hidden"{% endif %}>
-            {{ forms.selectField({
-                label: "Default Focal Point"|t('app'),
-                id: 'position',
-                name: 'position',
-                options: {
-                    'top-left': "Top-Left"|t('app'),
-                    'top-center': "Top-Center"|t('app'),
-                    'top-right': "Top-Right"|t('app'),
-                    'center-left': "Center-Left"|t('app'),
-                    'center-center': "Center-Center"|t('app'),
-                    'center-right': "Center-Right"|t('app'),
-                    'bottom-left': "Bottom-Left"|t('app'),
-                    'bottom-center': "Bottom-Center"|t('app'),
-                    'bottom-right': "Bottom-Right"|t('app')
-                },
-                value: transform.mode in ['crop', 'fit'] ? transform.position : 'center-center'
+                value: transform.mode in ['crop', 'letterbox'] ? transform.position : 'center-center'
             }) }}
         </div>
 
@@ -238,20 +222,20 @@
     $('#mode input').change(function() {
         const value = $(this).val();
 
-        // Crop mode requires a default focal point:
-        if (value == 'crop') {
+        // Letterbox mode requires a position:
+        if (value == 'letterbox') {
+            $('#fill-color').removeClass('hidden');
+            $('#position-container label[for="position"]').text(`{{ letterboxPositionLabel }}`);
+        } else {
+            $('#fill-color').addClass('hidden');
+            $('#position-container label[for="position"]').text(`{{ defaultPositionLabel }}`);
+        }
+
+        // Crop and letterbox modes requires a position:
+        if (value == 'crop' || value == 'letterbox') {
             $('#position-container').removeClass('hidden');
         } else {
             $('#position-container').addClass('hidden');
-        }
-
-        // Letterbox mode requires a position, as well:
-        if (value == 'letterbox') {
-            $('#fill-color').removeClass('hidden')
-            $('#letterbox-position-container').removeClass('hidden')
-        } else {
-            $('#fill-color').addClass('hidden')
-            $('#letterbox-position-container').addClass('hidden')
         }
     });
 


### PR DESCRIPTION
### Description

issue 1:
position (Default Focal Point) was not showing if you changed the transform mode to “fit”, but it was showing if you saved a “fit” mode transform and then edited it; the `position` dropdown should only be available for crop and letterbox transform modes;


issue 2:
because we had two `position` dropdowns in the markup (one for the “crop” mode, with “Default Focal Point” label, and one for the “letterbox” mode, with “Image Position” label), whatever was selected for the “letterbox” transform, was then overwritten by the hidden “crop” position value.

### Related issues
#16648 
