### PR TITLE
only get entry type select input for non-nested entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed a bug where it wasn’t possible to choose autosuggest inputs’ suggestions via mouse click. ([#17869](https://github.com/craftcms/cms/pull/17869))
 - Fixed a bug where nested entries within Matrix fields weren’t getting a “Copy” action if the field was set to the inline-editable blocks view mode and Min/Max Entries were set to 1. ([#17878](https://github.com/craftcms/cms/issues/17878))
 - Fixed a bug where Categories fields weren’t showing inline search inputs when “Show the search input” was enabled. ([#17886](https://github.com/craftcms/cms/pull/17886))
+- Fixed a bug where the “Entry type settings” action for nested entries could open the owner entry’s entry type settings. ([#17875](https://github.com/craftcms/cms/issues/17875))
 - Fixed a styling issue.
 
 ## 5.8.17 - 2025-09-05

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -2194,7 +2194,7 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
 JS, [
                 $view->namespaceInputId($entryTypeEditId),
                 ['entryTypeId' => $this->typeId],
-                $this->fieldId && !$this->sectionId,
+                isset($this->fieldId),
             ]);
 
             // Section settings

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -2178,13 +2178,15 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
             ];
 
             $view = Craft::$app->getView();
-            $view->registerJsWithVars(fn($id, $params) => <<<JS
+            $view->registerJsWithVars(fn($id, $params, $isNestedEntry) => <<<JS
 (() => {
   $('#' + $id).on('activate', function() {
     const params = $params;
-    const input = $(this).closest('.menu').data('disclosureMenu').\$trigger.closest('form').find('.entry-type-select').find('input');
-    if (input.length) {
-      params.entryTypeId = input.val();
+    if (!$isNestedEntry) {
+        const input = $(this).closest('.menu').data('disclosureMenu').\$trigger.closest('form').find('.entry-type-select').find('input');
+        if (input.length) {
+          params.entryTypeId = input.val();
+        }
     }
     new Craft.CpScreenSlideout('entry-types/edit', {params});
   });
@@ -2192,6 +2194,7 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
 JS, [
                 $view->namespaceInputId($entryTypeEditId),
                 ['entryTypeId' => $this->typeId],
+                $this->fieldId && !$this->sectionId,
             ]);
 
             // Section settings


### PR DESCRIPTION
### Description
When deciding which entry type to load when the “Entry type settings” action was activated, only attempt to check the `.entry-type-select input` if the entry that triggered this action is not a nested one.


### Related issues
#17875 
