### PR TITLE
force create new nested element revisions when matrix has enableVersioning set to false

### DIFF
--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -23,6 +23,7 @@ use craft\enums\Color;
 use craft\enums\PropagationMethod;
 use craft\events\BulkElementsEvent;
 use craft\events\DuplicateNestedElementsEvent;
+use craft\fields\Matrix;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
 use craft\helpers\Db;
@@ -1174,10 +1175,13 @@ JS, [
         $map = [];
 
         foreach ($elements as $element) {
+            $field = $element->getField();
+            $enableVersioning = $field instanceof Matrix && $field->enableVersioning;
+
             $elementRevisionId = $elementRevisionIds[] = $revisionsService->createRevision($element, null, null, [
                 'primaryOwnerId' => $revision->id,
                 'saveOwnership' => false,
-            ]);
+            ], force: !$enableVersioning);
             $ownershipData[] = [$elementRevisionId, $revision->id, $element->getSortOrder()];
             $map[$element->id] = $elementRevisionId;
         }


### PR DESCRIPTION
### Description

Steps to reproduce:
- set `->maxRevisions(3)`
- create a matrix field in e.g. cards mode, revisions disabled for the field (default)
- create a section with an entry type that uses the matrix field from the step above
- create an entry in that section; fully save & continue editing
- add one nested entry (title “one”) - save (& continue editing)
- add one nested entry (title “two”) - save (& continue editing)
- add one nested entry (title “three”) - save (& continue editing)
- view the latest revision (revision 3) - it correctly has nested entries “one” and “two”
- add another nested entry (title “four”) - save (& continue editing)
- view the latest revision (revision 4) - it only has nested entries “two” and “three”; nested entry “one” is missing

The nested elements aren’t duplicated for every revision, so the same nested element can belong to revisions 1, 2 and 3.

When there are enough revisions to trigger the `PruneRevisions` job and the owner is being deleted, nested entries that belong to it are hard deleted.

Let's say you have:
- current entry with:
    - owner “test” (id: 791)
    - nested entry: “one”, (id: 795)
    - nested entry: “two”, (id: 800)
    - nested entry: “three” (id: 805)
- and revisions:
    - rev 2: with nested entry: “one” (id: 797)
    - rev 3: with nested entries: “one” (id: 797) and “two” (id: 802)
- at this point, everything works as expected
- you add a nested entry: “four” (id: 810) & save the owner
- rev 4 is created and `PruneRevisions` job deletes rev 2; rev 2 has nested entry “one” (id: 797) in it, so it’s hard deleted too, which causes it to be missing from rev 3 and rev 4

**Solution:**
When the Matrix field has `enableVersioning` set to `false`, ensure that each owner revision has its own set of nested entries.

Tested with and without `enableVersioning` with cards and element index view modes.
(This solution doesn’t work retrospectively.)

### Related issues
#16443 
