### PR TITLE
Added event to change meta fields of entries

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -44,6 +44,7 @@ use craft\elements\db\EntryQuery;
 use craft\enums\CmsEdition;
 use craft\enums\Color;
 use craft\enums\PropagationMethod;
+use craft\events\DefineEntryMetaFields;
 use craft\events\DefineEntryTypesEvent;
 use craft\events\ElementCriteriaEvent;
 use craft\fieldlayoutelements\entries\EntryTitleField;
@@ -116,6 +117,13 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
      * @since 4.4.0
      */
     public const EVENT_DEFINE_PARENT_SELECTION_CRITERIA = 'defineParentSelectionCriteria';
+
+    /**
+     * @event DefineEntryMetaFields The event that is triggered when defining the meta fields.
+     * @see metaFieldsHtml()
+     * @since 5.8.18
+     */
+    public const EVENT_DEFINE_META_FIELDS = 'defineEntryMetaFields';
 
     /**
      * @inheritdoc
@@ -2566,6 +2574,18 @@ JS, [
         }
 
         $fields[] = parent::metaFieldsHtml($static);
+
+         // Fire a 'defineEntryMetaFields' event
+        if ($this->hasEventHandlers(self::EVENT_DEFINE_META_FIELDS)) {
+            $event = new DefineEntryMetaFields([
+                'entry' => $this,
+                'static' => $static,
+                'fields' => $fields
+            ]);
+            $this->trigger(self::EVENT_DEFINE_META_FIELDS, $event);
+            
+            return implode("\n", $event->fields);
+        }
 
         return implode("\n", $fields);
     }

--- a/src/events/DefineEntryMetaFields.php
+++ b/src/events/DefineEntryMetaFields.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+
+use craft\elements\Entry;
+use craft\base\Event;
+
+/**
+ * class DefineEntryMetaFields
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.8.18
+ */
+
+class DefineEntryMetaFields extends Event
+{
+    /**
+     * @var Entry The current entry
+     */
+    public Entry $entry;
+
+    /**
+     * @var bool Whether the fields should be static (non-interactive)
+     */
+    public bool $static;
+
+    /**
+     * @var array array of all meta fields
+     */
+    public array $fields;
+}


### PR DESCRIPTION
### Description
Added an event to change the meta fields 

ex: to add postDate and expiryDate to the entries with the handle `hero` and `text`.

```php
use yii\base\Event;
use craft\elements\Entry;
use craft\events\DefineEntryMetaFields;
use craft\helpers\Cp;

Event::on(
    Entry::class,
    Entry::EVENT_DEFINE_META_FIELDS,
    function (DefineEntryMetaFields $event) {


        if (in_array($event->entry->type->handle, ['hero','text'] )) {
            // Post Date
            $event->fields[] = Cp::dateTimeFieldHtml([
                'status' => $event->entry->getAttributeStatus('postDate'),
                'label' => Craft::t('app', 'Post Date'),
                'id' => 'postDate',
                'name' => 'postDate',
                'value' => $event->entry->postDate,
                'errors' => $event->entry->getErrors('postDate'),
                'disabled' => $event->static,
            ]);

            // Expiry Date
            $event->fields[] = Cp::dateTimeFieldHtml([
                'status' => $event->entry->getAttributeStatus('expiryDate'),
                'label' => Craft::t('app', 'Expiry Date'),
                'id' => 'expiryDate',
                'name' => 'expiryDate',
                'value' => $event->entry->expiryDate,
                'errors' => $event->entry->getErrors('expiryDate'),
                'disabled' => $event->static,
            ]);
        }
    }
);

```

### Related issues
[[5.x]: Backend - meta fields postDate and expiryDate not visible for entries without section.](https://github.com/craftcms/cms/discussions/17642)
