### PR TITLE
card should only show the generated fields that are selected under card attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed a bug where relational fields were showing the search input if “All” sources were selected, but there was only one available source. ([#17628](https://github.com/craftcms/cms/issues/17628))
 - Fixed a bug where top-level element sources’ expanded/collapsed states were stored as cookies rather than in local storage. ([#17649](https://github.com/craftcms/cms/issues/17649))
 - Fixed a bug where entry authors could be set to the current user when resaved in bulk. ([#17654](https://github.com/craftcms/cms/pull/17654))
+- Fixed a bug where generated fields were showing up within card views even if they weren’t selected. ([#17662](https://github.com/craftcms/cms/issues/17662))
 
 ## 5.8.8 - 2025-07-18
 

--- a/src/models/FieldLayout.php
+++ b/src/models/FieldLayout.php
@@ -1099,10 +1099,17 @@ class FieldLayout extends Model
             }
         }
 
-        $elements = array_merge($layoutElements, $attributes);
-
-        // get card view IDs stored in the field layout config
+        // get the card view config - array of all the attributes, fields and generated fields that should be shown in the card
         $cardViewValues = $this->getCardView();
+
+        // filter out any generated fields that shouldn't show in the card
+        $layoutElements = array_filter(
+            $layoutElements,
+            fn($key) => !str_starts_with($key, 'generatedField:') || in_array($key, $cardViewValues),
+            ARRAY_FILTER_USE_KEY
+        );
+
+        $elements = array_merge($layoutElements, $attributes);
 
         // make sure we don't have any cardViewValues that are no longer allowed to show in cards
         $cardViewValues = array_filter($cardViewValues, fn($value) => isset($elements[$value]));


### PR DESCRIPTION
### Description
Fixes an issue where the generated field values were showing in cards even if they were not selected as Card Attributes.


### Related issues
#17662 
