### PR TITLE
App::env() + parseEnv() improvements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -17,6 +17,8 @@
 
 ### Development
 - Reference tags now support fallback values when no attribute is specified. ([#17688](https://github.com/craftcms/cms/pull/17688))
+- Added support for referencing environment variables anywhere within settings that support them (e.g. `foo/$ENV_NAME/bar` or `foo-${ENV_NAME}-bar`). ([#17794](https://github.com/craftcms/cms/pull/17794))
+- Environmental settings can now reference `CRAFT_SITE` (the current site’s handle) and `CRAFT_SITE_UPPER` (the current site’s handle in UPPER_SNAKE_CASE) environment variables, which are defined at runtime. ([#17794](https://github.com/craftcms/cms/pull/17794))
 
 ### Extensibility
 - Added `Craft.BaseElementIndex::asyncSelectDefaultSource()`.

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -154,7 +154,6 @@ class App
             $value = static::env($m[1]);
             if ($value === null && $m[1] === 'CRAFT_SITE') {
                 return strtoupper(StringHelper::toSnakeCase(Craft::$app->getSites()->getCurrentSite()->handle));
-                ;
             }
             return $value;
         }, $value);

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -133,7 +133,12 @@ class App
         }
 
         if (($env = getenv($name)) !== false) {
-            return static::normalizeValue($env);
+            $value = static::normalizeValue($env);
+            if (is_string($value)) {
+                // parse nested variables
+                $value = self::parseNestedEnv($value);
+            }
+            return $value;
         }
 
         if (defined($name)) {
@@ -141,6 +146,18 @@ class App
         }
 
         return null;
+    }
+
+    private static function parseNestedEnv(string $value): string
+    {
+        return preg_replace_callback('/\$\{(\w+)}/', function($m) {
+            $value = static::env($m[1]);
+            if ($value === null && $m[1] === 'CRAFT_SITE') {
+                return strtoupper(StringHelper::toSnakeCase(Craft::$app->getSites()->getCurrentSite()->handle));
+                ;
+            }
+            return $value;
+        }, $value);
     }
 
     /**
@@ -221,15 +238,14 @@ class App
             return null;
         }
 
-        if (preg_match('/^\$(\w+)(\/.*)?/', $value, $matches)) {
-            $env = static::env($matches[1]);
+        // parse nested variables (e.g. foo-${VAR}-bar)
+        $value = self::parseNestedEnv($value);
 
-            if ($env === null) {
-                // No env var or constant is defined here by that name
-                return null;
-            }
+        // parse inline variables (e.g. foo/$VAR/bar)
+        $value = preg_replace_callback('/(?<=^|\/)\$(\w+)(?=$|\/)?/', fn($m) => static::env($m[1]), $value);
 
-            $value = $env . ($matches[2] ?? '');
+        if ($value === '') {
+            return null;
         }
 
         if (str_starts_with($value, '@')) {

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -150,13 +150,7 @@ class App
 
     private static function parseNestedEnv(string $value): string
     {
-        return preg_replace_callback('/\$\{(\w+)}/', function($m) {
-            $value = static::env($m[1]);
-            if ($value === null && $m[1] === 'CRAFT_SITE') {
-                return strtoupper(StringHelper::toSnakeCase(Craft::$app->getSites()->getCurrentSite()->handle));
-            }
-            return $value;
-        }, $value);
+        return preg_replace_callback('/\$\{(\w+)}/', fn(array $m) => static::env($m[1]), $value);
     }
 
     /**
@@ -237,10 +231,10 @@ class App
             return null;
         }
 
-        // parse nested variables (e.g. foo-${VAR}-bar)
+        // …${VAR}…
         $value = self::parseNestedEnv($value);
 
-        // parse inline variables (e.g. foo/$VAR/bar)
+        // …/$VAR/…
         $value = preg_replace_callback('/(?<=^|\/)\$(\w+)(?=$|\/)?/', fn($m) => static::env($m[1]), $value);
 
         if ($value === '') {

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -272,7 +272,7 @@ class App
             return (bool)$value;
         }
 
-        if (!is_string($value)) {
+        if (!is_string($value) || $value === '') {
             return null;
         }
 

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -227,8 +227,8 @@ class App
      */
     public static function parseEnv(?string $value): bool|string|null
     {
-        if ($value === null) {
-            return null;
+        if ($value === null || $value === '') {
+            return $value;
         }
 
         // …${VAR}…

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -511,6 +511,10 @@ class Sites extends Component
         if (Craft::$app->has('request', true) && Craft::$app->getRequest()->getIsSiteRequest()) {
             Craft::$app->language = $this->_currentSite->language;
         }
+
+        // Set the CRAFT_SITE and CRAFT_SITE_UPPER env vars
+        $_SERVER['CRAFT_SITE'] = $site->handle;
+        $_SERVER['CRAFT_SITE_UPPER'] = strtoupper(StringHelper::toSnakeCase($site->handle));
     }
 
     /**

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -513,8 +513,12 @@ class Sites extends Component
         }
 
         // Set the CRAFT_SITE and CRAFT_SITE_UPPER env vars
-        $_SERVER['CRAFT_SITE'] = $site->handle;
-        $_SERVER['CRAFT_SITE_UPPER'] = strtoupper(StringHelper::toSnakeCase($site->handle));
+        if ($site->handle !== null) {
+            $_SERVER['CRAFT_SITE'] = $site->handle;
+            $_SERVER['CRAFT_SITE_UPPER'] = strtoupper(StringHelper::toSnakeCase($site->handle));
+        } else {
+            unset($_SERVER['CRAFT_SITE'], $_SERVER['CRAFT_SITE_UPPER']);
+        }
     }
 
     /**

--- a/src/test/CraftConnector.php
+++ b/src/test/CraftConnector.php
@@ -121,6 +121,7 @@ class CraftConnector extends Yii2
         parent::resetApplication($closeSession);
         Db::reset();
         Session::reset();
+        unset($_SERVER['CRAFT_SITE'], $_SERVER['CRAFT_SITE_UPPER']);
     }
 
     /**

--- a/src/test/TestSetup.php
+++ b/src/test/TestSetup.php
@@ -453,7 +453,7 @@ class TestSetup
 
         $siteConfig = [
             'name' => 'Craft test site',
-            'handle' => 'default',
+            'handle' => 'defaultSite',
             'hasUrls' => true,
             'baseUrl' => self::SITE_URL,
             'language' => 'en-US',

--- a/tests/unit/helpers/AppHelperTest.php
+++ b/tests/unit/helpers/AppHelperTest.php
@@ -463,7 +463,7 @@ class AppHelperTest extends TestCase
             [false, '0'],
             [true, 'true'],
             [false, 'false'],
-            [false, ''],
+            [null, ''],
             [null, 'whatever'],
             [true, 1],
             [false, 0],

--- a/tests/unit/helpers/AppHelperTest.php
+++ b/tests/unit/helpers/AppHelperTest.php
@@ -37,24 +37,28 @@ class AppHelperTest extends TestCase
         self::assertSame('server', App::env('TEST_SERVER_ENV'));
         unset($_SERVER['TEST_SERVER_ENV']);
 
-        putenv('TEST_GETENV_ENV=getenv');
-        self::assertSame('getenv', App::env('TEST_GETENV_ENV'));
-        putenv('TEST_GETENV_ENV');
+        $variables = [
+            'TEST_1' => 'testing1',
+            'TEST_2' => 'foo-${TEST_1}-bar',
+            'TEST_3' => 'true',
+            'TEST_4' => 'false',
+        ];
 
-        putenv('TEST_GETENV_TRUE_ENV=true');
-        self::assertTrue(App::env('TEST_GETENV_TRUE_ENV'));
-        putenv('TEST_GETENV_TRUE_ENV');
+        foreach ($variables as $name => $value) {
+            putenv("$name=$value");
+        }
 
-        putenv('TEST_GETENV_FALSE_ENV=false');
-        self::assertFalse(App::env('TEST_GETENV_FALSE_ENV'));
-        putenv('TEST_GETENV_FALSE_ENV');
+        self::assertSame('testing1', App::env('TEST_1'));
+        self::assertSame('foo-testing1-bar', App::env('TEST_2'));
+        self::assertTrue(App::env('TEST_3'));
+        self::assertFalse(App::env('TEST_4'));
+
+        foreach (array_keys($variables) as $name) {
+            putenv($name);
+        }
 
         self::assertSame(CRAFT_TESTS_PATH, App::env('CRAFT_TESTS_PATH'));
         self::assertNull(App::env('TEST_NONEXISTENT_ENV'));
-
-        putenv('SHH=foo');
-        self::assertSame('foo', App::env('SHH'));
-        putenv('SHH');
     }
 
     /**
@@ -92,12 +96,35 @@ class AppHelperTest extends TestCase
      */
     public function testParseEnv(): void
     {
-        self::assertNull(App::parseEnv(null));
+        $variables = [
+            'TEST_1' => 'testing1',
+            'TEST_2' => 'foo${TEST_1}bar',
+            'TEST_DEFAULT_SITE_API_KEY' => 'abcdef',
+        ];
+
+        foreach ($variables as $name => $value) {
+            putenv("$name=$value");
+        }
+
+        self::assertSame('testing1', App::parseEnv('$TEST_1'));
+        self::assertSame('testing1', App::parseEnv('${TEST_1}'));
+        self::assertSame('testing1/foo/bar', App::parseEnv('$TEST_1/foo/bar'));
+        self::assertSame('foo/testing1/bar', App::parseEnv('foo/$TEST_1/bar'));
+        self::assertSame('footesting1bar', App::parseEnv('$TEST_2'));
+        self::assertSame('footesting1bar', App::parseEnv('${TEST_2}'));
+        self::assertSame('foo/footesting1bar/bar', App::parseEnv('foo/$TEST_2/bar'));
+        self::assertSame(null, App::parseEnv('$CRAFT_SITE'));
+        self::assertSame('abcdef', App::parseEnv('$TEST_${CRAFT_SITE}_API_KEY'));
         self::assertSame(CRAFT_TESTS_PATH, App::parseEnv('$CRAFT_TESTS_PATH'));
         self::assertSame(CRAFT_TESTS_PATH . '/foo/bar', App::parseEnv('$CRAFT_TESTS_PATH/foo/bar'));
         self::assertSame('CRAFT_TESTS_PATH', App::parseEnv('CRAFT_TESTS_PATH'));
-        self::assertSame(null, App::parseEnv('$TEST_MISSING'));
         self::assertSame(Craft::getAlias('@vendor/foo/bar'), App::parseEnv('@vendor/foo/bar'));
+        self::assertNull(App::parseEnv('$TEST_MISSING'));
+        self::assertNull(App::parseEnv(null));
+
+        foreach (array_keys($variables) as $name) {
+            putenv($name);
+        }
     }
 
     /**

--- a/tests/unit/helpers/AppHelperTest.php
+++ b/tests/unit/helpers/AppHelperTest.php
@@ -113,8 +113,9 @@ class AppHelperTest extends TestCase
         self::assertSame('footesting1bar', App::parseEnv('$TEST_2'));
         self::assertSame('footesting1bar', App::parseEnv('${TEST_2}'));
         self::assertSame('foo/footesting1bar/bar', App::parseEnv('foo/$TEST_2/bar'));
-        self::assertSame(null, App::parseEnv('$CRAFT_SITE'));
-        self::assertSame('abcdef', App::parseEnv('$TEST_${CRAFT_SITE}_API_KEY'));
+        self::assertSame('defaultSite', App::parseEnv('$CRAFT_SITE'));
+        self::assertSame('DEFAULT_SITE', App::parseEnv('$CRAFT_SITE_UPPER'));
+        self::assertSame('abcdef', App::parseEnv('$TEST_${CRAFT_SITE_UPPER}_API_KEY'));
         self::assertSame(CRAFT_TESTS_PATH, App::parseEnv('$CRAFT_TESTS_PATH'));
         self::assertSame(CRAFT_TESTS_PATH . '/foo/bar', App::parseEnv('$CRAFT_TESTS_PATH/foo/bar'));
         self::assertSame('CRAFT_TESTS_PATH', App::parseEnv('CRAFT_TESTS_PATH'));

--- a/tests/unit/helpers/StringHelperTest.php
+++ b/tests/unit/helpers/StringHelperTest.php
@@ -1868,6 +1868,7 @@ class StringHelperTest extends TestCase
             ['', ''],
             ['i_😘_u', 'I 😘 U'],
             ['2_2_alpha_n_numeric', '22 AlphaN Numeric'],
+            ['foo_bar', 'fooBar'],
         ];
     }
 
@@ -1884,7 +1885,6 @@ class StringHelperTest extends TestCase
             ['hello!@#iam!@#astring', 'HelloIamAstring', '!@#'],
             ['hello😀😁😂iam😀😁😂astring', 'HelloIamAstring', '😀😁😂'],
             ['hello😀😁😂iam😀😁😂a2string', 'HelloIamA2string', '😀😁😂'],
-
         ];
     }
 

--- a/tests/unit/web/twig/ExtensionTest.php
+++ b/tests/unit/web/twig/ExtensionTest.php
@@ -129,7 +129,7 @@ class ExtensionTest extends TestCase
     {
         Craft::$app->getProjectConfig()->set('system.name', 'Im a test system');
         $this->testRenderResult(
-            'Im a test system | default Craft test site ' . TestSetup::SITE_URL,
+            'Im a test system | defaultSite Craft test site ' . TestSetup::SITE_URL,
             '{{ systemName }} | {{ currentSite.handle }} {{ currentSite }} {{ siteUrl }}'
         );
     }


### PR DESCRIPTION
### Description

- `craft\helpers\App::env()` now supports parsing nested environment variables, e.g. `FOO="bar/${BAZ}"`.
- `craft\helpers\App::parseEnv()` now supports parsing nested environment variables using the `…/$NAME/…` and `…${NAME}…` syntaxes anywhere within the passed-in string (not just beginning with `$NAME/…`).
- `CRAFT_SITE` and `CRAFT_SITE_UPPER` environment variables are now defined when the current site is determined.
  - `CRAFT_SITE` is set to the site’s handle.
  - `CRAFT_SITE_UPPER` is set to the site’s handle, converted to UPPER_SNAKE_CASE.

So for example, it’s now possible to define per-site API token environment variables, such as:

```sh
API_KEY_EN=xxxxxx
API_KEY_DE=yyyyyy
API_KEY_NL=zzzzzz
```

…and then reference each of them dynamically, depending on the current site, by setting an API token setting to:

```sh
$API_KEY_${CRAFT_SITE_UPPER}
```

### Related issues

- #8709