### PR TITLE
Wrap plain text preview in .code class if monospace

### DIFF
--- a/src/fields/PlainText.php
+++ b/src/fields/PlainText.php
@@ -16,6 +16,7 @@ use craft\base\MergeableFieldInterface;
 use craft\base\SortableFieldInterface;
 use craft\elements\Entry;
 use craft\fields\conditions\TextFieldConditionRule;
+use craft\helpers\Html;
 use craft\helpers\StringHelper;
 
 /**
@@ -249,6 +250,22 @@ class PlainText extends Field implements InlineEditableFieldInterface, SortableF
         return TextFieldConditionRule::class;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function getPreviewHtml(mixed $value, ?ElementInterface $element = null): string
+    {
+        $previewHtml = parent::getPreviewHtml($value, $element);
+
+        if (!$this->code) {
+            return $previewHtml;
+        }
+
+        return Html::tag('div', $previewHtml, [
+            'class' => 'code',
+        ]);
+    }
+    
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
### Description

"Monospace" `PlainText` fields display the input with the `code` class. 

Card previews and table cell values should also reflect the `monospace` config.

<img width="478" alt="image" src="https://github.com/user-attachments/assets/a1a4ddce-d5e2-4860-803c-416c23c160af" />

<img width="974" alt="image" src="https://github.com/user-attachments/assets/c11ea62a-6c63-463d-9cff-7514db148480" />

### Related issues

https://github.com/craftcms/cms/pull/2636
