### PR TITLE
when checking if session exists, only account for id and completed attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed an error that could occur when indexing assets. ([#17240](https://github.com/craftcms/cms/issues/17240))
+
 ## 4.15.7 - 2025-06-24
 
 - Table fields with “Static Rows” enabled now get populated with the default row values when their value is `null`. ([#17452](https://github.com/craftcms/cms/pull/17452))

--- a/src/services/AssetIndexer.php
+++ b/src/services/AssetIndexer.php
@@ -317,7 +317,6 @@ class AssetIndexer extends Component
                     ->where([
                         'sessionId' => $indexingSession->id,
                         'completed' => false,
-                        'inProgress' => false,
                     ])
                     ->count();
 


### PR DESCRIPTION
### Description
Fixes an issue that could occur when indexing assets via the control panel.

When we’re checking if the indexing session still exists, we should try to get it by ID and where the `completed` value is `false`. As the JS side of asset indexing has a concurrency mechanism built in, there could still be some entries which are marked as being processed when the check occurs.


### Related issues
#17240 
