### PR TITLE
Bugfix/17464 address hot fields and value retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Table fields with “Static Rows” enabled now get populated with the default row values when their value is `null`. ([#17452](https://github.com/craftcms/cms/pull/17452))
 - Updated yii2-debug to 2.1.27. ([#17115](https://github.com/craftcms/cms/issues/17115))
 - Fixed a bug where Number fields’ Prefix Text and Suffix Text values weren’t getting translated. ([#17467](https://github.com/craftcms/cms/pull/17467))
+- Fixed a bug where some address field values could be cleared out unexpectedly when editing an address. ([#17468](https://github.com/craftcms/cms/pull/17468))
 
 ## 4.15.6.2 - 2025-06-04
 

--- a/src/fieldlayoutelements/addresses/AddressField.php
+++ b/src/fieldlayoutelements/addresses/AddressField.php
@@ -94,7 +94,7 @@ class AddressField extends BaseField
         ];
         for (let name of fieldNames) {
             fields[name] = $('#' + Craft.namespaceId(name, $namespace));
-            if (values) {
+            if (values && values[name] !== null) {
                 fields[name].val(values[name]);
             }
         }

--- a/src/fieldlayoutelements/addresses/AddressField.php
+++ b/src/fieldlayoutelements/addresses/AddressField.php
@@ -127,6 +127,21 @@ class AddressField extends BaseField
                         Object.fromEntries(fieldNames.map(name => [name, fields[name].val()])),
                         Object.fromEntries(hotFieldNames.map(name => [name, hotValues[name] || null]))
                     );
+                    let newField = null;
+                    hotFieldNames.forEach((name) => {
+                      // if value for any hotFieldNames is null, but we have one in fields
+                      if (values[name] == null && fields[name]?.val().trim() !== '') {
+                        // and the old and new field for that name is not a select - use the fields value
+                        newField = $(response.data.fieldsHtml).find('#' + Craft.namespaceId(name, $namespace));
+                        if (
+                          newField.length > 0 && 
+                          fields[name].prop('nodeName') !== 'SELECT' && 
+                          newField.prop('nodeName') !== 'SELECT'
+                        ) {
+                          values[name] = fields[name].val();
+                        }
+                      }
+                    });
                     const \$addressFields = $(
                         Object.entries(fields)
                             .filter(([name]) => name !== 'countryCode')


### PR DESCRIPTION
### Description
The first commit fixes an issue where if you create an address for a country that uses dropdown field for administrative area or locality, fully save, edit, change the country to a different one that also uses dropdown field for administrative area or locality and then saved it without making any amends, the old "hot field" dropdown value was saved. (This issue is only affecting v5.)

Example: create a US address, edit again and change the country to Andorra, save and observe that the City field is set to an incorrect text value that was used by the US address. (The same thing will happen if you go the other way around.)

The second commit improves the behaviour that was reported in the related issue. For the "hot fields" (country, administrative area and locality), when you change one of those values, retain all remaining values if the old and new field for those values are not dropdowns. E.g. when you have a US address with a City field filled out, and you change the State, retain the city value.


### Related issues
#17464 
