### PR TITLE
fields/delete command

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -19,6 +19,7 @@
 - Added “Icon” and “Color” settings to Checkboxes, Dropdown, Multi-select, and Radio Buttons field options. ([#16645](https://github.com/craftcms/cms/pull/16645))
 - Added support for read-only custom fields, via new “Editability Conditions” on custom fields’ field layout settings. ([#16805](https://github.com/craftcms/cms/pull/16805))  
 - The email settings page now shows a “Test” button when `allowAdminChanges` is disabled. ([#16508](https://github.com/craftcms/cms/discussions/16508))
+- Added the `fields/delete` command. ([#16828](https://github.com/craftcms/cms/pull/16828))
 - Added the `--batch-size` option for `resave/*` commands. ([#16586](https://github.com/craftcms/cms/issues/16586))
 - The `users/create` command now prompts to send an activation email, or outputs an activation URL. ([#16794](https://github.com/craftcms/cms/pull/16794))
 - Dragging headings within the Customize Sources modal now also drags any subsequent sources. ([#16737](https://github.com/craftcms/cms/issues/16737))

--- a/src/console/controllers/FieldsController.php
+++ b/src/console/controllers/FieldsController.php
@@ -511,4 +511,36 @@ MD, $infoByField->join("\n"))));
         $expected = $override ?? $outgoingFieldValue;
         return $persistingFieldValue !== $expected ? $expected : null;
     }
+
+    /**
+     * Deletes custom fields.
+     *
+     * @param string ...$handles
+     * @return int
+     * @since 5.7.0
+     */
+    public function actionDelete(string ...$handles): int
+    {
+        /** @var FieldInterface[] $fields */
+        $fields = [];
+        $fieldsService = Craft::$app->getFields();
+
+        foreach ($handles as $handle) {
+            $field = $fieldsService->getFieldByHandle($handle);
+            if (!$field) {
+                $this->stdout("Invalid field handle: $handle\n", Console::FG_RED);
+                return ExitCode::UNSPECIFIED_ERROR;
+            }
+            $fields[] = $field;
+        }
+
+        foreach ($fields as $field) {
+            $this->do("Deleting `$field->name`", function() use ($fieldsService, $field) {
+                $fieldsService->deleteField($field);
+            });
+        }
+
+        $this->stdout("Done\n", Console::FG_GREEN);
+        return ExitCode::OK;
+    }
 }


### PR DESCRIPTION
### Description

Adds a `fields/delete` action.

```sh
> php craft fields/delete address pullQuote
 → Deleting Address … ✓ done
 → Deleting Pull Quote … ✓ done
Done
```

### Related issues

- #16827