### PR TITLE
Adds a db/repair CLI command to repair and optimize database tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+- 
+- Added the `db/repair` CLI command to repair and optimize database tables.
+
 ## 4.14.15 - 2025-04-10 [CRITICAL]
 
 - Fixed an RCE vulnerability.

--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -529,4 +529,42 @@ MD);
             array_combine($possiblePrefixes, $possiblePrefixes),
         );
     }
+
+    /**
+     * Runs either `ANALYZE VERBOSE` (Postgres) or `OPTIMIZE TABLE` (MySQL) SQL
+     * against each table in the database.
+     *
+     * Note that this command can cause table locking and might interfere with
+     * site traffic while it is running.
+     *
+     *  Example:
+     *  ```
+     *  php craft db/repair
+     *  ```
+     * @return int
+     * @throws Exception
+     * @throws NotSupportedException
+     */
+    public function actionRepair(): int
+    {
+        $db = Craft::$app->getDb();
+        $schema = $db->getSchema();
+        if ($db->getIsPgsql()) {
+            $sql = 'ANALYZE VERBOSE';
+        } else {
+            $sql = 'OPTIMIZE TABLE';
+        }
+
+        foreach ($schema->getTableNames() as $tableName) {
+            $tableName = $schema->quoteTableName($schema->getRawTableName($tableName));
+            $this->stdout('Repairing ');
+            $this->stdout($tableName, Console::FG_CYAN);
+            $this->stdout(' ... ');
+            $db->createCommand("$sql $tableName;")->execute();
+            $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
+        }
+
+        $this->stdout("Finished repairing database tables." . PHP_EOL, Console::FG_GREEN);
+        return ExitCode::OK;
+    }
 }


### PR DESCRIPTION
Runs `OPTIMIZE TABLE` on each table for MySQL or `ANALYZE VERBOSE` for each table in PostgreSQL.

Both can cause table locking while they are running.

Can be merged into 5.x, too.