### PR TITLE
`strict` mode for Lightswitch field params

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -77,6 +77,7 @@
 
 ### Development
 - Added the `canonicalsOnly` element query param.
+- Lightswitch fields’ element query params now support passing in an array with `value` and `strict` keys. ([#17083](https://github.com/craftcms/cms/pull/17083))
 - Added the `defaultLabel` nested field to Link fields’ GraphQL data. ([#16637](https://github.com/craftcms/cms/issues/16637))
 - Added the `download` and `filename` nested fields to Link fields’ GraphQL data. ([#16844](https://github.com/craftcms/cms/pull/16844))
 - Added `element`, `asset`, `entry`, etc., nested fields to Link fields’ GraphQL data. ([#16698](https://github.com/craftcms/cms/pull/16698))

--- a/src/fields/Lightswitch.php
+++ b/src/fields/Lightswitch.php
@@ -78,7 +78,15 @@ class Lightswitch extends Field implements InlineEditableFieldInterface, Sortabl
     public static function queryCondition(array $instances, mixed $value, array &$params): array
     {
         $valueSql = static::valueSql($instances);
-        return Db::parseBooleanParam($valueSql, $value, $instances[0]->default, Schema::TYPE_JSON);
+        $strict = false;
+
+        if (is_array($value) && isset($value['value'])) {
+            $strict = $value['strict'] ?? $strict;
+            $value = $value['value'];
+        }
+
+        $defaultValue = $strict ? null : $instances[0]->default;
+        return Db::parseBooleanParam($valueSql, $value, $defaultValue, Schema::TYPE_JSON);
     }
 
     /**


### PR DESCRIPTION
### Description

Lightswitch fields’ element query params now support passing in an array with `value` and `strict` keys.

```twig
{% set entries = craft.entries()
  .section('news')
  .myLightswitchField({value: false, strict: true})
  .all() %}
```

If `strict` is `true`, elements without a value for the field will be omitted from the results, rather than treated as having the default value selected.

### Related issues

- #17043