### PR TITLE
various settings bugs (mostly integers and ignore trashed)

### DIFF
--- a/src/Entry/Data/EntryType.php
+++ b/src/Entry/Data/EntryType.php
@@ -63,7 +63,7 @@ final class EntryType extends Dto implements Actionable, Chippable, Colorable, C
     ) {
         $this->fieldLayoutId = $fieldLayoutId;
         $this->showSlugField = (bool) $showSlugField;
-        $this->showStatusField = (bool) $showSlugField;
+        $this->showStatusField = (bool) $showStatusField;
 
         if ($this->titleFormat === '') {
             $this->titleFormat = null;

--- a/src/Entry/Data/EntryType.php
+++ b/src/Entry/Data/EntryType.php
@@ -235,7 +235,7 @@ JS, [
         ];
 
         if ($validateHandleUniqueness) {
-            $rules['handle'][] = Rule::unique(Table::ENTRYTYPES, 'handle')->ignore($context->payload['entryTypeId'] ?? null);
+            $rules['handle'][] = Rule::unique(Table::ENTRYTYPES, 'handle')->ignore($context->payload['entryTypeId'] ?? null)->withoutTrashed('dateDeleted');
         }
 
         return $rules;

--- a/src/Entry/Data/EntryType.php
+++ b/src/Entry/Data/EntryType.php
@@ -52,10 +52,14 @@ final class EntryType extends Dto implements Actionable, Chippable, Colorable, C
         public TranslationMethod $titleTranslationMethod = TranslationMethod::Site,
         public ?string $titleTranslationKeyFormat = null,
         public ?string $titleFormat = null,
-        public bool $showSlugField = true,
+        public ?bool $showSlugField = true {
+            get => (bool) $this->showSlugField;
+        },
         public TranslationMethod $slugTranslationMethod = TranslationMethod::Site,
         public ?string $slugTranslationKeyFormat = null,
-        public bool $showStatusField = true,
+        public ?bool $showStatusField = true {
+            get => (bool) $this->showStatusField;
+        },
         public ?string $uid = null,
         public bool $validateHandleUniqueness = true,
         public ?string $group = null,

--- a/src/Entry/Data/EntryType.php
+++ b/src/Entry/Data/EntryType.php
@@ -52,20 +52,18 @@ final class EntryType extends Dto implements Actionable, Chippable, Colorable, C
         public TranslationMethod $titleTranslationMethod = TranslationMethod::Site,
         public ?string $titleTranslationKeyFormat = null,
         public ?string $titleFormat = null,
-        public ?bool $showSlugField = true {
-            get => (bool) $this->showSlugField;
-        },
+        public ?bool $showSlugField = true,
         public TranslationMethod $slugTranslationMethod = TranslationMethod::Site,
         public ?string $slugTranslationKeyFormat = null,
-        public ?bool $showStatusField = true {
-            get => (bool) $this->showStatusField;
-        },
+        public ?bool $showStatusField = true,
         public ?string $uid = null,
         public bool $validateHandleUniqueness = true,
         public ?string $group = null,
         public ?self $original = null,
     ) {
         $this->fieldLayoutId = $fieldLayoutId;
+        $this->showSlugField = (bool) $showSlugField;
+        $this->showStatusField = (bool) $showSlugField;
 
         if ($this->titleFormat === '') {
             $this->titleFormat = null;

--- a/src/Http/Controllers/FieldsController.php
+++ b/src/Http/Controllers/FieldsController.php
@@ -384,6 +384,7 @@ JS, [
         $fieldId = $request->input('fieldId');
 
         if ($fieldId) {
+            $fieldId = (int) $fieldId;
             $oldField = clone $this->fieldsService->getFieldById($fieldId);
             abort_unless((bool) $oldField, 400, 'Invalid field ID: '.$fieldId);
             $fieldUid = $oldField->uid;

--- a/src/Http/Controllers/Settings/EntryTypesController.php
+++ b/src/Http/Controllers/Settings/EntryTypesController.php
@@ -216,14 +216,13 @@ final class EntryTypesController
     {
         $entryTypeId = $request->input('entryTypeId');
 
-        abort_if(is_null($entryTypeId), 404, "Invalid entry type ID: $entryTypeId");
+        if ($entryTypeId) {
+            $entryTypeId = (int) $entryTypeId;
+            abort_if(is_null($found = $this->entryTypes->getEntryTypeById($entryTypeId)), 400, "Invalid entry type ID: $entryType");
 
-        $entryTypeId = (int) $entryTypeId;
-
-        abort_if(is_null($found = $this->entryTypes->getEntryTypeById($entryTypeId)), 400, "Invalid entry type ID: $entryType");
-
-        $entryType->uid = $found->uid;
-        $entryType->id = $entryTypeId;
+            $entryType->uid = $found->uid;
+            $entryType->id = $entryTypeId;
+        }
 
         $saveAsNew = false;
         $originalEntryType = null;

--- a/src/Http/Controllers/Settings/EntryTypesController.php
+++ b/src/Http/Controllers/Settings/EntryTypesController.php
@@ -91,7 +91,7 @@ final class EntryTypesController
 
         abort_if(is_null($entryTypeId), 404, "Invalid entry type ID: $entryTypeId");
 
-        $entryTypeId = (int)$entryTypeId;
+        $entryTypeId = (int) $entryTypeId;
 
         $entryType = $this->entryTypes->getEntryTypeById($entryTypeId);
 
@@ -218,7 +218,7 @@ final class EntryTypesController
 
         abort_if(is_null($entryTypeId), 404, "Invalid entry type ID: $entryTypeId");
 
-        $entryTypeId = (int)$entryTypeId;
+        $entryTypeId = (int) $entryTypeId;
 
         abort_if(is_null($found = $this->entryTypes->getEntryTypeById($entryTypeId)), 400, "Invalid entry type ID: $entryType");
 

--- a/src/Http/Controllers/Settings/EntryTypesController.php
+++ b/src/Http/Controllers/Settings/EntryTypesController.php
@@ -89,6 +89,10 @@ final class EntryTypesController
     {
         $entryTypeId ??= $request->input('entryTypeId');
 
+        abort_if(is_null($entryTypeId), 404, "Invalid entry type ID: $entryTypeId");
+
+        $entryTypeId = (int)$entryTypeId;
+
         $entryType = $this->entryTypes->getEntryTypeById($entryTypeId);
 
         abort_if(is_null($entryType), 404, 'Entry type not found');
@@ -212,11 +216,13 @@ final class EntryTypesController
     {
         $entryTypeId = $request->input('entryTypeId');
 
-        if ($entryTypeId) {
-            abort_if(is_null($found = $this->entryTypes->getEntryTypeById($entryTypeId)), 400, "Invalid entry type ID: $entryType");
-            $entryType->uid = $found->uid;
-        }
+        abort_if(is_null($entryTypeId), 404, "Invalid entry type ID: $entryTypeId");
 
+        $entryTypeId = (int)$entryTypeId;
+
+        abort_if(is_null($found = $this->entryTypes->getEntryTypeById($entryTypeId)), 400, "Invalid entry type ID: $entryType");
+
+        $entryType->uid = $found->uid;
         $entryType->id = $entryTypeId;
 
         $saveAsNew = false;

--- a/src/Http/Controllers/Settings/EntryTypesController.php
+++ b/src/Http/Controllers/Settings/EntryTypesController.php
@@ -89,7 +89,9 @@ final class EntryTypesController
     {
         $entryTypeId ??= $request->input('entryTypeId');
 
-        abort_if(is_null($entryTypeId), 404, "Invalid entry type ID: $entryTypeId");
+        if ($entryTypeId === null) {
+            return $this->create();
+        }
 
         $entryTypeId = (int) $entryTypeId;
 

--- a/src/Http/Controllers/Settings/SectionsController.php
+++ b/src/Http/Controllers/Settings/SectionsController.php
@@ -78,7 +78,7 @@ final readonly class SectionsController
 
         abort_if(is_null($sectionId), 404, "Invalid section ID: $sectionId");
 
-        $sectionId = (int)$sectionId;
+        $sectionId = (int) $sectionId;
 
         \Craft::$app->getView()->registerAssetBundle(EditSectionAsset::class);
 
@@ -129,7 +129,7 @@ final readonly class SectionsController
 
         abort_if(is_null($sectionId), 404, "Invalid section ID: $sectionId");
 
-        $sectionId = (int)$sectionId;
+        $sectionId = (int) $sectionId;
 
         abort_if(is_null($sections->getSectionById($sectionId)), 404, "Invalid section ID: $sectionId");
 

--- a/src/Http/Controllers/Settings/SectionsController.php
+++ b/src/Http/Controllers/Settings/SectionsController.php
@@ -127,13 +127,13 @@ final readonly class SectionsController
     ): Response {
         $sectionId = $request->input('sectionId');
 
-        abort_if(is_null($sectionId), 404, "Invalid section ID: $sectionId");
+        if ($sectionId) {
+            $sectionId = (int) $sectionId;
+            abort_if(is_null($sections->getSectionById($sectionId)), 404, "Invalid section ID: $sectionId");
 
-        $sectionId = (int) $sectionId;
+            $section->id = $sectionId;
+        }
 
-        abort_if(is_null($sections->getSectionById($sectionId)), 404, "Invalid section ID: $sectionId");
-
-        $section->id = $sectionId;
         $section->setEntryTypes($request->array('entryTypes'));
 
         // Site-specific settings

--- a/src/Http/Controllers/Settings/SectionsController.php
+++ b/src/Http/Controllers/Settings/SectionsController.php
@@ -76,6 +76,10 @@ final readonly class SectionsController
     {
         $sectionId ??= $request->input('sectionId');
 
+        abort_if(is_null($sectionId), 404, "Invalid section ID: $sectionId");
+
+        $sectionId = (int)$sectionId;
+
         \Craft::$app->getView()->registerAssetBundle(EditSectionAsset::class);
 
         $section = $sections->getSectionById($sectionId);
@@ -123,9 +127,11 @@ final readonly class SectionsController
     ): Response {
         $sectionId = $request->input('sectionId');
 
-        if ($sectionId) {
-            abort_if(is_null($sections->getSectionById($sectionId)), 404, "Invalid section ID: $sectionId");
-        }
+        abort_if(is_null($sectionId), 404, "Invalid section ID: $sectionId");
+
+        $sectionId = (int)$sectionId;
+
+        abort_if(is_null($sections->getSectionById($sectionId)), 404, "Invalid section ID: $sectionId");
 
         $section->id = $sectionId;
         $section->setEntryTypes($request->array('entryTypes'));

--- a/src/Http/Controllers/Settings/SitesController.php
+++ b/src/Http/Controllers/Settings/SitesController.php
@@ -148,7 +148,10 @@ final readonly class SitesController
             'group' => ['required', 'integer', Rule::exists(Table::SITEGROUPS, 'id')],
         ]);
 
-        $siteData->id = $request->input('siteId');
+        $siteId = $request->input('siteId');
+        if ($siteId) {
+            $siteData->id = (int) $siteId;
+        }
 
         if (! $this->sites->saveSite($siteData)) {
             return $this->asModelFailure($siteData, t('Couldn’t save the site.'));
@@ -178,7 +181,7 @@ final readonly class SitesController
         ]);
 
         $this->sites->deleteSiteById(
-            siteId: $data['id'],
+            siteId: (int) $data['id'],
             transferContentTo: $data['transferContentTo'] ?? null,
         );
 

--- a/src/Section/Commands/CreateCommand.php
+++ b/src/Section/Commands/CreateCommand.php
@@ -139,7 +139,7 @@ final class CreateCommand extends Command
                         'string',
                         'max:255',
                         new HandleRule(['id', 'dateCreated', 'dateUpdated', 'uid', 'title']),
-                        Rule::unique(Table::ENTRYTYPES, 'handle'),
+                        Rule::unique(Table::ENTRYTYPES, 'handle')->withoutTrashed('dateDeleted'),
                     ]],
                 ),
                 name: 'entryTypeHandle'

--- a/src/Section/Commands/CreateCommand.php
+++ b/src/Section/Commands/CreateCommand.php
@@ -99,7 +99,6 @@ final class CreateCommand extends Command
             ->confirm(
                 label: 'Enable entry versioning for the section?',
                 default: ! $this->option('noVersioning'),
-                required: true,
                 name: 'enableVersioning',
             )
             ->addIf(empty($entryTypes) && $allEntryTypes->isNotEmpty(), fn () => confirm(

--- a/src/Section/Data/Section.php
+++ b/src/Section/Data/Section.php
@@ -93,7 +93,7 @@ final class Section extends Dto implements Chippable, CpEditable, Iconic, String
                 'string',
                 'max:255',
                 new HandleRule(['id', 'dateCreated', 'dateUpdated', 'uid', 'title']),
-                Rule::unique(Table::SECTIONS)->ignore($context->payload['sectionId'] ?? null),
+                Rule::unique(Table::SECTIONS)->ignore($context->payload['sectionId'] ?? null)->withoutTrashed('dateDeleted'),
             ],
             'entryTypes' => ['required'],
             'type' => ['required', Rule::enum(SectionType::class)],

--- a/src/Section/Data/Section.php
+++ b/src/Section/Data/Section.php
@@ -45,7 +45,7 @@ final class Section extends Dto implements Chippable, CpEditable, Iconic, String
         public ?SectionType $type = null,
         public ?int $maxAuthors = 1,
         public ?int $maxLevels = null,
-        public bool $enableVersioning = true,
+        public ?bool $enableVersioning = true,
         public PropagationMethod $propagationMethod = PropagationMethod::All,
         public DefaultPlacement $defaultPlacement = DefaultPlacement::End,
         public ?array $previewTargets = null,
@@ -62,6 +62,7 @@ final class Section extends Dto implements Chippable, CpEditable, Iconic, String
                 'urlFormat' => '{url}',
             ],
         ];
+        $this->enableVersioning = (bool) $enableVersioning;
     }
 
     /**

--- a/src/Site/Data/Site.php
+++ b/src/Site/Data/Site.php
@@ -71,12 +71,12 @@ final class Site extends Dto implements Chippable, Stringable
                 'required',
                 'string',
                 new HandleRule(['id', 'dateCreated', 'dateUpdated', 'uid', 'title']),
-                Info::isInstalled() ? new Unique(Table::SITES, 'handle')->ignore($context?->payload['id'] ?? null) : null,
+                Info::isInstalled() ? new Unique(Table::SITES, 'handle')->ignore($context?->payload['id'] ?? null)->withoutTrashed('dateDeleted') : null,
             ]),
             'name' => array_filter([
                 'required',
                 'string',
-                Info::isInstalled() ? new Unique(Table::SITES, 'name')->ignore($context?->payload['id'] ?? null) : null,
+                Info::isInstalled() ? new Unique(Table::SITES, 'name')->ignore($context?->payload['id'] ?? null)->withoutTrashed('dateDeleted') : null,
             ]),
         ];
     }

--- a/src/Site/Data/Site.php
+++ b/src/Site/Data/Site.php
@@ -31,7 +31,20 @@ use function CraftCms\Cms\t;
 
 final class Site extends Dto implements Chippable, Stringable
 {
+    /**
+     * @var string|null Base URL
+     *
+     * @see getBaseUrl()
+     * @see setBaseUrl()
+     */
     private ?string $baseUrl;
+
+    /**
+     * @var bool|string Enabled
+     *
+     * @see getEnabled()
+     * @see setEnabled()
+     */
     private bool|string $enabled;
 
     public function __construct(

--- a/src/Site/Data/Site.php
+++ b/src/Site/Data/Site.php
@@ -31,6 +31,9 @@ use function CraftCms\Cms\t;
 
 final class Site extends Dto implements Chippable, Stringable
 {
+    private ?string $baseUrl;
+    private bool|string $enabled;
+
     public function __construct(
         public private(set) string $name,
         #[Rule(new HandleRule(['id', 'dateCreated', 'dateUpdated', 'uid', 'title']))]
@@ -40,19 +43,23 @@ final class Site extends Dto implements Chippable, Stringable
         public ?int $id = null,
         #[MapInputName('group')]
         public ?int $groupId = null,
-        #[Url] private ?string $baseUrl = null,
+        ?string $baseUrl = null,
         public ?bool $primary = false {
             get => (bool) $this->primary;
         },
-        public bool $hasUrls = true,
+        public ?bool $hasUrls = true {
+            get => (bool) $this->hasUrls;
+        },
         public int $sortOrder = 1,
         public ?string $uid = null,
         #[WithCast(DateTimeInterfaceCast::class, format: ['Y-m-d H:i:s'], type: Carbon::class)]
         public ?DateTimeInterface $dateCreated = null,
         #[WithCast(DateTimeInterfaceCast::class, format: ['Y-m-d H:i:s'], type: Carbon::class)]
         public ?DateTimeInterface $dateUpdated = null,
-        private bool|string $enabled = true
+        bool|string $enabled = true,
     ) {
+        $this->setBaseUrl($this->hasUrls ? $baseUrl : null);
+        $this->setEnabled($this->primary ? true : $enabled);
     }
 
     public static function get(int|string $id): ?static

--- a/src/Site/Data/SiteGroup.php
+++ b/src/Site/Data/SiteGroup.php
@@ -27,7 +27,7 @@ final class SiteGroup extends Dto
         public ?string $uid = null,
 
         #[Required]
-        #[Unique(Table::SITEGROUPS, 'name', ignore: new RouteParameterReference('id', nullable: true))]
+        #[Unique(Table::SITEGROUPS, 'name', ignore: new RouteParameterReference('id', nullable: true), withoutTrashed: true, deletedAtColumn: 'dateDeleted')]
         public string $name = '',
     ) {}
 


### PR DESCRIPTION
### Description
1. unique validation (for section and entry type handle, site handle and name, site group name) should ignore soft-deleted sections/entry types
2. the `sections/create` command wasn’t allowing you to select “No” for the `enableVersioning` question
3. in section and entry type controllers, the `edit` and `store` methods should check if the `sectionId` and `entryTypeId` values are `null` and if not, cast those to an integer, as that’s what the `Sections` and `EntryTypes` services accept
4. in the `SitesController`, `store` and `destroy` methods need to cast `siteId` to an integer
5. in the `FieldsController`, the `store` method needs to cast `fieldId` to an integer
6. data objects were ignoring the site’s `baseUrl` and `enabled` private properties; also, the values of those should remain dependent on other values (`baseUrl` on `hasUrls` and `enabled` on `primary`)
7. it was not possible to set entry type’s `showSlugField` and `showStatusField` to `false`
8. it was not possible to create an entry type via slideout from the section’s edit page


### Related issues
n/a
