### PR TITLE
“is of type” Link field condition operator

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -2,6 +2,7 @@
 
 ### Content Management
 - Matrix fields set to the “inline-editable blocks” view mode now have “Expand all blocks” and “Collapse all blocks” actions. ([#17141](https://github.com/craftcms/cms/pull/17141))
+- Link fields’ condition rules now have an “is of type” operator. ([#17277](https://github.com/craftcms/cms/pull/17277))
 - Read-only relational fields now display element chips/cards more consistently with editable fields. ([#17146](https://github.com/craftcms/cms/discussions/17146))
 - Added the “Notification Position” and “Sideout Position” user preferences. ([#17169](https://github.com/craftcms/cms/pull/17169))
 - Button Group, Dropdown, and Radio Buttons fields now display their selected option’s icon/color within field previews. ([#17178](https://github.com/craftcms/cms/discussions/17178))
@@ -20,6 +21,7 @@
 - Added `craft\elements\Asset::setMimeType()`.
 - Added `craft\events\RenderElementEvent`. ([#`17188`](https://github.com/craftcms/cms/discussions/17188))
 - Added `craft\fields\BaseRelationField::canShowSiteMenu()`.
+- Added `craft\fields\conditions\LinkFieldConditionRule`.
 - Added `craft\fields\data\OptionData::$color`.
 - Added `craft\fields\data\OptionData::$icon`.
 - Added `craft\helpers\Cp::buttonGroupFieldHtml()`.

--- a/src/db/CoalesceColumnsExpression.php
+++ b/src/db/CoalesceColumnsExpression.php
@@ -40,6 +40,9 @@ class CoalesceColumnsExpression extends BaseObject implements ExpressionInterfac
             fn(string $column) => str_contains($column, '(') ? $column : "[[$column]]",
             $this->columns,
         );
+        if (count($columns) === 1) {
+            return reset($columns);
+        }
         return sprintf('COALESCE(%s)', implode(', ', $columns));
     }
 }

--- a/src/fields/Link.php
+++ b/src/fields/Link.php
@@ -19,7 +19,7 @@ use craft\base\RelationalFieldTrait;
 use craft\elements\db\ElementQueryInterface;
 use craft\elements\Entry as EntryElement;
 use craft\events\RegisterComponentTypesEvent;
-use craft\fields\conditions\TextFieldConditionRule;
+use craft\fields\conditions\LinkFieldConditionRule;
 use craft\fields\data\LinkData;
 use craft\fields\linktypes\Asset;
 use craft\fields\linktypes\BaseLinkType;
@@ -865,7 +865,7 @@ JS;
      */
     public function getElementConditionRuleType(): array|string|null
     {
-        return TextFieldConditionRule::class;
+        return LinkFieldConditionRule::class;
     }
 
     /**

--- a/src/fields/conditions/LinkFieldConditionRule.php
+++ b/src/fields/conditions/LinkFieldConditionRule.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace craft\fields\conditions;
+
+use Craft;
+use craft\db\CoalesceColumnsExpression;
+use craft\fields\Link;
+use craft\fields\linktypes\BaseLinkType;
+use craft\helpers\Cp;
+use yii\db\QueryInterface;
+
+/**
+ * Options field condition rule.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.8.0
+ */
+class LinkFieldConditionRule extends TextFieldConditionRule
+{
+    private const OPERATOR_TYPE = 'type';
+
+    /**
+     * @var string|null The selected link type
+     */
+    public ?string $linkType = null;
+
+    protected function operators(): array
+    {
+        return [
+            ...parent::operators(),
+            self::OPERATOR_TYPE,
+        ];
+    }
+
+    protected function operatorLabel(string $operator): string
+    {
+        return match ($operator) {
+            self::OPERATOR_TYPE => Craft::t('app', 'is of type'),
+            default => parent::operatorLabel($operator),
+        };
+    }
+
+    protected function inputHtml(): string
+    {
+        if ($this->operator === self::OPERATOR_TYPE) {
+            /** @var Link $field */
+            $field = $this->field();
+            $linkTypeOptions = array_map(
+                fn(BaseLinkType $linkType) => ['value' => $linkType::id(), 'label' => $linkType::displayName()],
+                $field->getLinkTypes(),
+            );
+
+            return Cp::selectHtml([
+                'name' => 'linkType',
+                'options' => $linkTypeOptions,
+                'value' => $this->linkType,
+            ]);
+        }
+
+        return parent::inputHtml();
+    }
+
+    public function modifyQuery(QueryInterface $query): void
+    {
+        if ($this->operator === self::OPERATOR_TYPE) {
+            /** @phpstan-ignore-next-line */
+            $valueSql = array_map(fn(Link $field) => $field->getValueSql('type'), $this->fieldInstances());
+
+            $query->andWhere([
+                (new CoalesceColumnsExpression($valueSql))->getSql($query->params) => $this->linkType,
+            ]);
+        } else {
+            parent::modifyQuery($query);
+        }
+    }
+
+    protected function defineRules(): array
+    {
+        return [
+            ...parent::defineRules(),
+            [['linkType'], 'safe'],
+        ];
+    }
+}

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -2143,6 +2143,7 @@ return [
     'is less than or equals' => 'is less than or equals',
     'is less than' => 'is less than',
     'is not one of' => 'is not one of',
+    'is of type' => 'is of type',
     'is one of' => 'is one of',
     'is related to' => 'is related to',
     'item' => 'item',


### PR DESCRIPTION
### Description

Adds an “is of type” operator to Link fields’ condition rules.

![An entry condition builder, with a condition rule for a Link field. Its operator is set to “is of type”, and there’s a select input with “Entry” selected.](https://github.com/user-attachments/assets/621c1793-1bf8-414e-946a-100d6413858e)

Couple things to note:

- Existing Link field condition rules won’t have the new operator, because the underlying condition rule class has changed. Those rules will need to be removed and re-added to get it.
- Only elements that have been saved on Craft 5.5.0+ will match “is of type” Link rules. To ensure all Link field data is stored in the updated format, run the following command, setting `--with-fields` to a comma-delimited list of your Link field handles:
  ```sh
  php craft resave/all --with-fields=foo,bar,baz
  ```

### Related issues

- #17276