### PR TITLE
Better condition support for multi-instance relation fields

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -3,6 +3,9 @@
 > [!NOTE]
 > Elements with Link fields created before Craft 5.5.0 should be resaved to take advantage of the new “is of type” condition rule operator. ([#17277](https://github.com/craftcms/cms/pull/17277))
 
+> [!NOTE]
+> Elements with multi-instance relation fields created before Craft 5.3.0 should be resaved to ensure their condition rules continue to work properly. ([#17295](https://github.com/craftcms/cms/pull/17295))
+
 ### Content Management
 - Matrix fields set to the “inline-editable blocks” view mode now have “Expand all blocks” and “Collapse all blocks” actions. ([#17141](https://github.com/craftcms/cms/pull/17141))
 - Link fields’ condition rules now have an “is of type” operator. ([#17277](https://github.com/craftcms/cms/pull/17277))

--- a/src/fields/conditions/RelationalFieldConditionRule.php
+++ b/src/fields/conditions/RelationalFieldConditionRule.php
@@ -8,6 +8,8 @@ use craft\base\ElementInterface;
 use craft\elements\conditions\ElementConditionInterface;
 use craft\elements\db\ElementQueryInterface;
 use craft\elements\ElementCollection;
+use craft\fieldlayoutelements\BaseField;
+use craft\fieldlayoutelements\CustomField;
 use craft\fields\BaseRelationField;
 use yii\base\InvalidConfigException;
 
@@ -128,6 +130,33 @@ class RelationalFieldConditionRule extends BaseElementSelectConditionRule implem
     {
         $field = $this->field();
         if (!$field instanceof BaseRelationField) {
+            return;
+        }
+
+        // If this is one of multiple instances of the relation field in the layout,
+        // look at the JSON values rather than the `relations` table data
+        // (see https://github.com/craftcms/cms/issues/17290)
+        $allInstances = $field->layoutElement?->getLayout()->getFields(fn(BaseField $field) => (
+            $field instanceof CustomField &&
+            $field->getFieldUid() === $this->_fieldUid
+        ));
+        if (count($allInstances) > 1) {
+            $valueSql = $field->getValueSql();
+            switch ($this->operator) {
+                case self::OPERATOR_RELATED_TO:
+                    $qb = Craft::$app->getDb()->getQueryBuilder();
+                    $query->andWhere([
+                        'or',
+                        ...array_map(fn(int $id) => $qb->jsonContains($valueSql, $id), $this->getElementIds()),
+                    ]);
+                    break;
+                case self::OPERATOR_NOT_EMPTY:
+                    $query->andWhere(['not', [$valueSql => null]]);
+                    break;
+                case self::OPERATOR_EMPTY:
+                    $query->andWhere([$valueSql => null]);
+                    break;
+            }
             return;
         }
 

--- a/src/models/FieldLayout.php
+++ b/src/models/FieldLayout.php
@@ -574,6 +574,22 @@ class FieldLayout extends Model
     }
 
     /**
+     * Returns all fields in the layout that match a given callback.
+     *
+     * @param callable $filter
+     * @return BaseField[]
+     * @throws InvalidArgumentException if the field isn’t included
+     * @since 5.8.0
+     */
+    public function getFields(callable $filter): array
+    {
+        return iterator_to_array($this->_elements(fn(FieldLayoutElement $layoutElement) => (
+            $layoutElement instanceof BaseField &&
+            $filter($layoutElement)
+        )));
+    }
+
+    /**
      * Returns the field layout’s config.
      *
      * @return array|null


### PR DESCRIPTION
### Description

Improves condition rules for multi-instance relation fields, so they factor in the individual instance data, rather than the global field as a whole.

> [!NOTE]
> Any elements that have multi-instance relation fields, which haven’t been saved since Craft < 5.3.0, will not be matched accurately by relation conditions. To ensure all relation field data is stored in the updated format required by relation conditions going forward, run the following command, setting `--with-fields` to a comma-delimited list of your relation field handles:
>
> ```sh
> php craft resave/all --with-fields=foo,bar,baz
> ```

### Related issues

- #17290