### PR TITLE
Fixed EVENT_REGISTER_TABLE_ATTRIBUTES example

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -251,7 +251,7 @@ abstract class Element extends Component implements ElementInterface
      *     Entry::class,
      *     Element::EVENT_REGISTER_TABLE_ATTRIBUTES,
      *     function(RegisterElementTableAttributesEvent $e) {
-     *         $e->attributes[] = 'authorExpertise';
+     *         $e->tableAttributes['authorExpertise'] = ['label' => 'Author Expertise'];
      *     }
      * );
      *


### PR DESCRIPTION
### Description
Hi.
I think `attributes` is replaced with `tableAttributes` in `EVENT_REGISTER_TABLE_ATTRIBUTES`
Thanks!

