### PR TITLE
Tweak better condition support for multi-instance relation fields 

### DIFF
--- a/src/fields/conditions/RelationalFieldConditionRule.php
+++ b/src/fields/conditions/RelationalFieldConditionRule.php
@@ -151,10 +151,22 @@ class RelationalFieldConditionRule extends BaseElementSelectConditionRule implem
                     ]);
                     break;
                 case self::OPERATOR_NOT_EMPTY:
-                    $query->andWhere(['not', [$valueSql => null]]);
+                    $query->andWhere(
+                        [
+                            'and',
+                            ['not', [$valueSql => null]],
+                            ['not', [$valueSql => '[]']],
+                        ]
+                    );
                     break;
                 case self::OPERATOR_EMPTY:
-                    $query->andWhere([$valueSql => null]);
+                    $query->andWhere(
+                        [
+                            'or',
+                            [$valueSql => null],
+                            [$valueSql => '[]'],
+                        ]
+                    );
                     break;
             }
             return;


### PR DESCRIPTION
### Description
An empty relation field value can also be stored as an empty array (`[]`), so we need to factor that in for “is empty” and “has value” conditions.


### Related issues
#17295
