### PR TITLE
fix Getting unknown property: craft\console\Request::actionSegments from queue jobs

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1541,7 +1541,7 @@ JS;
                     $entry->getPrimaryOwnerId() === $element->getCanonicalId() &&
                     // this is so that extra drafts don't get created for matrix in matrix scenario
                     // where both are set to inline-editable blocks view mode
-                    Craft::$app->getRequest()->actionSegments !== ['elements', 'update-field-layout']
+                    (!Craft::$app->getRequest()->isSiteRequest || Craft::$app->getRequest()->actionSegments !== ['elements', 'update-field-layout'])
                 ) {
                     // Duplicate it as a draft. (We'll drop its draft status from NestedElementManager::saveNestedElements().)
                     $entry = Craft::$app->getDrafts()->createDraft($entry, Craft::$app->getUser()->getId(), null, null, [


### PR DESCRIPTION
## Description
actionSegments are only available when Craft::$app->getRequest()->isSiteRequest

So this fixes an error that occurs when:
- code is executed in a queue job
- a draft Entry was created from the drafts service
- serialized array is passed as a value to the matrix field
- you want to save the element (draft)

For example from this line:
https://github.com/digitalpulsebe/craft-multi-translator/blob/faa15ae8cff04d0bef92e07d0194c233ea0096d6/src/services/TranslateService.php#L81

## Related issues
https://github.com/digitalpulsebe/craft-multi-translator/issues/40

