### PR TITLE
Max Authors tweaks

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '5.6.11',
-    'schemaVersion' => '5.7.0.1',
+    'schemaVersion' => '5.7.0.2',
     'minVersionRequired' => '4.5.0',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/controllers/SectionsController.php
+++ b/src/controllers/SectionsController.php
@@ -154,7 +154,8 @@ class SectionsController extends Controller
         $section->handle = $this->request->getBodyParam('handle');
         $section->type = $this->request->getBodyParam('type') ?? Section::TYPE_CHANNEL;
         $section->enableVersioning = $this->request->getBodyParam('enableVersioning', true);
-        $section->maxAuthors = $this->request->getBodyParam('maxAuthors') ?: 1;
+        $maxAuthors = $this->request->getBodyParam('maxAuthors');
+        $section->maxAuthors = is_numeric($maxAuthors) ? (int)$maxAuthors : null;
         $section->propagationMethod = PropagationMethod::tryFrom($this->request->getBodyParam('propagationMethod') ?? '')
             ?? PropagationMethod::All;
         $section->previewTargets = $this->request->getBodyParam('previewTargets') ?: [];

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -923,7 +923,7 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
     {
         return array_merge(parent::attributeLabels(), [
             'authorIds' => Craft::t('app', '{max, plural, =1{Author} other {Authors}}', [
-                'max' => $this->getSection()?->maxAuthors ?? 1,
+                'max' => $this->getSection()?->maxAuthors ?? PHP_INT_MAX,
             ]),
             'postDate' => Craft::t('app', 'Post Date'),
             'expiryDate' => Craft::t('app', 'Expiry Date'),
@@ -973,16 +973,18 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
         ];
 
         $section = $this->getSection();
-        if ($section && $section->type !== Section::TYPE_SINGLE) {
+        if ($section && $section->type !== Section::TYPE_SINGLE && $section->maxAuthors !== 0) {
             $rules[] = [['authorIds'], 'required', 'on' => self::SCENARIO_LIVE];
-            $rules[] = [
-                ['authorIds'],
-                ArrayValidator::class,
-                'max' => $section->maxAuthors,
-                'tooMany' => Craft::t('app', '{num, plural, =1{Only one author is} other{Up to {num, number} authors are}} allowed.', [
-                    'num' => $section->maxAuthors,
-                ]),
-            ];
+            if (isset($section->maxAuthors)) {
+                $rules[] = [
+                    ['authorIds'],
+                    ArrayValidator::class,
+                    'max' => $section->maxAuthors,
+                    'tooMany' => Craft::t('app', '{num, plural, =1{Only one author is} other{Up to {num, number} authors are}} allowed.', [
+                        'num' => $section->maxAuthors,
+                    ]),
+                ];
+            }
         }
 
         return $rules;
@@ -2122,7 +2124,7 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
                 return Cp::elementSelectHtml([
                     'status' => $this->getAttributeStatus('authorIds'),
                     'label' => Craft::t('app', '{max, plural, =1{Author} other {Authors}}', [
-                        'max' => $section->maxAuthors,
+                        'max' => $section->maxAuthors ?? PHP_INT_MAX,
                     ]),
                     'id' => 'authorIds',
                     'name' => 'authorIds',
@@ -2308,13 +2310,17 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
 
         if ($section && $section->type !== Section::TYPE_SINGLE) {
             // Author
-            if (Craft::$app->edition !== CmsEdition::Solo && $user->can("viewPeerEntries:$section->uid")) {
+            if (
+                $section->maxAuthors !== 0 &&
+                Craft::$app->edition !== CmsEdition::Solo &&
+                $user->can("viewPeerEntries:$section->uid")
+            ) {
                 $fields[] = (function() use ($static, $section) {
                     $authors = $this->getAuthors();
                     $html = Cp::elementSelectFieldHtml([
                         'status' => $this->getAttributeStatus('authorIds'),
                         'label' => Craft::t('app', '{max, plural, =1{Author} other {Authors}}', [
-                            'max' => $section->maxAuthors,
+                            'max' => $section->maxAuthors ?? PHP_INT_MAX,
                         ]),
                         'id' => 'authorIds',
                         'name' => 'authorIds',

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -592,7 +592,7 @@ class Install extends Migration
             'handle' => $this->string()->notNull(),
             'type' => $this->enum('type', [Section::TYPE_SINGLE, Section::TYPE_CHANNEL, Section::TYPE_STRUCTURE])->notNull()->defaultValue('channel'),
             'enableVersioning' => $this->boolean()->defaultValue(false)->notNull(),
-            'maxAuthors' => $this->smallInteger()->unsigned()->defaultValue(1)->notNull(),
+            'maxAuthors' => $this->smallInteger()->unsigned(),
             'propagationMethod' => $this->string()->defaultValue(PropagationMethod::All->value)->notNull(),
             'defaultPlacement' => $this->enum('defaultPlacement', [Section::DEFAULT_PLACEMENT_BEGINNING, Section::DEFAULT_PLACEMENT_END])->defaultValue('end')->notNull(),
             'previewTargets' => $this->json(),

--- a/src/migrations/m250315_131608_unlimited_authors.php
+++ b/src/migrations/m250315_131608_unlimited_authors.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace craft\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Table;
+use craft\services\ProjectConfig;
+
+/**
+ * m250315_131608_unlimited_authors migration.
+ */
+class m250315_131608_unlimited_authors extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        if ($this->db->getIsPgsql()) {
+            $this->execute(sprintf('alter table %s alter column [[maxAuthors]] drop default, alter column [[maxAuthors]] drop not null', Table::SECTIONS));
+        } else {
+            $this->alterColumn(Table::SECTIONS, 'maxAuthors', $this->smallInteger()->unsigned());
+        }
+
+        $projectConfig = Craft::$app->getProjectConfig();
+        $sectionConfigs = $projectConfig->get(ProjectConfig::PATH_SECTIONS) ?? [];
+
+        foreach ($sectionConfigs as $uid => $config) {
+            if (!isset($config['maxAuthors'])) {
+                $config['maxAuthors'] = 1;
+                $projectConfig->set(sprintf('%s.%s', ProjectConfig::PATH_SECTIONS, $uid), $config);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        if ($this->db->getIsPgsql()) {
+            $this->update(Table::SECTIONS, ['maxAuthors' => 1], ['maxAuthors' => null]);
+            $this->execute(sprintf('alter table %s alter column [[maxAuthors]] set default 1, alter column [[maxAuthors]] set not null', Table::SECTIONS));
+        } else {
+            $this->alterColumn(Table::SECTIONS, 'maxAuthors', $this->smallInteger()->unsigned()->defaultValue(1)->notNull());
+        }
+
+        return true;
+    }
+}

--- a/src/models/Section.php
+++ b/src/models/Section.php
@@ -87,10 +87,10 @@ class Section extends Model implements Chippable, CpEditable, Iconic
     public ?string $type = null;
 
     /**
-     * @var int Max authors
+     * @var int|null Max authors
      * @since 5.0.0
      */
-    public int $maxAuthors = 1;
+    public int|null $maxAuthors = 1;
 
     /**
      * @var int|null Max levels
@@ -201,7 +201,7 @@ class Section extends Model implements Chippable, CpEditable, Iconic
     {
         $rules = parent::defineRules();
         $rules[] = [['id', 'structureId', 'maxLevels'], 'number', 'integerOnly' => true];
-        $rules[] = [['maxAuthors'], 'number', 'integerOnly' => true, 'min' => 1];
+        $rules[] = [['maxAuthors'], 'number', 'integerOnly' => true, 'min' => 0];
         $rules[] = [['handle'], HandleValidator::class, 'reservedWords' => ['id', 'dateCreated', 'dateUpdated', 'uid', 'title']];
         $rules[] = [
             ['type'], 'in', 'range' => [

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -648,7 +648,7 @@ class Entries extends Component
             $sectionRecord->handle = $data['handle'];
             $sectionRecord->type = $data['type'];
             $sectionRecord->enableVersioning = (bool)$data['enableVersioning'];
-            $sectionRecord->maxAuthors = $data['maxAuthors'] ?? 1;
+            $sectionRecord->maxAuthors = $data['maxAuthors'] ?? null;
             $sectionRecord->propagationMethod = $data['propagationMethod'] ?? PropagationMethod::All->value;
             $sectionRecord->defaultPlacement = $data['defaultPlacement'] ?? Section::DEFAULT_PLACEMENT_END;
             $sectionRecord->previewTargets = isset($data['previewTargets']) && is_array($data['previewTargets'])

--- a/src/templates/settings/sections/_edit.twig
+++ b/src/templates/settings/sections/_edit.twig
@@ -300,7 +300,6 @@
         value: section.maxAuthors,
         errors: section.getErrors('maxAuthors'),
         size: 5,
-        required: true,
         disabled: readOnly,
     }) }}
 {% endblock %}


### PR DESCRIPTION
### Description

- Makes sections’ “Max Authors” setting optional. When blank, no explicit maximum is enforced.
- Allows “Max Authors” to be set to `0`, which removes the “Authors” field from entry edit forms entirely.

### Related issues

- #16873