### PR TITLE
Speed up tests

### DIFF
--- a/tests/unit/helpers/AssetsHelperTest.php
+++ b/tests/unit/helpers/AssetsHelperTest.php
@@ -31,15 +31,6 @@ class AssetsHelperTest extends TestCase
      */
     protected UnitTester $tester;
 
-    public function _fixtures(): array
-    {
-        return [
-            'assets' => [
-                'class' => AssetFixture::class,
-            ],
-        ];
-    }
-
     /**
      * @dataProvider generateUrlDataProvider
      * @param string $expected
@@ -48,6 +39,10 @@ class AssetsHelperTest extends TestCase
      */
     public function testGenerateUrl(string $expected, array $params): void
     {
+        $this->tester->haveFixtures([
+            'assets' => AssetFixture::class,
+        ]);
+
         $assetQuery = Asset::find();
 
         foreach ($params as $key => $value) {

--- a/tests/unit/helpers/ElementHelperTest.php
+++ b/tests/unit/helpers/ElementHelperTest.php
@@ -30,15 +30,6 @@ class ElementHelperTest extends TestCase
      */
     protected UnitTester $tester;
 
-    public function _fixtures(): array
-    {
-        return [
-            'entries' => [
-                'class' => EntryFixture::class,
-            ],
-        ];
-    }
-
     /**
      * @dataProvider generateSlugDataProvider
      * @param string $expected
@@ -96,6 +87,12 @@ class ElementHelperTest extends TestCase
      */
     public function testSetUniqueUri(array $expected, array $config): void
     {
+        $this->tester->haveFixtures([
+            'entries' => [
+                'class' => EntryFixture::class,
+            ],
+        ]);
+
         $example = new ExampleElement($config);
         ElementHelper::setUniqueUri($example);
 

--- a/tests/unit/web/twig/ExtensionTest.php
+++ b/tests/unit/web/twig/ExtensionTest.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Collection;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
+use UnitTester;
 use yii\base\ErrorException;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
@@ -46,14 +47,10 @@ class ExtensionTest extends TestCase
      */
     protected View $view;
 
-    public function _fixtures(): array
-    {
-        return [
-            'globals' => [
-                'class' => GlobalSetFixture::class,
-            ],
-        ];
-    }
+    /**
+     * @var UnitTester
+     */
+    protected UnitTester $tester;
 
     /**
      * @throws LoaderError
@@ -141,6 +138,12 @@ class ExtensionTest extends TestCase
      */
     public function testElementGlobals(): void
     {
+        $this->tester->haveFixtures([
+            'globals' => [
+                'class' => GlobalSetFixture::class,
+            ],
+        ]);
+
         $this->testRenderResult(
             'A global set | A different global set',
             '{{ aGlobalSet }} | {{ aDifferentGlobalSet }}'
@@ -1002,6 +1005,12 @@ class ExtensionTest extends TestCase
 
     public function testFieldValueSqlFunction(): void
     {
+        $this->tester->haveFixtures([
+            'globals' => [
+                'class' => GlobalSetFixture::class,
+            ],
+        ]);
+
         $entryType = Craft::$app->getEntries()->getEntryTypeByHandle('test1');
         $field = $entryType->getFieldLayout()->getFieldByHandle('plainTextField');
         $valueSql = $field->getValueSql();


### PR DESCRIPTION
Backport of the 6.x branch. These tests were loading the full fixtures for every test method, while only one or two actually needed the fixtures.
