### PR TITLE
allow querying user via gql when running on solo license

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,5 +1,8 @@
 # Release Notes for Craft CMS 4.17 (WIP)
 
+### Administration
+- Added the “View user” GraphQL schema option for Craft Solo. ([#17863](https://github.com/craftcms/cms/pull/17863))
+
 ### Extensibility
 - Added `craft\web\GqlResponseFormatter`.
 - Added `craft\web\Response::FORMAT_GQL`.

--- a/src/fields/Users.php
+++ b/src/fields/Users.php
@@ -93,7 +93,7 @@ class Users extends BaseRelationField
         $allowedEntities = Gql::extractAllowedEntitiesFromSchema();
         $userGroupUids = $allowedEntities['usergroups'] ?? [];
 
-        if (in_array('everyone', $userGroupUids, false)) {
+        if (in_array('everyone', $userGroupUids, false) || in_array('solo', $userGroupUids, false)) {
             return [];
         }
 

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -13,6 +13,7 @@ use craft\base\GqlInlineFragmentFieldInterface;
 use craft\behaviors\FieldLayoutBehavior;
 use craft\db\Query as DbQuery;
 use craft\db\Table;
+use craft\elements\User;
 use craft\errors\GqlException;
 use craft\events\ConfigEvent;
 use craft\events\DefineGqlValidationRulesEvent;
@@ -1635,7 +1636,11 @@ class Gql extends Component
     private function _getUserSchemaComponents(): array
     {
         if (Craft::$app->edition !== Craft::Pro) {
-            return [];
+            return [
+                'query' => ['usergroups.solo:read' => [
+                    'label' => Craft::t('app', 'View {type}', ['type' => User::lowerDisplayName()]),
+                ]],
+            ];
         }
 
         $queryComponents = [];


### PR DESCRIPTION
### Description
As of 4.8.0, the GraphQL API is available for the Solo edition too. The Solo edition is limited to a single admin account, but it’s still possible to create a Users type field and add a relation to it. It’s also possible to query that field via PHP or Twig, but not GraphQL. 

This PR fixes an issue where it’s not possible to query users while on a Solo edition. A new “View user” option has been added to the schema creation page. If selected, it’ll be possible to query user-related fields and properties (e.g., Users field, entry author, etc.).

<img width="548" height="794" alt="Screenshot 2025-09-15 at 15 56 24" src="https://github.com/user-attachments/assets/040d1910-6721-4c85-bcc5-e660f947fe04" />


### Related issues
#17857
