### PR TITLE
add 'or' and 'and' to the list of operators

### DIFF
--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -51,7 +51,7 @@ class Db
     /**
      * @var array
      */
-    private static array $_operators = ['not ', '!=', '<=', '>=', '<', '>', '='];
+    private static array $_operators = ['not ', '!=', '<=', '>=', '<', '>', '=', 'or', 'and'];
 
     /**
      * @var string[] Numeric column types


### PR DESCRIPTION
### Description
Adds “or” and “and” to the list of Db helper operators.

We’re already escaping params when matching existing elements (https://github.com/craftcms/feed-me/pull/1551), but “or” and “and” are not on the list of things to escape resulting in a query not actually matching on the provided value. 

This doesn’t directly affect Feed Me for cms v4 but it does for v5. Targeting 4.15 for consistency.

### Related issues
https://github.com/craftcms/feed-me/issues/1624
