### PR TITLE
don't attempt to set default attributes when resaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where Assets fields’ “Show the search input” setting wasn’t always visible when “Restrict assets to a single location” was enabled. ([#17628](https://github.com/craftcms/cms/issues/17628))
 - Fixed a bug where relational fields were showing the search input if “All” sources were selected, but there was only one available source. ([#17628](https://github.com/craftcms/cms/issues/17628))
 - Fixed a bug where top-level element sources’ expanded/collapsed states were stored as cookies rather than in local storage. ([#17649](https://github.com/craftcms/cms/issues/17649))
+- Fixed a bug where entry authors could be set to the current user when resaved in bulk. ([#17654](https://github.com/craftcms/cms/pull/17654))
 
 ## 5.8.8 - 2025-07-18
 

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -2809,6 +2809,11 @@ JS;
      */
     private function maybeSetDefaultAttributes(): void
     {
+        // if we're resaving, we shouldn't be setting the defaults
+        if ($this->resaving) {
+            return;
+        }
+
         if (
             (!isset($this->_authorIds) || empty($this->_authorIds)) &&
             !isset($this->fieldId) &&


### PR DESCRIPTION
### Description
As of 5.8.0, the entry [authors are lazy eager-loaded]((https://github.com/craftcms/cms/commit/895662a114556496b6b9d026da1a8fe28f0e0c3e)) (and not set up front).

It means that [this check](https://github.com/craftcms/cms/blob/7d708030fcbe584be93a723a07e63b07483146ef/src/elements/Entry.php#L2817-L2821) started returning `true` when resaving, causing the author to be changed to the default - the currently logged-in user.

I don’t think there’s a need to eager-load authors before the `ResaveElements` job is run, but LMK if I’m wrong here, @brandonkelly.

(The resave command doesn’t have this problem.)


Steps to reproduce: 
1. fresh 5.8.x Pro install
2. create a second user (`u2`)
3. create a channel section with an entry type that has at least the title field in it (all default options for the section and the entry type)
4. as the first user (`u1`), create an entry in the section (the author will be the first user)
5. as the second user, go to cp > settings > sections and under “Site Settings”, change the Entry URI Format (e.g. from `my-channel/{slug}` to `my-channel2/{slug}`) and save
6. wait for the resave job to finish and check the section’s index page
7. the entry created in step 4 will now have the author set to `u2`


### Related issues
n/a; reported by @olivierbon 
