### PR TITLE
bump the year range from +/- 10 to +/- 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - When searching for elements, partial matches within titles are now scored higher than exact matches in other fields. ([#17739](https://github.com/craftcms/cms/issues/17739))
+- Date pickers’ year selects now have a range of 100 years in the past and future. ([#17782](https://github.com/craftcms/cms/pull/17782))
 - Fixed a bug where volumes’ filesystem settings weren’t respecting static translations of filesystem names. ([#17749](https://github.com/craftcms/cms/issues/17749))
 - Fixed an error that could occur when applying project config changes. ([#15357](https://github.com/craftcms/cms/issues/15357))
 - Fixed a bug where pressing the “Use defaults” button within element indexes’ View menus wasn’t removing the `sort` query string parameter, so the selected sort option could revert back if the window was reloaded. ([#17761](https://github.com/craftcms/cms/issues/17761))

--- a/src/web/assets/cp/CpAsset.php
+++ b/src/web/assets/cp/CpAsset.php
@@ -650,6 +650,7 @@ JS;
             'monthNamesShort' => $locale->getMonthNames(Locale::LENGTH_ABBREVIATED),
             'nextText' => Craft::t('app', 'Next'),
             'prevText' => Craft::t('app', 'Prev'),
+            'yearRange' => 'c-100:c+100',
         ];
     }
 


### PR DESCRIPTION
### Description
The default range of years that’s displayed for a date field is +/- 10 (https://api.jqueryui.com/datepicker/#option-yearRange). It’s still possible to select dates in years that are outside of that range, but it’s not intuitive or easy to do so. This PR changes the default range to +/- 100 years.


### Related issues
#17773
