### PR TITLE
Docs: List symbols in translation debugging output

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -6577,6 +6577,15 @@ class GeneralConfig extends BaseConfig
      * ->translationDebugOutput(true)
      * ```
      *
+     * The symbols are as follows:
+     *
+     * | Symbol | Example | Category |
+     * | `$` | `$Date Field$` | Site |
+     * | `@` | `$Entry Type$` | Application |
+     * | `%` | `%Object Template% | Other (plugin or custom source) |
+     *
+     * Translations _may_ be nested or surrounded by multiple symbols.
+     *
      * @group System
      * @param bool $value
      * @return self

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -2992,6 +2992,15 @@ class GeneralConfig extends BaseConfig
      * ```
      * :::
      *
+     * The symbols are as follows:
+     *
+     * | Symbol | Example | Category |
+     * | `$` | `$Date Field$` | Site |
+     * | `@` | `$Entry Type$` | Application |
+     * | `%` | `%Object Template% | Other (plugin or custom source) |
+     *
+     * Translations _may_ be nested or surrounded by multiple symbols.
+     *
      * @group System
      */
     public bool $translationDebugOutput = false;

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -2996,7 +2996,7 @@ class GeneralConfig extends BaseConfig
      *
      * | Symbol | Example | Category |
      * | `$` | `$Date Field$` | Site |
-     * | `@` | `$Entry Type$` | Application |
+     * | `@` | `@Entry Type@` | Application |
      * | `%` | `%Object Template% | Other (plugin or custom source) |
      *
      * Translations _may_ be nested or surrounded by multiple symbols.
@@ -6581,7 +6581,7 @@ class GeneralConfig extends BaseConfig
      *
      * | Symbol | Example | Category |
      * | `$` | `$Date Field$` | Site |
-     * | `@` | `$Entry Type$` | Application |
+     * | `@` | `@Entry Type@` | Application |
      * | `%` | `%Object Template% | Other (plugin or custom source) |
      *
      * Translations _may_ be nested or surrounded by multiple symbols.


### PR DESCRIPTION
We weren't indicating what `$`, `@`, and `%` meant, in the context of translation debug output. Spotted by @gcamacho079 !

`$ite` and `@app` were kinda easy to remember, but we couldn't come up with a mnemonic for `%` ("other").

Edit: Targeting 4.x so it can be merged into 5.x as well.