### PR TITLE
user group save - primary action should redirect to the listing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed a bug where the `folderPath` asset query param only accepted strings. ([#16981](https://github.com/craftcms/cms/issues/16981))
 - Fixed a bug where `craft\elements\Asset::getSrcset()` could return malformed results if any sizes didn’t have corresponding image URLs. ([#16984](https://github.com/craftcms/cms/issues/16984))
 - Fixed an error that could occur when uploading images. ([#16977](https://github.com/craftcms/cms/issues/16977))
+- Fixed a bug where the “Save” button on user group edit pages was redirecting to the same page, rather than the User Groups index page. ([#16988](https://github.com/craftcms/cms/issues/16988))
 - Fixed a styling issue. ([#16964](https://github.com/craftcms/cms/issues/16964))
 
 ## 4.14.11.1 - 2025-03-19

--- a/src/templates/settings/users/groups/_edit.twig
+++ b/src/templates/settings/users/groups/_edit.twig
@@ -39,7 +39,7 @@
 
 {% block content %}
     {{ actionInput('user-settings/save-group') }}
-    {{ redirectInput('settings/users/groups/{id}') }}
+    {{ redirectInput('settings/users') }}
 
     {% if not isNewGroup %}{{ hiddenInput('groupId', group.id) }}{% endif %}
 


### PR DESCRIPTION
### Description
When editing a user group, the primary save action should redirect to the listing page.


### Related issues
#16988 
