### PR TITLE
feat(gql): allow querying of single SectionEntryUnion

### DIFF
--- a/src/gql/queries/Entry.php
+++ b/src/gql/queries/Entry.php
@@ -97,6 +97,53 @@ class Entry extends Query
         $gqlService = Craft::$app->getGql();
 
         foreach (GqlHelper::getSchemaContainedSections() as $section) {
+            $singleName = "{$section->handle}Entry";
+            $singleTypeName = "{$section->handle}SectionEntryQuery";
+            $singleSectionQueryType = GqlEntityRegistry::getEntity($singleTypeName);
+
+            if (!$singleSectionQueryType) {
+                $entryTypesInSection = [];
+
+                // Loop through the entry types and create further queries
+                foreach ($section->getEntryTypes() as $entryType) {
+                    if (isset($entryTypeGqlTypes[$entryType->id])) {
+                        $entryTypesInSection[] = $entryTypeGqlTypes[$entryType->id];
+                    }
+                }
+
+                if (empty($entryTypesInSection)) {
+                    continue;
+                }
+
+                $arguments = EntryArguments::getArguments();
+
+                // Unset unusable arguments
+                unset(
+                    $arguments['section'],
+                    $arguments['sectionId'],
+                    $arguments['field'],
+                    $arguments['fieldId'],
+                    $arguments['ownerId'],
+                );
+
+                foreach ($section->getEntryTypes() as $entryType) {
+                    $arguments += $gqlService->getFieldLayoutArguments($entryType->getFieldLayout());
+                }
+
+                // Create the section query field
+                $singleSectionQueryType = [
+                    'name' => $singleName,
+                    'args' => $arguments,
+                    'description' => sprintf('Entry within the “%s” section.', $section->name),
+                    'type' => Type::listOf(GqlHelper::getUnionType("{$section->handle}SectionEntryUnion", $entryTypesInSection)),
+                    // Enforce the section argument and set the source to `null`, to enforce a new element query.
+                    'resolve' => fn($source, array $arguments, $context, ResolveInfo $resolveInfo) =>
+                        EntryResolver::resolveOne(null, $arguments + ['section' => $section->handle], $context, $resolveInfo),
+                ];
+            }
+
+            $gqlTypes[$singleName] = $singleSectionQueryType;
+            
             $name = "{$section->handle}Entries";
             $typeName = "{$section->handle}SectionEntriesQuery";
             $sectionQueryType = GqlEntityRegistry::getEntity($typeName);


### PR DESCRIPTION
### Description
This is a suggestion to add the ability to query for single SectionEntryUnion entries via GraphQL. The reason behind this is that we love to use the `[SectionEntryUnion]` query as it has beneficial type inference for typescript projects compared to the `[EntryInterface]` query. 

Unfortunately for section types "single" we have to unwrap the array just to get a single entry variable to work with like this: `const homepage = this.page()?.data?.homepageEntries?.at(0)`. This commit adds the missing `EntryResolver::resolveOne`. 

### Related issues
#17278 