### PR TITLE
Remove FS horizontal rule beneath URL

### DIFF
--- a/src/templates/settings/filesystems/_edit.twig
+++ b/src/templates/settings/filesystems/_edit.twig
@@ -92,4 +92,6 @@
             }) }}
         </div>
     {% endif %}
+
+    <hr />
 {% endmacro %}

--- a/src/templates/settings/filesystems/_edit.twig
+++ b/src/templates/settings/filesystems/_edit.twig
@@ -92,6 +92,4 @@
             }) }}
         </div>
     {% endif %}
-
-    <hr />
 {% endmacro %}


### PR DESCRIPTION
### Description
From the user's perspective, there isn't any difference between "base FS settings" and ones provided by the FS implementation, so the HR doesn't really make sense.

Furthermore, with the addition of `\craft\base\FsInterface::getShowUrlSetting`, a FS may need to provide it's own URL field, in which case it is weird that in one case it is above the HR and the other below.

<img width="2012" height="964" alt="CleanShot 2025-08-25 at 06 36 41@2x" src="https://github.com/user-attachments/assets/735ed7f5-8a11-4c6a-92e7-57bee630e5fe" />
