### PR TITLE
Show safe errors on GQL interface

### DIFF
--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -1296,7 +1296,8 @@ class Gql extends Component
             }
 
             // If devMode enabled or exception is safe to show, substitute the original exception here.
-            if (($devMode || $originException instanceof \GraphQL\Error\UserError) && !empty($originException->getMessage())) {
+            $isClientSafe = $originException instanceof \GraphQL\Error\ClientAware && $originException->isClientSafe();
+            if (($devMode || $isClientSafe) && !empty($originException->getMessage())) {
                 $error = $originException;
             } elseif (!$originException instanceof Error) {
                 // If devMode not enabled and the error seems to be originating from Craft, display a generic message

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -1295,8 +1295,8 @@ class Gql extends Component
                 $originException = $nextException;
             }
 
-            // If devMode enabled, substitute the original exception here.
-            if ($devMode && !empty($originException->getMessage())) {
+            // If devMode enabled or exception is safe to show, substitute the original exception here.
+            if (($devMode || $originException instanceof \GraphQL\Error\UserError) && !empty($originException->getMessage())) {
                 $error = $originException;
             } elseif (!$originException instanceof Error) {
                 // If devMode not enabled and the error seems to be originating from Craft, display a generic message


### PR DESCRIPTION
`\GraphQL\Error\UserError` [explicitly states](https://github.com/webonyx/graphql-php/blob/master/src/Error/UserError.php) that it is safe to show to the client, so we don't need to replace it with a generic error message, even if dev mode is disabled

### Description
On one of our platforms, we let an external party develop an integration that will be using the GQL interface. It would greatly improve their developer experience if validation errors are shown instead of the generic error message that is now shown when dev mode is disabled. 
This PR accomplishes that goal by only exposing client-safe errors through the interface.