### PR TITLE
don't show alternative save actions for nested elements

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -3809,17 +3809,19 @@ abstract class Element extends Component implements ElementInterface
         ];
 
         if ($this->getIsCanonical() || $this->isProvisionalDraft) {
-            $newElement = $this->createAnother();
-            if ($newElement && $elementsService->canSave($newElement)) {
-                $altActions[] = [
-                    'label' => $isUnpublishedDraft && $canSaveCanonical
-                        ? Craft::t('app', 'Create and add another')
-                        : Craft::t('app', 'Save and add another'),
-                    'shortcut' => true,
-                    'shift' => true,
-                    'eventData' => ['autosave' => false],
-                    'params' => ['addAnother' => 1],
-                ];
+            if (!ElementHelper::isNestedElement($this)) {
+                $newElement = $this->createAnother();
+                if ($newElement && $elementsService->canSave($newElement)) {
+                    $altActions[] = [
+                        'label' => $isUnpublishedDraft && $canSaveCanonical
+                            ? Craft::t('app', 'Create and add another')
+                            : Craft::t('app', 'Save and add another'),
+                        'shortcut' => true,
+                        'shift' => true,
+                        'eventData' => ['autosave' => false],
+                        'params' => ['addAnother' => 1],
+                    ];
+                }
             }
 
             if ($canSaveCanonical && $isUnpublishedDraft) {
@@ -3833,7 +3835,11 @@ abstract class Element extends Component implements ElementInterface
                 ];
             }
 
-            if (!$this->getIsRevision() && $elementsService->canDuplicateAsDraft($this)) {
+            if (
+                !$this->getIsRevision() &&
+                $elementsService->canDuplicateAsDraft($this) &&
+                !ElementHelper::isNestedElement($this)
+            ) {
                 $altActions[] = [
                     'label' => Craft::t('app', 'Save as a new {type}', [
                         'type' => static::lowerDisplayName(),

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -1092,4 +1092,15 @@ class ElementHelper
             }
         }
     }
+
+    /**
+     * Returns whether given element is nested.
+     *
+     * @param ElementInterface $element
+     * @return bool
+     */
+    public static function isNestedElement(ElementInterface $element): bool
+    {
+        return $element instanceof NestedElementInterface && $element->getOwnerId();
+    }
 }


### PR DESCRIPTION
### Description
Don’t show “Save and add another” and “Save as new entry” actions for nested entries that are being edited via full page edit.


### Related issues
#16807 
