### PR TITLE
Don't encode Emoji shortcodes for display on MB4

### DIFF
--- a/src/fields/PlainText.php
+++ b/src/fields/PlainText.php
@@ -178,7 +178,7 @@ class PlainText extends Field implements InlineEditableFieldInterface, SortableF
     private function _normalizeValueInternal(mixed $value, ?ElementInterface $element, bool $fromRequest): mixed
     {
         if ($value !== null) {
-            if (!$fromRequest) {
+            if (!$fromRequest && !Craft::$app->getDb()->getSupportsMb4()) {
                 $value = StringHelper::unescapeShortcodes(StringHelper::shortcodesToEmoji($value));
             }
 


### PR DESCRIPTION
### Description

Currently there's a block on encoding emoji on the way in - Craft checks for mb4 capabilities before storing a value. However, it does not check these values when _displaying_ the value in the CMS UI. As as result, the encoded value will get saved in anyway, even if you don't need or want this. This PR stops the encoding from happening when displaying an internal value too, so that the value always stays unencoded on supported databases which, in my opinion, is the correct behaviour.

### Related issues

#16917 