### PR TITLE
fix for primary owner not getting eager loaded and the fallback failing too

### DIFF
--- a/src/base/NestedElementTrait.php
+++ b/src/base/NestedElementTrait.php
@@ -200,7 +200,14 @@ trait NestedElementTrait
                 // Either we didn't try, or the primary owner couldn't be eager-loaded for some reason
                 $ownerType = $this->ownerType();
                 if (!$ownerType) {
-                    return null;
+                    // try again, using the $primaryOwnerId,
+                    // ownerType() was not able to get it this way cause $this->primaryOwnerId got nullified during the eager loading process
+                    $ownerType = Craft::$app->getElements()->getElementTypeById($primaryOwnerId);
+                    if (!$ownerType) {
+                        return null;
+                    }
+                    // if we were able to find the owner type, set the primaryOwnerId back to what it was
+                    $this->primaryOwnerId = $primaryOwnerId;
                 }
 
                 $query = $ownerType::find()->id($primaryOwnerId);

--- a/src/base/NestedElementTrait.php
+++ b/src/base/NestedElementTrait.php
@@ -198,16 +198,13 @@ trait NestedElementTrait
             /** @phpstan-ignore-next-line */
             if (!isset($this->_primaryOwner) || $this->_primaryOwner === false) {
                 // Either we didn't try, or the primary owner couldn't be eager-loaded for some reason
+                // if the $this->primaryOwnerId got nullified during the eager loading process, set it back to what it should be
+                if ($this->primaryOwnerId === null) {
+                    $this->primaryOwnerId = $primaryOwnerId;
+                }
                 $ownerType = $this->ownerType();
                 if (!$ownerType) {
-                    // try again, using the $primaryOwnerId,
-                    // ownerType() was not able to get it this way cause $this->primaryOwnerId got nullified during the eager loading process
-                    $ownerType = Craft::$app->getElements()->getElementTypeById($primaryOwnerId);
-                    if (!$ownerType) {
-                        return null;
-                    }
-                    // if we were able to find the owner type, set the primaryOwnerId back to what it was
-                    $this->primaryOwnerId = $primaryOwnerId;
+                    return null;
                 }
 
                 $query = $ownerType::find()->id($primaryOwnerId);


### PR DESCRIPTION
### Description
If you run a query that gets both nested and root entries, the primary owner for nested elements won’t get loaded if the first entry returned by the query:
- is not a nested element
- is a nested element that’s owned by an element type different to other nested element owners returned by the query

This will then lead to the `getSupportedSites()` returning wrong sites, and an attempt to save a nested element that was grabbed this way will fail with an `Attempting to save an element in an unsupported site` error.

**Steps to reproduce:**
- clean v5 install of 5.6.2 or above
- create 2 sites (`siteA` and `siteB`)
- create entry type `article`, all default settings, no fields needed except for the default title
- create a section `blog` that uses the `article` entry type
- create matrix field (`matrix`) that uses the `article` entry type; propagation method set to `none`
- create a global set (`myGlobalSet`) that has the `matrix` field in it’s field layout

- create an entry in the `blog` section
- edit `myGlobalSet` and for `siteB` only add an entry to the matrix field; save
- create a template file with the following code:
```
{% set entries = craft.entries.siteId(2).type('article').all() %} {# use the ID of `siteB` #}

{% for entry in entries %}
    {{ entry.title }}<br>
    ID: {{ entry.id }}<br>
    Supported Sites:{{ dump(entry.getSupportedSites)}} <br>
    Field ID: {{ entry.fieldId }}
    <hr>
{% endfor %}
```
- access the template via browser and note that for the blog entry, the “supported sites” lists both `siteA` and `siteB` and for the entry from the matrix field from the global, the “supported sites” is listed correctly as `siteB`

- now create a second entry (must be created after adding the entry to the global set) in the `blog` section
- access the template again and note that for the first blog entry, the “supported sites” lists both `siteA` and `siteB`; for the entry from the matrix field from the global, the “supported sites” is listed wrongly as the primary site (`siteA`) and for the second blog entry, the “supported sites” also correctly lists both sites

**The problem:**
The problem is that the `eagerLoadingMap` in the `NestedElementTrait` takes the `ownerType` of the [first source element](https://github.com/craftcms/cms/blob/5.6.13/src/base/NestedElementTrait.php#L41). If the first source element is a root entry, then there’s no owner, and therefore no owner type, so the map is `false`, and nothing gets eager loaded.

If the first source element is nested but its owner is of a different type than the owners of other source elements (e.g., the first source element’s owner is a Category, but there are other source elements in the set that are owned by Global Set or Entry, etc.), then the eager loading map will only look through the Categories, and so other source element owners won’t be eager loaded as expected.

The [fallback](https://github.com/craftcms/cms/blob/5.6.13/src/base/NestedElementTrait.php#L199-L213) we have to get the primary owner if it wasn’t eager loaded will then fail because the `primaryOwnerId` is lost (set to `null`) in the process of eager loading. If the `primaryOwner` wasn’t found during eager loading, it’ll still be set as [eager loaded as a `null` owner](https://github.com/craftcms/cms/blob/5.6.13/src/services/Elements.php#L3369) which will [remove the `primaryOwnerId` from the nested element](https://github.com/craftcms/cms/blob/5.6.13/src/base/NestedElementTrait.php#L397) we were getting it for which will cause the fallback for getting the `primaryOwner` to fail.

(related to [this change](https://github.com/craftcms/cms/commit/8cb3e36126291fd20143a5e26d6fabb9a0a1383e))

**Solution:**
When we reach the fallback for getting the nested element’s primary owner, and we can’t get the owner type, we should try to deduct it from the `primaryOwnerId` we had at the start of the method and only bail if we can’t get it that way too.

### Related issues
n/a - from a query that @olivierbon was working on in support
