### PR TITLE
Fix Cp helper class for frankendphp worker mode 

### DIFF
--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -107,7 +107,7 @@ class Cp
      * @var Site|false
      * @see requestedSite()
      */
-    private static Site|false $_requestedSite;
+    private static Site|null|false $_requestedSite;
 
     /**
      * Renders a control panel template.
@@ -3472,7 +3472,7 @@ JS;
      */
     public static function requestedSite(): ?Site
     {
-        if (!isset(self::$_requestedSite)) {
+        if (is_null(self::$_requestedSite)) {
             $sitesService = Craft::$app->getSites();
             $editableSiteIds = $sitesService->getEditableSiteIds();
 
@@ -3527,5 +3527,10 @@ JS;
                 'Changes to these settings aren’t permitted in this environment.',
             )) .
             Html::endTag('div');
+    }
+
+    public static function clearRequestedSite()
+    {
+        self::$_requestedSite = null;
     }
 }


### PR DESCRIPTION
### Description
I was testing frankenphp worker mode with Craft CMS and I found a problem that I don't think has a solution without some changes to Craft.

Basically the `craft\helpers\Cp` class has a static property of the requested site and it's only set once. If it's already set the property is returned. This is causing the sites dropdown to basically not work without restarting the worker.

The property It's also private and not nullable, so I can't do much from outside.

The changes:
• Static properties cannot be unset, so I updated the type hint of the `$_requestedSite` to be nullable. The function `requestedSite()` returns a nullable anyway, so maybe, it might even make sense.
• Then I updated the if in the `requestedSite()` function to set the variable only when it's null instead of uninitialized.
• I added a public function to clear the requested site, setting it to null. In this way I can call the function from outside at the start of each request to be sure that the correct site will be used.

Thanks.
