### PR TITLE
check if other instances have value before joining relations table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a performance degradation bug that occurred when working with Categories or Entries fields with “Maintain hierarchy” enabled. ([#16920](https://github.com/craftcms/cms/issues/16920))
 - Fixed a bug where Plain Text and Table fields were converting posted shortcode-looking strings to emoji. ([#12935](https://github.com/craftcms/cms/issues/12935), [#16917](https://github.com/craftcms/cms/issues/16917))
+- Fixed a bug where relation fields could show relations from another instance of the same field. ([#16912](https://github.com/craftcms/cms/issues/16912))
 
 ## 5.6.12 - 2025-03-18
 

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -19,6 +19,7 @@ use craft\base\MergeableFieldInterface;
 use craft\base\NestedElementInterface;
 use craft\base\RelationalFieldInterface;
 use craft\base\ThumbableFieldInterface;
+use craft\behaviors\CustomFieldBehavior;
 use craft\behaviors\EventBehavior;
 use craft\db\FixedOrderExpression;
 use craft\db\Query;
@@ -676,7 +677,7 @@ JS, [
             if (!empty($value)) {
                 $query->orderBy([new FixedOrderExpression('elements.id', $value, Craft::$app->getDb())]);
             }
-        } elseif ($value === null && $element?->id && $this->isFirstInstance($element) && $this->areAllOtherInstancesEmpty($element)) {
+        } elseif ($value === null && $element?->id && $this->fetchRelationsFromDbTable($element)) {
             // If $value is null, the element + field haven’t been saved since updating to Craft 5.3+,
             // or since the field was added to the field layout,
             // or the value was added to not first instance of the field.
@@ -748,54 +749,39 @@ JS, [
         return $query;
     }
 
-    private function isFirstInstance(?Elementinterface $element): bool
+    private function fetchRelationsFromDbTable(?Elementinterface $element): bool
     {
         if ($this->layoutElement?->uid === null) {
             return false;
         }
 
-        /** @var CustomField|null $first */
-        $first = Collection::make($element?->getFieldLayout()?->getCustomFieldElements())
-            ->filter(fn(CustomField $layoutElement) => $layoutElement->getField()->id === $this->id)
-            ->sortBy(fn(CustomField $layoutElement) => $layoutElement->dateAdded)
-            ->first();
-
-        // Compare handles here rather than UUIDs, since the UUID will change
-        //if we're hot-swapping field layouts (e.g. changing an entry's type).
-        return $this->handle === $first?->getField()->handle;
-    }
-
-    /**
-     * If there is more than one instance of this field in the element's layout,
-     * check if all of them, except the first one, are empty.
-     *
-     * @param ElementInterface|null $element
-     * @return bool
-     * @throws \craft\errors\InvalidFieldException
-     */
-    private function areAllOtherInstancesEmpty(?ElementInterface $element): bool
-    {
-        // This check will only look at the elements_sites.content,
-        // as the relations table should only be factored in for the first instance,
-        // if we don't have a value for it in the elements_sites.content
+        // Get all the instances of this field
+        /** @var Collection<CustomField> $fieldInstances */
         $fieldInstances = Collection::make($element?->getFieldLayout()?->getCustomFieldElements())
             ->filter(fn(CustomField $layoutElement) => $layoutElement->getField()->id === $this->id)
-            ->sortBy(fn(CustomField $layoutElement) => $layoutElement->dateAdded)
-            ->all();
+            ->sortBy(fn(CustomField $layoutElement) => $layoutElement->dateAdded);
 
-        array_shift($fieldInstances);
+        // Only fetch DB relations if this is the first instance
+        // (Compare handles here rather than UUIDs, since the UUID will change
+        // if we're hot-swapping field layouts, e.g. changing an entry's type)
+        /** @var CustomField|null $first */
+        $first = $fieldInstances->shift();
+        if ($this->handle !== $first?->getField()->handle) {
+            return false;
+        }
 
-        $empty = true;
-        if (!empty($fieldInstances)) {
-            foreach ($fieldInstances as $fieldInstance) {
-                if (!($this->isValueEmpty($element->getFieldValue($fieldInstance->handle ?? $fieldInstance->getOriginalHandle()), $element))) {
-                    $empty = false;
-                    break;
-                }
+        // Make sure none of the other instances have values
+        /** @var CustomFieldBehavior $behavior */
+        $behavior = $element->getBehavior('customFields');
+        foreach ($fieldInstances as $fieldInstance) {
+            /** @var self $field */
+            $field = $fieldInstance->getField();
+            if (isset($behavior->{$field->handle})) {
+                return false;
             }
         }
 
-        return $empty;
+        return true;
     }
 
     /**
@@ -1014,7 +1000,7 @@ JS, [
                 foreach ($rawValue as $targetElementId) {
                     $map[] = ['source' => $sourceElement->id, 'target' => $targetElementId];
                 }
-            } elseif ($this->isFirstInstance($sourceElement) && $this->areAllOtherInstancesEmpty($sourceElement)) {
+            } elseif ($this->fetchRelationsFromDbTable($sourceElement)) {
                 // The relation IDs aren't hardcoded yet and this is the first
                 // instance of this field in the field layout, so fetch the relations
                 // via the DB table

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -1049,7 +1049,7 @@ JS, [
                 foreach ($rawValue as $targetElementId) {
                     $map[] = ['source' => $sourceElement->id, 'target' => $targetElementId];
                 }
-            } elseif ($this->isFirstInstance($sourceElement)) {
+            } elseif ($this->isFirstInstance($sourceElement) && $this->areAllOtherInstancesEmpty($sourceElement)) {
                 // The relation IDs aren't hardcoded yet and this is the first
                 // instance of this field in the field layout, so fetch the relations
                 // via the DB table

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -682,10 +682,13 @@ JS, [
             } else {
                 $query->andWhere(['elements.id' => []]);
             }
-        } elseif ($value === null && $element?->id && $this->isFirstInstance($element)) {
+        } elseif ($value === null && $element?->id && $this->isFirstInstance($element) && $this->areAllOtherInstancesEmpty($element)) {
             // If $value is null, the element + field haven’t been saved since updating to Craft 5.3+,
-            // or since the field was added to the field layout. So only actually look at the `relations` table
-            // if this is the first instance of the field that was ever added to the field layout.
+            // or since the field was added to the field layout,
+            // or the value was added to not first instance of the field.
+            // So only actually look at the `relations` table
+            // if this is the first instance of the field that was ever added to the field layout
+            // and none of the other instances (which would have been added later on) have a value.
             if (!$this->allowMultipleSources && $this->source) {
                 $source = ElementHelper::findSource($class, $this->source, ElementSources::CONTEXT_FIELD);
 
@@ -804,6 +807,39 @@ JS, [
         // Compare handles here rather than UUIDs, since the UUID will change
         //if we're hot-swapping field layouts (e.g. changing an entry's type).
         return $this->handle === $first?->getField()->handle;
+    }
+
+    /**
+     * If there is more than one instance of this field in the element's layout,
+     * check if all of them, except the first one, are empty.
+     *
+     * @param ElementInterface|null $element
+     * @return bool
+     * @throws \craft\errors\InvalidFieldException
+     */
+    private function areAllOtherInstancesEmpty(?ElementInterface $element): bool
+    {
+        // This check will only look at the elements_sites.content,
+        // as the relations table should only be factored in for the first instance,
+        // if we don't have a value for it in the elements_sites.content
+        $fieldInstances = Collection::make($element?->getFieldLayout()?->getCustomFieldElements())
+            ->filter(fn(CustomField $layoutElement) => $layoutElement->getField()->id === $this->id)
+            ->sortBy(fn(CustomField $layoutElement) => $layoutElement->dateAdded)
+            ->all();
+
+        array_shift($fieldInstances);
+
+        $empty = true;
+        if (!empty($fieldInstances)) {
+            foreach ($fieldInstances as $fieldInstance) {
+                if (!($this->isValueEmpty($element->getFieldValue($fieldInstance->handle ?? $fieldInstance->getOriginalHandle()), $element))) {
+                    $empty = false;
+                    break;
+                }
+            }
+        }
+
+        return $empty;
     }
 
     /**


### PR DESCRIPTION
### Description
This can be reproduced with a single site setup and with adding a value to the relation field via the control panel:
- clean 5.6.11 install
- create a section `relations` with an entry type that can have just the default title
- create at least one entry in the `relations` section
- create an Entries field
- create a `blog` section with an entry type that contains that entries field added twice
- create an entry in the `blog` section, fill out the title and fully save
- edit the entry from the previous step, add an entry to the second Entries field - let it autosave
- reload the page - see that this relation will now show in both fields

For compatibility reasons with versions < 5.3.0, if the first instance of a relation field is `null`, we join in the legacy `relations` table and populate that first instance (as in the first one added to the layout, not the first one on the page) with its content.

This problem was exacerbated by https://github.com/craftcms/cms/pull/16818 because, when duplicating the element (e.g. to create a provisional draft), we no longer add an empty array as the value of the relation field. 

Fix: if the value of the first instance of the field is `null`, check if we have more than one instance of it in the layout, and if so, if any of those instances have a value. If yes, then don’t join in the relations table.

(While working on this, I discovered a potential bug related to the resave job the happens with and without this change. To be discussed internally.)

### Related issues
#16912 
