### PR TITLE
update the docblock for the before and after save user photo events

### DIFF
--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -168,13 +168,13 @@ class Users extends Component
     public const EVENT_AFTER_ASSIGN_USER_TO_DEFAULT_GROUP = 'afterAssignUserToDefaultGroup';
 
     /**
-     * @event UserSavePhotoEvent The event that is triggered before a user photo is saved.
+     * @event UserPhotoEvent The event that is triggered before a user photo is saved.
      * @since 4.4.0
      */
     public const EVENT_BEFORE_SAVE_USER_PHOTO = 'beforeSaveUserPhoto';
 
     /**
-     * @event UserSavePhotoEvent The event that is triggered after a user photo is saved.
+     * @event UserPhotoEvent The event that is triggered after a user photo is saved.
      * @since 4.4.0
      */
     public const EVENT_AFTER_SAVE_USER_PHOTO = 'afterSaveUserPhoto';


### PR DESCRIPTION
### Description
Updates the docblock for the before and after save user photo events.


### Related issues
#18030 
