### PR TITLE
serialising value for db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `craft\services\Users::ensureUserByEmail()` now prioritizes credentialed users.
 - Added compatibility with Symfony HTTP Client 7. ([#17065](https://github.com/craftcms/cms/pull/17065))
 - Fixed a bug where assets’ “View” buttons/links had outdated URLs after replacing the file. ([#17063](https://github.com/craftcms/cms/issues/17063))
+- Fixed a bug where Table fields weren’t saving their values properly. ([#17091](https://github.com/craftcms/cms/pull/17091))
 
 ## 4.15.0-beta.2 - 2025-04-10
 

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -659,7 +659,7 @@ abstract class Field extends SavableComponent implements FieldInterface
             return Db::prepareDateForDb($value);
         }
 
-        return $this->serializeValue($value, $element);
+        return self::serializeValue($value, $element);
     }
 
     /**

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -659,6 +659,8 @@ abstract class Field extends SavableComponent implements FieldInterface
             return Db::prepareDateForDb($value);
         }
 
+        // specifically calling `self::…` here rather than `$this->…`
+        // see https://github.com/craftcms/cms/pull/17091
         return self::serializeValue($value, $element);
     }
 


### PR DESCRIPTION
### Description
On `4.15`, when saving the value of a table field, all the content was being saved as null, for example `[{"col2":null},{"col2":null},{"col2":null}]` (on `4.x` it saved fine).

I tracked it down to this line https://github.com/craftcms/cms/commit/2a03181d96060cb92e04b830417a158514d19b2b#diff-7f5515881ed38a21d7f62769829d834174a01f871c5314a4996ab0444fb9e9b5R660-R662
(`self::serializeValue` vs `$this->serializeValue`)

In the case of a table field, calling `$this->serializeValue` meant getting [here](https://github.com/craftcms/cms/blob/4.15.0-beta.2/src/fields/Table.php#L505) and as it’s the value of each cell that’s getting serialised, [this](https://github.com/craftcms/cms/blob/4.15.0-beta.2/src/fields/Table.php#L507-L509) condition check was kicking in causing `null` to be returned.

### Related issues
n/a
