### PR TITLE
fix: route delete button pointer cursor

### DIFF
--- a/src/web/assets/routes/src/routes.scss
+++ b/src/web/assets/routes/src/routes.scss
@@ -158,6 +158,7 @@
     display: block;
     float: inline-start;
     color: var(--disabled-color);
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
### Description
This PR fixes the button cursor on the delete button when editing a route (at path [craft]/admin/settings/routes)

<img width="552" alt="SCR-20250508-rqwj-2" src="https://github.com/user-attachments/assets/fae308ca-533e-40eb-9608-1c257f31f5b2" />

### Related issues

