### PR TITLE
Store entry statuses statically

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -54,8 +54,10 @@
 - Number previews within card attribute designers now show an in-range value, if the Min Value and Max Value settings are set. ([#16986](https://github.com/craftcms/cms/pull/16986))
 - Range previews within card attribute designers new shew an in-range value. ([#16986](https://github.com/craftcms/cms/pull/16986))
 - Section and entry type names are now linked to their edit pages from entry indexes, for admins.
+- Added the `staticStatuses` config setting, for opting into entry statuses being stored statically and only updated on save. ([#17024](https://github.com/craftcms/cms/pull/17024))
 - Added the `db/repair` command. ([#16812](https://github.com/craftcms/cms/pull/16812))
 - Added the `fields/delete` command. ([#16828](https://github.com/craftcms/cms/pull/16828))
+- Added the `update-statuses` command. ([#17024](https://github.com/craftcms/cms/pull/17024))
 - Added the `--batch-size` option for `resave/*` commands. ([#16586](https://github.com/craftcms/cms/issues/16586))
 - The `users/create` command now prompts to send an activation email, or outputs an activation URL. ([#16794](https://github.com/craftcms/cms/pull/16794))
 - Dragging headings within the Customize Sources modal now also drags any subsequent sources. ([#16737](https://github.com/craftcms/cms/issues/16737))
@@ -97,6 +99,7 @@
 - Added `craft\db\Table::BULKOPEVENTS`.
 - Added `craft\db\Table::SEARCHINDEXQUEUE_FIELDS`.
 - Added `craft\db\Table::SEARCHINDEXQUEUE`.
+- Added `craft\elements\Entry::$oldStatus`. ([#17024](https://github.com/craftcms/cms/pull/17024))
 - Added `craft\elements\Entry::$placeInStructure`.
 - Added `craft\elements\actions\Copy`.
 - Added `craft\elements\actions\MoveDown`.

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -2957,6 +2957,24 @@ class GeneralConfig extends BaseConfig
     public mixed $softDeleteDuration = 2592000;
 
     /**
+     * @var bool Whether entries’ statuses should be stored statically, and only get updated on entry save, or when the
+     * `update-statuses` command is executed.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->staticStatuses()
+     * ```
+     * ```shell Environment Override
+     * CRAFT_STATIC_STATUSES=true
+     * ```
+     * :::
+     *
+     * @group System
+     * @since 5.7.0
+     */
+    public bool $staticStatuses = false;
+
+    /**
      * @var bool Whether user IP addresses should be stored/logged by the system.
      *
      * ::: code
@@ -6640,6 +6658,31 @@ class GeneralConfig extends BaseConfig
     public function softDeleteDuration(mixed $value): self
     {
         $this->softDeleteDuration = ConfigHelper::durationInSeconds($value);
+        return $this;
+    }
+
+    /**
+     * Whether entries’ statuses should be stored statically, and only get updated on entry save, or when the
+     * `update-statuses` command is executed.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->staticStatuses()
+     * ```
+     * ```shell Environment Override
+     * CRAFT_STATIC_STATUSES=true
+     * ```
+     * :::
+     *
+     * @group System
+     * @param bool $value
+     * @return self
+     * @see $staticStatuses
+     * @since 5.7.0
+     */
+    public function staticStatuses(bool $value = true): self
+    {
+        $this->staticStatuses = $value;
         return $this;
     }
 

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '5.6.14',
-    'schemaVersion' => '5.7.0.2',
+    'schemaVersion' => '5.7.0.3',
     'minVersionRequired' => '4.5.0',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/console/controllers/UpdateStatusesController.php
+++ b/src/console/controllers/UpdateStatusesController.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\console\controllers;
+
+use Craft;
+use craft\console\Controller;
+use craft\elements\Entry;
+use craft\events\MultiElementActionEvent;
+use craft\helpers\Console;
+use craft\helpers\DateTimeHelper;
+use craft\helpers\Db;
+use craft\services\Elements;
+use yii\console\ExitCode;
+
+/**
+ * Updates statically-stored entry statuses.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.7.0
+ */
+class UpdateStatusesController extends Controller
+{
+    /**
+     * Updates statically-stored entry statuses.
+     *
+     * @return int
+     */
+    public function actionIndex(): int
+    {
+        $now = Db::prepareDateForDb(DateTimeHelper::now());
+        $elementsService = Craft::$app->getElements();
+
+        $conditions = [
+            Entry::STATUS_LIVE => [
+                'and',
+                ['<=', 'entries.postDate', $now],
+                [
+                    'or',
+                    ['entries.expiryDate' => null],
+                    ['>', 'entries.expiryDate', $now],
+                ],
+            ],
+            Entry::STATUS_PENDING => ['>', 'entries.postDate', $now],
+            Entry::STATUS_EXPIRED => [
+                'and',
+                ['not', ['entries.expiryDate' => null]],
+                ['<=', 'entries.expiryDate', $now],
+            ],
+        ];
+
+        foreach ($conditions as $status => $condition) {
+            $query = Entry::find()
+                ->site('*')
+                ->unique()
+                ->status(null)
+                ->andWhere(['not', ['status' => $status]])
+                ->andWhere($condition);
+
+            $this->do("Updating $status entries", function() use ($elementsService, $query) {
+                $count = (int)$query->count();
+
+                $beforeCallback = function(MultiElementActionEvent $e) use ($query, $count) {
+                    if ($e->query === $query) {
+                        $this->stdout(Console::indentStr() . "    - [$e->position/$count] Updating entry ({$e->element->id}) ... ");
+                    }
+                };
+
+                $afterCallback = function(MultiElementActionEvent $e) use ($query, &$fail) {
+                    if ($e->query === $query) {
+                        if ($e->exception) {
+                            $this->stdout('error: ' . $e->exception->getMessage() . PHP_EOL, Console::FG_RED);
+                            $fail = true;
+                        } elseif ($e->element->hasErrors()) {
+                            $this->stdout('failed: ' . implode(', ', $e->element->getErrorSummary(true)) . PHP_EOL, Console::FG_RED);
+                            $fail = true;
+                        } else {
+                            $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
+                        }
+                    }
+                };
+
+                $elementsService->on(Elements::EVENT_BEFORE_RESAVE_ELEMENT, $beforeCallback);
+                $elementsService->on(Elements::EVENT_AFTER_RESAVE_ELEMENT, $afterCallback);
+                $elementsService->resaveElements($query, true, updateSearchIndex: false);
+                $elementsService->off(Elements::EVENT_BEFORE_RESAVE_ELEMENT, $beforeCallback);
+                $elementsService->off(Elements::EVENT_AFTER_RESAVE_ELEMENT, $afterCallback);
+            });
+        }
+
+        return ExitCode::OK;
+    }
+}

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1783,11 +1783,7 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
             return $status;
         }
 
-        if (isset($this->status)) {
-            return $this->status;
-        }
-
-        return $this->_status();
+        return $this->status ?? $this->_status();
     }
 
     /**

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -849,6 +849,16 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
     public ?DateTime $expiryDate = null;
 
     /**
+     * @var self::STATUS_*|null The entry’s previous status, if it had one
+     */
+    public ?string $oldStatus = null;
+
+    /**
+     * @var self::STATUS_LIVE|self::STATUS_PENDING|self::STATUS_EXPIRED
+     */
+    private string $status;
+
+    /**
      * @var bool Whether the entry was deleted along with its entry type
      * @see beforeDelete()
      * @internal
@@ -912,6 +922,9 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
     public function init(): void
     {
         parent::init();
+        if (isset($this->id)) {
+            $this->oldStatus = $this->getStatus();
+        }
         $this->_oldTypeId = $this->_typeId;
     }
 
@@ -1766,23 +1779,39 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
     {
         $status = parent::getStatus();
 
-        if ($status == self::STATUS_ENABLED && $this->postDate) {
-            $currentTime = DateTimeHelper::currentTimeStamp();
-            $postDate = $this->postDate->getTimestamp();
-            $expiryDate = $this->expiryDate?->getTimestamp();
-
-            if ($postDate <= $currentTime && ($expiryDate === null || $expiryDate > $currentTime)) {
-                return self::STATUS_LIVE;
-            }
-
-            if ($postDate > $currentTime) {
-                return self::STATUS_PENDING;
-            }
-
-            return self::STATUS_EXPIRED;
+        if ($status !== self::STATUS_ENABLED) {
+            return $status;
         }
 
-        return $status;
+        if (isset($this->status)) {
+            return $this->status;
+        }
+
+        return $this->_status();
+    }
+
+    /**
+     * @return self::STATUS_LIVE|self::STATUS_PENDING|self::STATUS_EXPIRED
+     */
+    private function _status(): string
+    {
+        $now = DateTimeHelper::now();
+        return match (true) {
+            !$this->postDate || $this->postDate > $now => self::STATUS_PENDING,
+            $this->expiryDate && $this->expiryDate <= $now => self::STATUS_EXPIRED,
+            default => self::STATUS_LIVE,
+        };
+    }
+
+    /**
+     * Sets the status, if it’s stored statically.
+     *
+     * @param self::STATUS_LIVE|self::STATUS_PENDING|self::STATUS_EXPIRED $status
+     * @since 5.7.0
+     */
+    public function setStatus(string $status): void
+    {
+        $this->status = $status;
     }
 
     /**
@@ -2711,6 +2740,16 @@ JS;
             $record->typeId = $this->getTypeId();
             $record->postDate = Db::prepareDateForDb($this->postDate);
             $record->expiryDate = Db::prepareDateForDb($this->expiryDate);
+
+            // todo: update after the next breakpoint
+            if (Craft::$app->getDb()->columnExists(Table::ENTRIES, 'status')) {
+                $status = $this->_status();
+                $record->status = $status;
+                // only update $this->status if it's already set, indicating that staticStatuses is enabled
+                if (isset($this->status)) {
+                    $this->status = $status;
+                }
+            }
 
             // Capture the dirty attributes from the record
             $dirtyAttributes = array_keys($record->getDirtyAttributes());

--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -860,6 +860,14 @@ class EntryQuery extends ElementQuery implements NestedElementQueryInterface
             'entries.expiryDate',
         ]);
 
+        // todo: update after the next breakpoint
+        if (
+            Craft::$app->getConfig()->getGeneral()->staticStatuses &&
+            Craft::$app->getDb()->columnExists(Table::ENTRIES, 'status')
+        ) {
+            $this->query->addSelect(['entries.status']);
+        }
+
         $this->_applySectionIdParam();
         $this->applyNestedElementParams('entries.fieldId', 'entries.primaryOwnerId');
 
@@ -984,6 +992,17 @@ class EntryQuery extends ElementQuery implements NestedElementQueryInterface
      */
     protected function statusCondition(string $status): mixed
     {
+        if (
+            in_array($status, [Entry::STATUS_LIVE, Entry::STATUS_PENDING, Entry::STATUS_EXPIRED]) &&
+            Craft::$app->getConfig()->getGeneral()->staticStatuses
+        ) {
+            return [
+                'elements.enabled' => true,
+                'elements_sites.enabled' => true,
+                'entries.status' => $status,
+            ];
+        }
+
         // Always consider “now” to be the current time @ 59 seconds into the minute.
         // This makes entry queries more cacheable, since they only change once every minute (https://github.com/craftcms/cms/issues/5389),
         // while not excluding any entries that may have just been published in the past minute (https://github.com/craftcms/cms/issues/7853).

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -15,6 +15,7 @@ use craft\base\Field;
 use craft\db\Migration;
 use craft\db\Table;
 use craft\elements\Asset;
+use craft\elements\Entry;
 use craft\elements\User;
 use craft\enums\CmsEdition;
 use craft\enums\PropagationMethod;
@@ -414,6 +415,11 @@ class Install extends Migration
             'typeId' => $this->integer()->notNull(),
             'postDate' => $this->dateTime(),
             'expiryDate' => $this->dateTime(),
+            'status' => $this->enum('status', [
+                Entry::STATUS_LIVE,
+                Entry::STATUS_PENDING,
+                Entry::STATUS_EXPIRED,
+            ])->notNull()->defaultValue(Entry::STATUS_LIVE),
             'deletedWithEntryType' => $this->boolean()->null(),
             'deletedWithSection' => $this->boolean()->null(),
             'dateCreated' => $this->dateTime()->notNull(),
@@ -893,6 +899,7 @@ class Install extends Migration
         $this->createIndex(null, Table::SYSTEMMESSAGES, ['language'], false);
         $this->createIndex(null, Table::ENTRIES, ['postDate'], false);
         $this->createIndex(null, Table::ENTRIES, ['expiryDate'], false);
+        $this->createIndex(null, Table::ENTRIES, ['status'], false);
         $this->createIndex(null, Table::ENTRIES, ['sectionId'], false);
         $this->createIndex(null, Table::ENTRIES, ['typeId'], false);
         $this->createIndex(null, Table::ENTRIES_AUTHORS, ['authorId'], false);

--- a/src/migrations/m250403_171253_static_statuses.php
+++ b/src/migrations/m250403_171253_static_statuses.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+use craft\elements\Entry;
+use craft\helpers\DateTimeHelper;
+use craft\helpers\Db;
+
+/**
+ * m250403_171253_static_statuses migration.
+ */
+class m250403_171253_static_statuses extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn(Table::ENTRIES, 'status', $this->enum('status', [
+            Entry::STATUS_LIVE,
+            Entry::STATUS_PENDING,
+            Entry::STATUS_EXPIRED,
+        ])->notNull()->defaultValue(Entry::STATUS_LIVE)->after('expiryDate'));
+        $this->createIndex(null, Table::ENTRIES, ['status'], false);
+
+        $currentTimeDb = Db::prepareDateForDb(DateTimeHelper::now());
+        $this->update(Table::ENTRIES, ['status' => Entry::STATUS_PENDING], [
+            'or',
+            ['postDate' => null],
+            ['>', 'postDate', $currentTimeDb],
+        ]);
+        $this->update(Table::ENTRIES, ['status' => Entry::STATUS_EXPIRED], [
+            'and',
+            ['not', ['postDate' => null]],
+            ['<=', 'entries.expiryDate', $currentTimeDb],
+        ]);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->dropColumn(Table::ENTRIES, 'status');
+        return true;
+    }
+}

--- a/src/records/Entry.php
+++ b/src/records/Entry.php
@@ -21,6 +21,7 @@ use yii\db\ActiveQueryInterface;
  * @property int $typeId Type ID
  * @property string|null $postDate Post date
  * @property string|null $expiryDate Expiry date
+ * @property string $status Live
  * @property Element $element Element
  * @property Section $section Section
  * @property EntryType $type Type

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1514,6 +1514,10 @@ class Elements extends Component
             'dirtyFields' => [],
         ];
 
+        if ($canonical instanceof Entry) {
+            $newAttributes['oldStatus'] = $canonical->oldStatus;
+        }
+
         foreach ($changedAttributes as $attribute) {
             $newAttributes['siteAttributes'][$attribute['siteId']]['dirtyAttributes'][] = $attribute['attribute'];
         }


### PR DESCRIPTION
### Description

Adds a new `status` column to the `entries` table, which statically stores entries’ last-known date-based status (`live`, `pending`, or `expired`), updated whenever entries are saved.

By default the column is completely ignored by element queries, and entry queries will continue taking the `postDate` and `expiryDate` columns into account when fetching entries by `live`/`pending`/`expired` status.

However, that behavior can be altered using a new `staticStatuses` config setting. When that’s enabled, entry queries will look at the `status` column instead of `postDate` and `expiryDate`. So if an entry is saved with a future post date, and its `status` column is set to `pending`, it will continue to be excluded from entry query results for `live` entries, even passed its post date, until it’s saved again.

There’s also a new `update-statuses` command, which will look for entries whose statically-stored statuses need to be updated based on their `postDate` and `expiryDate` values, and resaves them so their statuses get updated (and caches get cleared, etc.).

Sites with `staticStatuses` enabled should start running `update-statuses` every 1 or 5 minutes using a Cron job, to ensure that statically-stored entry statuses are kept up-to-date.

And finally, entries have a new `oldStatus` property, making it easy for event listeners to catch the moment that an entry goes live or expires:

```php
use craft\base\Event;
use craft\elements\Entry;
use craft\events\ModelEvent;
use craft\helpers\ElementHelper;

Event::on(Entry::class, Entry::EVENT_AFTER_SAVE, function (ModelEvent $event) {
    /** @var Entry $entry */
    $entry = $event->sender;

    if (
        !ElementHelper::isDraftOrRevision($entry) &&
        $entry->getStatus() !== $entry->oldStatus
    ) {
        if ($entry->getStatus() === Entry::STATUS_LIVE) {
            // the entry just went live
        } elseif ($entry->oldStatus === Entry::STATUS_LIVE) {
            // the entry just stopped being live
        }
    }
});
```

### Related issues

- #9170
- #9394
- #9638
- #10858