### PR TITLE
the key for table columns should be 'attr' too

### DIFF
--- a/src/controllers/ElementIndexesController.php
+++ b/src/controllers/ElementIndexesController.php
@@ -186,7 +186,7 @@ class ElementIndexesController extends BaseElementsController
         $tableColumns = Collection::make($elementSources->getSourceTableAttributes($this->elementType, $this->sourceKey))
             ->map(fn(array $attribute, string $key) => [
                 ...$attribute,
-                'key' => $key,
+                'attr' => $key,
             ])
             ->values()
             ->all();


### PR DESCRIPTION
### Description
Selecting a custom field on the element index page (via View > Table Columns checkboxes) wasn’t working as expected. The custom fields were showing on the list, but selecting one to show in the table wasn’t actually showing the corresponding column in the table.

It looks like when introducing lazy-loading of element source attribute info (https://github.com/craftcms/cms/commit/835207d7ddf0f4517b3aabac7ab390375af28abf), we accidentally changed the name of the key that holds the custom field uid from `attr` to `key`. This caused the input value of the custom field checkbox to be `1` instead of `field:<uid>`, leading to this issue.


### Related issues
n/a; reported by @riasvdv 
