### PR TITLE
GQL, relatedTo* and default site

### DIFF
--- a/src/gql/base/RelationArgumentHandler.php
+++ b/src/gql/base/RelationArgumentHandler.php
@@ -38,6 +38,9 @@ abstract class RelationArgumentHandler extends ArgumentHandler
         foreach ($criteriaList as $criteria) {
             /** @var ElementQuery $elementQuery */
             $elementQuery = Craft::configure(Craft::$app->getElements()->createElementQuery($elementType), $criteria);
+            if ($elementQuery->siteId == null) {
+                $elementQuery->site('*');
+            }
             $idSets[] = $elementQuery->ids();
         }
 


### PR DESCRIPTION
### Description
When using `relatedTo*` in GQL we should default to all sites, as opposed to the primary site.

Steps to reproduce:
- clean v4 installation
- create 2 sites (`siteA` and `siteB`)
- create a category group which contains a category (`cat1`) that is disabled for the primary site (`siteA`) and enabled a non-primary site (`siteB`)
- create a Categories field (`myCategories`) for that group
- create a section (`gh16875`) with an entry type which contains the `myCategories` field; this section is enabled for both sites, propagation method all (but also tested with none)
- in that section, create an entry which has the `cat1` category in it; save;

This query in twig will return the entry, and the content of the `myCategories` will be empty.

```twig
{% set results = craft.entries()
  .site('siteA')
  .section('gh16875')
  .myCategories({'id': <category_id>})
  .all() %}
```

If you switch to `siteB` the same query will return the entry and the `cat1` category in the `myCategories` field.

In GQL, this query:

```graphql
query myQuery {
  entries(
    site: "siteA"
    section: "gh16875"
    relatedToCategories: [{id: ["<category_id>"]}]
  ) {
    id
    title
    ... on gh16875_default_Entry {
      myCategories {
        id
        title
      }
    }
  }
}
```

will return an empty array for both `siteA` and `siteB`.

With this PR, the GQL query will return the same results as the twig.

### Related issues
#16875 
