### PR TITLE
`plugin/install` & `plugin/uninstall` improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -9,6 +9,8 @@
 ### Administration
 - Added the `db/repair` command. ([#16812](https://github.com/craftcms/cms/pull/16812))
 - Added the `--batch-size` option for `resave/*` commands. ([#16586](https://github.com/craftcms/cms/issues/16586))
+- The `plugin/install` command now accepts an `edition` argument, and prompts for the default edition if none is specified. ([#17030](https://github.com/craftcms/cms/pull/17030))
+- The `plugin/uninstall` command now reports if no plugin is installed with the provided handle. ([#17030](https://github.com/craftcms/cms/pull/17030))
 - The `users/create` command now prompts to send an activation email, or outputs an activation URL. ([#16794](https://github.com/craftcms/cms/pull/16794))
 - Dragging headings within the Customize Sources modal now also drags any subsequent sources. ([#16737](https://github.com/craftcms/cms/issues/16737))
 - When switching field types, any field settings which are defined by the same base class are now preserved. ([#16783](https://github.com/craftcms/cms/pull/16783))

--- a/src/console/controllers/PluginController.php
+++ b/src/console/controllers/PluginController.php
@@ -8,7 +8,9 @@
 namespace craft\console\controllers;
 
 use Craft;
+use craft\base\PluginInterface;
 use craft\console\Controller;
+use craft\errors\InvalidPluginException;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Console;
 use Throwable;
@@ -118,11 +120,13 @@ class PluginController extends Controller
      * @param string|null $handle The plugin handle (omitted if --all provided).
      * @return int
      */
-    public function actionInstall(?string $handle = null): int
+    public function actionInstall(?string $handle = null, ?string $edition = null): int
     {
+        $pluginsService = Craft::$app->getPlugins();
+
         if ($this->all) {
             // get all plugins’ info
-            $pluginInfo = Craft::$app->getPlugins()->getAllPluginInfo();
+            $pluginInfo = $pluginsService->getAllPluginInfo();
 
             // filter out the ones that are already installed
             $pluginInfo = array_filter($pluginInfo, function(array $info) {
@@ -140,7 +144,47 @@ class PluginController extends Controller
                 $this->_installPluginByHandle($handle);
             }
         } else {
-            $this->_installPluginByHandle($handle);
+            if ($pluginsService->isPluginInstalled($handle)) {
+                $plugin = $pluginsService->getPlugin($handle);
+                if ($edition === null || $edition === $plugin->edition) {
+                    $this->stderr(sprintf("%s%s is already installed.\n", $plugin->name, $edition !== null ? " ($edition)" : ''), Console::FG_YELLOW);
+                    return ExitCode::UNSPECIFIED_ERROR;
+                }
+                try {
+                    $pluginsService->switchEdition($handle, $edition);
+                } catch (Throwable $e) {
+                    $this->stderr("{$e->getMessage()}\n", Console::FG_RED);
+                    return ExitCode::UNSPECIFIED_ERROR;
+                }
+                $this->stdout($this->markdownToAnsi("$plugin->name switched to the `$edition` edition.") . "\n");
+                return ExitCode::OK;
+            }
+
+            if ($edition === null && $this->interactive) {
+                // see if it's a multi-edition plugin
+                try {
+                    $info = $pluginsService->getPluginInfo($handle);
+                } catch (InvalidPluginException $e) {
+                    $this->stderr("{$e->getMessage()}\n", Console::FG_RED);
+                    return ExitCode::UNSPECIFIED_ERROR;
+                }
+
+                /** @var class-string<PluginInterface> $class */
+                $class = $info['class'];
+                $editions = $class::editions();
+                if (count($editions) > 1) {
+                    $this->stdout("Which edition?\n");
+                    foreach ($editions as $edition) {
+                        $this->stdout($this->markdownToAnsi("- `$edition`") . "\n");
+                    }
+                    $edition = $this->prompt('Choose:', [
+                        'default' => reset($editions),
+                        'validate' => fn($input) => in_array($input, $editions),
+                    ]);
+                }
+            }
+
+            $this->_installPluginByHandle($handle, $edition);
         }
 
         return ExitCode::OK;
@@ -154,9 +198,11 @@ class PluginController extends Controller
      */
     public function actionUninstall(?string $handle = null): int
     {
+        $pluginsService = Craft::$app->getPlugins();
+
         if ($this->all) {
             // get all plugins’ info
-            $pluginInfo = Craft::$app->getPlugins()->getAllPluginInfo();
+            $pluginInfo = $pluginsService->getAllPluginInfo();
 
             // filter out the ones that are uninstalled/disabled
             $pluginInfo = array_filter($pluginInfo, function(array $info) {
@@ -178,6 +224,12 @@ class PluginController extends Controller
                 $this->_uninstallPluginByHandle($handle);
             }
         } else {
+            $plugin = $pluginsService->isPluginInstalled($handle);
+            if (!$plugin) {
+                $this->stderr($this->markdownToAnsi("No plugin is installed with the handle `$handle`.") . "\n");
+                return ExitCode::OK;
+            }
+
             $this->_uninstallPluginByHandle($handle);
         }
 
@@ -258,7 +310,7 @@ class PluginController extends Controller
      * @param null|string $handle
      * @return int
      */
-    private function _installPluginByHandle(?string $handle = null): int
+    private function _installPluginByHandle(?string $handle, ?string $edition = null): int
     {
         if ($handle === null) {
             $handle = $this->_pluginPrompt(
@@ -278,7 +330,7 @@ class PluginController extends Controller
         $start = microtime(true);
 
         try {
-            $success = Craft::$app->getPlugins()->installPlugin($handle);
+            $success = Craft::$app->getPlugins()->installPlugin($handle, $edition);
         } catch (Throwable $e) {
             $success = false;
         } finally {


### PR DESCRIPTION
### Description

`plugin/install` now has an `$edition` argument, for specifying the edition that should be installed.

```sh
php craft plugin/install freeform pro
```

It can also be used to switch the active edition for an already-installed plugin.

If a multi-edition plugin is being installed and no edition is specified, the user will be prompted to choose which edition should be installed.

![A terminal window showing the edition prompt when installing a multi-edition plugin](https://github.com/user-attachments/assets/2789ae33-b14f-4f00-ba35-f7c27a778e37)

Plus, the `plugin/uninstall` command will now display a `No plugin is installed with the handle [X].` message, when an invalid plugin handle is passed.


### Related issues

- #17028
- #7722