### PR TITLE
Matrix field, eager loading and revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed a bug where Link fields could show multiple info icons within their advanced fields. ([#17329](https://github.com/craftcms/cms/issues/17329))
 - Fixed a bug where element chips and cards could get hyperlinks, “Edit”, and “Copy” actions, when the current user didn’t have permission to edit content in the element’s site.
 - Fixed a bug where the `up` command was updating project config YAML files when admin changes weren’t allowed. ([#17345](https://github.com/craftcms/cms/issues/17345))
+- Fixed a bug where nested entry revisions were getting included in GraphQL results unexpectedly, for Matrix fields with versioning enabled. ([#17324](https://github.com/craftcms/cms/issues/17324))
 - Fixed styling issues. ([#17335](https://github.com/craftcms/cms/pull/17335), [#17342](https://github.com/craftcms/cms/pull/17342))
 
 ## 5.7.7 - 2025-05-20

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1297,7 +1297,8 @@ JS;
                 'allowOwnerRevisions' => true,
                 // only include revisions if any of the source elements is a revision
                 // see https://github.com/craftcms/cms/issues/14448 and https://github.com/craftcms/cms/issues/17324
-                'revisions' => Collection::make($sourceElements)->filter(fn($sourceElement) => $sourceElement->getIsRevision())->isNotEmpty(),
+                'revisions' => Collection::make($sourceElements)
+                    ->contains(fn($sourceElement) => $sourceElement->getIsRevision()),
             ],
         ];
     }

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1295,7 +1295,9 @@ JS;
                 'fieldId' => $this->id,
                 'allowOwnerDrafts' => true,
                 'allowOwnerRevisions' => true,
-                'revisions' => null,
+                // only include revisions if any of the source elements is a revision
+                // see https://github.com/craftcms/cms/issues/14448 and https://github.com/craftcms/cms/issues/17324
+                'revisions' => Collection::make($sourceElements)->filter(fn($sourceElement) => $sourceElement->getIsRevision())->isNotEmpty(),
             ],
         ];
     }


### PR DESCRIPTION
### Description
With the introduction of [nested entry revisions](https://github.com/craftcms/cms/pull/17008), the fix for #14448 is a bit too eager, causing all the revisions to be returned when eager loading matrix entries with `with` (via GQL, twig, php).

Solution: when eager loading matrix entries, only include revisions if any of the source elements are a revision.

(Side note: the same tweak works in v4; however, since matrix blocks don’t have separate revisions there, the reported behaviour doesn’t manifest itself, so I left it as is.)

Before:
<img width="1224" alt="Screenshot 2025-05-28 at 08 34 09" src="https://github.com/user-attachments/assets/8bbdca0d-76d6-4a8d-841f-b81e9869f386" />
<img width="1218" alt="Screenshot 2025-05-28 at 08 34 28" src="https://github.com/user-attachments/assets/3c9b5d60-7c74-4144-9906-57d1ff92b839" />

After:
<img width="1180" alt="Screenshot 2025-05-28 at 08 33 37" src="https://github.com/user-attachments/assets/59f7e1aa-8a23-49f4-abec-7e638eb0750a" />
<img width="1199" alt="Screenshot 2025-05-28 at 08 32 47" src="https://github.com/user-attachments/assets/d9596be7-177b-4aab-ad07-4988fa7875dc" />


### Related issues
#17324 
