### PR TITLE
disable generated fields field if allow admin changes is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where Generated Fields settings were still interative when `allowAdminChanges` was disabled. ([#17535](https://github.com/craftcms/cms/pull/17535))
+
 ## 5.8.0 - 2025-07-01
 
 > [!NOTE]

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -3375,6 +3375,7 @@ JS;
             'allowAdd' => true,
             'allowReorder' => true,
             'allowDelete' => true,
+            'static' => $config['disabled'],
         ];
 
         $view = Craft::$app->getView();

--- a/src/templates/_includes/forms.twig
+++ b/src/templates/_includes/forms.twig
@@ -505,6 +505,7 @@
                 errors: config.fieldLayout.getErrors('generatedFields') ?? [],
                 data: {'error-key': 'fieldLayout.generatedFields'},
                 fieldLayout: config.fieldLayout ?? null,
+                disabled: config.disabled ?? false,
             }, 'template:_includes/forms/generatedFieldsTable') }}
         {% endif %}
 


### PR DESCRIPTION
### Description
Disable the "generated fields" field if allow admin changes is `false`.

### Related issues
n/a
