### PR TITLE
setting fill colour and grayscale images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where relational fields with “Maintain hierarchy” enabled weren’t displaying the correct relations after an element was moved within its structure. ([#16843](https://github.com/craftcms/cms/issues/16843))
+- Fixed a bug where letterbox transforms were getting transparent fills if the source image was grayscale. ([#16857](https://github.com/craftcms/cms/issues/16857))
 
 ## 4.14.10 - 2025-03-04
 

--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -559,7 +559,8 @@ class Raster extends Image
         if ($fill === 'transparent') {
             $this->_fill = $this->_image->palette()->color('#ffffff', 0);
         } else {
-            $this->_fill = $this->_image->palette()->color($fill);
+            // set alpha to 100, otherwise it'll be set to 0 (fully transparent) for grayscale images
+            $this->_fill = $this->_image->palette()->color($fill, 100);
         }
 
         return $this;


### PR DESCRIPTION
### Description
When getting a colour to set a non-transparent fill colour for an image, set the `$alpha` property to 100. 

The RGB palette already uses 100 as a [default](https://github.com/pixelandtonic/Imagine/blob/main/src/Image/Palette/RGB.php#L123), and the CMYK palette doesn’t support alpha and will [ignore `null` and `100` values](https://github.com/pixelandtonic/Imagine/blob/main/src/Image/Palette/CMYK.php#L98-L100), but the Grayscale palette [defaults to `0`](https://github.com/pixelandtonic/Imagine/blob/main/src/Image/Palette/Grayscale.php#L119) causing any background you choose to be set as fully transparent.

Before:
<img width="465" alt="Screenshot 2025-03-10 at 15 29 58" src="https://github.com/user-attachments/assets/e2747e38-9c8f-485e-8da3-bf3aaaefdcd1" />

After:
<img width="452" alt="Screenshot 2025-03-10 at 15 30 37" src="https://github.com/user-attachments/assets/5a2c5f7e-4542-48b8-8efc-ca28d66c80d3" />


### Related issues
#16857 
