### PR TITLE
Support distance calculation and limits in address queries

### DIFF
--- a/src/elements/Address.php
+++ b/src/elements/Address.php
@@ -296,6 +296,11 @@ class Address extends Element implements AddressInterface, NestedElementInterfac
     public ?string $longitude = null;
 
     /**
+     * @var float|null Distance in meters
+     */
+    public ?float $distance = null;
+
+    /**
      * @inheritdoc
      */
     public function init(): void

--- a/src/elements/db/AddressQuery.php
+++ b/src/elements/db/AddressQuery.php
@@ -12,6 +12,7 @@ use craft\db\QueryAbortedException;
 use craft\db\Table;
 use craft\elements\Address;
 use craft\helpers\Db;
+use yii\db\Expression;
 
 /**
  * AddressQuery represents a SELECT SQL statement for categories in a way that is independent of DBMS.
@@ -315,6 +316,26 @@ class AddressQuery extends ElementQuery implements NestedElementQueryInterface
      * @since 5.0.0
      */
     public ?string $lastName = null;
+
+    /**
+     * @var null|array Narrows the query results based on the distance to a set of coordinates.
+     *                 ---
+     *                 ```php
+     *                 // Fetch addresses by distance to the given coordinates
+     *                 $addresses = \craft\elements\Address::find()
+     *                 ->distanceTo(['latitude' => 44.0473,'longitude' => -121.3338])
+     *                 ->all();
+     *                 ```
+     *                 ```twig
+     *                 {# Fetch addresses by distance to the given coordinates #}
+     *                 {% set addresses = craft.addresses()
+     *                 .distanceTo({ latitude: 44.0473, longitude: -121.3338 })
+     *                 .all() %}
+     *                 ```
+     *
+     * @used-by distanceTo()
+     */
+    public ?array $distanceTo = null;
 
     /**
      * Narrows the query results based on the country the addresses belong to.
@@ -864,6 +885,31 @@ class AddressQuery extends ElementQuery implements NestedElementQueryInterface
     }
 
     /**
+     * Calculate the distance of the address to a given set of coordinates, and
+     * optionally narrows the query results by minimum or maximum distance.
+     * Excludes addresses without valid coordinates.
+     *
+     * The coordinates should be provided as an associative array with the following keys:
+     *
+     * | Key | Value
+     * | - | -
+     * | `latitude` | Required, the latitude of the point to measure distance to.
+     * | `longitude` | Required, the longitude of the point to measure distance to.
+     * | `min` | Minimum distance in meters to narrow results by.
+     * | `max` | Maximum distance in meters to narrow results by.
+     *
+     * @return static self reference
+     *
+     * @uses $distanceTo
+     */
+    public function distanceTo(array $coordinates): static
+    {
+        $this->distanceTo = $coordinates;
+
+        return $this;
+    }
+
+    /**
      * @inheritdoc
      */
     protected function beforePrepare(): bool
@@ -963,6 +1009,34 @@ class AddressQuery extends ElementQuery implements NestedElementQueryInterface
 
         if ($this->fullName) {
             $this->subQuery->andWhere(Db::parseParam('addresses.fullName', $this->fullName));
+        }
+
+        if ($this->distanceTo) {
+            $latitude = $this->distanceTo['latitude'];
+            $longitude = $this->distanceTo['longitude'];
+            $min = $this->distanceTo['min'] ?? null;
+            $max = $this->distanceTo['max'] ?? null;
+
+            $distance = new Expression(
+                'ST_Distance_Sphere(
+                    POINT([[addresses.longitude]], [[addresses.latitude]]),
+                    POINT(:lng, :lat)
+                )',
+                [':lng' => $longitude, ':lat' => $latitude]
+            );
+            $this->subQuery->addSelect(['distance' => $distance]);
+            $this->query->addSelect(['distance' => $distance]);
+
+            $this->subQuery->andWhere(['not', ['[[addresses.latitude]]' => null]]);
+            $this->subQuery->andWhere(['not', ['[[addresses.longitude]]' => null]]);
+
+            if ($min) {
+                $this->query->andWhere(['>=', $distance, $min]);
+            }
+
+            if ($max) {
+                $this->query->andWhere(['<=', $distance, $max]);
+            }
         }
 
         return true;

--- a/src/elements/db/AddressQuery.php
+++ b/src/elements/db/AddressQuery.php
@@ -1032,10 +1032,12 @@ class AddressQuery extends ElementQuery implements NestedElementQueryInterface
 
             if ($min) {
                 $this->query->andWhere(['>=', $distance, $min]);
+                $this->subQuery->andWhere(['>=', $distance, $min]);
             }
 
             if ($max) {
                 $this->query->andWhere(['<=', $distance, $max]);
+                $this->subQuery->andWhere(['<=', $distance, $max]);
             }
         }
 


### PR DESCRIPTION
### Description

Proof-of-concept for distance queries for addresses, as suggested in https://github.com/craftcms/cms/discussions/17227

The PR adds a `AddressQuery::distanceTo()` method to calculate the distance of an address to a given place, limit the query by minimum and/or maximum distance, and order results by distance.

Usage:

```twig
{# Calculate the distance to the given coordinates, and order the results by distance. #}
{% set addresses = craft.addresses()
    .distanceTo({
        latitude: 50.93515,
        longitude: 6.936852,
    })
    .orderBy('distance ASC')
    .all()
%}

{# Calculate the distance to the given coordinates, and only
 # returns results with a distance between 10 and 50 kilometers.
 #}
{% set addresses = craft.addresses()
    .distanceTo({
        latitude: 50.93515,
        longitude: 6.936852,
        min: 10000,
        max: 50000,
    })
    .all()
%}
```

Definitely more of a proof of concept, there are a couple of things left to do:

- [ ] The code is only tested with MySQL (requires 8+), will probably need some adjustments for PostgreSQL.
- [ ] Align more closely with Craft coding standards
- [ ] Add better validation and error handling for invalid inputs to the `distanceTo()` function
- [ ] The `distance` property will be a float representing the distance in meters, and `min` and `max` expect a distance in meters as well. Might want to support both metric and imperial units?
- [ ] A filter to turn the `distance` property into a localized string (similar to the `money` or `date` filters) would be helpful.
- [ ] Is it really necessary to add all conditions to both the `query` and `subQuery`? I don't completely understand this, but in my testing, adding the conditions only to the main query resulted in incorrect results, especially with pagination.

### Related issues

https://github.com/craftcms/cms/discussions/17227