### PR TITLE
Load provisional changes onto the canonical elements

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -31,12 +31,14 @@
 - Added `Craft.BaseElementIndex::asyncSelectSource()`.
 - Added `Craft.BaseElementIndex::asyncSelectSourceByKey()`.
 - Added `Craft.BaseElementIndex::ensureSourceAttributeInfo()`.
+- Added `craft\base\ElementTrait::$hasProvisionalChanges`. ([#17915](https://github.com/craftcms/cms/pull/17915))
 - Added `craft\fields\BaseRelationField::VIEW_MODE_CARDS_GRID`.
 - Added `craft\fields\BaseRelationField::VIEW_MODE_CARDS`.
 - Added `craft\fields\BaseRelationField::VIEW_MODE_LIST_INLINE`.
 - Added `craft\fields\BaseRelationField::VIEW_MODE_LIST`.
 - Added `craft\fields\BaseRelationField::VIEW_MODE_THUMBS`.
 - Added `craft\fields\Matrix::VIEW_MODE_CARDS_GRID`.
+- Added `craft\helpers\ElementHelper::loadProvisionalChanges()`. ([#17915](https://github.com/craftcms/cms/pull/17915))
 - Added `craft\web\GqlResponseFormatter`.
 - Added `craft\web\Response::FORMAT_GQL`.
 - Added `craft\web\twig\nodes\BaseNode`.
@@ -56,4 +58,5 @@
 - Global set queries no longer register cache tags.
 - Improved element index performance. ([#17557](https://github.com/craftcms/cms/pull/17557))
 - Improved element query performance. ([#17850](https://github.com/craftcms/cms/pull/17850))
+- Fixed a bug where elements with unsaved changes could show outdated attribute/field values within element index tables, chips, and cards throughout the control panel. ([#17915](https://github.com/craftcms/cms/pull/17915))
 - Updated Twig to 3.21. ([#17603](https://github.com/craftcms/cms/discussions/17603))

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -1363,8 +1363,8 @@ abstract class Element extends Component implements ElementInterface
             return '';
         }
 
-        // See if there are any provisional drafts we should swap these out with
-        ElementHelper::swapInProvisionalDrafts($elements);
+        // See if there are any provisional changes we should show
+        ElementHelper::loadProvisionalChanges($elements);
 
         if ($request->getParam('prevalidate')) {
             foreach ($elements as $element) {

--- a/src/base/ElementTrait.php
+++ b/src/base/ElementTrait.php
@@ -59,6 +59,12 @@ trait ElementTrait
     public bool $isProvisionalDraft = false;
 
     /**
+     * @var bool Whether provisional changes have been loaded onto this element.
+     * @since 5.9.0
+     */
+    public bool $hasProvisionalChanges = false;
+
+    /**
      * @var string|null The element’s UID
      */
     public ?string $uid = null;

--- a/src/controllers/AppController.php
+++ b/src/controllers/AppController.php
@@ -802,8 +802,8 @@ class AppController extends Controller
 
             $elements = $query->all();
 
-            // See if there are any provisional drafts we should swap these out with
-            ElementHelper::swapInProvisionalDrafts($elements);
+            // See if there are any provisional changes we should show
+            ElementHelper::loadProvisionalChanges($elements);
 
             foreach ($elements as $element) {
                 foreach ($instances as $key => $instance) {

--- a/src/controllers/RelationalFieldsController.php
+++ b/src/controllers/RelationalFieldsController.php
@@ -59,7 +59,7 @@ class RelationalFieldsController extends Controller
             }
         }
 
-        ElementHelper::swapInProvisionalDrafts($elements);
+        ElementHelper::loadProvisionalChanges($elements);
 
         $html = $this->getView()->renderTemplate('_includes/forms/elementSelect.twig', [
             'elements' => $elements,

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -405,8 +405,8 @@ class NestedElementManager extends Component
                         ->all();
                 }
 
-                // See if there are any provisional drafts we should swap these out with
-                ElementHelper::swapInProvisionalDrafts($elements);
+                // See if there are any provisional changes we should show
+                ElementHelper::loadProvisionalChanges($elements);
 
                 if ($this->hasErrors($owner)) {
                     foreach ($elements as $element) {

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -1503,7 +1503,7 @@ JS, [
             $value = [];
         }
 
-        ElementHelper::swapInProvisionalDrafts($value);
+        ElementHelper::loadProvisionalChanges($value);
 
         if ($this->validateRelatedElements && $element !== null) {
             // Pre-validate related elements

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -579,7 +579,10 @@ class Cp
             );
         }
 
-        if ($element->isProvisionalDraft && ($config['showProvisionalDraftLabel'] ?? $config['showLabel'])) {
+        if (
+            ($config['showProvisionalDraftLabel'] ?? $config['showLabel']) &&
+            ($element->isProvisionalDraft || $element->hasProvisionalChanges)
+        ) {
             $config['labelHtml'] = ($config['labelHtml'] ?? '') . self::changeStatusLabelHtml();
         }
 
@@ -724,7 +727,7 @@ JS, [
 
         $labels = array_filter([
             $element->showStatusIndicator() ? static::componentStatusLabelHtml($element) : null,
-            $element->isProvisionalDraft ? self::changeStatusLabelHtml() : null,
+            $element->isProvisionalDraft || $element->hasProvisionalChanges ? self::changeStatusLabelHtml() : null,
         ]);
 
         if (!empty($labels)) {

--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -1016,40 +1016,15 @@ class ElementHelper
      */
     public static function swapInProvisionalDrafts(array &$elements): void
     {
-        $user = self::$provisionalDraftUser ?? Craft::$app->getUser()->getIdentity();
-        if (!$user) {
-            return;
-        }
-
-        // filter out drafts and revisions
-        // (don't just exclude derivative elements though! see https://github.com/craftcms/cms/issues/16626)
-        $canonicalElements = array_filter(
-            $elements,
-            fn(ElementInterface $element) => !$element->getIsDraft() && !$element->getIsRevision(),
-        );
-
-        if (empty($canonicalElements)) {
-            return;
-        }
-
-        $first = reset($canonicalElements);
-
         /** @var T[] $drafts */
-        $drafts = $first::find()
-            ->draftOf($canonicalElements)
-            ->draftCreator($user)
-            ->provisionalDrafts()
-            ->siteId($first->siteId)
-            ->status(null)
-            ->indexBy('canonicalId')
-            ->all();
+        $drafts = self::provisionalDrafts($elements);
 
         if (empty($drafts)) {
             return;
         }
 
         // array_filter() preserves keys, so it's safe to loop through it rather than $elements here
-        foreach ($canonicalElements as $i => $element) {
+        foreach ($elements as $i => $element) {
             if (isset($drafts[$element->id])) {
                 $draft = $drafts[$element->id];
                 $draft->setCanonical($element);
@@ -1071,6 +1046,72 @@ class ElementHelper
                 $elements[$i] = $draft;
             }
         }
+    }
+
+    /**
+     * Swaps out any canonical elements with provisional drafts, when they exist.
+     *
+     * @template T of ElementInterface
+     * @param T[] $elements
+     * @since 5.9.0
+     */
+    public static function loadProvisionalChanges(array $elements): void
+    {
+        $drafts = self::provisionalDrafts($elements);
+
+        if (empty($drafts)) {
+            return;
+        }
+
+        // array_filter() preserves keys, so it's safe to loop through it rather than $elements here
+        foreach ($elements as $element) {
+            if (isset($drafts[$element->id])) {
+                $draft = $drafts[$element->id];
+                $element->hasProvisionalChanges = true;
+
+                foreach ($draft->getModifiedAttributes() as $name) {
+                    $element->$name = $draft->$name;
+                }
+
+                foreach ($draft->getModifiedFields() as $handle) {
+                    $element->setFieldValue($handle, $draft->getFieldValue($handle));
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ElementInterface[] $elements
+     * @return ElementInterface[]
+     */
+    private static function provisionalDrafts(array $elements): array
+    {
+        $user = self::$provisionalDraftUser ?? Craft::$app->getUser()->getIdentity();
+        if (!$user) {
+            return [];
+        }
+
+        // filter out drafts and revisions
+        // (don't just exclude derivative elements though! see https://github.com/craftcms/cms/issues/16626)
+        $canonicalElements = array_filter(
+            $elements,
+            fn(ElementInterface $element) => !$element->getIsDraft() && !$element->getIsRevision(),
+        );
+
+        if (empty($canonicalElements)) {
+            return [];
+        }
+
+        $first = reset($canonicalElements);
+
+        return $first::find()
+            ->draftOf($canonicalElements)
+            ->draftCreator($user)
+            ->provisionalDrafts()
+            ->siteId($first->siteId)
+            ->status(null)
+            ->indexBy('canonicalId')
+            ->all();
     }
 
     /**


### PR DESCRIPTION
### Description

When loading elements to be displayed in the control panel, previously elements would be replaced with their provisional drafts, if any existed for the current user.

With this change, any changed attributes/fields on the provisional drafts will get copied over to the canonical elements, without actually replacing the canonical elements in the array of elements to be shown.

The benefit is that any attributes/fields which haven’t changed in the provisional draft will still show their latest values within element indexes, relational fields, etc.

### Related issues

- #17892