### PR TITLE
User cache invalidation remediation

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -22,8 +22,10 @@
 - Added `craft\db\pgsql\QueryBuilder::jsonContains()`.
 - Added `craft\db\pgsql\QueryBuilder::jsonExtract()`.
 - Added `craft\queue\ReleasableQueueInterface`. ([#16672](https://github.com/craftcms/cms/pull/16672))
+- Added `craft\records\User::haveIndexAttributesChanged()`.
 - Added `craft\services\Search::indexElementIfQueued()`.
 - Added `craft\services\Search::queueIndexElement()`.
+- `craft\cache\ElementQueryTagDependency` now merges cache tags provided by the element query with any tags already set on its `$tags` property.  
 
 ### System
 - `craft\queue\Queue::release()` and `releaseAll()` now call `release()` and `releaseAll()` on the proxied queue if it implements `craft\queue\ReleasableQueueInterface`. ([#16672](https://github.com/craftcms/cms/pull/16672))
@@ -31,5 +33,6 @@
 - The `resourcepaths` table is now truncated when clearing control panel resources, via the Caches utility or the `clear-caches/cp-resources` command. ([#16514](https://github.com/craftcms/cms/issues/16514))
 - Date values for custom fields are now represented as ISO-8601 date strings (with time zones) within element exports. ([#16629](https://github.com/craftcms/cms/pull/16629))
 - “Updating search indexes” queue jobs no longer do anything if search indexes were already updated for the element since the job was created. ([#16644](https://github.com/craftcms/cms/pull/16644))
+- User caches are no longer invalidated on login attempts or when user management actions are taken. ([#16937](https://github.com/craftcms/cms/pull/16937))
 - Updated Yii to 2.0.52.
 - Updated yii2-debug to 2.1.26.

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -12,6 +12,7 @@ use Craft;
 use craft\behaviors\CustomFieldBehavior;
 use craft\behaviors\DraftBehavior;
 use craft\behaviors\RevisionBehavior;
+use craft\cache\ElementQueryTagDependency;
 use craft\db\Connection;
 use craft\db\ExcludeDescendantIdsExpression;
 use craft\db\Query;
@@ -1187,8 +1188,13 @@ abstract class Element extends Component implements ElementInterface
         }
 
         // Only cache if there's no search term
-        if (!$elementQuery->search) {
-            $elementQuery->cache();
+        if ($elementQuery instanceof ElementQuery && !$elementQuery->search) {
+            $elementQuery->cache(dependency: new ElementQueryTagDependency($elementQuery, [
+                'tags' => [
+                    'element-index-query',
+                    sprintf('element-index-query::%s', static::class),
+                ],
+            ]));
         }
 
         $variables['elements'] = static::indexElements($elementQuery, $sourceKey);

--- a/src/cache/ElementQueryTagDependency.php
+++ b/src/cache/ElementQueryTagDependency.php
@@ -46,7 +46,7 @@ class ElementQueryTagDependency extends TagDependency
     protected function generateDependencyData($cache)
     {
         if ($this->elementQuery) {
-            $this->tags = $this->elementQuery->getCacheTags();
+            $this->tags = array_unique(array_merge($this->tags, $this->elementQuery->getCacheTags()));
         }
         return parent::generateDependencyData($cache);
     }

--- a/src/records/User.php
+++ b/src/records/User.php
@@ -113,4 +113,29 @@ class User extends ActiveRecord
         return $this->hasMany(UserGroup::class, ['id' => 'groupId'])
             ->viaTable(Table::USERGROUPS_USERS, ['userId' => 'id']);
     }
+
+    /**
+     * Returns whether any properties that affect the user's status have changed.
+     *
+     * @retrun bool
+     * @since 4.15.0
+     */
+    public function haveIndexAttributesChanged(): bool
+    {
+        if ($this->getIsNewRecord()) {
+            return false;
+        }
+
+        return !empty($this->getDirtyAttributes([
+            'active',
+            'email',
+            'firstName',
+            'fullName',
+            'lastLoginDate',
+            'lastName',
+            'pending',
+            'suspended',
+            'username',
+        ]));
+    }
 }

--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -404,7 +404,12 @@ class Search extends Component
 
         $results = $query
             ->andWhere(['elementId' => $elementQuery])
-            ->cache(true, new ElementQueryTagDependency($elementQuery))
+            ->cache(true, new ElementQueryTagDependency($elementQuery, [
+                'tags' => [
+                    'element-index-query',
+                    sprintf('element-index-query::%s', $elementQuery->elementType),
+                ],
+            ]))
             ->all();
 
         // Score the results

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -44,6 +44,7 @@ use yii\base\Component;
 use yii\base\Exception;
 use yii\base\InvalidArgumentException;
 use yii\base\UserException;
+use yii\caching\TagDependency;
 
 /**
  * The Users service provides APIs for managing users.
@@ -526,6 +527,8 @@ class Users extends Component
         $userRecord->password = null;
         $userRecord->verificationCode = null;
 
+        $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
+
         if (!$userRecord->save()) {
             return false;
         }
@@ -534,6 +537,11 @@ class Users extends Component
         $user->pending = false;
         $user->password = null;
         $user->verificationCode = null;
+        
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
+        
         return true;
     }
 
@@ -718,14 +726,16 @@ class Users extends Component
             $userRecord->lastLoginAttemptIp = Craft::$app->getRequest()->getUserIP();
         }
 
+        $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
         $userRecord->save();
 
         // Update the User model too
         $user->lastLoginDate = $now;
         $user->invalidLoginCount = null;
 
-        // Invalidate caches
-        Craft::$app->getElements()->invalidateCachesForElement($user);
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
     }
 
     /**
@@ -772,6 +782,7 @@ class Users extends Component
             $user->invalidLoginCount = $userRecord->invalidLoginCount;
         }
 
+        $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
         $userRecord->save();
 
         // Update the User model too
@@ -784,8 +795,9 @@ class Users extends Component
             ]));
         }
 
-        // Invalidate caches
-        Craft::$app->getElements()->invalidateCachesForElement($user);
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
     }
 
     /**
@@ -846,6 +858,8 @@ class Users extends Component
             $userRecord->invalidLoginCount = null;
             $userRecord->lastInvalidLoginDate = null;
             $userRecord->lockoutDate = null;
+
+            $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
             $userRecord->save();
 
             // If they have an unverified email address, now is the time to set it to their primary email address
@@ -864,8 +878,9 @@ class Users extends Component
             ]));
         }
 
-        // Invalidate caches
-        Craft::$app->getElements()->invalidateCachesForElement($user);
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
 
         return true;
     }
@@ -903,6 +918,8 @@ class Users extends Component
             $userRecord->invalidLoginCount = null;
             $userRecord->lastInvalidLoginDate = null;
             $userRecord->lockoutDate = null;
+
+            $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
             $userRecord->save();
 
             $user->active = false;
@@ -928,9 +945,9 @@ class Users extends Component
             ]));
         }
 
-        // Invalidate caches
-        Craft::$app->getElements()->invalidateCachesForElement($user);
-
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
         return true;
     }
 
@@ -956,6 +973,8 @@ class Users extends Component
             $userRecord->username = $user->unverifiedEmail;
         }
 
+        $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
+
         if (!$userRecord->save()) {
             $user->addErrors($userRecord->getErrors());
             return false;
@@ -964,6 +983,8 @@ class Users extends Component
         // If the user status is pending, let's activate them.
         if ($userRecord->pending) {
             $this->activateUser($user);
+        } elseif ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
         }
 
         return true;
@@ -995,6 +1016,8 @@ class Users extends Component
             $userRecord->invalidLoginCount = null;
             $userRecord->invalidLoginWindowStart = null;
             $userRecord->lockoutDate = null;
+
+            $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
             $userRecord->save();
 
             $transaction->commit();
@@ -1015,8 +1038,9 @@ class Users extends Component
             ]));
         }
 
-        // Invalidate caches
-        Craft::$app->getElements()->invalidateCachesForElement($user);
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
 
         return true;
     }
@@ -1043,6 +1067,8 @@ class Users extends Component
         $userRecord = $this->_getUserRecordById($user->id);
         $userRecord->suspended = true;
         $user->suspended = true;
+
+        $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
         $userRecord->save();
 
         // Destroy all sessions for this user
@@ -1055,8 +1081,9 @@ class Users extends Component
             ]));
         }
 
-        // Invalidate caches
-        Craft::$app->getElements()->invalidateCachesForElement($user);
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
 
         return true;
     }
@@ -1085,6 +1112,8 @@ class Users extends Component
         try {
             $userRecord = $this->_getUserRecordById($user->id);
             $userRecord->suspended = false;
+
+            $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
             $userRecord->save();
 
             $transaction->commit();
@@ -1104,8 +1133,9 @@ class Users extends Component
             ]));
         }
 
-        // Invalidate caches
-        Craft::$app->getElements()->invalidateCachesForElement($user);
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
 
         return true;
     }
@@ -1196,6 +1226,7 @@ class Users extends Component
         }
 
         $transaction = Craft::$app->getDb()->beginTransaction();
+        $indexAttributesChanged = $userRecord->haveIndexAttributesChanged();
         $userRecord->save();
 
         $originalUser = clone $user;
@@ -1214,8 +1245,9 @@ class Users extends Component
 
         $transaction->commit();
 
-        // Invalidate caches
-        Craft::$app->getElements()->invalidateCachesForElement($user);
+        if ($indexAttributesChanged) {
+            $this->invalidateIndexCaches();
+        }
 
         return $unhashedCode;
     }
@@ -1348,6 +1380,8 @@ class Users extends Component
                 'newGroupIds' => $event->newGroupIds,
             ]));
         }
+
+        $this->invalidateIndexCaches();
 
         return true;
     }
@@ -1631,5 +1665,17 @@ class Users extends Component
         }
 
         return $url;
+    }
+
+    /**
+     * Invalidates user index caches.
+     *
+     * @since 4.15.0
+     */
+    public function invalidateIndexCaches(): void
+    {
+        TagDependency::invalidate(Craft::$app->getCache(), [
+            sprintf('element-index-query::%s', User::class),
+        ]);
     }
 }


### PR DESCRIPTION
### Description

Previously, user caches have been invalidated whenever they:

- are activated, unlocked, suspended, or unsuspended (52154d71dc457f1cb784cd8c336a09f6e5b929e5)
- attempt to login (48953f70cd74902d29230de34f4260580bd9ff9e)
- are set to pending or inactive (2076b4e24597b3c1e098073b33ed240570e084c3)

These were done specifically so user indexes show up-to-date information. However they also can end up inadvertently clearing front-end caches, if any user data is output within `{% cache %}` tags, or if the site has full-page caching that monitors all cache tag invalidations (like we do with Craft Cloud).

To fix, we’re now assigning `element-index-query` and `element-index-query::<element-type>` tags to element index query caches, and when any of the above actions occur, we are now _only_ invalidating caches tagged with `element-index-query::craft\elements\User`.

(Normal user caches will still be cleared any time a user is fully saved.)

### Related issues

- #9947
- #10313