### PR TITLE
[Multisite] Section Breadcrumbs

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1259,8 +1259,9 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
             return [];
         }
 
+        $requestedSite = Cp::requestedSite();
         $sections = Collection::make(Craft::$app->getEntries()->getEditableSections())
-            ->filter(fn(Section $s) => in_array(Cp::requestedSite()->id, $s->siteIds));
+            ->filter(fn(Section $s) => !$requestedSite || in_array(Cp::requestedSite()->id, $s->siteIds));
         /** @var Collection $sectionOptions */
         $sectionOptions = $sections
             ->filter(fn(Section $s) => $s->type !== Section::TYPE_SINGLE)

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -1259,7 +1259,8 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
             return [];
         }
 
-        $sections = Collection::make(Craft::$app->getEntries()->getEditableSections());
+        $sections = Collection::make(Craft::$app->getEntries()->getEditableSections())
+            ->filter(fn(Section $s) => in_array(Cp::requestedSite()->id, $s->siteIds));
         /** @var Collection $sectionOptions */
         $sectionOptions = $sections
             ->filter(fn(Section $s) => $s->type !== Section::TYPE_SINGLE)


### PR DESCRIPTION
### Description

We have a multisite setup with multiple Site Groups and individual locale based Sites within each Group. Sections are enabled based on the needs for the Site Group and as it stands right now, we have several different `Pages` Sections based on which Site Group you're editing. This is done for the sake of access to specific Entry Types.

Currently, the Section breadcrumbs generated for Entries includes _all_ editable Sections within Craft to display in the top UI bar. This leads to confusion because the Site you're currently editing shows a number of Sections which aren't actually available or applicable, resulting in this behavior:

![Screenshot 2025-06-04 at 1 49 32 PM](https://github.com/user-attachments/assets/3260f1e4-b375-4646-bec4-3c49ee499087)

Additionally, the breadcrumb links for Sections which aren't part of the current Site ultimately just end up taking you to `All Entries` since that Section doesn't exist for that Site.

### What's Changed

We could (and likely will in the short term) change the names of the "Pages" Sections to be more specific to the Site Groups, but it seems like it'd make more sense to only show Sections which are relevant to the requested site in the breadcrumbs. This PR updates the `$sections` Collection within the `crumbs()` function to only include a Section if it's enabled for the requested Site.