### PR TITLE
Enable Rector php7.3 set

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -19,4 +19,4 @@ return RectorConfig::configure()
         // autoload may need to be bootstrapped to early load some child classes
         RemoveExtraParametersRector::class,
     ])
-    ->withPhpSets(php72: true);
+    ->withPhpSets(php73: true);

--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -42,7 +42,7 @@ class Db
     public const SIMPLE_TYPE_TEXTUAL = 'textual';
 
     /**
-     * @var array
+     * @var string[]
      */
     private static array $_operators = ['not ', '!=', '<=', '>=', '<', '>', '='];
 

--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -970,7 +970,7 @@ class Html extends \yii\helpers\Html
      * Replaces textareas with markers
      *
      * @param string $html
-     * @return array
+     * @return array<string, string>
      */
     private static function _escapeTextareas(string &$html): array
     {
@@ -1013,8 +1013,7 @@ class Html extends \yii\helpers\Html
      * Replaces markers with textareas.
      *
      * @param string $html
-     * @param array $markers
-     * @return string
+     * @param array<string, string> $markers
      */
     private static function _restoreTextareas(string $html, array $markers): string
     {

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -8,7 +8,6 @@
 namespace craft\web\twig;
 
 use CommerceGuys\Addressing\Formatter\FormatterInterface;
-use Countable;
 use Craft;
 use craft\base\ElementInterface;
 use craft\base\FieldLayoutProviderInterface;
@@ -320,9 +319,6 @@ class Extension extends AbstractExtension implements GlobalsInterface
                 return is_callable($obj);
             }),
             new TwigTest('countable', function($obj): bool {
-                if (!function_exists('is_countable')) {
-                    return is_array($obj) || $obj instanceof Countable;
-                }
                 return is_countable($obj);
             }),
             new TwigTest('float', function($obj): bool {
@@ -1266,7 +1262,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
     public function indexOfFilter(mixed $haystack, mixed $needle, ?int $default = -1): ?int
     {
         if (is_string($haystack)) {
-            $index = strpos($haystack, $needle);
+            $index = strpos($haystack, (string) $needle);
         } elseif (is_array($haystack)) {
             $index = array_search($needle, $haystack, false);
         } elseif (is_object($haystack) && $haystack instanceof IteratorAggregate) {


### PR DESCRIPTION
### Description

- [x] Ensure array docblock correctly set on usage on string functions when it always string data
- [x] replace is_array() and instanceof Countable to `is_countable()` as function already exists.
- [x] Ensure cast to string for mixed typed needle on strpos

### Related issues

