### PR TITLE
allow copy action for static matrix blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed a bug where focus was moved to the top of the body after the final tag in a Tags field was removed. ([#17861](https://github.com/craftcms/cms/pull/17861))
 - Fixed a bug where element queries weren’t handling generated field params properly, for generated fields with the same handle as custom fields. ([#17851](https://github.com/craftcms/cms/issues/17851), [#17855](https://github.com/craftcms/cms/issues/17855))
 - Fixed a bug where it wasn’t possible to choose autosuggest inputs’ suggestions via mouse click. ([#17869](https://github.com/craftcms/cms/pull/17869))
+- Fixed a bug where nested entries within Matrix fields weren’t getting a “Copy” action if the field was set to the inline-editable blocks view mode and Min/Max Entries were set to 1. ([#17878](https://github.com/craftcms/cms/issues/17878))
 - Fixed a styling issue.
 
 ## 5.8.17 - 2025-09-05

--- a/src/templates/_components/fieldtypes/Matrix/block.twig
+++ b/src/templates/_components/fieldtypes/Matrix/block.twig
@@ -90,9 +90,12 @@
   {% endif %}
 {% endif %}
 
+{% set actionMenuItems = actionMenuItems|merge([
+  {hr: true},
+]) %}
+
 {% if not staticEntries %}
   {% set actionMenuItems = actionMenuItems|merge([
-    {hr: true},
     {
       icon: 'trash',
       label: 'Delete'|t('app'),
@@ -109,17 +112,22 @@
         data: {action: 'duplicate'},
       },
     },
-    {
-      icon: 'clone-dashed',
-      color: 'fuchsia',
-      label: 'Copy'|t('app'),
-      attributes: {
-        data: {action: 'copy'},
-      },
-    },
-    {hr: true},
   ]) %}
+{% endif %}
 
+{% set actionMenuItems = actionMenuItems|merge([
+  {
+    icon: 'clone-dashed',
+    color: 'fuchsia',
+    label: 'Copy'|t('app'),
+    attributes: {
+      data: {action: 'copy'},
+    },
+  },
+  {hr: true},
+]) %}
+
+{% if not staticEntries %}
   {% for entryType in entryTypes %}
     {% set actionMenuItems = actionMenuItems|push({
       icon: entryType.icon ?? 'plus',
@@ -130,20 +138,6 @@
       },
     }) %}
   {% endfor %}
-{% else %}
-  {# copy action should be available even for the "static" field - one entry type with min and max entries set to the same value #}
-  {% set actionMenuItems = actionMenuItems|merge([
-    {hr: true},
-    {
-      icon: 'clone-dashed',
-      color: 'fuchsia',
-      label: 'Copy'|t('app'),
-      attributes: {
-        data: {action: 'copy'},
-      },
-    },
-    {hr: true},
-  ]) %}
 {% endif %}
 
 {% namespace baseInputName %}

--- a/src/templates/_components/fieldtypes/Matrix/block.twig
+++ b/src/templates/_components/fieldtypes/Matrix/block.twig
@@ -130,6 +130,20 @@
       },
     }) %}
   {% endfor %}
+{% else %}
+  {# copy action should be available even for the "static" field - one entry type with min and max entries set to the same value #}
+  {% set actionMenuItems = actionMenuItems|merge([
+    {hr: true},
+    {
+      icon: 'clone-dashed',
+      color: 'fuchsia',
+      label: 'Copy'|t('app'),
+      attributes: {
+        data: {action: 'copy'},
+      },
+    },
+    {hr: true},
+  ]) %}
 {% endif %}
 
 {% namespace baseInputName %}


### PR DESCRIPTION
### Description
When you have a matrix field with one entry type and min and max entries set to the same value, it should still be possible to copy the nested entries (blocks), as you might want to paste them into another element.


### Related issues
#17878
