### PR TITLE
show search input should show when restrict location is on (for assets field)

### DIFF
--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -842,7 +842,7 @@ class Assets extends BaseRelationField
         }
 
         ArrayHelper::removeValue($sources, 'temp');
-        return count($sources) === 1;
+        return count($sources) === 1 && $this->sources !== '*';
     }
 
     /**

--- a/src/fields/Assets.php
+++ b/src/fields/Assets.php
@@ -842,7 +842,7 @@ class Assets extends BaseRelationField
         }
 
         ArrayHelper::removeValue($sources, 'temp');
-        return count($sources) === 1 && $this->sources !== '*';
+        return count($sources) === 1 && ($this->sources !== '*' || $this->restrictLocation);
     }
 
     /**

--- a/src/templates/_components/fieldtypes/Assets/settings.twig
+++ b/src/templates/_components/fieldtypes/Assets/settings.twig
@@ -1,6 +1,8 @@
 {% extends '_components/fieldtypes/elementfieldsettings.twig' %}
 {% import '_includes/forms.twig' as forms %}
 
+{% set restrictLocation = field.restrictLocation %}
+
 {% macro uploadLocationField(config) %}
     {% embed '_includes/forms/field.twig' with config %}
         {% block input %}

--- a/src/templates/_components/fieldtypes/elementfieldsettings.twig
+++ b/src/templates/_components/fieldtypes/elementfieldsettings.twig
@@ -140,7 +140,7 @@
 
     {% block showSearchInputField %}
         {{ forms.lightswitchField({
-            fieldClass: field.allowMultipleSources ? 'hidden' : null,
+            fieldClass: field.allowMultipleSources and (restrictLocation is not defined or not restrictLocation) ? 'hidden' : null,
             label: 'Show the search input'|t('app'),
             id: 'show-search-input',
             name: 'showSearchInput',
@@ -184,31 +184,39 @@
     {% endblock %}
 {% endblock %}
 
-{% if field.allowMultipleSources %}
+{% if field.allowMultipleSources or restrictLocation is defined %}
 {% js %}
 (() => {
   const $inputs = $('#{{ 'sources-field'|namespaceInputId }} input');
   const $searchField = $('#{{ 'show-search-input-field'|namespaceInputId }}');
 
+  const $restrictLocationToggle = $('#{{ 'restrict-location-toggle'|namespaceInputId }}');
+  const $restrictLocationInput = $restrictLocationToggle.find('input');
+
   const updateSearchField = function() {
     let showSearchField = false;
     let foundChecked = false;
-    for (let i = 0; i < $inputs.length; i++) {
-      const $input = $inputs.eq(i);
-      const val = $input.val();
-      const checked = $input.prop('checked');
-      if (val === '*') {
-        if (checked) {
-          showSearchField = false;
-          break;
-        }
-      } else if (checked) {
-        if (foundChecked) {
-          showSearchField = false;
-          break;
-        }
+
+    if ($restrictLocationInput.length > 0 && $restrictLocationInput.val() == 1) {
         showSearchField = true;
-        foundChecked = true;
+    } else {
+      for (let i = 0; i < $inputs.length; i++) {
+        const $input = $inputs.eq(i);
+        const val = $input.val();
+        const checked = $input.prop('checked');
+        if (val === '*') {
+          if (checked) {
+            showSearchField = false;
+            break;
+          }
+        } else if (checked) {
+          if (foundChecked) {
+            showSearchField = false;
+            break;
+          }
+          showSearchField = true;
+          foundChecked = true;
+        }
       }
     }
 
@@ -219,6 +227,11 @@
     }
   };
 
+  if ($restrictLocationInput.length > 0) {
+    $restrictLocationToggle.on('change', () => {
+      updateSearchField();
+    });
+  }
   $inputs.on('change', () => {
     updateSearchField();
   });


### PR DESCRIPTION
### Description
Fixes a bug where the “Show the search input” field was not shown for the Assets field when a single source was selected via the “Restrict assets to a single location”.

Fixes a bug where the search input was shown on the element edit page when the Assets field had Sources “All” selected, with only one source available to select.


### Related issues
#17628 
