### PR TITLE
allow for the field layout to be passed to the registerCardAttributes event

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -34,6 +34,7 @@
 - Added `Craft.BaseElementIndex::ensureSourceAttributeInfo()`.
 - Added `craft\base\ElementTrait::$hasProvisionalChanges`. ([#17915](https://github.com/craftcms/cms/pull/17915))
 - Added `craft\elements\conditions\HintableConditionRuleTrait`. ([#17909](https://github.com/craftcms/cms/pull/17909))
+- Added `craft\events\RegisterElementCardAttributesEvent::$fieldLayout`. ([#17920](https://github.com/craftcms/cms/pull/17920))
 - Added `craft\fields\BaseRelationField::VIEW_MODE_CARDS_GRID`.
 - Added `craft\fields\BaseRelationField::VIEW_MODE_CARDS`.
 - Added `craft\fields\BaseRelationField::VIEW_MODE_LIST_INLINE`.
@@ -44,6 +45,7 @@
 - Added `craft\web\GqlResponseFormatter`.
 - Added `craft\web\Response::FORMAT_GQL`.
 - Added `craft\web\twig\nodes\BaseNode`.
+- `craft\base\ElementInterface::cardAttributes()` now has a `$fieldLayout` argument. ([#17920](https://github.com/craftcms/cms/pull/17920))
 - `craft\helpers\FileHelper::writeToFile()` now throws an exception if the file path isn’t writable, or there isn’t sufficient free space on the disk. ([#17762](https://github.com/craftcms/cms/pull/17762))
 - `craft\helpers\UrlHelper` now encodes square brackets in generated URLs. ([#17840](https://github.com/craftcms/cms/pull/17840))
 - `craft\web\Request::accepts()` now accepts wildcard characters (`*`) in the `$contentType` argument, to check for a range of MIME types (e.g. `application/*+json`).

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -1624,13 +1624,13 @@ abstract class Element extends Component implements ElementInterface
     /**
      * @inheritdoc
      */
-    public static function cardAttributes(): array
+    public static function cardAttributes(?FieldLayout $fieldLayout = null): array
     {
         $cardAttributes = static::defineCardAttributes();
 
         // Fire a 'registerCardAttributes' event
         if (Event::hasHandlers(static::class, self::EVENT_REGISTER_CARD_ATTRIBUTES)) {
-            $event = new RegisterElementCardAttributesEvent(['cardAttributes' => $cardAttributes]);
+            $event = new RegisterElementCardAttributesEvent(['cardAttributes' => $cardAttributes, 'fieldLayout' => $fieldLayout]);
             Event::trigger(static::class, self::EVENT_REGISTER_CARD_ATTRIBUTES, $event);
             return $event->cardAttributes;
         }

--- a/src/base/ElementInterface.php
+++ b/src/base/ElementInterface.php
@@ -547,10 +547,13 @@ interface ElementInterface extends
      * This method should return an array whose keys represent element attribute names, and whose values make
      * up the table’s column headers.
      *
+     * @param FieldLayout|null $fieldLayout
+     * @since 5.9.0
      * @return array The card attributes.
+     *
      * @since 5.5.0
      */
-    public static function cardAttributes(): array;
+    public static function cardAttributes(?FieldLayout $fieldLayout = null): array;
 
     /**
      * Returns the list of card attribute keys that should be shown by default, if the field layout hasn't been customised.

--- a/src/events/RegisterElementCardAttributesEvent.php
+++ b/src/events/RegisterElementCardAttributesEvent.php
@@ -7,6 +7,7 @@
 
 namespace craft\events;
 
+use craft\models\FieldLayout;
 use yii\base\Event;
 
 /**
@@ -21,4 +22,10 @@ class RegisterElementCardAttributesEvent extends Event
      * @var array List of registered card attributes for the element type.
      */
     public array $cardAttributes = [];
+
+    /**
+     * @var FieldLayout|null The field layout associated with the card designer
+     * @since 5.9.0
+     */
+    public ?FieldLayout $fieldLayout = null;
 }

--- a/src/helpers/Cp.php
+++ b/src/helpers/Cp.php
@@ -2749,7 +2749,7 @@ JS, [
             'disabled' => false,
         ];
 
-        $allOptions = $fieldLayout->type::cardAttributes();
+        $allOptions = $fieldLayout->type::cardAttributes($fieldLayout);
 
         foreach ($fieldLayout->getAllElements() as $layoutElement) {
             if ($layoutElement instanceof BaseField && $layoutElement->previewable()) {

--- a/src/models/FieldLayout.php
+++ b/src/models/FieldLayout.php
@@ -1047,7 +1047,7 @@ class FieldLayout extends Model
 
         // filter only the selected attributes
         $attributes = array_filter(
-            $this->type::cardAttributes(),
+            $this->type::cardAttributes($this),
             fn($cardAttribute, $key) => in_array($key, $cardViewValues),
             ARRAY_FILTER_USE_BOTH
         );


### PR DESCRIPTION
### Description
The `Element::EVENT_REGISTER_CARD_ATTRIBUTES` event allows you to adjust what card attributes are available in the card view designer. However, if you want to, e.g. add a new attribute, there’s currently no way to limit that addition to e.g. a specific entry type or to a field layout that contains a specific field.

This PR adds the ability to pass the `FieldLayout` to the `RegisterElementCardAttributesEvent`, giving you greater control over when card attributes should be adjusted.


### Related issues
n/a; from a conversation with @tommysvr 
