### PR TITLE
don't push new job for each item if `ttr` is `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an error that could occur when changing a field’s type. ([#17045](https://github.com/craftcms/cms/issues/17045))
 - Fixed a bug where field settings weren’t being retained when changing a field’s type to a preselected value. ([#17045](https://github.com/craftcms/cms/issues/17045))
+- Fixed a bug where batched jobs that were pushed without an explicit TTR were getting new jobs spawned after each item processed. ([#17058](https://github.com/craftcms/cms/pull/17058))
 
 ## 4.15.0-beta.1 - 2025-04-08
 

--- a/src/queue/BaseBatchedJob.php
+++ b/src/queue/BaseBatchedJob.php
@@ -145,7 +145,7 @@ abstract class BaseBatchedJob extends BaseJob
             // Make sure we don't hit the TTL, even if the next item takes twice as long as the average
             $runningTime = microtime(true) - $start;
             $avgRunningTime = $runningTime / $i;
-            if ($runningTime + ($avgRunningTime * 2) > $this->ttr) {
+            if ($this->ttr !== null && $runningTime + ($avgRunningTime * 2) > $this->ttr) {
                 break;
             }
 

--- a/src/queue/BaseBatchedJob.php
+++ b/src/queue/BaseBatchedJob.php
@@ -12,6 +12,7 @@ use craft\base\Batchable;
 use craft\helpers\ConfigHelper;
 use craft\helpers\Queue as QueueHelper;
 use craft\i18n\Translation;
+use yii\queue\RetryableJobInterface;
 
 /**
  * BaseBatchedJob is the base class for large jobs that may need to spawn
@@ -60,6 +61,18 @@ abstract class BaseBatchedJob extends BaseJob
 
     private ?Batchable $_data = null;
     private ?int $_totalItems = null;
+
+    /**
+     * @inheritdoc
+     */
+    public function init(): void
+    {
+        parent::init();
+
+        $this->ttr = $this->ttr ??
+            ($this instanceof RetryableJobInterface ? $this->getTtr() : null) ??
+            Craft::$app->getQueue()->ttr;
+    }
 
     public function __sleep(): array
     {
@@ -142,7 +155,7 @@ abstract class BaseBatchedJob extends BaseJob
                 }
             }
 
-            // Make sure we don't hit the TTL, even if the next item takes twice as long as the average
+            // Make sure we don't hit the TTR, even if the next item takes twice as long as the average
             $runningTime = microtime(true) - $start;
             $avgRunningTime = $runningTime / $i;
             if ($this->ttr !== null && $runningTime + ($avgRunningTime * 2) > $this->ttr) {


### PR DESCRIPTION
### Description
The check to ensure we didn’t hit the TTL was kicking in for every batched job that had the `ttr` set to `null,` causing a new job to be added to the queue for each item that needed to be processed.

Example:
- have an install with 2 sites and a section enabled for only one site 
- go and enable that section for the second site
- the `ResaveElements` job gets triggered with `ttr` set to `null` (default), and each item it’s supposed to resave is pushed to the queue as a new job

### Related issues
n/a
