### PR TITLE
Allow actionButton to be set as a template variable

### DIFF
--- a/src/templates/_layouts/cp.twig
+++ b/src/templates/_layouts/cp.twig
@@ -74,7 +74,7 @@
 {% set contentNotice = (contentNotice ?? block('contentNotice') ?? '')|trim %}
 {% set sidebar = (sidebar ?? block('sidebar') ?? '')|trim %}
 {% set toolbar = (toolbar ?? block('toolbar') ?? '')|trim %}
-{% set actionButton = (block('actionButton') ?? '')|trim %}
+{% set actionButton = (actionButton ?? block('actionButton') ?? '')|trim %}
 {% set additionalButtons = additionalButtons ?? null %}
 {% set details = (details ?? block('details') ?? '')|trim %}
 {% set footer = (footer ?? block('footer') ?? '')|trim %}


### PR DESCRIPTION
### Description

Allows element index creation in a controller without the need for a template.

Example:

```php
public function actionIndex(): Response
    {
        return $this
            ->renderTemplate('_layouts/elementindex', [
                'elementType' => Organisation::class,
                'title' => Craft::t('_kraftwerk', 'Organisations'),
                'selectedSubnavItem' => 'organisations',
                'crumbs' => [
                    [
                        'label' => Craft::t('_kraftwerk', 'Kraftwerk'),
                        'url' => '_kraftwerk',
                    ],
                    [
                        'label' => Craft::t('_kraftwerk', 'Organisations'),
                        'url' => '_kraftwerk/organisations',
                    ]
                ],
                'actionButton' => Html::tag(
                    'a',
                    Craft::t('_kraftwerk', 'New Organisation'),
                    [
                        'href' => UrlHelper::actionUrl('elements/create', [
                            'elementType' => Organisation::class,
                        ]),
                        'class' => 'btn submit add icon',
                        'data-icon' => 'plus',
                    ]),
            ]);
    }
```
