### PR TITLE
Empty/not empty operators for option field condition rules

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,6 +1,7 @@
 # Release Notes for Craft CMS 4.15 (WIP)
 
 ### Content Management
+- Condition rules for Checkboxes, Dropdown, Multi-select, and Radio Buttons fields now include “has a value” and “is empty” operators. ([#17015](https://github.com/craftcms/cms/pull/17015))
 - The Assets index page now prompts for confirmation when moving more than 50 assets, or assets totalling more than 50MB, at once. ([#16908](https://github.com/craftcms/cms/pull/16908))
 - The success notification displayed after an asset move now includes an “Undo” button, if less than 50 assets/50MB were involved in the move. ([#16908](https://github.com/craftcms/cms/pull/16908))
 - Window scrolling is now blocked when a modal window is open. ([#16768](https://github.com/craftcms/cms/pull/16768))
@@ -20,6 +21,7 @@
 - Global nav items and breadcrumbs can now have `aria-label` attributes via an `ariaLabel` property.
 - Added `craft\base\ElementInterface::getSerializedFieldValuesForDb()`.
 - Added `craft\base\FieldInterface::serializeValueForDb()`.
+- Added `craft\base\conditions\BaseMultiSelectConditionRule::$includeEmptyOperators`.
 - Added `craft\db\Connection::getIsMaria()`.
 - Added `craft\db\Table::SEARCHINDEXQUEUE_FIELDS`.
 - Added `craft\db\Table::SEARCHINDEXQUEUE`.

--- a/src/base/conditions/BaseMultiSelectConditionRule.php
+++ b/src/base/conditions/BaseMultiSelectConditionRule.php
@@ -27,16 +27,40 @@ abstract class BaseMultiSelectConditionRule extends BaseConditionRule
     private array $_values = [];
 
     /**
+     * @var bool Whether “has a value” and “is empty” operators should be available to the condition rule.
+     * @since 4.15.0
+     */
+    protected bool $includeEmptyOperators = false;
+
+    /**
+     * @inheritdoc
+     */
+    public function init(): void
+    {
+        parent::init();
+
+        if ($this->includeEmptyOperators) {
+            $this->reloadOnOperatorChange = true;
+        }
+    }
+
+    /**
      * Returns the operators that should be allowed for this rule.
      *
      * @return array
      */
     protected function operators(): array
     {
-        return [
+        $operators = [
             self::OPERATOR_IN,
             self::OPERATOR_NOT_IN,
         ];
+
+        if ($this->includeEmptyOperators) {
+            array_push($operators, self::OPERATOR_NOT_EMPTY, self::OPERATOR_EMPTY);
+        }
+
+        return $operators;
     }
 
     /**
@@ -84,6 +108,10 @@ abstract class BaseMultiSelectConditionRule extends BaseConditionRule
      */
     protected function inputHtml(): string
     {
+        if (in_array($this->operator, [self::OPERATOR_NOT_EMPTY, self::OPERATOR_EMPTY])) {
+            return '';
+        }
+
         $multiSelectId = 'multiselect';
 
         return
@@ -112,10 +140,17 @@ abstract class BaseMultiSelectConditionRule extends BaseConditionRule
      * Returns the rule’s value, prepped for [[Db::parseParam()]] based on the selected operator.
      *
      * @param callable|null $normalizeValue Method for normalizing a given selected value.
-     * @return array|null
+     * @return string|array|null
      */
-    protected function paramValue(?callable $normalizeValue = null): ?array
+    protected function paramValue(?callable $normalizeValue = null): string|array|null
     {
+        if (in_array($this->operator, [self::OPERATOR_EMPTY, self::OPERATOR_NOT_EMPTY])) {
+            return match ($this->operator) {
+                self::OPERATOR_NOT_EMPTY => ':notempty:',
+                self::OPERATOR_EMPTY => ':empty:',
+            };
+        }
+
         $values = [];
         foreach ($this->_values as $value) {
             if ($normalizeValue !== null) {
@@ -159,6 +194,8 @@ abstract class BaseMultiSelectConditionRule extends BaseConditionRule
         return match ($this->operator) {
             self::OPERATOR_IN => !empty(array_intersect($value, $this->_values)),
             self::OPERATOR_NOT_IN => empty(array_intersect($value, $this->_values)),
+            self::OPERATOR_NOT_EMPTY => !empty($value),
+            self::OPERATOR_EMPTY => empty($value),
             default => throw new InvalidConfigException("Invalid operator: $this->operator"),
         };
     }

--- a/src/fields/conditions/OptionsFieldConditionRule.php
+++ b/src/fields/conditions/OptionsFieldConditionRule.php
@@ -20,6 +20,8 @@ class OptionsFieldConditionRule extends BaseMultiSelectConditionRule implements 
 {
     use FieldConditionRuleTrait;
 
+    protected bool $includeEmptyOperators = true;
+
     protected function options(): array
     {
         /** @var BaseOptionsField $field */
@@ -53,7 +55,7 @@ class OptionsFieldConditionRule extends BaseMultiSelectConditionRule implements 
     /**
      * @inheritdoc
      */
-    protected function elementQueryParam(): ?array
+    protected function elementQueryParam(): string|array|null
     {
         if (!$this->field() instanceof BaseOptionsField) {
             return null;


### PR DESCRIPTION
### Description

Adds “has a value” and “is empty” operators to option fields’ condition rules.

### Related issues

- #17000