### PR TITLE
Fix twig error in de-CH translation

### DIFF
--- a/src/translations/de-CH/app.php
+++ b/src/translations/de-CH/app.php
@@ -1723,7 +1723,7 @@ return [
     'The primary site will be loaded by default on the front end.' => 'Die primäre Site wird standardmässig im Front-End geladen.',
     'The request could not be understood by the server due to malformed syntax.' => 'Der Server konnte deine Anfrage aufgrund fehlerhafter Syntax nicht verarbeiten.',
     'The requested URL was not found on this server.' => 'Die angeforderte URL wurde auf diesem Server nicht gefunden.',
-    'The selected {relatedType} {count, plural, =1{contains} other{contain}} validation errors, preventing this {type} from being saved. Edit the {relatedType} to fix them.' => 'Das ausgewählte {relatedType} enthält {count, plural, one {einen Validierungsfehler} other {{count} Validierungsfehler}}, wodurch das Speichern dieses {type} verhindert wird. {relatedType} bearbeiten, um das Problem zu beheben.',
+    'The selected {relatedType} {count, plural, =1{contains} other{contain}} validation errors, preventing this {type} from being saved. Edit the {relatedType} to fix them.' => 'Das ausgewählte {relatedType} enthält {count, plural, one {einen Validierungsfehler} other {# Validierungsfehler}}, wodurch das Speichern dieses {type} verhindert wird. {relatedType} bearbeiten, um das Problem zu beheben.',   
     'The server doesn’t meet Craft’s new requirements:' => 'Der Server erfüllt die neuen Anforderungen von Craft nicht:',
     'The subpath cannot overlap with any other volumes sharing the same filesystem.' => 'Der Unterpfad darf sich nicht mit anderen Volumen überschneiden, die dasselbe Dateisystem nutzen.',
     'The table name prefix' => 'Präfix des Tabellennamens',
@@ -2206,6 +2206,7 @@ return [
     'tag' => 'Schlagwort',
     'tags' => 'Schlagwörter',
     'test_email_body' => "Hallo {{user.friendlyName|e}},
+
 
 Glückwunsch! Craft konnte erfolgreich eine E-Mail versenden. Hier sind die von dir verwendeten Einstellungen: {{ settings }}",
     'test_email_heading' => 'Wenn du deine E-Mail-Einstellungen testest:',


### PR DESCRIPTION
A bracket error resulted in the ICU Plural rules not being applied and raw twig being dumped in the cp when alt text was missing on a related asset – in the "Swiss german" translation.

before:

<img width="874" height="77" alt="ScreenShot 2025-09-08 at 4  34 06" src="https://github.com/user-attachments/assets/4da3bc6f-6a56-4d25-a862-395718476d4d" />

after:

<img width="832" height="57" alt="ScreenShot 2025-09-08 at 4  34 21" src="https://github.com/user-attachments/assets/0550eae4-1763-4ef6-a98a-683f3ccc629f" />

