### PR TITLE
Bugfix/17005 replacing assets via gql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where `craft\services\Assets::EVENT_BEFORE_REPLACE_ASSET` and `EVENT_BEFORE_REPLACE_ASSET` events weren’t getting triggered when replacing an asset file via GraphQL. ([#17005](https://github.com/craftcms/cms/issues/17005))
+- Fixed a bug where replacing a file via GraphQL could result in two assets referring to the same file. ([#17031](https://github.com/craftcms/cms/pull/17031))
+
 ## 4.14.13 - 2025-04-04
 
 - Fixed an error that could occur when clearing control panel resources, if the `resourceBasePath` setting was set to a nonexistent folder path. ([#17021](https://github.com/craftcms/cms/pull/17021))

--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -106,8 +106,12 @@ class Asset extends ElementMutationResolver
         $asset->setVolumeId($volume->id);
 
         $asset = $this->populateElementWithData($asset, $arguments, $resolveInfo);
+        $triggerReplaceEvents = (
+            $asset->getScenario() === AssetElement::SCENARIO_REPLACE &&
+            $assetService->hasEventHandlers(Assets::EVENT_BEFORE_REPLACE_ASSET)
+        );
 
-        if ($asset->getScenario() === AssetElement::SCENARIO_REPLACE) {
+        if ($triggerReplaceEvents) {
             $assetService->trigger(Assets::EVENT_BEFORE_REPLACE_ASSET, new ReplaceAssetEvent([
                 'asset' => $asset,
                 'replaceWith' => $asset->tempFilePath,
@@ -117,7 +121,7 @@ class Asset extends ElementMutationResolver
 
         $asset = $this->saveElement($asset);
 
-        if ($asset->getScenario() === AssetElement::SCENARIO_REPLACE) {
+        if ($triggerReplaceEvents) {
             $assetService->trigger(Assets::EVENT_AFTER_REPLACE_ASSET, new ReplaceAssetEvent([
                 'asset' => $asset,
                 'filename' => $this->filename,

--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -225,7 +225,11 @@ class Asset extends ElementMutationResolver
         }
 
         $asset->tempFilePath = $tempPath;
-        $asset->setFilename($filename);
+        if ($asset->id !== null && $asset->getFilename() !== $filename) {
+            $asset->newFilename = $filename;
+        } else {
+            $asset->setFilename($filename);
+        }
         $asset->avoidFilenameConflicts = true;
 
         return true;

--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -11,12 +11,14 @@ use Craft;
 use craft\base\ElementInterface;
 use craft\db\Table;
 use craft\elements\Asset as AssetElement;
+use craft\events\ReplaceAssetEvent;
 use craft\gql\base\ElementMutationResolver;
 use craft\helpers\Assets as AssetsHelper;
 use craft\helpers\Db;
 use craft\helpers\FileHelper;
 use craft\helpers\UrlHelper;
 use craft\models\Volume;
+use craft\services\Assets;
 use GraphQL\Error\Error;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -35,6 +37,8 @@ class Asset extends ElementMutationResolver
 {
     /** @inheritdoc */
     protected array $immutableAttributes = ['id', 'uid', 'volumeId', 'folderId'];
+
+    private ?string $filename = null;
 
     /**
      * Save an asset using the passed arguments.
@@ -98,10 +102,27 @@ class Asset extends ElementMutationResolver
             }
         }
 
+        /** @var AssetElement $asset */
         $asset->setVolumeId($volume->id);
 
         $asset = $this->populateElementWithData($asset, $arguments, $resolveInfo);
+
+        if ($asset->getScenario() === AssetElement::SCENARIO_REPLACE) {
+            $assetService->trigger(Assets::EVENT_BEFORE_REPLACE_ASSET, new ReplaceAssetEvent([
+                'asset' => $asset,
+                'replaceWith' => $asset->tempFilePath,
+                'filename' => $this->filename,
+            ]));
+        }
+
         $asset = $this->saveElement($asset);
+
+        if ($asset->getScenario() === AssetElement::SCENARIO_REPLACE) {
+            $assetService->trigger(Assets::EVENT_AFTER_REPLACE_ASSET, new ReplaceAssetEvent([
+                'asset' => $asset,
+                'filename' => $this->filename,
+            ]));
+        }
 
         return $elementService->getElementById($asset->id, AssetElement::class);
     }
@@ -225,6 +246,7 @@ class Asset extends ElementMutationResolver
         }
 
         $asset->tempFilePath = $tempPath;
+        $this->filename = $filename;
         if ($asset->id !== null && $asset->getFilename() !== $filename) {
             $asset->newFilename = $filename;
         } else {


### PR DESCRIPTION
### Description
**Issue 1:**
Fixes a bug where `avoidFilenameConflicts` wasn’t always working as expected.

For example, if you have two assets with filenames `file-one.png` and `file-two.png` and you’re replacing the `file-one.png` via GQL mutation, the data specifies that the new filename is supposed to be `file-two.png` then the file will be uploaded, and the asset will be updated, but you’ll end up with two separate assets with files with filename `file-two.png`.

**Issue 2:**
Trigger `Assets::EVENT_BEFORE_REPLACE_ASSET` and `Assets::EVENT_AFTER_REPLACE_ASSET` when replacing an asset via GQL mutation.


### Related issues
#17005 
