### PR TITLE
Bugfix/categories field inline search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed a bug where element queries weren’t handling generated field params properly, for generated fields with the same handle as custom fields. ([#17851](https://github.com/craftcms/cms/issues/17851), [#17855](https://github.com/craftcms/cms/issues/17855))
 - Fixed a bug where it wasn’t possible to choose autosuggest inputs’ suggestions via mouse click. ([#17869](https://github.com/craftcms/cms/pull/17869))
 - Fixed a bug where nested entries within Matrix fields weren’t getting a “Copy” action if the field was set to the inline-editable blocks view mode and Min/Max Entries were set to 1. ([#17878](https://github.com/craftcms/cms/issues/17878))
+- Fixed a bug where Categories fields weren’t showing inline search inputs when “Show the search input” was enabled. ([#17886](https://github.com/craftcms/cms/pull/17886))
 - Fixed a styling issue.
 
 ## 5.8.17 - 2025-09-05

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -1542,7 +1542,15 @@ JS, [
      */
     protected function showSearchInput(?ElementInterface $element): bool
     {
-        if (!$this->showSearchInput || $this->sources === '*') {
+        if (!$this->showSearchInput) {
+            return false;
+        }
+
+        if (!$this->allowMultipleSources) {
+            return true;
+        }
+
+        if ($this->sources === '*') {
             return false;
         }
 

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -191,4 +191,17 @@ class Categories extends BaseRelationField
             'groupId' => $groupIds,
         ];
     }
+
+    /**
+     * @inheritdoc
+     */
+    protected function showSearchInput(?ElementInterface $element): bool
+    {
+        if (!$this->showSearchInput) {
+            return false;
+        }
+
+        $sources = $this->getInputSources($element);
+        return is_array($sources) && count($sources) === 1;
+    }
 }

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -191,12 +191,4 @@ class Categories extends BaseRelationField
             'groupId' => $groupIds,
         ];
     }
-
-    /**
-     * @inheritdoc
-     */
-    protected function showSearchInput(?ElementInterface $element): bool
-    {
-        return $this->showSearchInput;
-    }
 }

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -197,11 +197,6 @@ class Categories extends BaseRelationField
      */
     protected function showSearchInput(?ElementInterface $element): bool
     {
-        if (!$this->showSearchInput) {
-            return false;
-        }
-
-        $sources = $this->getInputSources($element);
-        return is_array($sources) && count($sources) === 1;
+        return $this->showSearchInput;
     }
 }


### PR DESCRIPTION
### Description
The Categories field was not showing the search input, even when the “Show the search input” toggle was on. That’s because the Categories field uses a single `source`, not the `sources` property (and the `sources` was returning an asterisk, which caused the field to always refuse to show the search input).

### Related issues
n/a, reported by @tommysvr 
