### PR TITLE
Add ElementHelper::EVENT_BEFORE_RENDER_ELEMENT event

### DIFF
--- a/src/events/BeforeRenderElementEvent.php
+++ b/src/events/BeforeRenderElementEvent.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use craft\base\Element;
+
+/**
+ * Asset event class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.7.5
+ */
+class BeforeRenderElementEvent extends CancelableEvent
+{
+    /**
+     * @var Element The element associated with the event.
+     */
+    public Element $element;
+
+    /**
+     * @var array Additional variables to be passed to the template
+     */
+    public array $variables;
+
+    /**
+     * @var array Array of template paths to check for partials
+     */
+    public array $templates;
+
+    /**
+     * @var string The output of the event
+     */
+    public string $output = '';
+}

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -17,6 +17,7 @@ use craft\config\GeneralConfig;
 use craft\db\Query;
 use craft\db\Table;
 use craft\errors\OperationAbortedException;
+use craft\events\BeforeRenderElementEvent;
 use craft\fieldlayoutelements\CustomField;
 use craft\i18n\Locale;
 use craft\services\ElementSources;
@@ -24,6 +25,7 @@ use craft\web\View;
 use DateTime;
 use Throwable;
 use Twig\Markup;
+use yii\base\Event;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
 use yii\base\NotSupportedException;
@@ -37,6 +39,27 @@ use yii\base\NotSupportedException;
 class ElementHelper
 {
     private const URI_MAX_LENGTH = 255;
+
+    /**
+     * @event BeforeRenderElementEvent The event that is triggered before an element is rendered.
+     * @since 5.7.5
+     *
+     *  ```php
+     *  use craft\events\AuthorizationCheckEvent;
+     *  use craft\services\Elements;
+     *  use yii\base\Event;
+     *
+     *  Event::on(
+     *      craft\helpers\ElementHelper::class,
+     *      craft\helpers\ElementHelper::EVENT_BEFORE_RENDER_ELEMENT,
+     *      function(craft\events\BeforeRenderElementEvent $event) {
+     *         $event->output = '…';
+     *      }
+     *  );
+     *  ```
+     */
+    public const EVENT_BEFORE_RENDER_ELEMENT = 'beforeRenderElement';
+
 
     /**
      * Generates a new temporary slug.
@@ -1017,6 +1040,17 @@ class ElementHelper
         $providerHandle = $element->getFieldLayout()?->provider?->getHandle();
         if ($providerHandle !== null) {
             array_unshift($templates, sprintf('%s/%s/%s', $generalConfig->partialTemplatesPath, $refHandle, $providerHandle));
+        }
+
+        if (Event::hasHandlers(static::class, self::EVENT_BEFORE_RENDER_ELEMENT)) {
+            $event = new BeforeRenderElementEvent([
+                'element' => $element,
+                'variables' => $variables,
+                'templates' => $templates,
+                'output' => '',
+            ]);
+            Event::trigger(static::class, self::EVENT_BEFORE_RENDER_ELEMENT, $event);
+            return $event->output;
         }
 
         foreach ($templates as $template) {


### PR DESCRIPTION
Adds an event that allows developers to override the `_partial/` template rendering for elements.

### Description

I'm currently implementing this in a custom module by adding a new Behaviour to Neo's `Block` and `BlockQuery`  classes. The behaviour adds a `renderComponents()` method which in turn does custom rendering. This event would allow me to remove that functionality completely and simplify the implementation.

Additionally it would allow other developers to do more complex rendering in their own PHP classes before rendering templates.

### Related issues

https://github.com/craftcms/cms/discussions/17188