### PR TITLE
Nested entry revisions

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -37,6 +37,7 @@
 - Added an optional “Download” advanced field to Link fields. ([#16844](https://github.com/craftcms/cms/pull/16844))
 - Added the “SMS” link type for Link fields. ([#16850](https://github.com/craftcms/cms/discussions/16850))
 - Added the “Allow custom URL schemes” setting for Link fields with the “URL” link type enabled. ([#16850](https://github.com/craftcms/cms/discussions/16850))
+- Added the “Enable versioning for entries in this field” setting to Matrix fields. ([#17008](https://github.com/craftcms/cms/pull/17008))
 - Relational fields now have “Default [Type] Placement” settings, which control whether newly-related elements are placed before or after existing relations. ([#16989](https://github.com/craftcms/cms/pull/16989))
 - Added support for read-only custom fields, via new “Editability Conditions” on custom fields’ field layout settings. ([#16805](https://github.com/craftcms/cms/pull/16805))
 - “Template” field layout UI elements are now re-rendered on each autosave. ([#16837](https://github.com/craftcms/cms/discussions/16837))
@@ -97,6 +98,10 @@
 - Added `craft\fieldlayoutelements\CustomField::setEditCondition()`.
 - Added `craft\fields\BaseOptionsField::$optionColors`, which can be set to `true` by subclasses to enable the “Color” setting for field options. ([#16645](https://github.com/craftcms/cms/pull/16645))
 - Added `craft\fields\BaseOptionsField::$optionIcons`, which can be set to `true` by subclasses to enable the “Icon” setting for field options. ([#16645](https://github.com/craftcms/cms/pull/16645))
+- Added `craft\fields\BaseRelationField::$defaultPlacement`.
+- Added `craft\fields\BaseRelationField::DEFAULT_PLACEMENT_BEGINNING`.
+- Added `craft\fields\BaseRelationField::DEFAULT_PLACEMENT_END`.
+- Added `craft\fields\Matrix::$enableVersioning`.
 - Added `craft\fields\data\ColorData::$label`. ([#16492](https://github.com/craftcms/cms/pull/16492))
 - Added `craft\fields\data\JsonData`.
 - Added `craft\fields\data\LinkData::$download`.
@@ -119,9 +124,6 @@
 - Added `craft\web\CpScreenResponseBehavior::toolbarTemplate()`.
 - Added `craft\web\View::registerIcon()`.
 - Added `craft\web\assets\codemirror\CodeMirrorAsset`.
-- Added `craft\fields\BaseRelationField::DEFAULT_PLACEMENT_BEGINNING`.
-- Added `craft\fields\BaseRelationField::DEFAULT_PLACEMENT_END`.
-- Added `craft\fields\BaseRelationField::$defaultPlacement`.
 - `craft\base\Element::fieldLayoutFields()` now has an `editableOnly` argument.
 - `craft\base\ElementInterface::eagerLoadingMap()` and `craft\base\EagerLoadingFieldInterface::eagerLoadingMap()` can now specify mappings for multiple target element types, or not specify the element types at all. ([#16972](https://github.com/craftcms/cms/pull/16972))
 - `craft\cache\ElementQueryTagDependency` now merges cache tags provided by the element query with any tags already set on its `$tags` property.  

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -45,6 +45,7 @@ use craft\enums\PropagationMethod;
 use craft\events\DefineEntryTypesEvent;
 use craft\events\ElementCriteriaEvent;
 use craft\fieldlayoutelements\entries\EntryTitleField;
+use craft\fields\Matrix;
 use craft\gql\interfaces\elements\Entry as EntryInterface;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
@@ -2027,7 +2028,13 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
      */
     public function hasRevisions(): bool
     {
-        return $this->getSection()?->enableVersioning ?? false;
+        $section = $this->getSection();
+        if ($section) {
+            return $section->enableVersioning;
+        }
+
+        $field = $this->getField();
+        return $field instanceof Matrix && $field->enableVersioning;
     }
 
     /**
@@ -2577,31 +2584,35 @@ JS;
      */
     public function beforeSave(bool $isNew): bool
     {
-        $section = $this->getSection();
-        if ($section) {
-            // Make sure the entry has at least one revision if the section has versioning enabled
-            if ($this->_shouldSaveRevision()) {
-                $hasRevisions = self::find()
-                    ->revisionOf($this)
+        if ($this->_shouldSaveRevision()) {
+            // Make sure the entry has at least one revision
+            $hasRevisions = static::find()
+                ->revisionOf($this)
+                ->site('*')
+                ->status(null)
+                ->exists();
+
+            if (!$hasRevisions) {
+                /** @var self|null $current */
+                $current = static::find()
+                    ->id($this->id)
                     ->site('*')
                     ->status(null)
-                    ->exists();
-                if (!$hasRevisions) {
-                    /** @var self|null $currentEntry */
-                    $currentEntry = self::find()
-                        ->id($this->id)
-                        ->site('*')
-                        ->status(null)
-                        ->one();
+                    ->one();
 
-                    // May be null if the entry is currently stored as an unpublished draft
-                    if ($currentEntry) {
-                        $revisionNotes = 'Revision from ' . Craft::$app->getFormatter()->asDatetime($currentEntry->dateUpdated);
-                        Craft::$app->getRevisions()->createRevision($currentEntry, $currentEntry->getAuthorId(), $revisionNotes);
-                    }
+                // May be null if the entry is currently stored as an unpublished draft
+                if ($current) {
+                    Craft::$app->getRevisions()->createRevision(
+                        $current,
+                        $current->getAuthorId(),
+                        sprintf('Revision from %s', Craft::$app->getFormatter()->asDatetime($current->dateUpdated)),
+                    );
                 }
             }
+        }
 
+        $section = $this->getSection();
+        if ($section) {
             // Set the structure ID for Element::attributes() and afterSave()
             if ($section->type === Section::TYPE_STRUCTURE) {
                 $this->structureId = $section->structureId;
@@ -2926,7 +2937,7 @@ JS;
             !$this->resaving &&
             !$this->getIsDraft() &&
             !$this->getIsRevision() &&
-            $this->getSection()?->enableVersioning
+            $this->hasRevisions()
         );
     }
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -207,6 +207,12 @@ class Matrix extends Field implements
     public ?int $maxEntries = null;
 
     /**
+     * @var bool Enable versioning
+     * @since 5.7.0
+     */
+    public bool $enableVersioning = false;
+
+    /**
      * @var string The view mode
      * @phpstan-var self::VIEW_MODE_*
      * @since 5.0.0
@@ -1557,7 +1563,6 @@ JS;
                 ->ownerId($element->id)
                 ->siteId($element->siteId)
                 ->drafts(null)
-                ->revisions(null)
                 ->status(null)
                 ->indexBy($uids ? 'uid' : 'id')
                 ->all();

--- a/src/templates/_components/fieldtypes/Matrix/settings.twig
+++ b/src/templates/_components/fieldtypes/Matrix/settings.twig
@@ -162,6 +162,16 @@
     disabled: readOnly,
 }) }}
 
+{{ forms.lightswitchField({
+    label: 'Enable versioning for entries in this field'|t('app'),
+    id: 'enableVersioning',
+    name: 'enableVersioning',
+    on: field.enableVersioning,
+    errors: field.getErrors('enableVersioning'),
+    data: {'error-key': 'enableVersioning'},
+    disabled: readOnly,
+}) }}
+
 <hr>
 
 {{ forms.selectField({

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -657,6 +657,7 @@ return [
     'Emerald' => 'Emerald',
     'Emirate' => 'Emirate',
     'Enable focal point' => 'Enable focal point',
+    'Enable versioning for entries in this field' => 'Enable versioning for entries in this field',
     'Enable versioning for entries in this section' => 'Enable versioning for entries in this section',
     'Enable' => 'Enable',
     'Enabled for all sites' => 'Enabled for all sites',


### PR DESCRIPTION
### Description

Adds an “Enable versioning for entries in this field” setting to Matrix fields. When enabled, nested entries will get new versions created for them each time they are saved, regardless of whether they were saved directly on their own edit page, or via a Matrix field’s input.

### Related issues

- #16248