### PR TITLE
Only clear CP resources if they exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed an error that could occur when clearing control panel resources, if the `resourceBasePath` setting was set to a nonexistent folder path. ([#17021](https://github.com/craftcms/cms/pull/17021))
+
 ## 4.14.12 - 2025-04-01
 
 - Fixed a bug where relations weren’t always propagating to newly-added sites for sections correctly. ([#16924](https://github.com/craftcms/cms/pull/16924))

--- a/src/utilities/ClearCaches.php
+++ b/src/utilities/ClearCaches.php
@@ -183,7 +183,7 @@ class ClearCaches extends Utility
                     }
 
                     $basePath = Craft::getAlias($basePath);
-                    if ($basePath !== false) {
+                    if ($basePath !== false && file_exists($basePath)) {
                         FileHelper::clearDirectory($basePath, [
                             'except' => ['.gitignore'],
                         ]);


### PR DESCRIPTION
### Description
There are some environments (e.g. Craft Cloud) `where \craft\config\GeneralConfig::$resourceBasePath` may not exist at all. In that case, we don't want a "The dir argument must be a directory" error thrown.