### PR TITLE
searchTermOptions GraphQL query argument

### DIFF
--- a/src/gql/base/ElementArguments.php
+++ b/src/gql/base/ElementArguments.php
@@ -7,6 +7,7 @@
 
 namespace craft\gql\base;
 
+use craft\gql\GqlEntityRegistry;
 use craft\gql\types\input\criteria\Asset;
 use craft\gql\types\input\criteria\Category;
 use craft\gql\types\input\criteria\Entry;
@@ -14,6 +15,7 @@ use craft\gql\types\input\criteria\Tag;
 use craft\gql\types\input\criteria\User;
 use craft\gql\types\QueryArgument;
 use craft\helpers\Gql;
+use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\Type;
 
 /**
@@ -69,6 +71,31 @@ abstract class ElementArguments extends Arguments
                 'name' => 'search',
                 'type' => Type::string(),
                 'description' => 'Narrows the query results to only elements that match a search query.',
+            ],
+            'searchTermOptions' => [
+                'name' => 'searchTermOptions',
+                'type' => GqlEntityRegistry::getOrCreate('SearchTermOptions', fn() => new InputObjectType([
+                    'name' => 'SearchTermOptions',
+                    'fields' => fn() => [
+                        'subLeft' => [
+                            'name' => 'subLeft',
+                            'type' => Type::boolean(),
+                        ],
+                        'subRight' => [
+                            'name' => 'subRight',
+                            'type' => Type::boolean(),
+                        ],
+                        'exclude' => [
+                            'name' => 'exclude',
+                            'type' => Type::boolean(),
+                        ],
+                        'exact' => [
+                            'name' => 'exact',
+                            'type' => Type::boolean(),
+                        ],
+                    ],
+                ])),
+                'description' => 'Defines the default options that should be applied terms within the `search` argument.',
             ],
             'relatedTo' => [
                 'name' => 'relatedTo',

--- a/src/gql/base/ElementResolver.php
+++ b/src/gql/base/ElementResolver.php
@@ -14,6 +14,7 @@ use craft\base\GqlInlineFragmentFieldInterface;
 use craft\elements\db\ElementQuery;
 use craft\gql\ArgumentManager;
 use craft\gql\ElementQueryConditionBuilder;
+use craft\helpers\ArrayHelper;
 use craft\helpers\Gql as GqlHelper;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Support\Collection;
@@ -83,6 +84,13 @@ abstract class ElementResolver extends Resolver
         $arguments = $argumentManager->prepareArguments($arguments);
 
         $fieldName = GqlHelper::getFieldNameWithAlias($resolveInfo, $source, $context);
+
+        // combine `search` and `searchTermOptions` if both are set
+        $searchTermOptions = ArrayHelper::remove($arguments, 'searchTermOptions');
+        if ($searchTermOptions && isset($arguments['search'])) {
+            $searchTermOptions['query'] = $arguments['search'];
+            $arguments['search'] = $searchTermOptions;
+        }
 
         /** @var ElementQuery $query */
         $query = static::prepareQuery($source, $arguments, $fieldName);


### PR DESCRIPTION
### Description

Adds a new `searchTermOptions` GraphQL query argument, with `subLeft`, `subRight`, `exclude`, and `exact` sub-fields. When specified, they will override the [defaultSearchTermOptions](https://craftcms.com/docs/5.x/reference/config/general.html#defaultsearchtermoptions) config setting values.

```graphql
query {
  entries {
    search: "salty dog"
    searchTermOptions: {
      subRight: false
    }
  }
}
```

### Related issues

- #16970