### PR TITLE
Enable Rector php7.2 set

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -19,4 +19,4 @@ return RectorConfig::configure()
         // autoload may need to be bootstrapped to early load some child classes
         RemoveExtraParametersRector::class,
     ])
-    ->withPhpSets(php71: true);
+    ->withPhpSets(php72: true);

--- a/src/fieldlayoutelements/CustomField.php
+++ b/src/fieldlayoutelements/CustomField.php
@@ -251,7 +251,7 @@ class CustomField extends BaseField
         return ArrayHelper::merge(parent::containerAttributes($element, $static), [
             'id' => "{$this->_field->handle}-field",
             'data' => [
-                'type' => get_class($this->_field),
+                'type' => $this->_field !== null ? get_class($this->_field) : self::class,
             ],
         ]);
     }

--- a/src/fieldlayoutelements/CustomField.php
+++ b/src/fieldlayoutelements/CustomField.php
@@ -248,10 +248,13 @@ class CustomField extends BaseField
      */
     protected function containerAttributes(?ElementInterface $element = null, bool $static = false): array
     {
+        /** @var FieldInterface $field */
+        $field = $this->_field;
+
         return ArrayHelper::merge(parent::containerAttributes($element, $static), [
             'id' => "{$this->_field->handle}-field",
             'data' => [
-                'type' => $this->_field !== null ? get_class($this->_field) : self::class,
+                'type' => get_class($field),
             ],
         ]);
     }

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -302,8 +302,9 @@ class Fields extends Component
         }
 
         // Make sure the current field class is in there if it's supposed to be
-        if ($includeCurrent && !in_array($field !== null ? get_class($field) : self::class, $types, true)) {
-            $types[] = $field !== null ? get_class($field) : self::class;
+        /** @var FieldInterface $field */
+        if ($includeCurrent && !in_array(get_class($field), $types, true)) {
+            $types[] = get_class($field);
         }
 
         // Fire a 'defineCompatibleFieldTypes' event

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -302,8 +302,8 @@ class Fields extends Component
         }
 
         // Make sure the current field class is in there if it's supposed to be
-        if ($includeCurrent && !in_array(get_class($field), $types, true)) {
-            $types[] = get_class($field);
+        if ($includeCurrent && !in_array($field !== null ? get_class($field) : self::class, $types, true)) {
+            $types[] = $field !== null ? get_class($field) : self::class;
         }
 
         // Fire a 'defineCompatibleFieldTypes' event


### PR DESCRIPTION
### Description

Applied rule: `GetClassOnNullRector` from php 7.2 set to change get_class() with null argument to use self::class.

### Related issues

