### PR TITLE
getActionMenuItems and actionMenuItems can be dependent on an element

### DIFF
--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -542,9 +542,9 @@ abstract class Field extends SavableComponent implements FieldInterface, Iconic,
     /**
      * @inheritdoc
      */
-    public function getActionMenuItems(): array
+    public function getActionMenuItems(?ElementInterface $element = null, bool $static = false): array
     {
-        $items = $this->actionMenuItems();
+        $items = $this->actionMenuItems($element, $static);
 
         // Fire a 'defineActionMenuItems' event
         if ($this->hasEventHandlers(self::EVENT_DEFINE_ACTION_MENU_ITEMS)) {
@@ -558,7 +558,7 @@ abstract class Field extends SavableComponent implements FieldInterface, Iconic,
         return $items;
     }
 
-    protected function actionMenuItems(): array
+    protected function actionMenuItems(?ElementInterface $element = null, bool $static = false): array
     {
         $items = [];
         $userSessionService = Craft::$app->getUser();

--- a/src/fieldlayoutelements/CustomField.php
+++ b/src/fieldlayoutelements/CustomField.php
@@ -562,7 +562,7 @@ class CustomField extends BaseField
     {
         if ($this->_field instanceof Actionable) {
             $this->_field->static = $static;
-            $items = $this->_field->getActionMenuItems();
+            $items = $this->_field->getActionMenuItems($element, $static);
         } else {
             $items = [];
         }

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -819,30 +819,32 @@ class Matrix extends Field implements
     /**
      * @inheritdoc
      */
-    protected function actionMenuItems(): array
+    protected function actionMenuItems(?ElementInterface $element = null, bool $static = false): array
     {
         $items = [];
         $view = Craft::$app->getView();
 
-        if ($this->viewMode === self::VIEW_MODE_BLOCKS) {
-            // Expand/Collapse all
-            $expandAllId = sprintf('expand-all-%s', mt_rand());
-            $collapseAllId = sprintf('collapse-all-%s', mt_rand());
-            $items[] = [
-                'id' => $expandAllId,
-                'icon' => 'expand',
-                'label' => StringHelper::upperCaseFirst(Craft::t('app', 'Expand all blocks', [
-                    'type' => Entry::pluralLowerDisplayName(),
-                ])),
-            ];
-            $items[] = [
-                'id' => $collapseAllId,
-                'icon' => 'collapse',
-                'label' => StringHelper::upperCaseFirst(Craft::t('app', 'Collapse all blocks', [
-                    'type' => Entry::pluralLowerDisplayName(),
-                ])),
-            ];
-            $view->registerJsWithVars(fn($expandAllId, $collapseAllId, $fieldId) => <<<JS
+        // actions that should only be available if we have an element
+        if ($element) {
+            if ($this->viewMode === self::VIEW_MODE_BLOCKS) {
+                // Expand/Collapse all
+                $expandAllId = sprintf('expand-all-%s', mt_rand());
+                $collapseAllId = sprintf('collapse-all-%s', mt_rand());
+                $items[] = [
+                    'id' => $expandAllId,
+                    'icon' => 'expand',
+                    'label' => StringHelper::upperCaseFirst(Craft::t('app', 'Expand all blocks', [
+                        'type' => Entry::pluralLowerDisplayName(),
+                    ])),
+                ];
+                $items[] = [
+                    'id' => $collapseAllId,
+                    'icon' => 'collapse',
+                    'label' => StringHelper::upperCaseFirst(Craft::t('app', 'Collapse all blocks', [
+                        'type' => Entry::pluralLowerDisplayName(),
+                    ])),
+                ];
+                $view->registerJsWithVars(fn($expandAllId, $collapseAllId, $fieldId) => <<<JS
 (() => {
   const expandAllBtn = $('#' + $expandAllId);
   const collapseAllBtn = $('#' + $collapseAllId);
@@ -870,40 +872,40 @@ class Matrix extends Field implements
   }, 1);
 })();
 JS, [
-                $view->namespaceInputId($expandAllId),
-                $view->namespaceInputId($collapseAllId),
-                $view->namespaceInputId($this->getInputId()),
-            ]);
-        }
-
-        // Copy all
-        if ($this->maxEntries !== 1 && $this->viewMode !== self::VIEW_MODE_INDEX) {
-            if (!empty($items)) {
-                $items[] = ['type' => 'hr'];
+                    $view->namespaceInputId($expandAllId),
+                    $view->namespaceInputId($collapseAllId),
+                    $view->namespaceInputId($this->getInputId()),
+                ]);
             }
-            $copyAllId = sprintf('action-copy-all-%s', mt_rand());
-            $items[] = [
-                'id' => $copyAllId,
-                'icon' => 'clone-dashed',
-                'color' => \craft\enums\Color::Fuchsia,
-                'label' => StringHelper::upperCaseFirst(Craft::t('app', 'Copy all {type}', [
-                    'type' => Entry::pluralLowerDisplayName(),
-                ])),
-            ];
 
-            if ($this->viewMode === self::VIEW_MODE_CARDS) {
-                $view->registerJsWithVars(fn($copyAllId, $fieldId) => <<<JS
+            // Copy all
+            if ($this->maxEntries !== 1 && $this->viewMode !== self::VIEW_MODE_INDEX) {
+                if (!empty($items)) {
+                    $items[] = ['type' => 'hr'];
+                }
+                $copyAllId = sprintf('action-copy-all-%s', mt_rand());
+                $items[] = [
+                    'id' => $copyAllId,
+                    'icon' => 'clone-dashed',
+                    'color' => \craft\enums\Color::Fuchsia,
+                    'label' => StringHelper::upperCaseFirst(Craft::t('app', 'Copy all {type}', [
+                        'type' => Entry::pluralLowerDisplayName(),
+                    ])),
+                ];
+
+                if ($this->viewMode === self::VIEW_MODE_CARDS) {
+                    $view->registerJsWithVars(fn($copyAllId, $fieldId) => <<<JS
 (() => {
   $('#' + $copyAllId).on('activate', () => {
     Craft.cp.copyElements($('#' + $fieldId + ' > .nested-element-cards > .elements > li > .element'));
   });
 })();
 JS, [
-                    $view->namespaceInputId($copyAllId),
-                    $view->namespaceInputId($this->getInputId()),
-                ]);
-            } else {
-                $view->registerJsWithVars(fn($copyAllId, $fieldId, $baseInfo) => <<<JS
+                        $view->namespaceInputId($copyAllId),
+                        $view->namespaceInputId($this->getInputId()),
+                    ]);
+                } else {
+                    $view->registerJsWithVars(fn($copyAllId, $fieldId, $baseInfo) => <<<JS
 (() => {
   $('#' + $copyAllId).on('activate', () => {
     const elementInfo = [];
@@ -921,13 +923,14 @@ JS, [
   });
 })();
 JS, [
-                    $view->namespaceInputId($copyAllId),
-                    $view->namespaceInputId($this->getInputId()),
-                    [
-                        'type' => Entry::class,
-                        'fieldId' => $this->id,
-                    ],
-                ]);
+                        $view->namespaceInputId($copyAllId),
+                        $view->namespaceInputId($this->getInputId()),
+                        [
+                            'type' => Entry::class,
+                            'fieldId' => $this->id,
+                        ],
+                    ]);
+                }
             }
         }
 


### PR DESCRIPTION
### Description
Allow `$element` and `$static` to be passed to the field’s `getActionMenuItems()` and `actionMenuItems()` so that action menu items can be added depending on whether the field is in an Element context or not.

As it’s potentially a breaking change, we might actually have to target v6?


### Related issues
#17404
More info & context: https://github.com/craftcms/cms/pull/17416
