### PR TITLE
only show copy all action menu item if the field is part of an element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed an error that could occur when loading control panel resources on the front end.
 - Fixed a bug where entries’ section breadcrumbs were getting hyperlinked even if the section’s source was disabled. ([#17411](https://github.com/craftcms/cms/issues/17411))
 - Fixed a bug where entries that were pasted within a Matrix field were losing custom field translations for other sites. ([17414](https://github.com/craftcms/cms/issues/17414))
+- Fixed a bug where Matrix fields’ chips were getting “Copy all entries” actions. ([#17404](https://github.com/craftcms/cms/issues/17404))
 
 ## 5.7.10 - 2025-06-04
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -837,56 +837,51 @@ class Matrix extends Field implements
             ];
 
             if ($this->viewMode === self::VIEW_MODE_CARDS) {
-                $view->registerJsWithVars(fn($copyAllId, $fieldId) => <<<JS
+                $copyAllJs = <<<JS
+copyAllBtn.on('activate', () => {
+  Craft.cp.copyElements(field.find('> .nested-element-cards > .elements > li > .element'));
+});
+JS;
+            } else {
+                $baseInfo = Json::encode([
+                    'type' => Entry::class,
+                    'fieldId' => $this->id,
+                ]);
+                $copyAllJs = <<<JS
+copyAllBtn.on('activate', () => {
+  const elementInfo = [];
+  field.find('> .blocks > .matrixblock').each((i, element) => {
+    element = $(element);
+    elementInfo.push(Object.assign({
+        id: element.data('id'),
+        draftId: element.data('draftId'),
+        revisionId: element.data('revisionId'),
+        ownerId: element.data('ownerId'),
+        siteId: element.data('siteId'),
+      }, $baseInfo));
+  });
+  Craft.cp.copyElements(elementInfo);
+});
+JS;
+            }
+
+            $view->registerJsWithVars(fn($copyAllId, $fieldId) => <<<JS
 (() => {
   const copyAllBtn = $('#' + $copyAllId);
-  
-  $('#' + $copyAllId).on('activate', () => {
-    Craft.cp.copyElements($('#' + $fieldId + ' > .nested-element-cards > .elements > li > .element'));
-  });
-  
-  setTimeout(() => {
-    const menu = copyAllBtn.closest('.menu').data('disclosureMenu');
-    const trigger = menu.\$trigger; 
-    const isElementFieldTrigger = trigger.parents('div.field').length;
-    
-    // only show the copy all button if the trigger is part of an element's field
-    menu.on('show', () => {
-      menu.toggleItem(copyAllBtn[0], isElementFieldTrigger);
-    });
-  }, 1);
+  const field = $('#' + $fieldId);
+  if (field.length) {
+    $copyAllJs
+  } else {
+    setTimeout(() => {
+      const menu = copyAllBtn.closest('.menu').data('disclosureMenu');
+      menu.removeItem(copyAllBtn[0]);
+    }, 1);
+  }
 })();
 JS, [
-                    $view->namespaceInputId($copyAllId),
-                    $view->namespaceInputId($this->getInputId()),
-                ]);
-            } else {
-                $view->registerJsWithVars(fn($copyAllId, $fieldId, $baseInfo) => <<<JS
-(() => {
-  $('#' + $copyAllId).on('activate', () => {
-    const elementInfo = [];
-    $('#' + $fieldId + ' > .blocks > .matrixblock').each((i, element) => {
-      element = $(element);
-      elementInfo.push(Object.assign({
-          id: element.data('id'),
-          draftId: element.data('draftId'),
-          revisionId: element.data('revisionId'),
-          ownerId: element.data('ownerId'),
-          siteId: element.data('siteId'),
-        }, $baseInfo));
-    });
-    Craft.cp.copyElements(elementInfo);
-  });
-})();
-JS, [
-                    $view->namespaceInputId($copyAllId),
-                    $view->namespaceInputId($this->getInputId()),
-                    [
-                        'type' => Entry::class,
-                        'fieldId' => $this->id,
-                    ],
-                ]);
-            }
+                $view->namespaceInputId($copyAllId),
+                $view->namespaceInputId($this->getInputId()),
+            ]);
         }
 
         $parentItems = parent::actionMenuItems();

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -839,9 +839,22 @@ class Matrix extends Field implements
             if ($this->viewMode === self::VIEW_MODE_CARDS) {
                 $view->registerJsWithVars(fn($copyAllId, $fieldId) => <<<JS
 (() => {
+  const copyAllBtn = $('#' + $copyAllId);
+  
   $('#' + $copyAllId).on('activate', () => {
     Craft.cp.copyElements($('#' + $fieldId + ' > .nested-element-cards > .elements > li > .element'));
   });
+  
+  setTimeout(() => {
+    const menu = copyAllBtn.closest('.menu').data('disclosureMenu');
+    const trigger = menu.\$trigger; 
+    const isElementFieldTrigger = trigger.parents('div.field').length;
+    
+    // only show the copy all button if the trigger is part of an element's field
+    menu.on('show', () => {
+      menu.toggleItem(copyAllBtn[0], isElementFieldTrigger);
+    });
+  }, 1);
 })();
 JS, [
                     $view->namespaceInputId($copyAllId),


### PR DESCRIPTION
### Description
Prevents the “Copy all {type}” action menu item from showing for the Matrix field outside an element context.

I also opened a [second PR](https://github.com/craftcms/cms/pull/17415) for this issue, which prevents the item from being added altogether, instead of only hiding it when the disclosure menu is opened; however, it contains a potentially breaking change, so it’s targeting 5.8 for now.

Note: In 5.8, there are additional Expand and Collapse action menu items, which are already hidden when the disclosure menu is opened.



### Related issues
#17404 
