### PR TITLE
if value is null and staticRows is true, use the defaults even if ele…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Table fields with “Static Rows” enabled now get populated with the default row values when their value is `null`. ([#17452](https://github.com/craftcms/cms/pull/17452))
 - Updated yii2-debug to 2.1.27. ([#17115](https://github.com/craftcms/cms/issues/17115))
 
 ## 4.15.6.2 - 2025-06-04

--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -452,7 +452,7 @@ class Table extends Field
 
         if (is_string($value) && !empty($value)) {
             $value = Json::decodeIfJson($value);
-        } elseif ($value === null && $this->isFresh($element)) {
+        } elseif ($value === null && ($this->isFresh($element) || $this->staticRows)) {
             $value = $defaults;
         }
 


### PR DESCRIPTION
### Description
[The docs](https://craftcms.com/docs/4.x/table-fields.html#the-field) say the default values will only be used for new elements. But when the static rows setting is turned on, the expectation is that the default values will be used even when the table field is added to a preexisting element. 

If the element with a static rows table field was previously saved, even if all the cells are empty, the value won’t be `null`, and so the empty values will be used to populate it; however if the value of the table field with static rows is `null`, there should be no harm in using the defaults for the preexisting element.


### Related issues
#17451 
