### PR TITLE
Updated dutch translation for "Critical", 

### DIFF
--- a/src/translations/nl/app.php
+++ b/src/translations/nl/app.php
@@ -485,7 +485,7 @@ return [
     'Created at' => 'Gemaakt op',
     'Created by' => 'Gemaakt door',
     'Credentialed' => 'Gecertificeerd',
-    'Critical' => 'Kritische',
+    'Critical' => 'Kritisch',
     'Crop' => 'Bijsnijden',
     'Currency' => 'Valuta',
     'Current Password' => 'Huidige wachtwoord',


### PR DESCRIPTION
in this context it should not be used as an adjective in dutch.

Elaboration:
"A critical update" => "Een kritisch**e** update" (As adjective)
"This update is critical" => "Deze update is kritisch" (Not as adjective)
