### PR TITLE
matrix field in blocks mode and owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where Matrix fields could load nested entries that belonged to other owner elements. ([#17551](https://github.com/craftcms/cms/issues/17551))
 - Fixed a potential user account enumeration bug when `preventUserEnumeration` was enabled.
 
 ## 5.8.1 - 2025-07-03

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1028,7 +1028,6 @@ JS, [
                 ->canonicalsOnly()
                 ->status(null)
                 ->limit(null)
-                ->eagerly()
                 ->all();
         }
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1028,10 +1028,6 @@ JS, [
                 ->canonicalsOnly()
                 ->status(null)
                 ->limit(null)
-                // clear out ownerId and primaryOwnerId in case they were set,
-                // or we'll only get the eager loading working for the first source element
-                ->ownerId(null)
-                ->primaryOwnerId(null)
                 ->eagerly()
                 ->all();
         }


### PR DESCRIPTION
### Description
Reverts changes from https://github.com/craftcms/cms/pull/17470 to fix an issue where matrix fields in inline-editable blocks mode were showing entries from other owners.

To keep the issue described under https://github.com/craftcms/cms/pull/17470 in check, I also removed the lazy eager loading for matrix blocks.


### Related issues
#17551, #17552 
