### PR TITLE
bugfix/17445 2fa, passkeys and `maxInvalidLogins`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added `craft\fields\linktypes\BaseLinkType::isValueEmpty()`.
+- Added `craft\services\Auth::getAuthErrorMessage()`.
 - Added `craft\services\ElementSources::sourceExists()`.
 - Updated yii2-debug to 2.1.27. ([#17115](https://github.com/craftcms/cms/issues/17115))
 - Fixed a PHP error that could occur when rendering a field layout’s form, if it didn’t have customizable tabs.
@@ -11,6 +12,7 @@
 - Fixed a bug where entries that were pasted within a Matrix field were losing custom field translations for other sites. ([17414](https://github.com/craftcms/cms/issues/17414))
 - Fixed a bug where Matrix fields’ chips were getting “Copy all entries” actions. ([#17404](https://github.com/craftcms/cms/issues/17404))
 - Fixed a bug where Link fields were validating if a deleted element was selected. ([#17409](https://github.com/craftcms/cms/issues/17409))
+- Users’ maximum invalid login counts now factor in invalid two-step verification attempts. ([#17454](https://github.com/craftcms/cms/pull/17454))
 
 ## 5.7.10 - 2025-06-04
 

--- a/src/controllers/AuthController.php
+++ b/src/controllers/AuthController.php
@@ -136,9 +136,10 @@ class AuthController extends Controller
         $this->requireAcceptsJson();
 
         $code = $this->request->getRequiredBodyParam('code');
+        $authService = Craft::$app->getAuth();
 
-        if (!Craft::$app->getAuth()->verify(TOTP::class, $code)) {
-            return $this->asFailure(Craft::t('app', 'Invalid verification code.'));
+        if (!$authService->verify(TOTP::class, $code)) {
+            return $this->asFailure($authService->getAuthErrorMessage());
         }
 
         return $this->asSuccess(Craft::t('app', 'Verification successful.'));
@@ -155,9 +156,10 @@ class AuthController extends Controller
         $this->requireAcceptsJson();
 
         $code = $this->request->getRequiredBodyParam('code');
+        $authService = Craft::$app->getAuth();
 
-        if (!Craft::$app->getAuth()->verify(RecoveryCodes::class, $code)) {
-            return $this->asFailure(Craft::t('app', 'Invalid recovery code.'));
+        if (!$authService->verify(RecoveryCodes::class, $code)) {
+            return $this->asFailure($authService->getAuthErrorMessage(Craft::t('app', 'Invalid recovery code.')));
         }
 
         return $this->asSuccess(Craft::t('app', 'Verification successful.'));

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -1334,6 +1334,23 @@ class User extends Element implements IdentityInterface
     }
 
     /**
+     * Handles an invalid login for a user and sets the authError param.
+     *
+     * @return void
+     */
+    public function handleInvalidLoginParam(): void
+    {
+        Craft::$app->getUsers()->handleInvalidLogin($this);
+        // Was that one bad password/2fa code/passkey too many?
+        if ($this->locked && !Craft::$app->getConfig()->getGeneral()->preventUserEnumeration) {
+            // Will set the authError to either AccountCooldown or AccountLocked
+            $this->authError = $this->_getAuthError();
+        } else {
+            $this->authError = self::AUTH_INVALID_CREDENTIALS;
+        }
+    }
+
+    /**
      * Determines whether the user is allowed to be logged in with a given password.
      *
      * @param string $password The user’s plain text password.
@@ -1363,14 +1380,7 @@ class User extends Element implements IdentityInterface
         }
 
         if (!$passwordValid) {
-            Craft::$app->getUsers()->handleInvalidLogin($this);
-            // Was that one bad password too many?
-            if ($this->locked && !Craft::$app->getConfig()->getGeneral()->preventUserEnumeration) {
-                // Will set the authError to either AccountCooldown or AccountLocked
-                $this->authError = $this->_getAuthError();
-            } else {
-                $this->authError = self::AUTH_INVALID_CREDENTIALS;
-            }
+            $this->handleInvalidLoginParam();
             return false;
         }
 
@@ -1421,7 +1431,7 @@ class User extends Element implements IdentityInterface
         }
 
         if (!$keyValid) {
-            $this->authError = self::AUTH_INVALID_CREDENTIALS;
+            $this->handleInvalidLoginParam();
             return false;
         }
 

--- a/src/services/Auth.php
+++ b/src/services/Auth.php
@@ -233,6 +233,7 @@ class Auth extends Component
      *
      * @param string|null $defaultMessage
      * @return string
+     * @since 5.7.11
      */
     public function getAuthErrorMessage(?string $defaultMessage = null): string
     {

--- a/src/services/Auth.php
+++ b/src/services/Auth.php
@@ -21,6 +21,7 @@ use craft\helpers\Component as ComponentHelper;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Json;
 use craft\helpers\Session as SessionHelper;
+use craft\helpers\User as UserHelper;
 use craft\models\UserGroup;
 use craft\records\WebAuthn as WebAuthnRecord;
 use craft\web\Session;
@@ -204,6 +205,7 @@ class Auth extends Component
         $user = $this->getUser($sessionDuration);
 
         if (!$this->getMethod($methodClass, $user)->verify(...$args)) {
+            $user?->handleInvalidLoginParam();
             return false;
         }
 
@@ -222,6 +224,32 @@ class Auth extends Component
         }
 
         return true;
+    }
+
+    /**
+     * Returns an authentication error message based on the authentication error value.
+     * If a default message was passed and the authentication error value is for invalid credentials,
+     * that default message will be used.
+     *
+     * @param string|null $defaultMessage
+     * @return string
+     */
+    public function getAuthErrorMessage(?string $defaultMessage = null): string
+    {
+        $user = $this->getUser();
+        $authError = null;
+        if ($user) {
+            $authError = UserHelper::getAuthStatus($user);
+        }
+        if ($authError == User::AUTH_INVALID_CREDENTIALS || !$authError) {
+            if ($defaultMessage) {
+                return $defaultMessage;
+            }
+
+            return Craft::t('app', 'Invalid verification code.');
+        }
+
+        return UserHelper::getLoginFailureMessage($authError, $user);
     }
 
     /**


### PR DESCRIPTION
### Description
Passkey and 2fa login attempts should be factored into the `maxInvalidLogins`.

When a user tries to login with a passkey that's deemed invalid, or provided a valid password but invalid verification code (e.g. totp or recovery code) update the account locking parameters and lock the account if `maxInvalidLogins` is reached, just like we do when logging in with a password.


### Related issues
#17445 
