### PR TITLE
[5.x] Element relations not saved when creating an element with `Craft::createObject()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where relations weren’t always propagating to newly-added sites for sections correctly. ([#16924](https://github.com/craftcms/cms/pull/16924))
 - Fixed a bug where Assets fields set to restrict assets to a single location were relocating assets on element propagation. ([#12767](https://github.com/craftcms/cms/issues/12767), [#16936](https://github.com/craftcms/cms/issues/16936))
+- Fixed a bug where relations weren’t getting saved for new elements, if the element was created with `Craft::createObject()` with its relation field data included in the passed-in config. ([#16942](https://github.com/craftcms/cms/pull/16942))
 
 ## 4.14.11.1 - 2025-03-19
 

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -951,8 +951,10 @@ JS, [
     {
         // Skip if nothing changed, or the element is just propagating and we're not localizing relations
         if (
-            ($element->duplicateOf || $element->isFieldDirty($this->handle) || $this->maintainHierarchy) &&
-            (!$element->propagating || $this->localizeRelations)
+            $isNew || (
+                ($element->duplicateOf || $element->isFieldDirty($this->handle) || $this->maintainHierarchy) &&
+                (!$element->propagating || $this->localizeRelations)
+            )
         ) {
             /** @var ElementQueryInterface|Collection $value */
             $value = $element->getFieldValue($this->handle);


### PR DESCRIPTION
### Description
Noticed a quirk/bug when creating an element using `Craft::createObject()` and setting data on a element relation custom field.

The test code for creating an entry is as follows:

```php
$randomEntry = Entry::find()->orderBy('RAND()')->one();
$section = Craft::$app->getEntries()->getSectionByHandle('test');

$entry = Craft::createObject([
    'class' => Entry::class,
    'sectionId' => $section->id,
    'title' => 'My Test Entry',
    'enabled' => true,
    'myRelatedEntry' => [$randomEntry->id],
]);

Craft::$app->getElements()->saveElement($entry);
````

With this code the element saves and if you view the element in the CP or look at its content in the DB everything looks correct. The related element shows up in the field etc.

However, no rows are added to the `relations` DB table. This means that if you were to do an element query e.g. `Entry::find()->relatedTo([123])->one()` the entry would not be returned.

Tracked this issue down to two parts. 

Because the element is being created with `createObject()` and mass assignment the `$_initialized` property on the element is still false when it hits the following bit of code, so the field is not marked as dirty.

https://github.com/craftcms/cms/blob/f48af604a0c4f5d65dfddcfd3eb2ea143dc87206/src/base/Element.php#L5056-L5058

This however doesn't stop the content from saving, but in the case of a relationship field it prevents the relation from saving in the `updateRelations()` method when figuring out if the field should be included.

https://github.com/craftcms/cms/blob/f48af604a0c4f5d65dfddcfd3eb2ea143dc87206/src/base/Element.php#L6199-L6205

To get the ball rolling on a solution for this I took the idea that if this element is a brand new element we can pass `$isNew` from the `afterSave()` to `updateRelations()`. As, in theory, if it is new we probably want to be trying to save all the data we can.

### Related issues
https://github.com/craftcms/commerce/pull/3931
