### PR TITLE
prevent selectize fields from reopening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where relational fields with “Maintain hierarchy” enabled weren’t displaying the correct relations after an element was moved within its structure. ([#16843](https://github.com/craftcms/cms/issues/16843))
 - Fixed a bug where letterbox transforms were getting transparent fills if the source image was grayscale. ([#16857](https://github.com/craftcms/cms/issues/16857))
 - Fixed a bug where elements could be missing data for attributes that shared a name with an eager-loadable attribute from another element type. ([#16862](https://github.com/craftcms/cms/issues/16862))
+- Fixed a bug where Selectize inputs would re-expand themselves after a selection was made. ([#16865](https://github.com/craftcms/cms/pull/16865))
 
 ## 4.14.10 - 2025-03-04
 

--- a/src/fieldlayoutelements/addresses/AddressField.php
+++ b/src/fieldlayoutelements/addresses/AddressField.php
@@ -127,7 +127,6 @@ class AddressField extends BaseField
                         Object.fromEntries(fieldNames.map(name => [name, fields[name].val()])),
                         Object.fromEntries(hotFieldNames.map(name => [name, hotValues[name] || null]))
                     );
-                    const activeElementId = document.activeElement ? document.activeElement.id : null;
                     const \$addressFields = $(
                         Object.entries(fields)
                             .filter(([name]) => name !== 'countryCode')
@@ -138,9 +137,6 @@ class AddressField extends BaseField
                     Craft.appendHeadHtml(response.data.headHtml);
                     Craft.appendBodyHtml(response.data.bodyHtml);
                     initFields(values);
-                    if (activeElementId) {
-                        $('#' + activeElementId).focus();                        
-                    }
                 }).catch(e => {
                     Craft.cp.displayError();
                     throw e;


### PR DESCRIPTION
### Description
Stop calling focus on the active element to prevent selectize field from closing and reopening once a selection has been made.

Before:

https://github.com/user-attachments/assets/77a844c9-eee9-4825-9a18-a12079e60aea

After:

https://github.com/user-attachments/assets/8110318d-714e-4838-bc1d-a919be9596e4



### Related issues
n/a
