### PR TITLE
ensure `draftId` is not passed to `createElementEditor` if it’s no longer applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improved error responses for `assets/generate-transform` requests. ([#17228](https://github.com/craftcms/cms/issues/17228))
 - Updated the symfony/yaml requirement to allow `^6.0`. ([#17229](https://github.com/craftcms/cms/discussions/17229))
+- Fixed an error that could occur when attempting to edit a newly-created nested entry within a Matrix field set to the element index view mode. ([#17231](https://github.com/craftcms/cms/pull/17231))
 
 ## 5.7.5 - 2025-05-06
 

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -631,14 +631,14 @@ $('#' + $id).on('activate', (ev) => {
   } else {
     // focus on the button so that when the slideout is closed, it's returned to the button
     $(ev.currentTarget).focus();
-    
-    let jsSettings = JSON.parse(`$settings`);
+
+    const settings = $settings;
     // if settings have draftId but the replaced card doesn't have the data-draft-id attribute anymore,
     // remove the draftId from the settings before creating element editor, so the correct element can be retrieved
-    if (jsSettings.draftId !== null && !Garnish.hasAttr($(ev.currentTarget).parents('.card'), 'data-draft-id')) {
-      jsSettings.draftId = null;
+    if (settings.draftId && !Garnish.hasAttr($(ev.currentTarget).parents('.card'), 'data-draft-id')) {
+      delete settings.draftId;
     }
-    Craft.createElementEditor($elementType, jsSettings);
+    Craft.createElementEditor($elementType, settings);
   }
 });
 JS, [

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -631,7 +631,14 @@ $('#' + $id).on('activate', (ev) => {
   } else {
     // focus on the button so that when the slideout is closed, it's returned to the button
     $(ev.currentTarget).focus();
-    Craft.createElementEditor($elementType, $settings);
+    
+    let jsSettings = JSON.parse(`$settings`);
+    // if settings have draftId but the replaced card doesn't have the data-draft-id attribute anymore,
+    // remove the draftId from the settings before creating element editor, so the correct element can be retrieved
+    if (jsSettings.draftId !== null && !Garnish.hasAttr($(ev.currentTarget).parents('.card'), 'data-draft-id')) {
+      jsSettings.draftId = null;
+    }
+    Craft.createElementEditor($elementType, jsSettings);
   }
 });
 JS, [


### PR DESCRIPTION
### Description
**Steps to reproduce:**
- create a matrix field in element index view mode; entry type can contain only title
- create a section with an entry type that uses this matrix field
- create an entry in this section, add a new nested entry to the matrix field and save that nested entry, but don’t save the root entry
- click the edit icon for the nested entry - “A server error occurred” notification will show, and the nested entry won’t be loaded in a slideout
- if you reload the page and try to edit the nested entry again, all will work as expected

The issue was that the `draftId` from the card of a draft version of the nested entry was lingering behind, causing a response/redirect to be returned, instead of the element.

### Related issues
n/a
