### PR TITLE
add default db creds to the example env file

### DIFF
--- a/packages/craftcms-playwright/README.md
+++ b/packages/craftcms-playwright/README.md
@@ -30,7 +30,7 @@ All commands should be run from the cms repo’s location
 ## Notes
 
 - it uses the same fixtures mechanism as our Codeception tests (`*Fixture.php` files from `<cms repo directory>/tests/fixtures` are copied over to the ddev env and have their namespace adjusted)
-- it uses ddev with MySQL 8 as a default, but can be switched to PostgreSQL by editing `<cms repo directory>/tests-playwright/ddev-config/config.local.yaml` file
+- it uses ddev with MySQL 8 as a default, but can be switched to PostgreSQL by editing `<cms repo directory>/tests-playwright/ddev-config/config.local.yaml` file; remember to also check your `<cms repo directory>/tests-playwright/.env` file; 
 - tests are located here: `<cms repo directory>/tests-playwright/tests`
 
 > [!TIP]

--- a/tests-playwright/.env.example
+++ b/tests-playwright/.env.example
@@ -12,3 +12,12 @@ REPO_PATH=../../../.
 CODECEPTION_FIXTURES_NAMESPACE='crafttests\fixtures'
 # the location of the *Fixture.php files relative to the root of your repo
 CODECEPTION_FIXTURES_PATH=tests/fixtures
+
+CRAFT_DB_DRIVER="mysql"
+CRAFT_DB_SERVER="db"
+CRAFT_DB_PORT="3306"
+CRAFT_DB_DATABASE="db"
+CRAFT_DB_USER="db"
+CRAFT_DB_PASSWORD="db"
+CRAFT_DB_SCHEMA="public"
+CRAFT_DB_TABLE_PREFIX=""


### PR DESCRIPTION
### Description
This PR adds the default database credentials to the `.env.example` file.

@gcamacho079 recently encountered an issue where the default db credentials were, all of a sudden, not auto-magically added to her `<cms_repo>/packages/craftcms-playwright/.ddev/.env.web` file. 
Adding the defaults to the example `.env` file seems like a good idea. That way, it’s easier to know how you can control those values for the playwright environment.


### Related issues
n/a
