### PR TITLE
Cite CVE-2025-23209 directly in release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,7 +400,7 @@
 - Fixed an error that occurred when adding “Full Name” to user cards. ([#16358](https://github.com/craftcms/cms/issues/16358))
 - Fixed an error that could occur if `craft\base\NestedElementTrait::getOwner()` or `getPrimaryOwner()` were called on a nested element whose owner didn’t exist in the same site. ([#16359](https://github.com/craftcms/cms/issues/16359))
 - Fixed a styling issue. ([#16342](https://github.com/craftcms/cms/issues/16342))
-- Fixed an RCE vulnerability.
+- Fixed an RCE vulnerability, [CVE-2025-23209](https://www.cve.org/CVERecord?id=CVE-2025-23209).
 
 ## 5.5.7 - 2024-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,7 +400,7 @@
 - Fixed an error that occurred when adding “Full Name” to user cards. ([#16358](https://github.com/craftcms/cms/issues/16358))
 - Fixed an error that could occur if `craft\base\NestedElementTrait::getOwner()` or `getPrimaryOwner()` were called on a nested element whose owner didn’t exist in the same site. ([#16359](https://github.com/craftcms/cms/issues/16359))
 - Fixed a styling issue. ([#16342](https://github.com/craftcms/cms/issues/16342))
-- Fixed an RCE vulnerability, [CVE-2025-23209](https://www.cve.org/CVERecord?id=CVE-2025-23209).
+- Fixed an RCE vulnerability. ([CVE-2025-23209](https://www.cve.org/CVERecord?id=CVE-2025-23209))
 
 ## 5.5.7 - 2024-12-17
 


### PR DESCRIPTION
### Description

Be clear about which RCE was fixed by calling out CVE-2025-23209 directly.
