### PR TITLE
allow copying nested matrix entries even when maxEntries reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where it wasn’t possible to copy nested entries within Matrix fields set to cards or element index views, if the Max Entires setting had been reached. ([#17373](https://github.com/craftcms/cms/issues/17373))
+
 ## 5.7.8.2 - 2025-05-30
 
 - Fixed an error that could occur when saving an element. ([#17268](https://github.com/craftcms/cms/issues/17268))

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1980,17 +1980,7 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
      */
     public function canCopy(User $user): bool
     {
-        // if it's a nested element and the field has a separate method to check if elements can be copied - use it
-        if (
-            ($field = $this->getField()) instanceof ElementContainerFieldInterface &&
-            method_exists($field::class, 'canCopyElement') &&
-            /** @phpstan-ignore-next-line */
-            $field->canCopyElement($this, $user)
-        ) {
-            return true;
-        }
-
-        return Craft::$app->getElements()->canDuplicate($this, $user);
+        return Craft::$app->getElements()->canView($this, $user);
     }
 
     /**

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1980,6 +1980,16 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
      */
     public function canCopy(User $user): bool
     {
+        // if it's a nested element and the field has a separate method to check if elements can be copied - use it
+        if (
+            ($field = $this->getField()) instanceof ElementContainerFieldInterface &&
+            method_exists($field::class, 'canCopyElement') &&
+            /** @phpstan-ignore-next-line */
+            $field->canCopyElement($this, $user)
+        ) {
+            return true;
+        }
+
         return Craft::$app->getElements()->canDuplicate($this, $user);
     }
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -586,26 +586,6 @@ class Matrix extends Field implements
     }
 
     /**
-     * Returns whether the given user is authorized to copy an element.
-     *
-     * This will only be called if the element can be [[canView()|viewed]] and/or [[canSave()|saved]].
-     *
-     * @param NestedElementInterface $element
-     * @param User $user
-     * @return bool|null
-     */
-    public function canCopyElement(NestedElementInterface $element, User $user): ?bool
-    {
-        $owner = $element->getOwner();
-
-        if (!$owner || !Craft::$app->getElements()->canSave($owner, $user)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * @inheritdoc
      */
     public function canDeleteElement(NestedElementInterface $element, User $user): ?bool

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -586,6 +586,26 @@ class Matrix extends Field implements
     }
 
     /**
+     * Returns whether the given user is authorized to copy an element.
+     *
+     * This will only be called if the element can be [[canView()|viewed]] and/or [[canSave()|saved]].
+     *
+     * @param NestedElementInterface $element
+     * @param User $user
+     * @return bool|null
+     */
+    public function canCopyElement(NestedElementInterface $element, User $user): ?bool
+    {
+        $owner = $element->getOwner();
+
+        if (!$owner || !Craft::$app->getElements()->canSave($owner, $user)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * @inheritdoc
      */
     public function canDeleteElement(NestedElementInterface $element, User $user): ?bool


### PR DESCRIPTION
### Description
Allow copying nested matrix entries even when the `maxEntries` limit was reached.


### Related issues
#17373 
