### PR TITLE
don't overwrite the variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed an error that occurred when saving an entry with a Lightswitch field. ([#17721](https://github.com/craftcms/cms/issues/17721))
+
 ## 5.8.13.1 - 2025-08-06
 
 - Fixed errors that could occur if a field layout was referencing an invalid field UUID. ([#17713](https://github.com/craftcms/cms/issues/17713))

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1522,15 +1522,15 @@ class Elements extends Component
             $newAttributes['siteAttributes'][$attribute['siteId']]['dirtyAttributes'][] = $attribute['attribute'];
         }
 
-        foreach ($changedFields as $field) {
-            $layoutElement = $element->getFieldLayout()?->getElementByUid($field['layoutElementUid']);
+        foreach ($changedFields as $changedField) {
+            $layoutElement = $element->getFieldLayout()?->getElementByUid($changedField['layoutElementUid']);
             if ($layoutElement instanceof CustomField) {
                 try {
                     $field = $layoutElement->getField();
                 } catch (FieldNotFoundException) {
                     continue;
                 }
-                $newAttributes['siteAttributes'][$field['siteId']]['dirtyFields'][] = $field->handle;
+                $newAttributes['siteAttributes'][$changedField['siteId']]['dirtyFields'][] = $field->handle;
             }
         }
 


### PR DESCRIPTION
### Description
Commit https://github.com/craftcms/cms/commit/26c510022211e9a9357f3357f79a1c51d0969512 accidentally overwrites the existing `$field` value with new data, causing the reported error.

Steps to reproduce:
1. clean 5.8.13.1 install
2. create 2 sites
3. create Lightswitch field (all default settings)
4. create a Section with an Entry Type that uses that Lightswitch field; the section needs to be enabled for both sites; propagation method set to `all`
5. create an entry in the section from step 4; provide only the title & save
6. edit the entry from step 5 and toggle the Lightswitch field; wait for the autosave to complete and try to fully save the entry; you’ll get the `Getting unknown property: craft\fields\Lightswitch::siteId` error.

### Related issues
#17721 
