### PR TITLE
Move .lp-draghandle to DOM root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where the Live Preview drag bar wasn’t easily draggable when a nested slideout was open. ([#17781](https://github.com/craftcms/cms/issues/17781))
+
 ## 5.8.19 - 2025-10-28
 
 - Icon pickers now return focus to the “Choose” button when the modal is closed without making a selection.

--- a/src/web/assets/cp/src/css/_preview.scss
+++ b/src/web/assets/cp/src/css/_preview.scss
@@ -137,6 +137,7 @@
 }
 
 .lp-draghandle {
+  inset-block-start: 0;
   position: absolute;
   z-index: 101;
   width: 4px;

--- a/src/web/assets/cp/src/css/_preview.scss
+++ b/src/web/assets/cp/src/css/_preview.scss
@@ -126,16 +126,6 @@
     }
   }
 
-  .lp-draghandle {
-    position: absolute;
-    z-index: 101;
-    inset-block-start: 0;
-    inset-inline-end: 0;
-    width: 4px;
-    height: 100%;
-    cursor: col-resize;
-  }
-
   & > footer {
     padding-block: 5px;
     padding-inline: var(--pane-padding, var(--xl));
@@ -144,6 +134,15 @@
     justify-content: end;
     height: 44px;
   }
+}
+
+.lp-draghandle {
+  position: absolute;
+  z-index: 101;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  background: #f00;
 }
 
 .lp-preview-container {

--- a/src/web/assets/cp/src/css/_preview.scss
+++ b/src/web/assets/cp/src/css/_preview.scss
@@ -143,7 +143,6 @@
   width: 4px;
   height: 100%;
   cursor: col-resize;
-  background: #f00;
 }
 
 .lp-preview-container {

--- a/src/web/assets/cp/src/js/Preview.js
+++ b/src/web/assets/cp/src/js/Preview.js
@@ -146,6 +146,7 @@ Craft.Preview = Garnish.Base.extend(
       this.addListener(Garnish.$win, 'resize', 'handleWindowResize');
 
       this.$editorContainer.css(Craft.left, -this.editorWidthInPx + 'px');
+      this.$dragHandle.css(Craft.left, (this.editorWidthInPx - 2) + 'px');
       this.$previewContainer.css(Craft.right, -this.getIframeWidth());
 
       this.slideIn(animate);
@@ -218,7 +219,7 @@ Craft.Preview = Garnish.Base.extend(
       );
 
       this.$dragHandle = $('<div/>', {class: 'lp-draghandle'}).appendTo(
-        this.$editorContainer
+        Garnish.$bod
       );
       $('<div/>', {class: 'flex-grow'}).appendTo(this.$editorHeader);
       this.$spinner = $('<div/>', {
@@ -737,6 +738,7 @@ Craft.Preview = Garnish.Base.extend(
 
     updateWidths: function () {
       this.$editorContainer.css('width', this.editorWidthInPx + 'px');
+      this.$dragHandle.css(Craft.left, (this.editorWidthInPx - 2) + 'px');
       this.$previewContainer.width(this.getIframeWidth());
       if (this._devicePreviewIsActive()) {
         this.updateDevicePreview();


### PR DESCRIPTION
### Description

Moves the `.lp-draghandle` element to the DOM root, so it can avoid z-index conflicts with nested modal shade elements.

### Related issues

- #17781