### PR TITLE
craft\web\twig\Extension->checkArrowFunction() should also check for popen

### DIFF
--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -121,6 +121,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
                 'exec',
                 'file_get_contents',
                 'file_put_contents',
+                'popen',
             ])
         ) {
             throw new RuntimeError(sprintf('The "%s" %s does not support passing "%s".', $thing, $type, $arrow));


### PR DESCRIPTION
Can also be merged into 5.x.