### PR TITLE
prevent throwing an exception if layout contains non-existent field

### DIFF
--- a/src/fieldlayoutelements/CustomField.php
+++ b/src/fieldlayoutelements/CustomField.php
@@ -232,6 +232,12 @@ class CustomField extends BaseField
     {
         $this->_fieldUid = $uid;
         $this->_field = null;
+
+        if (($field = Craft::$app->getFields()->getFieldByUid($uid)) === null) {
+            throw new FieldNotFoundException($uid);
+        } else {
+            $this->setField($field);
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Following the changes from https://github.com/craftcms/cms/commit/e80ca1b60bf4daa8958e6a7d0801ec8ab6f427f0, if you have a field layout that (for some reason) references a field which no longer exists, you’ll get a `FieldNotFoundException` when attempting to apply project config or access some areas of the control panel.

Before the change mentioned above, we were checking if the field exists and throwing an exception from within the `craft\fieldlayoutelements\CustomField::setFieldUid()` method. That exception was then caught, and we carried on. Moving the check to the `craft\fieldlayoutelements\CustomField::getField()` means there are plenty of places where it won’t be caught.

Checking if the field exists and throwing the exception from the `craft\fieldlayoutelements\CustomField::setFieldUid()` method fixes the issue.

@brandonkelly, I’m not able to reproduce the error that the related commit fixed (on a version prior to 5.8.13), so I wasn’t able to test if this PR affects that issue.


### Related issues
#17713 
