### PR TITLE
Parse `orderBy` expressions for column mappings

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -17,6 +17,7 @@
 - Added the `defaultLabel` nested field to Link fields’ GraphQL data. ([#16637](https://github.com/craftcms/cms/issues/16637))
 - Added `element`, `asset`, `entry`, etc., nested fields to Link fields’ GraphQL data. ([#16698](https://github.com/craftcms/cms/pull/16698))
 - Added the `withProvisionalDrafts` GraphQL element query argument. ([#16720](https://github.com/craftcms/cms/pull/16720))
+- It’s now possible to reference custom field handles in advanced element query `orderBy` expressions. ([#16729](https://github.com/craftcms/cms/pull/16729))
 
 ### Extensibility
 - Global nav items and breadcrumbs can now have `aria-label` attributes via an `ariaLabel` property.

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -3365,32 +3365,21 @@ class ElementQuery extends Query implements ElementQueryInterface
             $orderBy = array_filter($orderBy, fn($value) => !$value instanceof OrderByPlaceholderExpression);
         }
 
-        // Rename orderBy keys based on the real column name mapping
-        // (yes this is awkward but we need to preserve the order of the keys!)
+        // Parse orderBy keys for column mappings
         $orderByColumns = array_keys($orderBy);
-
-        foreach (array_keys($this->_columnMap) as $orderValue) {
-            // Are we ordering by this column name?
-            $pos = array_search($orderValue, $orderByColumns, true);
-
-            if ($pos !== false) {
-                $columnName = $this->_resolveColumnMapping($orderValue);
-
-                // Swap it with the mapped column name
-                if (is_array($columnName)) {
-                    $params = [];
-                    $orderByColumns[$pos] = (new CoalesceColumnsExpression($columnName))->getSql($params);
-                } else {
-                    if (isset($this->_columnsToCast[$orderValue])) {
-                        $orderByColumns[$pos] = "CAST($columnName AS {$this->_columnsToCast[$orderValue]})";
-                    } else {
-                        $orderByColumns[$pos] = $columnName;
-                    }
-                }
-
-                $orderBy = array_combine($orderByColumns, $orderBy);
+        foreach ($orderByColumns as $i => $column) {
+            $parsed = $this->_parseStrForColumnMappings($column);
+            // add CAST()?
+            if (
+                isset($this->_columnsToCast[$column]) &&
+                !str_contains($parsed, 'COALESCE(')
+            ) {
+                $orderByColumns[$i] = "CAST($parsed AS {$this->_columnsToCast[$column]})";
+            } else {
+                $orderByColumns[$i] = $parsed;
             }
         }
+        $orderBy = array_combine($orderByColumns, $orderBy);
 
         // swap `score` direction value with a fixed order expression
         if (isset($this->_searchResults)) {
@@ -3596,7 +3585,7 @@ class ElementQuery extends Query implements ElementQueryInterface
         }
 
         if (is_string($this->where)) {
-            $where = $this->_parseStringCondition($this->where);
+            $where = $this->_parseStrForColumnMappings($this->where);
         } elseif (is_array($this->where)) {
             $where = $this->_parseArrayCondition($this->where);
         } else {
@@ -3606,14 +3595,14 @@ class ElementQuery extends Query implements ElementQueryInterface
         $this->subQuery->andWhere($where);
     }
 
-    private function _parseStringCondition(string $condition): string
+    private function _parseStrForColumnMappings(string $str): string
     {
-        if (!str_contains($condition, '[')) {
-            return $this->_resolveColumnMappingForCondition($condition) ?? $condition;
+        if (!str_contains($str, '[')) {
+            return $this->_columnMappingSql($str) ?? $str;
         }
 
         return preg_replace_callback('/\[\[(\w+(?:\.\w+)?)]]/', function(array $match) {
-            $mapping = $this->_resolveColumnMappingForCondition($match[1]);
+            $mapping = $this->_columnMappingSql($match[1]);
             if ($mapping === null) {
                 return $match[0];
             }
@@ -3621,10 +3610,10 @@ class ElementQuery extends Query implements ElementQueryInterface
                 return "[[$mapping]]";
             }
             return $mapping;
-        }, $condition);
+        }, $str);
     }
 
-    private function _resolveColumnMappingForCondition(string $str): ?string
+    private function _columnMappingSql(string $str): ?string
     {
         if (!isset($this->_columnMap[$str])) {
             return null;
@@ -3646,7 +3635,7 @@ class ElementQuery extends Query implements ElementQueryInterface
             if (in_array($operator, ['NOT', 'AND', 'OR'])) {
                 foreach ($condition as $value) {
                     if (is_string($value)) {
-                        $value = $this->_parseStringCondition($value);
+                        $value = $this->_parseStrForColumnMappings($value);
                     } elseif (is_array($value)) {
                         $value = $this->_parseArrayCondition($value);
                     }
@@ -3654,14 +3643,14 @@ class ElementQuery extends Query implements ElementQueryInterface
                 }
             } else {
                 if (isset($condition[0]) && is_string($condition[0])) {
-                    $condition[0] = $this->_resolveColumnMappingForCondition($condition[0]) ?? $condition[0];
+                    $condition[0] = $this->_columnMappingSql($condition[0]) ?? $condition[0];
                 }
                 array_push($parsed, ...$condition);
             }
         } else {
             // Hash format: [column => value]
             foreach ($condition as $key => $value) {
-                $key = $this->_resolveColumnMappingForCondition($key) ?? $key;
+                $key = $this->_columnMappingSql($key) ?? $key;
                 $parsed[$key] = $value;
             }
         }


### PR DESCRIPTION
### Description

Expands on #16318, adding column mapping parsing for `orderBy` expressions.

```php
{% set entries = craft.entries()
  .section('notes')
  .orderBy('ISNULL([[datePublished]]), datePublished ASC, title ASC')
  .all() %}
```

### Related issues

- #16725