### PR TITLE
only show focal point toggle button if user has permissions to edit images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed a bug where `craft\elements\Asset::getSrcset()` could return malformed results if any sizes didn’t have corresponding image URLs. ([#16984](https://github.com/craftcms/cms/issues/16984))
 - Fixed an error that could occur when uploading images. ([#16977](https://github.com/craftcms/cms/issues/16977))
 - Fixed a bug where the “Save” button on user group edit pages was redirecting to the same page, rather than the User Groups index page. ([#16988](https://github.com/craftcms/cms/issues/16988))
+- Fixed a bug where asset previows had an “Enable focal point” button even if the logged-in user didn’t have permission to save the asset. ([#16997](https://github.com/craftcms/cms/issues/16997))
 - Fixed a styling issue. ([#16964](https://github.com/craftcms/cms/issues/16964))
 
 ## 4.14.11.1 - 2025-03-19

--- a/src/templates/assets/_previews/image.twig
+++ b/src/templates/assets/_previews/image.twig
@@ -1,9 +1,12 @@
 {% set containerId = "asset-image-preview#{random()}" %}
 {% set toggleId = "toggle-focal#{random()}" %}
-{% set enableFocalPoint = asset.mimeType != 'image/svg+xml' %}
+{% set enableFocalPoint = (
+  asset.mimeType != 'image/svg+xml' and
+  craft.app.elements.canSave(asset)
+) %}
 
 <div id="{{ containerId }}" class="button-fade asset-image-preview">
-    {% if enableFocalPoint and currentUser and currentUser.can('editImages:'~asset.volume.uid) %}
+    {% if enableFocalPoint %}
         <div class="buttons">
             <div class="btn" id="{{ toggleId }}">
             </div>

--- a/src/templates/assets/_previews/image.twig
+++ b/src/templates/assets/_previews/image.twig
@@ -3,7 +3,7 @@
 {% set enableFocalPoint = asset.mimeType != 'image/svg+xml' %}
 
 <div id="{{ containerId }}" class="button-fade asset-image-preview">
-    {% if enableFocalPoint %}
+    {% if enableFocalPoint and currentUser and currentUser.can('editImages:'~asset.volume.uid) %}
         <div class="buttons">
             <div class="btn" id="{{ toggleId }}">
             </div>


### PR DESCRIPTION
### Description
Only show the enable/disable focal point button if the user has permission to edit images in the asset’s volume.


### Related issues
#16997 
