### PR TITLE
Translate prefix and suffix in Number input.twig

### DIFF
--- a/src/templates/_components/fieldtypes/Number/input.twig
+++ b/src/templates/_components/fieldtypes/Number/input.twig
@@ -16,8 +16,8 @@
         id: descriptionId,
         class: 'visually-hidden',
         text: [
-            hasPrefix ? 'Value prefixed by “{prefix}”.'|t('app', {prefix: prefix}),
-            hasSuffix ? 'Value suffixed by “{suffix}”.'|t('app', {suffix: suffix}),
+            hasPrefix ? 'Value prefixed by “{prefix}”.'|t('app', {prefix: prefix|t('site')}),
+            hasSuffix ? 'Value suffixed by “{suffix}”.'|t('app', {suffix: suffix|t('site')}),
         ]|filter|join(' '),
     }) }}
 {% endif %}
@@ -25,7 +25,7 @@
 <div class="flex">
     {% if hasPrefix %}
         <div aria-hidden="true">
-            {{ prefix|md(inlineOnly=true)|raw }}
+            {{ prefix|t('site')|md(inlineOnly=true)|raw }}
         </div>
     {% endif %}
     <div>
@@ -40,7 +40,7 @@
     </div>
     {% if hasSuffix %}
         <div aria-hidden="true">
-            {{ suffix|md(inlineOnly=true)|raw }}
+            {{ suffix|t('site')|md(inlineOnly=true)|raw }}
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
### Description

If I add a suffix in the settings of a number field, let's say "items", when I want the user to enter a number of "items", then this is not translated. In my case, the admin user has set the language to Dutch. Now the field name and instructions for instance are all translated to Dutch when I add those to the `translations/nl/site.php` translations file. However any postfixes or suffixes are not translated and remain in English, just the way I entered it. In my opinion this should also be translatable so that all the texts involved in the form are in the preferred language of the user.

I'm targeting the 4.x branch here as I'm encountering this in a 4.x setup. I hope you can merge this forward to 5.x too.

### Related issues

None