### PR TITLE
ensure quality is never below -1 and above 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a bug where some older dates could be formatted incorrectly. ([#16953](https://github.com/craftcms/cms/issues/16953))
 - Fixed a bug where the `folderPath` asset query param only accepted strings. ([#16981](https://github.com/craftcms/cms/issues/16981))
 - Fixed a bug where `craft\elements\Asset::getSrcset()` could return malformed results if any sizes didn’t have corresponding image URLs. ([#16984](https://github.com/craftcms/cms/issues/16984))
+- Fixed an error that could occur when uploading images. ([#16977](https://github.com/craftcms/cms/issues/16977))
 - Fixed a styling issue. ([#16964](https://github.com/craftcms/cms/issues/16964))
 
 ## 4.14.11.1 - 2025-03-19

--- a/src/image/Raster.php
+++ b/src/image/Raster.php
@@ -824,6 +824,9 @@ class Raster extends Image
         switch ($extension) {
             case 'jpeg':
             case 'jpg':
+                // ensure quality is between -1 and 100
+                // https://github.com/craftcms/cms/issues/16977
+                $quality = min(100, max(-1, $quality));
                 return ['jpeg_quality' => $quality, 'flatten' => true];
 
             case 'gif':


### PR DESCRIPTION
### Description
When getting options to save a jpeg image, ensure the quality is between -1 and 100 (as per the docs for [imagejpeg](https://www.php.net/manual/en/function.imagejpeg.php)).

I'm not able to reproduce the reported error, but this should ensure the quality value is within the accepted range.

### Related issues
#16977
