### PR TITLE
check for event_after_replace_asset too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `new` is now a reserved filesystem handle.
 - Fixed an error that could occur when running the `utils/fix-field-layout-uids` command. ([#17848](https://github.com/craftcms/cms/issues/17848))
 - Fixed a bug where the `EVENT_DEFINE_EXTRA_FIELDS` event wasn’t getting triggered for elements. ([#17866](https://github.com/craftcms/cms/issues/17866))
+- Fixed a bug where `craft\services\Assets::EVENT_AFTER_REPLACE_ASSET` events weren’t getting triggered when replacing an asset file via GraphQL. ([#17005](https://github.com/craftcms/cms/issues/17005))
 
 ## 4.16.13 - 2025-09-05
 
@@ -243,7 +244,7 @@
 
 ## 4.14.14 - 2025-04-08
 
-- Fixed a bug where `craft\services\Assets::EVENT_BEFORE_REPLACE_ASSET` and `EVENT_BEFORE_REPLACE_ASSET` events weren’t getting triggered when replacing an asset file via GraphQL. ([#17005](https://github.com/craftcms/cms/issues/17005))
+- Fixed a bug where `craft\services\Assets::EVENT_BEFORE_REPLACE_ASSET` events weren’t getting triggered when replacing an asset file via GraphQL. ([#17005](https://github.com/craftcms/cms/issues/17005))
 - Fixed a bug where replacing a file via GraphQL could result in two assets referring to the same file. ([#17031](https://github.com/craftcms/cms/pull/17031))
 - Fixed a bug where the window wasn’t automatically scrolling when dragging structure elements near its edges. ([#17036](https://github.com/craftcms/cms/issues/17036))
 

--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -108,7 +108,10 @@ class Asset extends ElementMutationResolver
         $asset = $this->populateElementWithData($asset, $arguments, $resolveInfo);
         $triggerReplaceEvents = (
             $asset->getScenario() === AssetElement::SCENARIO_REPLACE &&
-            $assetService->hasEventHandlers(Assets::EVENT_BEFORE_REPLACE_ASSET)
+            (
+                $assetService->hasEventHandlers(Assets::EVENT_BEFORE_REPLACE_ASSET) ||
+                $assetService->hasEventHandlers(Assets::EVENT_AFTER_REPLACE_ASSET)
+            )
         );
 
         if ($triggerReplaceEvents) {


### PR DESCRIPTION
### Description
Part two of #17031.

When checking whether the asset replace events should be triggered when replacing via GQL mutation, check for both `EVENT_BEFORE_REPLACE_ASSET` and `EVENT_AFTER_REPLACE_ASSET`.


### Related issues
#17705 
