### PR TITLE
[6.x] Remove phpstan from lint staged

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,12 +1,8 @@
 {
   "yii2-adapter/**/*.php": [
-    "./yii2-adapter/vendor/bin/ecs check --config ./yii2-adapter/ecs.php --ansi --fix",
-    "./yii2-adapter/vendor/bin/phpstan analyse --memory-limit=1G --configuration=./yii2-adapter/phpstan.neon"
+    "./yii2-adapter/vendor/bin/ecs check --config ./yii2-adapter/ecs.php --ansi --fix"
   ],
-  "!(yii2-adapter)/**/*.php": [
-    "./vendor/bin/pint --parallel",
-    "./vendor/bin/phpstan analyse --memory-limit=1G"
-  ],
+  "!(yii2-adapter)/**/*.php": ["./vendor/bin/pint --parallel"],
   "*.scss": ["stylelint --fix --allow-empty-input"],
   "*.{html,json,css,scss}": "prettier --ignore-unknown --write"
 }


### PR DESCRIPTION
### Description

PHPStan [should always be ran on the whole project](https://phpstan.org/blog/why-you-should-always-analyse-whole-project) and running it only on staged files causes unexpected errors.