### PR TITLE
allow for dates to be formatted without IntlDateFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a bug where relations weren’t getting saved for new elements, if the element was created with `Craft::createObject()` with its relation field data included in the passed-in config. ([#16942](https://github.com/craftcms/cms/pull/16942))
 - Fixed a bug where relational fields with a “Related To” rule on their selectable elements condition weren’t making all expected elements selectable. ([#16945](https://github.com/craftcms/cms/issues/16945))
 - Fixed a bug where some subdivisions weren’t available when creating addresses. ([#16951](https://github.com/craftcms/cms/issues/16951))
+- Fixed a bug where some older dates could be formatted incorrectly. ([#16953](https://github.com/craftcms/cms/issues/16953))
 
 ## 4.14.11.1 - 2025-03-19
 

--- a/src/i18n/Formatter.php
+++ b/src/i18n/Formatter.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\helpers\DateTimeHelper;
 use DateTime;
 use DateTimeZone;
+use Exception;
 use IntlTimeZone;
 use NumberFormatter;
 use Yii;
@@ -89,7 +90,6 @@ class Formatter extends \yii\i18n\Formatter
             return $dateFormattedWithoutIntl;
         }
 
-
         if (strncmp($format, 'php:', 4) === 0) {
             return $this->_formatDateTimeValueWithPhpFormat($value, substr($format, 4), 'date');
         }
@@ -104,18 +104,13 @@ class Formatter extends \yii\i18n\Formatter
      * @param int|string|DateTime $value
      * @param string|null $format
      * @return string|null
-     * @throws \Exception
+     * @throws Exception
      */
-    protected function formatDateWithoutIntl(int|string|DateTime $value, ?string $format): ?string
+    private function formatDateWithoutIntl(int|string|DateTime $value, ?string $format): ?string
     {
         // see https://github.com/craftcms/cms/issues/16953 for more details on why this method was added
 
-        if (!($value instanceof DateTime)) {
-            return null;
-        }
-
-        $intlLoaded = extension_loaded('intl');
-        if (!$intlLoaded) {
+        if (!$value instanceof DateTime || !extension_loaded('intl')) {
             return null;
         }
 
@@ -125,9 +120,9 @@ class Formatter extends \yii\i18n\Formatter
 
         // get PHP DateTime offset for this date
         $phpOffset = $value->getTimezone()->getOffset($value);
-        // get DST offset that intl time zone would use (divided by 1000, cause different units)
+        // get DST offset that intl time zone would use (divided by 1000, b/c different units)
         $dstIntlOffset = ($intlTimeZone->getRawOffset() + $intlTimeZone->getDSTSavings()) / 1000;
-        // get raw offset that intl time zone would use (divided by 1000, cause different units)
+        // get raw offset that intl time zone would use (divided by 1000, b/c different units)
         $rawIntlOffset = $intlTimeZone->getRawOffset() / 1000;
 
         // compare the php and intl offsets

--- a/src/i18n/Formatter.php
+++ b/src/i18n/Formatter.php
@@ -11,9 +11,12 @@ use Craft;
 use craft\helpers\DateTimeHelper;
 use DateTime;
 use DateTimeZone;
+use IntlTimeZone;
 use NumberFormatter;
+use Yii;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
+use yii\helpers\FormatConverter;
 
 /**
  * @inheritdoc
@@ -80,11 +83,68 @@ class Formatter extends \yii\i18n\Formatter
             $format = $this->dateTimeFormats[$format]['date'];
         }
 
+        // https://github.com/craftcms/cms/issues/16953
+        $dateFormattedWithoutIntl = $this->formatDateWithoutIntl($value, $format);
+        if ($dateFormattedWithoutIntl !== null) {
+            return $dateFormattedWithoutIntl;
+        }
+
+
         if (strncmp($format, 'php:', 4) === 0) {
             return $this->_formatDateTimeValueWithPhpFormat($value, substr($format, 4), 'date');
         }
 
         return parent::asDate($value, $format);
+    }
+
+    /**
+     * Checks if the date should be formatted without the help of intl.
+     * This is needed for some "old" dates, like dates from 19th century from Europe/Amsterdam timezone
+     *
+     * @param int|string|DateTime $value
+     * @param string|null $format
+     * @return string|null
+     * @throws \Exception
+     */
+    protected function formatDateWithoutIntl(int|string|DateTime $value, ?string $format): ?string
+    {
+        // see https://github.com/craftcms/cms/issues/16953 for more details on why this method was added
+
+        if (!($value instanceof DateTime)) {
+            return null;
+        }
+
+        $intlLoaded = extension_loaded('intl');
+        if (!$intlLoaded) {
+            return null;
+        }
+
+        $intlTimeZone = IntlTimeZone::fromDateTimeZone($value->getTimezone());
+        $intlTimeZone->getOffset($value->getTimestamp(), true, $o1, $o2);
+        $intlTimeZone->getOffset($value->getTimestamp(), false, $o3, $o4);
+
+        // get PHP DateTime offset for this date
+        $phpOffset = $value->getTimezone()->getOffset($value);
+        // get DST offset that intl time zone would use (divided by 1000, cause different units)
+        $dstIntlOffset = ($intlTimeZone->getRawOffset() + $intlTimeZone->getDSTSavings()) / 1000;
+        // get raw offset that intl time zone would use (divided by 1000, cause different units)
+        $rawIntlOffset = $intlTimeZone->getRawOffset() / 1000;
+
+        // compare the php and intl offsets
+        // if either are the same, we're good to proceed with the intl approach, as we used to;
+        // but if they're both different, we should use PHP to format the date
+        if ($phpOffset === $dstIntlOffset || $phpOffset === $rawIntlOffset) {
+            return null;
+        }
+
+        // copied from yii\i18n\Formatter::formatDateTimeValue()
+        if (strncmp($format, 'php:', 4) === 0) {
+            $format = substr($format, 4);
+        } else {
+            $format = FormatConverter::convertDateIcuToPhp($format, 'date', Yii::$app->language);
+        }
+
+        return $value->format($format);
     }
 
     /**


### PR DESCRIPTION
### Description
Entering “old” dates, like `1881-01-07` in the `Europe/Amsterdam` timezone, are saved correctly in the database. However, after the page reloads, they’re displayed incorrectly, causing subsequent saves to adjust the date to the wrong one.

All dates are stored in the database as UTC. When you enter a date in the control panel, and your system timezone is set to, e.g. `Europe/Amsterdam`, the PHP `DateTime` object is created. In this case, it’s `1881-01-07 00:00:00` in the `Europe/Amsterdam` timezone. It’s then [converted to UTC](https://github.com/craftcms/cms/blob/5.6.13/src/helpers/Db.php#L168) before being stored in the database. 

The timezone used in Amsterdam in the 19th century was different than it is now. (It used to be 19 minutes and 32 seconds ahead of GMT, then 20 minutes ahead of GMT, and then changed again in 1940. More info: https://www.timeanddate.com/time/zone/netherlands#time.)

So, when you use `07-01-1881`, it’s stored in the DB as `1881-01-06 23:40:28` (UTC). It’s then retrieved and converted to `1881-01-07 00:00:00` in `Europe/Amsterdam` as expected, but then the intl formatter has trouble correctly formatting it as `1881-01-07`. 
It looks like this is happening because the `IntlTimeZone` has the raw and current offsets set to the offsets that are used nowadays (3600000 for this timezone, which translates to 1 hour). This means that when it tries to format the date, it subtracts 1 hour, causing `1881-01-07` to become `1881-01-06`.

(To clarify, there’s a potential for this to happen with different timezones too. For example, `1883-10-31` in the `America/Los_Angeles` timezone is stored as `1883-10-31 07:52:58`.)

**Solution**
Check if the timezone offset returned by PHP `DateTime` matches either the raw offset or one adjusted with DST savings returned by the `IntlTimeZone`. If neither match, err on the side of caution and use PHP `DateTime::format()` to format the date.


### Related issues
#16953 
