### PR TITLE
TTR is ignored for `BaseBatchedJob` that implement `RetryableJobInterface`

### DIFF
--- a/src/queue/BaseBatchedJob.php
+++ b/src/queue/BaseBatchedJob.php
@@ -12,6 +12,7 @@ use craft\base\Batchable;
 use craft\helpers\ConfigHelper;
 use craft\helpers\Queue as QueueHelper;
 use craft\i18n\Translation;
+use yii\queue\RetryableJobInterface;
 
 /**
  * BaseBatchedJob is the base class for large jobs that may need to spawn
@@ -31,7 +32,7 @@ use craft\i18n\Translation;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.4.0
  */
-abstract class BaseBatchedJob extends BaseJob
+abstract class BaseBatchedJob extends BaseJob implements RetryableJobInterface
 {
     /**
      * @var int The number of items that should be processed in a single batch
@@ -177,5 +178,21 @@ abstract class BaseBatchedJob extends BaseJob
             'index' => $this->batchIndex + 1,
             'total' => $totalBatches,
         ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTtr(): ?int
+    {
+        return $this->ttr;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function canRetry($attempt, $error): bool
+    {
+        return false;
     }
 }

--- a/src/queue/BaseBatchedJob.php
+++ b/src/queue/BaseBatchedJob.php
@@ -152,7 +152,7 @@ abstract class BaseBatchedJob extends BaseJob implements RetryableJobInterface
         if ($this->itemOffset < $this->totalItems()) {
             $nextJob = clone $this;
             $nextJob->batchIndex++;
-            QueueHelper::push($nextJob, $this->priority, 0, $this->ttr, $queue);
+            QueueHelper::push($nextJob, $this->priority, 0, $this->getTtr(), $queue);
         }
     }
 

--- a/src/queue/BaseBatchedJob.php
+++ b/src/queue/BaseBatchedJob.php
@@ -183,7 +183,7 @@ abstract class BaseBatchedJob extends BaseJob implements RetryableJobInterface
     /**
      * @inheritdoc
      */
-    public function getTtr(): ?int
+    public function getTtr()
     {
         return $this->ttr;
     }


### PR DESCRIPTION
### Description
It is not uncommon for jobs to implement `yii\queue\RetryableJobInterface`.
- Feed Me: https://github.com/craftcms/feed-me/blob/6.x/src/queue/jobs/FeedImport.php#L22
- Blitz: https://github.com/putyourlightson/craft-blitz/blob/develop/src/jobs/GenerateCacheJob.php#L18

In that scenario, the Job's `getTtr` [will be ignored](https://github.com/craftcms/cms/blob/4.15/src/queue/BaseBatchedJob.php#L154) and prefer `BaseBatchedJob::$ttr`.

To remedy this in a non-breaking way, `BaseBatchedJob` now implements `yii\queue\RetryableJobInterface`.

Note: here is where Yii accounts for `yii\queue\RetryableJobInterface` when pushing a job: https://github.com/yiisoft/yii2-queue/blob/master/src/Queue.php#L155-L159