### PR TITLE
Fix src path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
 const {getConfigs} = require('@craftcms/webpack');
 
-module.exports = getConfigs();
+module.exports = getConfigs(
+  'yii2-adapter/legacy/web/assets/*/webpack.config.js'
+);

--- a/yii2-adapter/legacy/web/assets/cp/src/css/_login.scss
+++ b/yii2-adapter/legacy/web/assets/cp/src/css/_login.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-@use '../../../../../../node_modules/@craftcms/sass/mixins';
+@use '@craftcms/sass/mixins';
 
 .login-alt-menu {
   z-index: 1001;


### PR DESCRIPTION
I noticed after #17898 that partial builds (like `npm run build -- --config-name=cp`) were broken. This fixes those up. 