### PR TITLE
on activation, clear out events so they don't stack up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where multiple “New file uploaded.” notifications could be shown at once. ([#16688](https://github.com/craftcms/cms/issues/16688))
+
 ## 4.14.5 - 2025-02-11
 
 - Fixed a bug where multi-site elements’ search indexes could be updated twice.

--- a/src/elements/actions/ReplaceFile.php
+++ b/src/elements/actions/ReplaceFile.php
@@ -48,6 +48,7 @@ class ReplaceFile extends ElementAction
             settings.fileInput = \$fileInput;
             settings.paramName = 'replaceFile';
             settings.replace = true;
+            settings.events = {};
 
             const fileuploaddone = settings.events?.fileuploaddone;
             settings.events = Object.assign({}, settings.events || {}, {


### PR DESCRIPTION
### Description
When activating the `ReplaceFile` event, clear out any previous events so that the toast notifications don’t stack up even after being dismissed.


### Related issues
#16688 
