### PR TITLE
Switch source disclosure to local storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a bug where element indexes in structure view weren’t switching to table/card view when searching.
 - Fixed a bug where Assets fields’ “Show the search input” setting wasn’t always visible when “Restrict assets to a single location” was enabled. ([#17628](https://github.com/craftcms/cms/issues/17628))
 - Fixed a bug where relational fields were showing the search input if “All” sources were selected, but there was only one available source. ([#17628](https://github.com/craftcms/cms/issues/17628))
+- Fixed a bug where top-level element sources’ expanded/collapsed states were stored as cookies rather than in local storage. ([#17649](https://github.com/craftcms/cms/issues/17649))
 
 ## 5.8.8 - 2025-07-18
 

--- a/src/templates/_elements/sources.twig
+++ b/src/templates/_elements/sources.twig
@@ -100,7 +100,6 @@
                         {% embed '_includes/disclosure-toggle' with {
                             persist: true,
                             storageKey: 'sources-list:'~ key,
-                            storageMode: 'cookies',
                             controls: key,
                             attributes: {
                                 class: 'source-item__toggle'


### PR DESCRIPTION
Switches the main sources nav to be stored in local storage instead of cookies. 

I meant to do this in the original PR but accidentally only did it for nested sources. 

Fixes #17649
