### PR TITLE
`element`, `entry`, etc. sub-fields for Link GQL fields

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -14,11 +14,13 @@
 - Added `bluesky`, `flickr`, `mastodon`, and `medium` icons.
 
 ### Development
-- Added `defaultLabel`, `elementSlug`, and `elementUri` nested fields to Link fields’ GraphQL data. ([#16637](https://github.com/craftcms/cms/issues/16637), [#16104](https://github.com/craftcms/cms/discussions/16104))
+- Added the `defaultLabel` nested field to Link fields’ GraphQL data. ([#16637](https://github.com/craftcms/cms/issues/16637))
+- Added `element`, `asset`, `entry`, etc., nested fields to Link fields’ GraphQL data. ([#16698](https://github.com/craftcms/cms/pull/16698))
 
 ### Extensibility
 - Global nav items and breadcrumbs can now have `aria-label` attributes via an `ariaLabel` property.
 - Editable tables now support `icon` columns.
+- Added `craft\base\ElementInterface::baseGqlType()`.
 - Added `craft\base\ElementInterface::getSerializedFieldValuesForDb()`.
 - Added `craft\base\FieldInterface::serializeValueForDb()`.
 - Added `craft\db\Table::BULKOPEVENTS`.
@@ -28,6 +30,7 @@
 - Added `craft\fields\BaseOptionsField::$optionColors`, which can be set to `true` by subclasses to enable the “Color” setting for field options. ([#16645](https://github.com/craftcms/cms/pull/16645))
 - Added `craft\fields\BaseOptionsField::$optionIcons`, which can be set to `true` by subclasses to enable the “Icon” setting for field options. ([#16645](https://github.com/craftcms/cms/pull/16645))
 - Added `craft\fields\data\ColorData::$label`. ([#16492](https://github.com/craftcms/cms/pull/16492))
+- Added `craft\fields\linktypes\BaseElementLinkType::elementGqlType()`.
 - Added `craft\queue\ReleasableQueueInterface`. ([#16672](https://github.com/craftcms/cms/pull/16672))
 - Added `craft\services\Elements::getBulkOpKeys()`.
 - Added `craft\services\Search::indexElementIfQueued()`.

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -66,6 +66,7 @@ use craft\events\SetEagerLoadedElementsEvent;
 use craft\events\SetElementRouteEvent;
 use craft\fieldlayoutelements\BaseField;
 use craft\fieldlayoutelements\CustomField;
+use craft\gql\interfaces\Element as ElementGqlType;
 use craft\helpers\App;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
@@ -86,6 +87,7 @@ use craft\validators\SlugValidator;
 use craft\validators\StringValidator;
 use craft\web\UploadedFile;
 use DateTime;
+use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Collection;
 use ReflectionClass;
 use Throwable;
@@ -2128,6 +2130,14 @@ abstract class Element extends Component implements ElementInterface
             'elementType' => User::class,
             'map' => $map,
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function baseGqlType(): Type
+    {
+        return ElementGqlType::getType();
     }
 
     /**

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -18,6 +18,7 @@ use craft\enums\AttributeStatus;
 use craft\errors\InvalidFieldException;
 use craft\models\FieldLayout;
 use craft\models\Site;
+use GraphQL\Type\Definition\Type;
 use Twig\Markup;
 use yii\web\Response;
 
@@ -613,6 +614,14 @@ interface ElementInterface extends
      * should be ignored
      */
     public static function eagerLoadingMap(array $sourceElements, string $handle): array|null|false;
+
+    /**
+     * Returns the base GraphQL type name that represents elements of this type.
+     *
+     * @return Type
+     * @since 5.7.0
+     */
+    public static function baseGqlType(): Type;
 
     /**
      * Returns the GraphQL scopes required by element’s context.

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -46,6 +46,7 @@ use craft\events\AssetEvent;
 use craft\events\DefineAssetUrlEvent;
 use craft\events\GenerateTransformEvent;
 use craft\fieldlayoutelements\assets\AltField;
+use craft\gql\interfaces\elements\Asset as AssetInterface;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Assets;
 use craft\helpers\Cp;
@@ -72,6 +73,7 @@ use craft\validators\AssetLocationValidator;
 use craft\validators\DateTimeValidator;
 use craft\validators\StringValidator;
 use DateTime;
+use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Collection;
 use Throwable;
 use Twig\Markup;
@@ -344,6 +346,14 @@ class Asset extends Element
     public static function gqlTypeName(Volume $volume): string
     {
         return sprintf('%s_Asset', $volume->handle);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function baseGqlType(): Type
+    {
+        return AssetInterface::getType();
     }
 
     /**

--- a/src/elements/Category.php
+++ b/src/elements/Category.php
@@ -21,6 +21,7 @@ use craft\elements\conditions\categories\CategoryCondition;
 use craft\elements\conditions\ElementConditionInterface;
 use craft\elements\db\CategoryQuery;
 use craft\elements\db\ElementQuery;
+use craft\gql\interfaces\elements\Category as CategoryInterface;
 use craft\helpers\Cp;
 use craft\helpers\Db;
 use craft\helpers\Html;
@@ -30,6 +31,7 @@ use craft\models\FieldLayout;
 use craft\records\Category as CategoryRecord;
 use craft\services\ElementSources;
 use craft\services\Structures;
+use GraphQL\Type\Definition\Type;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
 
@@ -156,6 +158,14 @@ class Category extends Element
     public static function gqlTypeName(CategoryGroup $categoryGroup): string
     {
         return sprintf('%s_Category', $categoryGroup->handle);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function baseGqlType(): Type
+    {
+        return CategoryInterface::getType();
     }
 
     /**

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -44,6 +44,7 @@ use craft\enums\PropagationMethod;
 use craft\events\DefineEntryTypesEvent;
 use craft\events\ElementCriteriaEvent;
 use craft\fieldlayoutelements\entries\EntryTitleField;
+use craft\gql\interfaces\elements\Entry as EntryInterface;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
 use craft\helpers\DateTimeHelper;
@@ -63,6 +64,7 @@ use craft\validators\ArrayValidator;
 use craft\validators\DateCompareValidator;
 use craft\validators\DateTimeValidator;
 use DateTime;
+use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Throwable;
@@ -741,6 +743,14 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
     public static function gqlTypeName(EntryType $entryType): string
     {
         return sprintf('%s_Entry', $entryType->handle);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function baseGqlType(): Type
+    {
+        return EntryInterface::getType();
     }
 
     /**

--- a/src/elements/Tag.php
+++ b/src/elements/Tag.php
@@ -13,10 +13,12 @@ use craft\db\Table;
 use craft\elements\conditions\ElementConditionInterface;
 use craft\elements\conditions\tags\TagCondition;
 use craft\elements\db\TagQuery;
+use craft\gql\interfaces\elements\Tag as TagInterface;
 use craft\helpers\Db;
 use craft\models\FieldLayout;
 use craft\models\TagGroup;
 use craft\records\Tag as TagRecord;
+use GraphQL\Type\Definition\Type;
 use yii\base\InvalidConfigException;
 use yii\validators\InlineValidator;
 
@@ -137,6 +139,14 @@ class Tag extends Element
     public static function gqlTypeName(TagGroup $tagGroup): string
     {
         return sprintf('%s_Tag', $tagGroup->handle);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function baseGqlType(): Type
+    {
+        return TagInterface::getType();
     }
 
     /**

--- a/src/fields/linktypes/BaseElementLinkType.php
+++ b/src/fields/linktypes/BaseElementLinkType.php
@@ -15,6 +15,7 @@ use craft\fields\Link;
 use craft\helpers\Cp;
 use craft\helpers\Html;
 use craft\services\ElementSources;
+use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Collection;
 use yii\base\InvalidArgumentException;
 
@@ -47,6 +48,17 @@ abstract class BaseElementLinkType extends BaseLinkType
     public static function displayName(): string
     {
         return static::elementType()::displayName();
+    }
+
+    /**
+     * Returns the GraphQL type that elements of this type should
+     *
+     * @return Type
+     * @since 5.7.0
+     */
+    public static function elementGqlType(): Type
+    {
+        return static::elementType()::baseGqlType();
     }
 
     /**

--- a/src/gql/types/LinkData.php
+++ b/src/gql/types/LinkData.php
@@ -36,9 +36,7 @@ class LinkData extends ObjectType
             'elementType' => $source->getElement() ? $source->getElement()::class : null,
             'elementId' => $source->getElement()?->id,
             'elementSiteId' => $source->getElement()?->siteId,
-            'elementSlug' => $source->getElement()?->slug,
             'elementTitle' => $source->getElement() ? (string)$source->getElement() : null,
-            'elementUri' => $source->getElement()?->uri,
             default => $source->$fieldName,
         };
     }

--- a/src/gql/types/generators/LinkDataType.php
+++ b/src/gql/types/generators/LinkDataType.php
@@ -8,10 +8,14 @@
 namespace craft\gql\types\generators;
 
 use Craft;
+use craft\fields\data\LinkData as LinkFieldData;
+use craft\fields\Link;
+use craft\fields\linktypes\BaseElementLinkType;
 use craft\gql\base\GeneratorInterface;
 use craft\gql\base\ObjectType;
 use craft\gql\base\SingleGeneratorInterface;
 use craft\gql\GqlEntityRegistry;
+use craft\gql\interfaces\Element;
 use craft\gql\types\LinkData;
 use GraphQL\Type\Definition\Type;
 
@@ -47,27 +51,59 @@ class LinkDataType implements GeneratorInterface, SingleGeneratorInterface
         $typeName = self::getName();
         return GqlEntityRegistry::getOrCreate($typeName, fn() => new LinkData([
             'name' => $typeName,
-            'fields' => fn() => Craft::$app->getGql()->prepareFieldDefinitions([
-                'type' => Type::string(),
-                'value' => Type::string(),
-                'label' => Type::string(),
-                'defaultLabel' => Type::string(),
-                'urlSuffix' => Type::string(),
-                'url' => Type::string(),
-                'link' => Type::string(),
-                'target' => Type::string(),
-                'title' => Type::string(),
-                'class' => Type::string(),
-                'id' => Type::string(),
-                'rel' => Type::string(),
-                'ariaLabel' => Type::string(),
-                'elementType' => Type::string(),
-                'elementId' => Type::int(),
-                'elementSiteId' => Type::int(),
-                'elementSlug' => Type::string(),
-                'elementTitle' => Type::string(),
-                'elementUri' => Type::string(),
-            ], $typeName),
+            'fields' => function() use ($context, $typeName) {
+                $fields = [
+                    'type' => Type::string(),
+                    'value' => Type::string(),
+                    'label' => Type::string(),
+                    'defaultLabel' => Type::string(),
+                    'urlSuffix' => Type::string(),
+                    'url' => Type::string(),
+                    'link' => Type::string(),
+                    'target' => Type::string(),
+                    'title' => Type::string(),
+                    'class' => Type::string(),
+                    'id' => Type::string(),
+                    'rel' => Type::string(),
+                    'ariaLabel' => Type::string(),
+                    'elementType' => Type::string(),
+                    'elementId' => Type::int(),
+                    'elementSiteId' => Type::int(),
+                    'elementSlug' => Type::string(),
+                    'elementTitle' => Type::string(),
+                    'elementUri' => Type::string(),
+                ];
+
+                if ($context instanceof Link) {
+                    $hasElementType = false;
+
+                    foreach ($context->getLinkTypes() as $linkType) {
+                        if ($linkType instanceof BaseElementLinkType) {
+                            $hasElementType = true;
+                            $fields[$linkType::id()] = [
+                                'name' => $linkType::id(),
+                                'type' => $linkType::elementGqlType(),
+                                'resolve' => function(LinkFieldData $value) use ($linkType) {
+                                    if ($value->getType() === $linkType::id()) {
+                                        return $value->getElement();
+                                    }
+                                    return null;
+                                },
+                            ];
+                        }
+                    }
+
+                    if ($hasElementType) {
+                        $fields['element'] = [
+                            'name' => 'element',
+                            'type' => Element::getType(),
+                            'resolve' => fn(LinkFieldData $value) => $value->getElement(),
+                        ];
+                    }
+                }
+
+                return Craft::$app->getGql()->prepareFieldDefinitions($fields, $typeName);
+            },
         ]));
     }
 }

--- a/src/gql/types/generators/LinkDataType.php
+++ b/src/gql/types/generators/LinkDataType.php
@@ -69,9 +69,7 @@ class LinkDataType implements GeneratorInterface, SingleGeneratorInterface
                     'elementType' => Type::string(),
                     'elementId' => Type::int(),
                     'elementSiteId' => Type::int(),
-                    'elementSlug' => Type::string(),
                     'elementTitle' => Type::string(),
-                    'elementUri' => Type::string(),
                 ];
 
                 if ($context instanceof Link) {


### PR DESCRIPTION
### Description

Adds support for accessing linked element data to Link fields over GraphQL.

```graphql
query{
  entries (section:"news", type:"link") {
    title
    ...on link_Entry {
      linkUrl{
        label
        defaultLabel
        element {
          id
          slug
          uri
          # ...
        }
        entry {
          id
          postDate
          # ...
        }
      }
    }
  }
}
```

Each selected element type will get an element-type specific field (`asset`, `entry`, etc.), and there’s also a generic `element` field that can be used for generic element data if that’s all you need.

### Related issues

- #16104
- https://github.com/craftcms/cms/issues/16667#issuecomment-2651672931