### PR TITLE
Docs: Element Events

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -223,7 +223,7 @@ abstract class Element extends Component implements ElementInterface
      * ```php
      * use craft\base\Element;
      * use craft\elements\Entry;
-     * use craft\events\PrepareElementQueryForTableAttributeEvent;
+     * use craft\events\ElementIndexTableAttributeEvent;
      * use craft\events\RegisterElementTableAttributesEvent;
      * use craft\events\SetElementTableAttributeHtmlEvent;
      * use craft\helpers\Cp;
@@ -240,7 +240,7 @@ abstract class Element extends Component implements ElementInterface
      * Event::on(
      *     Entry::class,
      *     Element::EVENT_PREP_QUERY_FOR_TABLE_ATTRIBUTE,
-     *     function(PrepareElementQueryForTableAttributeEvent $e) {
+     *     function(ElementIndexTableAttributeEvent $e) {
      *         $query = $e->query;
      *         $attr = $e->attribute;
      *

--- a/src/elements/db/ElementQuery.php
+++ b/src/elements/db/ElementQuery.php
@@ -81,25 +81,25 @@ class ElementQuery extends Query implements ElementQueryInterface
     public const EVENT_DEFINE_CACHE_TAGS = 'defineCacheTags';
 
     /**
-     * @event PopulateElementEvent The event that is triggered before an element is populated.
+     * @event PopulateElementEvent The event that is triggered before an element is populated from a database row.
      *
-     * If [[PopulateElementEvent::$element]] is set by an event handler, the replacement will be returned by [[createElement()]] instead.
+     * If [[PopulateElementEvent::$element]] is set by an event handler, the replacement will be returned by [[createElement()]] instead of the original.
      *
      * @since 4.5.0
      */
     public const EVENT_BEFORE_POPULATE_ELEMENT = 'beforePopulateElement';
 
     /**
-     * @event PopulateElementEvent The event that is triggered after an element is populated.
+     * @event PopulateElementEvent The event that is triggered after an element is populated from a database row.
      *
-     * If [[PopulateElementEvent::$element]] is replaced by an event handler, the replacement will be returned by [[createElement()]] instead.
+     * If [[PopulateElementEvent::$element]] is replaced by an event handler, the replacement will be returned by [[createElement()]] instead of the original.
      */
     public const EVENT_AFTER_POPULATE_ELEMENT = 'afterPopulateElement';
 
     /**
-     * @event PopulateElementEvent The event that is triggered after an element is populated.
+     * @event PopulateElementEvent The event triggered after all elements are populated.
      *
-     * If [[PopulateElementEvent::$element]] is replaced by an event handler, the replacement will be returned by [[createElement()]] instead.
+     * The query’s results are assigned to [[PopulateElementsEvent::$elements]], and are returned after all handlers are invoked. Handlers may add, remove, modify, and replace populated elements.
      */
     public const EVENT_AFTER_POPULATE_ELEMENTS = 'afterPopulateElements';
 


### PR DESCRIPTION
- Fixes a reference to a class that was renamed before releasing (2575dc041bdbda3f36dc6b4428e40cf8e4bac0e6)
- Fixes and clarifies a duplicate docblock (119082b13a3b0f33fe386d62acb9c069edc00d56)