### PR TITLE
[5.8] Add `Json` type to Craft's GraphQL type definitions

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -12,6 +12,9 @@
 - Entry type edit pages now have a “Save as a new entry type” action. ([#15977](https://github.com/craftcms/cms/discussions/15977))
 - The `accessibilityDefaults` config setting can now contain `notificationPosition` and `slideoutPosition` keys. ([#17169](https://github.com/craftcms/cms/pull/17169))
 
+### Development
+- User `preferences` field now returns a JSON object in GraphQL queries.
+
 ### Extensibility
 - Element edit pages now support being passed a hashed `returnUrl` query string param. ([#17137](https://github.com/craftcms/cms/discussions/17137))
 - Added `craft\base\Element::EVENT_RENDER`. ([#17188](https://github.com/craftcms/cms/discussions/17188))
@@ -20,6 +23,7 @@
 - Added `craft\fields\BaseRelationField::canShowSiteMenu()`.
 - Added `craft\fields\data\OptionData::$color`.
 - Added `craft\fields\data\OptionData::$icon`.
+- Added `craft\gql\types\Json`.
 - Added `craft\helpers\Cp::buttonGroupFieldHtml()`.
 - Added `craft\helpers\Cp::buttonGroupHtml()`.
 - Added `craft\models\FieldLayout::resetUids()`.

--- a/src/gql/interfaces/elements/User.php
+++ b/src/gql/interfaces/elements/User.php
@@ -13,6 +13,7 @@ use craft\gql\GqlEntityRegistry;
 use craft\gql\interfaces\Element;
 use craft\gql\resolvers\elements\Address as AddressResolver;
 use craft\gql\types\generators\UserType;
+use craft\gql\types\Json;
 use craft\helpers\Gql;
 use GraphQL\Type\Definition\InterfaceType;
 use GraphQL\Type\Definition\Type;
@@ -85,7 +86,7 @@ class User extends Element
             ],
             'preferences' => [
                 'name' => 'preferences',
-                'type' => Type::nonNull(Type::string()),
+                'type' => Json::getType(),
                 'description' => 'The user’s preferences.',
                 'complexity' => Gql::nPlus1Complexity(),
             ],

--- a/src/gql/types/Json.php
+++ b/src/gql/types/Json.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\gql\types;
+
+use craft\errors\GqlException;
+use craft\gql\base\SingularTypeInterface;
+use craft\gql\GqlEntityRegistry;
+use craft\helpers\Json as JsonHelper;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\NullValueNode;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Class JsonType
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.8.0
+ */
+class Json extends ScalarType implements SingularTypeInterface
+{
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return 'CraftJson';
+    }
+
+    public static function getType(): Type
+    {
+        return GqlEntityRegistry::getOrCreate(static::getName(), fn() => new self());
+    }
+
+    public function serialize($value)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return JsonHelper::encode($value);
+        }
+
+        if (is_string($value)) {
+            // If the value is a string, we need to check if it's JSON encoded
+            $decodedValue = JsonHelper::decodeIfJson($value);
+            if ($decodedValue !== null) {
+                return $decodedValue;
+            }
+        }
+
+        return $value;
+    }
+
+    public function parseValue($value)
+    {
+        if (!is_string($value) && !is_array($value) && !is_null($value)) {
+            throw new GqlException('Data must be either a string, array, or null.');
+        }
+
+        return $value;
+    }
+
+    public function parseLiteral(Node $valueNode, ?array $variables = null)
+    {
+        if ($valueNode instanceof StringValueNode) {
+            return JsonHelper::decodeIfJson($valueNode->value);
+        }
+
+        if ($valueNode instanceof NullValueNode) {
+            return null;
+        }
+
+        // This message will be lost by the wrapping exception, but it feels good to provide one.
+        throw new GqlException("Data must be either an array, string or null.");
+    }
+}

--- a/src/gql/types/Json.php
+++ b/src/gql/types/Json.php
@@ -30,7 +30,7 @@ class Json extends ScalarType implements SingularTypeInterface
      */
     public static function getName(): string
     {
-        return 'CraftJson';
+        return 'Json';
     }
 
     public static function getType(): Type


### PR DESCRIPTION
### Description
This PR adds the `JSON` to Craft's GraphQL inbuilt types.

Along with this, user queries have been updated so that the `preferences` field now returns a JSON object rather than a string.

Before:
![CleanShot 2025-05-12 at 10 21 55@2x](https://github.com/user-attachments/assets/e98e1b04-0793-4db3-a6eb-696c0c74ef2f)


After:
![CleanShot 2025-05-12 at 10 22 11@2x](https://github.com/user-attachments/assets/5b94dff2-c08f-463e-8d17-d71b989c6435)

