### PR TITLE
Prevents narrowing of mapped fields based on type or section

### DIFF
--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -123,6 +123,14 @@ class EntryQuery extends ElementQuery implements NestedElementQueryInterface
     public mixed $authorId = null;
 
     /**
+     * @var bool A flag that forces the mapping of all custom fields regardless of $typeId or $sectionId
+     * .
+     * @used-by withAllFieldLayouts()
+     * @used-by fieldLayouts()
+     */
+    public mixed $withAllFieldLayouts = false;
+
+    /**
      * @var mixed The user group ID(s) that the resulting entries’ authors must be in.
      * ---
      * ```php
@@ -242,6 +250,9 @@ class EntryQuery extends ElementQuery implements NestedElementQueryInterface
                 break;
             case 'authorGroup':
                 $this->authorGroup($value);
+                break;
+            case 'withAllFieldLayouts':
+                $this->withAllFieldLayouts($value);
                 break;
             default:
                 $this->nestedTraitSet($name, $value);
@@ -523,6 +534,20 @@ class EntryQuery extends ElementQuery implements NestedElementQueryInterface
     public function authorId(mixed $value): static
     {
         $this->authorId = $value;
+        return $this;
+    }
+
+    /**
+     * Prevents narrowing of custom and generated fields based on type or section. This is useful for
+     * query resolvers with scopes on the query that may have varying entry types or sections set (some with
+     * a given field, some without).
+     *
+     * @param boolean $value
+     * @return $this
+     */
+    public function withAllFieldLayouts(bool $value): static
+    {
+        $this->withAllFieldLayouts = $value;
         return $this;
     }
 
@@ -1230,7 +1255,7 @@ class EntryQuery extends ElementQuery implements NestedElementQueryInterface
         $this->_normalizeTypeId();
         $this->_normalizeSectionId();
 
-        if ($this->typeId || $this->sectionId) {
+        if (($this->typeId || $this->sectionId) && !$this->withAllFieldLayouts) {
             $fieldLayouts = [];
             $sectionsService = Craft::$app->getEntries();
             if ($this->typeId) {


### PR DESCRIPTION
### Description

Sometimes, you want to write a query resolver that has a handful of possible conditions for matching entries. For instance, let's say I have a resolver that I want to use to fetch both entryType1 and entryType2, or sometimes just one or the other. entryType1 has a field on it called `foo`. Both entry types have a field called `bar`.

I might have a condition that's like:

```
$query->andWhere(['or', ['foo' => 'baz'], ['bar' => 'qux']]);
```

This works fine! Yay!

But, if I do this:

```
$query->type('entryType2');
$query->andWhere(['or', ['foo' => 'baz'], ['bar' => 'qux']]);
```

Ruh roh! In this case `foo` doesn't get mapped to a JSON-embedded field in `content`. Because it's kind of annoying to have to juggle which entries have which fields, I've added:

```
$query->withAllFieldLayouts(true);
$query->type('entryType2');
$query->andWhere(['or', ['foo' => 'baz'], ['bar' => 'qux']]);
```

Now it JUST WORKS.

### Related issues

Kind of related to my work is this: https://github.com/craftcms/cms/blob/5.x/src/elements/db/ElementQuery.php#L2806-L2808

It will bypass a missing field if it's wrapped in an OR condition (hey that's what I'm trying to do!), but it fails to map the field in $_columnMap. 

I think my work closes a loop that was started here, but not finished.