### PR TITLE
Fix GraphQL element Generator assuming a field layout

### DIFF
--- a/src/gql/base/Generator.php
+++ b/src/gql/base/Generator.php
@@ -42,17 +42,19 @@ abstract class Generator
         $contentFieldGqlTypes = [];
         $layout = $context instanceof FieldLayout ? $context : $context->getFieldLayout();
 
-        foreach ($layout->getCustomFields() as $contentField) {
-            /** @var Field $contentField */
-            if ($contentField->includeInGqlSchema($schema)) {
-                $contentFieldGqlTypes[$contentField->handle] = $contentField->getContentGqlType();
+        if ($layout) {
+            foreach ($layout->getCustomFields() as $contentField) {
+                /** @var Field $contentField */
+                if ($contentField->includeInGqlSchema($schema)) {
+                    $contentFieldGqlTypes[$contentField->handle] = $contentField->getContentGqlType();
+                }
             }
-        }
-
-        foreach ($layout->getGeneratedFields() as $generatedField) {
-            $handle = $generatedField['handle'] ?? '';
-            if ($handle !== '' && !isset($contentFieldGqlTypes[$handle])) {
-                $contentFieldGqlTypes[$handle] = Type::string();
+    
+            foreach ($layout->getGeneratedFields() as $generatedField) {
+                $handle = $generatedField['handle'] ?? '';
+                if ($handle !== '' && !isset($contentFieldGqlTypes[$handle])) {
+                    $contentFieldGqlTypes[$handle] = Type::string();
+                }
             }
         }
 


### PR DESCRIPTION
Due to https://github.com/craftcms/cms/commit/d3c8e8193d5fb51c801a184c4c498828d8f0acfe looks like there's an issue with assuming an element always returns a field layout. Case in point https://github.com/verbb/formie/issues/2481#issuecomment-3028132180

```
$layout = $context instanceof FieldLayout ? $context : $context->getFieldLayout();

foreach ($layout->getCustomFields() as $contentField) {
```

Which, according to the [function definition for an element](https://github.com/craftcms/cms/blob/c1d201710af51ff7f6f80c42cab2bb7c5e72528e/src/base/Element.php#L3342-L3349) `getFieldLayout()` can be null, so there always needs to be a check for that.

