### PR TITLE
Don’t abort queries that allow `null` custom field value

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -78,6 +78,7 @@
 ### Development
 - Added the `canonicalsOnly` element query param.
 - Lightswitch fields’ element query params now support passing in an array with `value` and `strict` keys. ([#17083](https://github.com/craftcms/cms/pull/17083))
+- Element queries are no longer aborted if an unresolvable custom field param is set, if the param is set to an array that includes `null`. ([#17084](https://github.com/craftcms/cms/pull/17084))
 - Added the `defaultLabel` nested field to Link fields’ GraphQL data. ([#16637](https://github.com/craftcms/cms/issues/16637))
 - Added the `download` and `filename` nested fields to Link fields’ GraphQL data. ([#16844](https://github.com/craftcms/cms/pull/16844))
 - Added `element`, `asset`, `entry`, etc., nested fields to Link fields’ GraphQL data. ([#16698](https://github.com/craftcms/cms/pull/16698))
@@ -144,8 +145,9 @@
 - Added `craft\web\assets\codemirror\CodeMirrorAsset`.
 - `craft\base\Element::fieldLayoutFields()` now has an `editableOnly` argument.
 - `craft\base\ElementInterface::eagerLoadingMap()` and `craft\base\EagerLoadingFieldInterface::eagerLoadingMap()` can now specify mappings for multiple target element types, or not specify the element types at all. ([#16972](https://github.com/craftcms/cms/pull/16972))
-- `craft\cache\ElementQueryTagDependency` now merges cache tags provided by the element query with any tags already set on its `$tags` property.  
+- `craft\cache\ElementQueryTagDependency` now merges cache tags provided by the element query with any tags already set on its `$tags` property.
 - `craft\elements\NestedElementManager::getCardsHtml()` and `getIndexHtml()` now accept `canPaste` config options, which can be set to `true`, `false`, or a JavaScript function. 
+- `craft\helpers\Db::parseBooleanParam()` now accepts `null` and `array<string|bool|null>` values.
 - `craft\services\Elements::duplicateElement()` now has a `checkAuthorization` argument.
 - `craft\services\Fields::getLayoutByType()` now has a `create` argument.
 - `craft\services\Users::ensureUserByEmail()` now prioritizes credentialed users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 - Lightswitch fields’ element query params now support passing in an array with `value` and `strict` keys. ([#17083](https://github.com/craftcms/cms/pull/17083))
-- Link fields marked as translatable now swap the selected element with the localized version when their value is getting propagated to a new site for the element. ([#17072](https://github.com/craftcms/cms/issues/17072))
+- Element queries are no longer aborted if an unresolvable custom field param is set, if the param is set to an array that includes `null`. ([#17084](https://github.com/craftcms/cms/pull/17084))
+- Link fields marked as translatable now swap the selected element with the localized version when their value is getting propagated to a new site for the element. ([#17072](https://github.com/craftcms/cms/issues/17072)) 
+- `craft\helpers\Db::parseBooleanParam()` now accepts `null` and `array<string|bool|null>` values.
 - `craft\services\Users::ensureUserByEmail()` now prioritizes credentialed users.
 - Added compatibility with Symfony HTTP Client 7. ([#17065](https://github.com/craftcms/cms/pull/17065))
 - Fixed a bug where Assets fields weren’t respecting their “Default Asset Placement” setting.

--- a/src/db/QueryParam.php
+++ b/src/db/QueryParam.php
@@ -116,7 +116,7 @@ final class QueryParam
     }
 
     /**
-     * @var string[] The param values.
+     * @var array The param values.
      */
     public array $values = [];
 

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -21,6 +21,7 @@ use craft\db\Connection;
 use craft\db\FixedOrderExpression;
 use craft\db\Query;
 use craft\db\QueryAbortedException;
+use craft\db\QueryParam;
 use craft\db\Table;
 use craft\elements\ElementCollection;
 use craft\elements\User;
@@ -2748,6 +2749,18 @@ class ElementQuery extends Query implements ElementQueryInterface
 
                 // Make sure the custom field exists in one of the field layouts
                 if (!isset($fieldsByHandle[$handle])) {
+                    // If it looks like null/:empty: is a valid option, let it slide
+                    $value = is_array($fieldAttributes->$handle) && isset($fieldAttributes->$handle['value'])
+                        ? $fieldAttributes->$handle['value']
+                        : $fieldAttributes->$handle;
+                    if (is_array($value) && in_array(null, $value, true)) {
+                        $values = [...$value];
+                        $operator = QueryParam::extractOperator($values) ?? QueryParam::OR;
+                        if ($operator === QueryParam::OR) {
+                            continue;
+                        }
+                    }
+
                     throw new QueryAbortedException("No custom field with the handle \"$handle\" exists in the field layouts involved with this element query.");
                 }
 

--- a/src/helpers/Db.php
+++ b/src/helpers/Db.php
@@ -823,7 +823,7 @@ class Db
      * `null` values as well.
      *
      * @param string $column The database column that the param is targeting.
-     * @param string|bool $value The param value
+     * @param string|bool|null|array<string|bool|null> $value The param value
      * @param bool|null $defaultValue How `null` values should be treated
      * @param string $columnType The database column type the param is targeting
      * @return array
@@ -835,17 +835,26 @@ class Db
         ?bool $defaultValue = null,
         string $columnType = Schema::TYPE_BOOLEAN,
     ): array {
-        self::_normalizeEmptyValue($value);
-        $operator = self::_parseParamOperator($value, '=');
-        $value = $value && $value !== ':empty:';
-        if ($operator === '!=') {
-            $value = !$value;
+        if (is_array($value)) {
+            return [
+                'or',
+                ...array_map(fn($val) => static::parseBooleanParam($column, $val, $defaultValue, $columnType), $value),
+            ];
         }
 
+        if ($value !== null) {
+            self::_normalizeEmptyValue($value);
+            $value = $value && $value !== ':empty:';
+        }
+
+        $operator = self::_parseParamOperator($value, '=');
+
         if ($columnType === Schema::TYPE_JSON) {
+            /** @phpstan-ignore-next-line */
             $value = match ($value) {
                 true => 'true',
                 false => 'false',
+                null => null,
             };
             $defaultValue = match ($defaultValue) {
                 true => 'true',
@@ -855,8 +864,12 @@ class Db
         }
 
         $condition = [$column => $value];
-        if ($defaultValue === $value) {
+        if ($defaultValue === $value && $value !== null) {
             $condition = ['or', $condition, [$column => null]];
+        }
+
+        if ($operator === '!=') {
+            $condition = ['not', $condition];
         }
 
         return $condition;


### PR DESCRIPTION
### Description

As of Craft 5.6 (1459e6d4b7cfd5d5cb439b33acddef810b622e2c), element queries which include any unresolvable custom field params are aborted so they return no results.

This change makes it possible to sidestep that behavior, by setting the param value to an array which includes `null` as one of the possible values.

```twig
{% set entries = craft.entries()
  .section('sectionWithoutDropdownField')
  .myDropdownField(['red', null])
  .all() %}

{% set entries = craft.entries()
  .section('sectionWithoutDropdownField')
  .myDropdownField({
    value: ['red', null],
    caseInsensitive: true,
  })
  .all() %}
```



### Related issues

- #17043