### PR TITLE
relocate assets when propagating if localising relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where relations weren’t always propagating to newly-added sites for sections correctly. ([#16924](https://github.com/craftcms/cms/pull/16924))
+- Fixed a bug where Assets fields set to restrict assets to a single location were relocating assets on element propagation. ([#12767](https://github.com/craftcms/cms/issues/12767), [#16936](https://github.com/craftcms/cms/issues/16936))
 
 ## 4.14.11.1 - 2025-03-19
 

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -629,53 +629,55 @@ class Assets extends BaseRelationField
                 }
             }
 
-            // Are there any related assets?
-            /** @var AssetQuery $query */
-            /** @var Asset[] $assets */
-            $assets = $query->all();
+            if (!$element->propagating || $this->localizeRelations) {
+                // Are there any related assets?
+                /** @var AssetQuery $query */
+                /** @var Asset[] $assets */
+                $assets = $query->all();
 
-            if (!empty($assets)) {
-                // Only enforce the restricted asset location for canonical elements
-                if ($this->restrictLocation && $isCanonical) {
-                    if (!$this->allowSubfolders) {
-                        $rootRestrictedFolderId = $getUploadFolderId();
+                if (!empty($assets)) {
+                    // Only enforce the restricted asset location for canonical elements
+                    if ($this->restrictLocation && $isCanonical) {
+                        if (!$this->allowSubfolders) {
+                            $rootRestrictedFolderId = $getUploadFolderId();
+                        } else {
+                            $rootRestrictedFolderId = $this->_uploadFolder($element, true, false)->id;
+                        }
+
+                        $assetsToMove = array_filter($assets, function(Asset $asset) use ($rootRestrictedFolderId, $assetsService) {
+                            if ($asset->folderId === $rootRestrictedFolderId) {
+                                return false;
+                            }
+                            if (!$this->allowSubfolders) {
+                                return true;
+                            }
+                            $rootRestrictedFolder = $assetsService->getFolderById($rootRestrictedFolderId);
+                            return (
+                                $asset->volumeId !== $rootRestrictedFolder->volumeId ||
+                                !str_starts_with($asset->folderPath, $rootRestrictedFolder->path)
+                            );
+                        });
                     } else {
-                        $rootRestrictedFolderId = $this->_uploadFolder($element, true, false)->id;
+                        // Find the files with temp sources and just move those.
+                        /** @var Asset[] $assetsToMove */
+                        $assetsToMove = $assetsService->createTempAssetQuery()
+                            ->id(array_map(fn(Asset $asset) => $asset->id, $assets))
+                            ->all();
                     }
 
-                    $assetsToMove = array_filter($assets, function(Asset $asset) use ($rootRestrictedFolderId, $assetsService) {
-                        if ($asset->folderId === $rootRestrictedFolderId) {
-                            return false;
-                        }
-                        if (!$this->allowSubfolders) {
-                            return true;
-                        }
-                        $rootRestrictedFolder = $assetsService->getFolderById($rootRestrictedFolderId);
-                        return (
-                            $asset->volumeId !== $rootRestrictedFolder->volumeId ||
-                            !str_starts_with($asset->folderPath, $rootRestrictedFolder->path)
-                        );
-                    });
-                } else {
-                    // Find the files with temp sources and just move those.
-                    /** @var Asset[] $assetsToMove */
-                    $assetsToMove = $assetsService->createTempAssetQuery()
-                        ->id(array_map(fn(Asset $asset) => $asset->id, $assets))
-                        ->all();
-                }
+                    if (!empty($assetsToMove)) {
+                        $uploadFolder = $assetsService->getFolderById($getUploadFolderId());
 
-                if (!empty($assetsToMove)) {
-                    $uploadFolder = $assetsService->getFolderById($getUploadFolderId());
-
-                    // Resolve all conflicts by keeping both
-                    foreach ($assetsToMove as $asset) {
-                        $asset->avoidFilenameConflicts = true;
-                        try {
-                            $assetsService->moveAsset($asset, $uploadFolder);
-                        } catch (FsObjectNotFoundException $e) {
-                            // Don't freak out about that.
-                            Craft::warning('Couldn’t move asset because the file doesn’t exist: ' . $e->getMessage());
-                            Craft::$app->getErrorHandler()->logException($e);
+                        // Resolve all conflicts by keeping both
+                        foreach ($assetsToMove as $asset) {
+                            $asset->avoidFilenameConflicts = true;
+                            try {
+                                $assetsService->moveAsset($asset, $uploadFolder);
+                            } catch (FsObjectNotFoundException $e) {
+                                // Don't freak out about that.
+                                Craft::warning('Couldn’t move asset because the file doesn’t exist: ' . $e->getMessage());
+                                Craft::$app->getErrorHandler()->logException($e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Description
When propagating elements, only move assets if the Assets field is localized.

(It’s the same solution as we had in [PR#12777](https://github.com/craftcms/cms/pull/12777), but it never got merged in.)


### Related issues
#12767
#16936 
