### PR TITLE
Docs: Resource Base URL config setting

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -2457,7 +2457,7 @@ class GeneralConfig extends BaseConfig
     public string $resourceBasePath = '@webroot/cpresources';
 
     /**
-     * @var string The URL to the root directory that should store published control panel resources.
+     * @var string The URL to the root directory where control panel resources are published.
      *
      * ::: code
      * ```php Static Config
@@ -5974,7 +5974,7 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * The URL to the root directory that should store published control panel resources.
+     * The URL to the root directory where control panel resources are published.
      *
      * ```php
      * ->resourceBaseUrl('@web/craft-resources')


### PR DESCRIPTION
These docblocks were not easily differentiable from the `resourceBasePath`, as pointed out by @ccchapman [over here](https://github.com/craftcms/docs/pull/697)!

As noted in the commit message, this setting doesn't actually impact the location of those assets, just Craft’s ability to generate URLs to the folder where they were published (per `resourceBasePath`).