### PR TITLE
Don't include the 'Section settings' action for entries not belonging to a section

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -2199,24 +2199,26 @@ JS, [
             ]);
 
             // Section settings
-            $sectionEditId = sprintf('edit-section-%s', mt_rand());
-            $actions[] = [
-                'id' => $sectionEditId,
-                'icon' => 'gear',
-                'label' => Craft::t('app', 'Section settings'),
-            ];
+            if (!empty($this->sectionId)) {
+                $sectionEditId = sprintf('edit-section-%s', mt_rand());
+                $actions[] = [
+                    'id' => $sectionEditId,
+                    'icon' => 'gear',
+                    'label' => Craft::t('app', 'Section settings'),
+                ];
 
-            $view = Craft::$app->getView();
-            $view->registerJsWithVars(fn($id, $params) => <<<JS
-(() => {
-  $('#' + $id).on('activate', function() {
-    new Craft.CpScreenSlideout('sections/edit-section', {params: $params});
-  });
-})();
-JS, [
-                $view->namespaceInputId($sectionEditId),
-                ['sectionId' => $this->sectionId],
-            ]);
+                $view = Craft::$app->getView();
+                $view->registerJsWithVars(fn($id, $params) => <<<JS
+    (() => {
+      $('#' + $id).on('activate', function() {
+        new Craft.CpScreenSlideout('sections/edit-section', {params: $params});
+      });
+    })();
+    JS, [
+                    $view->namespaceInputId($sectionEditId),
+                    ['sectionId' => $this->sectionId],
+                ]);
+            }
         }
 
         return $actions;


### PR DESCRIPTION
This is pretty trivial – but after maintaining the [CP Field Inspect](https://plugins.craftcms.com/cp-field-inspect?craft5) plugin for a decade I'd be honoured to be a very minor contributor to the Craft release bringing its demise – hence this PR 😀

### Description

Craft 5.8 adds “Entry type settings” (https://github.com/craftcms/cms/commit/a8bfc9024e70e527d46801825899cfced3d764f3) and “Section settings” (https://github.com/craftcms/cms/commit/de7dc61804d0ced52677bfec1f4d969d23fe0677) actions to entries.

These actions are both added to all entries, though – which in case of the "Section settings", means that for entry chips and cards for entries *not* belonging to a section, that action will be N/A, and its slideout form will be for creating a *new* section, which doesn't make a ton of sense (and also doesn't actually seem to work; "A server error occurred" when attempting to save the new section via slideout).

**This PR makes sure that the "Section settings" action is only added to entries belonging to a section.**

### Related issues

https://github.com/craftcms/cms/discussions/17438