### PR TITLE
accept any value for the rel attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `craft\htmlpurifier\RelAttrLinkTypeDef`.
+- The default HTML Purifier config now allows `rel` attributes to be set to any value. ([#16798](https://github.com/craftcms/cms/pull/16798))
 - Fixed an error that could occur when generating an image transform URL via a console request. ([#16793](https://github.com/craftcms/cms/issues/16793))
 - Fixed a bug where `_includes/forms/button.twig` was always adding `class="btngroup-btn-first"` to the resulting button HTML.
 

--- a/src/helpers/HtmlPurifier.php
+++ b/src/helpers/HtmlPurifier.php
@@ -7,6 +7,7 @@
 
 namespace craft\helpers;
 
+use craft\htmlpurifier\RelAttrLinkTypeDef;
 use craft\htmlpurifier\VideoEmbedUrlDef;
 use HTMLPurifier_Config;
 use HTMLPurifier_Encoder;
@@ -83,6 +84,8 @@ class HtmlPurifier extends \yii\helpers\HtmlPurifier
 
             $def->addElement('oembed', 'Block', 'Inline', 'Common');
             $def->addAttribute('oembed', 'url', new VideoEmbedUrlDef());
+
+            $def->addAttribute('a', 'rel', new RelAttrLinkTypeDef('rel'));
         }
     }
 }

--- a/src/htmlpurifier/RelAttrLinkTypeDef.php
+++ b/src/htmlpurifier/RelAttrLinkTypeDef.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\htmlpurifier;
+
+use HTMLPurifier_AttrDef_HTML_LinkTypes;
+
+/**
+ * Class VideoEmbedUrlDef
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.14.10
+ */
+class RelAttrLinkTypeDef extends HTMLPurifier_AttrDef_HTML_LinkTypes
+{
+    public function validate($string, $config, $context)
+    {
+        // allow any value in the "rel" attribute
+        $allowed = $config->get('Attr.' . $this->name);
+        if (isset($allowed['*']) && $allowed['*']) {
+            return $string;
+        }
+
+        return parent::validate($string, $config, $context);
+    }
+}


### PR DESCRIPTION
### Description
Allow `"Attr.AllowedRel"` HTML Purifier config property to have a value of `"*"`, in which case any value is allowed for the `rel` attribute (on an `a` tag).


### Related issues
[PT-2002](https://linear.app/craftcms/issue/PT-2002/updated-link-modal)
