### PR TITLE
Interface DocBlock @template

### DIFF
--- a/src/elements/conditions/ElementConditionInterface.php
+++ b/src/elements/conditions/ElementConditionInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @link https://craftcms.com/
  * @copyright Copyright (c) Pixel & Tonic, Inc.

--- a/src/elements/conditions/ElementConditionInterface.php
+++ b/src/elements/conditions/ElementConditionInterface.php
@@ -28,7 +28,7 @@ interface ElementConditionInterface extends ConditionInterface
     /**
      * Modifies a given query based on the configured condition rules.
      *
-     * @param T $query
+     * @param TQuery $query
      */
     public function modifyQuery(ElementQueryInterface $query): void;
 

--- a/src/elements/conditions/ElementConditionInterface.php
+++ b/src/elements/conditions/ElementConditionInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://craftcms.com/
  * @copyright Copyright (c) Pixel & Tonic, Inc.
@@ -16,6 +17,8 @@ use craft\elements\db\ElementQueryInterface;
  *
  * A base implementation is provided by [[ElementCondition]].
  *
+ * @template TQuery of ElementQueryInterface
+ * @template TElement of ElementInterface
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.0.0
  * @mixin ElementCondition
@@ -25,14 +28,14 @@ interface ElementConditionInterface extends ConditionInterface
     /**
      * Modifies a given query based on the configured condition rules.
      *
-     * @param ElementQueryInterface $query
+     * @param T $query
      */
     public function modifyQuery(ElementQueryInterface $query): void;
 
     /**
      * Returns whether the given element matches the condition.
      *
-     * @param ElementInterface $element
+     * @param TElement $element
      * @return bool
      */
     public function matchElement(ElementInterface $element): bool;

--- a/src/elements/conditions/ElementConditionRuleInterface.php
+++ b/src/elements/conditions/ElementConditionRuleInterface.php
@@ -14,6 +14,8 @@ use craft\elements\db\ElementQueryInterface;
 /**
  * ElementConditionRuleInterface defines the common interface to be implemented by element condition rule classes.
  *
+ * @template TQuery of ElementQueryInterface
+ * @template TElement of ElementInterface
  * @property-read string[] $exclusiveQueryParams The query param names that this rule should have exclusive control over
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.0.0
@@ -30,14 +32,14 @@ interface ElementConditionRuleInterface extends ConditionRuleInterface
     /**
      * Modifies the given query with the condition rule.
      *
-     * @param ElementQueryInterface $query
+     * @param TQuery $query
      */
     public function modifyQuery(ElementQueryInterface $query): void;
 
     /**
      * Returns whether the given element matches the condition rule.
      *
-     * @param ElementInterface $element
+     * @param TElement $element
      * @return bool
      */
     public function matchElement(ElementInterface $element): bool;


### PR DESCRIPTION
### Description
Allow for `@template` DocBlock usage in classes implementing the following classes for improved static analysis:
- `\craft\elements\db\ElementConditionInterface`
- `\craft\elements\db\ElementConditionRuleInterface`

### Related issues
n/a