### PR TITLE
[4.x][5.x] Fixed condition rules losing their condition when being created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fixed a bug where “Fit” image transforms were showing the “Default Focal Point” setting. ([#16665](https://github.com/craftcms/cms/pull/16665))
 - Fixed a bug where the “Image Position” setting wasn’t saving for “Letterbox” image transforms. ([#16648](https://github.com/craftcms/cms/issues/16648))
 - Fixed a bug where the `up` command, the `app/migrate` action, and the Project Config utility weren’t aware of pending project config changes if a database backup was restored but caches weren’t cleared. ([#16668](https://github.com/craftcms/cms/issues/16668))
-- Fixed a bug where the creation of a condition rule wouldn’t have the condition set. ([#16676](https://github.com/craftcms/cms/pull/16676))
+- Fixed a bug where condition rules weren’t always getting created with their condition set. ([#16676](https://github.com/craftcms/cms/pull/16676))
 - Fixed a potential phishing attack vector.
 
 ## 4.14.4 - 2025-02-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug where “Fit” image transforms were showing the “Default Focal Point” setting. ([#16665](https://github.com/craftcms/cms/pull/16665))
 - Fixed a bug where the “Image Position” setting wasn’t saving for “Letterbox” image transforms. ([#16648](https://github.com/craftcms/cms/issues/16648))
 - Fixed a bug where the `up` command, the `app/migrate` action, and the Project Config utility weren’t aware of pending project config changes if a database backup was restored but caches weren’t cleared. ([#16668](https://github.com/craftcms/cms/issues/16668))
+- Fixed a bug where the creation of a condition rule wouldn’t have the condition set. ([#16676](https://github.com/craftcms/cms/pull/16676))
 - Fixed a potential phishing attack vector.
 
 ## 4.14.4 - 2025-02-04

--- a/src/services/Conditions.php
+++ b/src/services/Conditions.php
@@ -96,6 +96,11 @@ class Conditions extends Component
                     $newClass = ArrayHelper::remove($newConfig, 'class');
                 }
 
+                // Make sure the condition is being passed to the condition rule when it's being constructed
+                if (isset($config['condition'])) {
+                    $newConfig['condition'] = $config['condition'];
+                }
+
                 // Is the type changing?
                 if ($class !== null && $newClass !== $class) {
                     // Remove any config attributes that aren't defined by the same class between both types


### PR DESCRIPTION
### Description
Tracking through the creation of a condition rule. The condition is set in the config when [creating a rule on a condition](https://github.com/craftcms/cms/blob/5.x/src/base/conditions/BaseCondition.php#L110) (mostly applicable in `5.x`) however the condition [can be lost when creating the new config for the rule](https://github.com/craftcms/cms/blob/4.x/src/services/Conditions.php#L90-L115).

This means when the new rule class is created it does not have the condition available.

This PR is applicable for both `4.x` and `5.x`.

### Related issues
craftcms/commerce#3890
