### PR TITLE
Return URLs saved into session are now sanitized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Fixed a SQL error that could occur when running garbage collection. ([#17197](https://github.com/craftcms/cms/issues/17197))
 - Fixed a PHP error that could occur if malformed UTF-8 data was passed to `craft\helpers\StringHepler::replaceMb4()`. ([#17202](https://github.com/craftcms/cms/issues/17202))
 - Fixed a bug where “Applying new propagation method” jobs weren’t propagating elements to newly-supported sites. ([#17207](https://github.com/craftcms/cms/issues/17207))
+- Return URLs are now sanitized before being saved to the PHP session.
 - Fixed a styling issue.
-- Return URLs saved into session are now sanitized.
 
 ## 4.15.2 - 2025-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a PHP error that could occur if malformed UTF-8 data was passed to `craft\helpers\StringHepler::replaceMb4()`. ([#17202](https://github.com/craftcms/cms/issues/17202))
 - Fixed a bug where “Applying new propagation method” jobs weren’t propagating elements to newly-supported sites. ([#17207](https://github.com/craftcms/cms/issues/17207))
 - Fixed a styling issue.
+- Return URLs saved into session are now sanitized.
 
 ## 4.15.2 - 2025-04-23
 

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -467,6 +467,14 @@ class User extends \yii\web\User
     }
 
     /**
+     * @inheritDoc
+     */
+    public function setReturnUrl($url)
+    {
+        parent::setReturnUrl(strip_tags($url));
+    }
+
+    /**
      * @inheritdoc
      */
     protected function renewAuthStatus(): void

--- a/src/web/User.php
+++ b/src/web/User.php
@@ -467,9 +467,9 @@ class User extends \yii\web\User
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
-    public function setReturnUrl($url)
+    public function setReturnUrl($url): void
     {
         parent::setReturnUrl(strip_tags($url));
     }


### PR DESCRIPTION
Make sure no PHP or HTML code can be saved to session when setting a returnUrl on a request.

Can be merged into Craft 5.

