### PR TITLE
Docs: Cache commands help text

### DIFF
--- a/src/console/controllers/ClearCachesController.php
+++ b/src/console/controllers/ClearCachesController.php
@@ -77,8 +77,15 @@ class ClearCachesController extends Controller
         $actions = parent::defineActions();
 
         foreach (ClearCaches::cacheOptions() as $option) {
+            $summary = $option['label'];
+
+            // When available, supplement with the tooltip text:
+            if (isset($option['info'])) {
+                $summary = sprintf('%s (%s)', $summary, $option['info']);
+            }
+
             $actions[$option['key']] = [
-                'helpSummary' => $option['label'],
+                'helpSummary' => $summary,
                 'action' => [
                     'class' => ClearCacheAction::class,
                     'action' => $option['action'],

--- a/src/utilities/ClearCaches.php
+++ b/src/utilities/ClearCaches.php
@@ -126,7 +126,7 @@ class ClearCaches extends Utility
             [
                 'key' => 'data',
                 'label' => Craft::t('app', 'Data caches'),
-                'info' => Craft::t('app', 'Anything cached with `Craft::$app->cache->set()`'),
+                'info' => Craft::t('app', 'Anything cached with `Craft::$app->getCache()->set()`'),
                 'action' => [Craft::$app->getCache(), 'flush'],
             ],
             [
@@ -152,7 +152,7 @@ class ClearCaches extends Utility
                 'key' => 'compiled-templates',
                 'label' => Craft::t('app', 'Compiled templates'),
                 'info' => Craft::t('app', 'Contents of {path}', [
-                    'path' => '`storage/runtime/compiled_templates/`',
+                    'path' => sprintf('`%s/`', FileHelper::relativePath($pathService->getCompiledTemplatesPath(false), Craft::getAlias('@root'))),
                 ]),
                 'action' => $pathService->getCompiledTemplatesPath(false),
             ],
@@ -160,7 +160,7 @@ class ClearCaches extends Utility
                 'key' => 'compiled-classes',
                 'label' => Craft::t('app', 'Compiled classes'),
                 'info' => Craft::t('app', 'Contents of {path}', [
-                    'path' => '`storage/runtime/compiled_classes/`',
+                    'path' => sprintf('`%s/`', FileHelper::relativePath($pathService->getCompiledClassesPath(false), Craft::getAlias('@root'))),
                 ]),
                 'action' => $pathService->getCompiledClassesPath(false),
             ],
@@ -168,7 +168,7 @@ class ClearCaches extends Utility
                 'key' => 'cp-resources',
                 'label' => Craft::t('app', 'Control panel resources'),
                 'info' => Craft::t('app', 'Contents of {path}', [
-                    'path' => '`web/cpresources/`',
+                    'path' => sprintf('`%s/`', Craft::$app->getConfig()->getGeneral()->resourceBasePath),
                 ]),
                 'action' => function() {
                     $basePath = Craft::$app->getConfig()->getGeneral()->resourceBasePath;
@@ -198,7 +198,7 @@ class ClearCaches extends Utility
                 'key' => 'temp-files',
                 'label' => Craft::t('app', 'Temp files'),
                 'info' => Craft::t('app', 'Contents of {path}', [
-                    'path' => '`storage/runtime/temp/`',
+                    'path' => sprintf('`%s/`', FileHelper::relativePath($pathService->getTempPath(), Craft::getAlias('@root'))),
                 ]),
                 'action' => $pathService->getTempPath(),
             ],


### PR DESCRIPTION
Two primary changes, here:

1. Command help is now assembled from the action label _and_ the `info` key (which we also use for popups in the control panel).
2. The cache paths displayed in those help messages now respect an overriden `CRAFT_STORAGE_PATH`, including when that directory is outside the project root.

The remaining outlier here is the `resourceBasePath`, which begins with an alias, by default. I've just echoed it out, directly, rather than evaluating the alias and localizing the path. 🤷