### PR TITLE
Docs: Service Accessors

### DIFF
--- a/src/services/Addresses.php
+++ b/src/services/Addresses.php
@@ -31,7 +31,7 @@ use yii\base\Component;
 
 /**
  * Addresses service.
- * An instance of the Addresses service is globally accessible in Craft via [[\craft\base\ApplicationTrait::getAddresses()|`Craft::$app->addresses`]].
+ * An instance of the Addresses service is globally accessible in Craft via [[\craft\base\ApplicationTrait::getAddresses()|`Craft::$app->getAddresses()`]].
  *
  * @property-read AddressFormatRepository $addressFormatRepository
  * @property-read CountryRepository $countryRepository

--- a/src/services/Announcements.php
+++ b/src/services/Announcements.php
@@ -23,7 +23,7 @@ use yii\helpers\Markdown;
 /**
  * Announcements service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getAnnouncements()|`Craft::$app->announcements`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getAnnouncements()|`Craft::$app->getAnnouncements()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.7.0

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -21,7 +21,7 @@ use yii\base\Component;
 /**
  * The API service provides APIs for calling the Craft API (api.craftcms.com).
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getApi()|`Craft::$app->api`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getApi()|`Craft::$app->getApi()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/AssetIndexer.php
+++ b/src/services/AssetIndexer.php
@@ -45,7 +45,7 @@ use yii\db\Exception as DbException;
 /**
  * Asset Indexer service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getAssetIndexer()|`Craft::$app->assetIndexer`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getAssetIndexer()|`Craft::$app->getAssetIndexer()`]].
  *
  * @property-read array $existingIndexingSessions
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>

--- a/src/services/Assets.php
+++ b/src/services/Assets.php
@@ -51,7 +51,7 @@ use yii\db\Expression;
 /**
  * Assets service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getAssets()|`Craft::$app->assets`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getAssets()|`Craft::$app->getAssets()`]].
  *
  * @property-read VolumeFolder $currentUserTemporaryUploadFolder
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>

--- a/src/services/Categories.php
+++ b/src/services/Categories.php
@@ -36,7 +36,7 @@ use yii\base\Exception;
 /**
  * Categories service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getCategories()|`Craft::$app->categories`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getCategories()|`Craft::$app->getCategories()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Composer.php
+++ b/src/services/Composer.php
@@ -23,7 +23,7 @@ use yii\base\Exception;
 /**
  * Composer service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getComposer()|`Craft::$app->composer`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getComposer()|`Craft::$app->getComposer()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Conditions.php
+++ b/src/services/Conditions.php
@@ -21,7 +21,7 @@ use yii\base\InvalidConfigException;
 /**
  * The Conditions service provides APIs for managing conditions.
  *
- * An instance of the Conditions service is globally accessible in Craft via [[\craft\base\ApplicationTrait::getConditions()|`Craft::$app->conditions`]].
+ * An instance of the Conditions service is globally accessible in Craft via [[\craft\base\ApplicationTrait::getConditions()|`Craft::$app->getConditions()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.0.0

--- a/src/services/Config.php
+++ b/src/services/Config.php
@@ -25,7 +25,7 @@ use yii\base\InvalidArgumentException;
  * The Config service provides APIs for retrieving the values of Craft’s [config settings](http://craftcms.com/docs/config-settings),
  * as well as the values of any plugins’ config settings.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getConfig()|`Craft::$app->config`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getConfig()|`Craft::$app->getConfig()`]].
  *
  * @property-read DbConfig $db the DB config settings
  * @property-read GeneralConfig $general the general config settings

--- a/src/services/Dashboard.php
+++ b/src/services/Dashboard.php
@@ -33,7 +33,7 @@ use yii\base\Exception;
 /**
  * Dashboard service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getDashboard()|`Craft::$app->dashboard`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getDashboard()|`Craft::$app->getDashboard()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Deprecator.php
+++ b/src/services/Deprecator.php
@@ -26,7 +26,7 @@ use yii\db\Exception;
 
 /**
  * Deprecator service.
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getDeprecator()|`Craft::$app->deprecator`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getDeprecator()|`Craft::$app->getDeprecator()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Drafts.php
+++ b/src/services/Drafts.php
@@ -30,7 +30,7 @@ use yii\di\Instance;
 /**
  * Drafts service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getDrafts()|`Craft::$app->drafts`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getDrafts()|`Craft::$app->getDrafts()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.2.0

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -22,7 +22,7 @@ use yii\base\Component;
 /**
  * The Element Sources service provides APIs for managing element indexes.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getElementSources()|`Craft::$app->elementSources`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getElementSources()|`Craft::$app->getElementSources()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.0.0

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -78,7 +78,7 @@ use yii\caching\TagDependency;
 /**
  * The Elements service provides APIs for managing elements.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getElements()|`Craft::$app->elements`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getElements()|`Craft::$app->getElements()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -18,7 +18,7 @@ use yii\base\Component;
 /**
  * The Entries service provides APIs for managing entries in Craft.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getEntries()|`Craft::$app->entries`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getEntries()|`Craft::$app->getEntries()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -78,7 +78,7 @@ use yii\web\BadRequestHttpException;
 /**
  * Fields service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getFields()|`Craft::$app->fields`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getFields()|`Craft::$app->getFields()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Fs.php
+++ b/src/services/Fs.php
@@ -24,7 +24,7 @@ use yii\base\InvalidConfigException;
 /**
  * Filesystems service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getfs()|`Craft::$app->fs`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getFs()|`Craft::$app->getFs()`]].
  *
  * @property-read FsInterface[] $allFilesystems All filesystems
  * @property-read string[] $allFilesystemTypes All registered filesystem types

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -41,7 +41,7 @@ use yii\di\Instance;
 /**
  * Garbage Collection service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getGc()|`Craft::$app->gc`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getGc()|`Craft::$app->getGc()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.1.0

--- a/src/services/Globals.php
+++ b/src/services/Globals.php
@@ -28,7 +28,7 @@ use yii\base\Component;
 /**
  * Globals service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getGlobals()|`Craft::$app->globals`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getGlobals()|`Craft::$app->getGlobals()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -96,7 +96,7 @@ use yii\caching\TagDependency;
 /**
  * GraphQL service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getGql()|`Craft::$app->gql`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getGql()|`Craft::$app->getGql()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.3.0

--- a/src/services/ImageTransforms.php
+++ b/src/services/ImageTransforms.php
@@ -39,7 +39,7 @@ use yii\di\Instance;
 /**
  * Image Transforms service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getImageTransforms()|`Craft::$app->imageTransforms`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getImageTransforms()|`Craft::$app->getImageTransforms()`]].
  *
  * @property-read ImageTransform[] $allTransforms
  * @property-read array $pendingTransformIndexIds

--- a/src/services/Images.php
+++ b/src/services/Images.php
@@ -28,7 +28,7 @@ use yii\base\Exception;
 /**
  * Images service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getImages()|`Craft::$app->images`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getImages()|`Craft::$app->getImages()`]].
  *
  * @property bool $isGd Whether image manipulations will be performed using GD or not
  * @property bool $isImagick Whether image manipulations will be performed using Imagick or not

--- a/src/services/Path.php
+++ b/src/services/Path.php
@@ -16,7 +16,7 @@ use yii\base\Exception;
 /**
  * The Path service provides APIs for getting server paths that are used by Craft.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getPath()|`Craft::$app->path`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getPath()|`Craft::$app->getPath()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/PluginStore.php
+++ b/src/services/PluginStore.php
@@ -21,7 +21,7 @@ use yii\base\Component;
 /**
  * Plugin Store service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getPluginStore()|`Craft::$app->pluginStore`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getPluginStore()|`Craft::$app->getPluginStore()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Plugins.php
+++ b/src/services/Plugins.php
@@ -36,7 +36,7 @@ use yii\web\HttpException;
 /**
  * The Plugins service provides APIs for managing plugins.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getPlugins()|`Craft::$app->plugins`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getPlugins()|`Craft::$app->getPlugins()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/ProjectConfig.php
+++ b/src/services/ProjectConfig.php
@@ -41,7 +41,7 @@ use yii\web\ServerErrorHttpException;
 /**
  * Project Config service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getProjectConfig()|`Craft::$app->projectConfig`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getProjectConfig()|`Craft::$app->getProjectConfig()`]].
  *
  * @property-read bool $isApplyingExternalChanges
  * @property-read bool $isApplyingYamlChanges

--- a/src/services/Relations.php
+++ b/src/services/Relations.php
@@ -21,7 +21,7 @@ use yii\base\Component;
 /**
  * Relations service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getRelations()|`Craft::$app->relations`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getRelations()|`Craft::$app->getRelations()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Revisions.php
+++ b/src/services/Revisions.php
@@ -27,7 +27,7 @@ use yii\base\InvalidArgumentException;
 /**
  * Revisions service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getRevisions()|`Craft::$app->revisions`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getRevisions()|`Craft::$app->getRevisions()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.2.0

--- a/src/services/Routes.php
+++ b/src/services/Routes.php
@@ -17,7 +17,7 @@ use yii\base\Component;
 /**
  * Routes service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getRoutes()|`Craft::$app->routes`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getRoutes()|`Craft::$app->getRoutes()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -34,7 +34,7 @@ use yii\db\Schema;
 /**
  * Search service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getSearch()|`Craft::$app->search`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getSearch()|`Craft::$app->getSearch()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Security.php
+++ b/src/services/Security.php
@@ -17,7 +17,7 @@ use yii\helpers\Inflector;
 /**
  * Security service.
  *
- * An instance of the service is available via [[\yii\base\Application::getSecurity()|`Craft::$app->security`]].
+ * An instance of the service is available via [[\yii\base\Application::getSecurity()|`Craft::$app->getSecurity()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -43,7 +43,7 @@ use yii\db\Exception as DbException;
 /**
  * Sites service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getSites()|`Craft::$app->sites`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getSites()|`Craft::$app->getSites()`]].
  *
  * @property-read Site[] $allSites all of the sites
  * @property int[] $allSiteIds all of the site IDs

--- a/src/services/Structures.php
+++ b/src/services/Structures.php
@@ -25,7 +25,7 @@ use yii\base\Exception;
 /**
  * Structures service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getStructures()|`Craft::$app->structures`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getStructures()|`Craft::$app->getStructures()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/SystemMessages.php
+++ b/src/services/SystemMessages.php
@@ -20,7 +20,7 @@ use yii\db\Expression;
 /**
  * System Messages service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getSystemMessages()|`Craft::$app->systemMessages`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getSystemMessages()|`Craft::$app->getSystemMessages()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Tags.php
+++ b/src/services/Tags.php
@@ -27,7 +27,7 @@ use yii\base\Component;
 /**
  * Tags service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getTags()|`Craft::$app->tags`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getTags()|`Craft::$app->getTags()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -23,7 +23,7 @@ use yii\web\AssetBundle;
 /**
  * Template Caches service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getTemplateCaches()|`Craft::$app->templateCaches`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getTemplateCaches()|`Craft::$app->getTemplateCaches()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Tokens.php
+++ b/src/services/Tokens.php
@@ -22,7 +22,7 @@ use yii\db\Expression;
 /**
  * The Tokens service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getTokens()|`Craft::$app->tokens`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getTokens()|`Craft::$app->getTokens()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Updates.php
+++ b/src/services/Updates.php
@@ -22,7 +22,7 @@ use yii\base\InvalidArgumentException;
 /**
  * Updates service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getUpdates()|`Craft::$app->updates`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getUpdates()|`Craft::$app->getUpdates()`]].
  *
  * @property bool $isCraftDbMigrationNeeded Whether Craft needs to run any database migrations
  * @property bool $isCraftSchemaVersionCompatible Whether the uploaded DB schema is equal to or greater than the installed schema

--- a/src/services/UserGroups.php
+++ b/src/services/UserGroups.php
@@ -23,7 +23,7 @@ use yii\base\Component;
 /**
  * User Groups service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getUserGroups()|`Craft::$app->userGroups`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getUserGroups()|`Craft::$app->getUserGroups()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -33,7 +33,7 @@ use yii\db\Exception;
 /**
  * User Permissions service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getUserPermissions()|`Craft::$app->userPermissions`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getUserPermissions()|`Craft::$app->getUserPermissions()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -48,7 +48,7 @@ use yii\base\UserException;
 /**
  * The Users service provides APIs for managing users.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getUsers()|`Craft::$app->users`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getUsers()|`Craft::$app->getUsers()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Utilities.php
+++ b/src/services/Utilities.php
@@ -29,7 +29,7 @@ use yii\base\Component;
 /**
  * The Utilities service provides APIs for managing utilities.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getUtilities()|`Craft::$app->utilities()`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getUtilities()|`Craft::$app->getUtilities()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0

--- a/src/services/Volumes.php
+++ b/src/services/Volumes.php
@@ -33,7 +33,7 @@ use yii\base\InvalidConfigException;
 /**
  * Volumes service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getVolumes()|`Craft::$app->volumes()`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getVolumes()|`Craft::$app->getVolumes()`]].
  *
  * @property-read int[] $allVolumeIds
  * @property-read string[] $allVolumeTypes

--- a/src/services/Webpack.php
+++ b/src/services/Webpack.php
@@ -23,7 +23,7 @@ use yii\web\AssetBundle;
 /**
  * Webpack service.
  *
- * An instance of the service is available via [[\craft\base\ApplicationTrait::getWebpack()|`Craft::$app->webpack()`]].
+ * An instance of the service is available via [[\craft\base\ApplicationTrait::getWebpack()|`Craft::$app->getWebpack()`]].
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.7.22


### PR DESCRIPTION
Someone reported a [goof in the auto-generated docs](https://github.com/craftcms/docs/issues/685), so I went to check if it was present anywhere else. Only a couple actually had the extra parentheses (i.e. `volumes()` instead of `volumes`, as a property accessor), but I figured I would just standardize them to use methods.

Targeting 4.x; may need an additional two updates for the new services in 5.x (`Auth` and `Sso`).