### PR TITLE
Bugfix/17644 site settings and drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Craft no longer logs warnings for requests that don’t meet the user agent and IP requirements for maintaining a user session, unless a PHP session already exists or the user is attempting to sign in.
 - Fixed a bug where transformed images based on named transforms weren’t getting regenerated when the transform settings changed. ([#17615](https://github.com/craftcms/cms/issues/17615))
+- Fixed a SQL error that could occur when applying a draft that belonged to fewer sites than the canonical element. ([#17644](https://github.com/craftcms/cms/issues/17644))
 - Fixed an RCE vulnerability.
 
 ## 4.16.4 - 2025-07-08

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3278,7 +3278,9 @@ class Elements extends Component
         $dirtyFields = $element->getDirtyFields();
 
         // Get the element's site record
-        if (!$isNewElement && !$element->isNewForSite) {
+        if ($isNewElement && $element->isNewForSite) {
+            $siteSettingsRecord = null;
+        } else {
             $siteSettingsRecord = Element_SiteSettingsRecord::findOne([
                 'elementId' => $element->id,
                 'siteId' => $element->siteId,

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3278,7 +3278,7 @@ class Elements extends Component
         $dirtyFields = $element->getDirtyFields();
 
         // Get the element's site record
-        if ($isNewElement && $element->isNewForSite) {
+        if ($isNewElement || $element->isNewForSite) {
             $siteSettingsRecord = null;
         } else {
             $siteSettingsRecord = Element_SiteSettingsRecord::findOne([

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1758,7 +1758,7 @@ class Elements extends Component
                 // Now propagate $mainClone to any sites the source element didn’t already exist in
                 foreach ($supportedSites as $siteId => $siteInfo) {
                     if (!isset($propagatedTo[$siteId]) && $siteInfo['propagate']) {
-                        $siteClone = false;
+                        $siteClone = $element->getIsDraft() && !$element->getIsUnpublishedDraft() ? null : false;
                         if (!$this->_propagateElement($mainClone, $supportedSites, $siteId, $siteClone)) {
                             throw $siteClone
                                 ? new InvalidElementException($siteClone, "Element $siteClone->id could not be propagated to site $siteId: " . implode(', ', $siteClone->getFirstErrors()))


### PR DESCRIPTION
### Description
Fixes an integrity constraint violation error that can be thrown when updating the `elements_sites` table when applying a draft that belongs to fewer sites than the canonical.


### Related issues
#17644 
