### PR TITLE
Bugfix/18015 validate allowed extension early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where assets with disallowed file extensions could still be uploaded to the system’s temp directory. ([#18015](https://github.com/craftcms/cms/issues/18015))
+
 ## 4.16.15 - 2025-10-28
 
 - Reverted an element query performance optimization for MySQL 9. ([#16401](https://github.com/craftcms/cms/issues/16401))

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -1291,7 +1291,7 @@ class AssetsController extends Controller
             throw new UploadFailedException($uploadedFile->error);
         }
 
-        // Make sure the new filename has a valid extension
+        // Make sure the file extension is allowed
         $allowedExtensions = Craft::$app->getConfig()->getGeneral()->allowedFileExtensions;
         $extension = strtolower(pathinfo($uploadedFile->name, PATHINFO_EXTENSION));
 

--- a/src/controllers/AssetsController.php
+++ b/src/controllers/AssetsController.php
@@ -15,6 +15,7 @@ use craft\db\Query;
 use craft\db\Table;
 use craft\elements\Asset;
 use craft\elements\conditions\ElementCondition;
+use craft\errors\AssetDisallowedExtensionException;
 use craft\errors\AssetException;
 use craft\errors\DeprecationException;
 use craft\errors\ElementNotFoundException;
@@ -1288,6 +1289,14 @@ class AssetsController extends Controller
     {
         if ($uploadedFile->getHasError()) {
             throw new UploadFailedException($uploadedFile->error);
+        }
+
+        // Make sure the new filename has a valid extension
+        $allowedExtensions = Craft::$app->getConfig()->getGeneral()->allowedFileExtensions;
+        $extension = strtolower(pathinfo($uploadedFile->name, PATHINFO_EXTENSION));
+
+        if (is_array($allowedExtensions) && !in_array($extension, $allowedExtensions, true)) {
+            throw new AssetDisallowedExtensionException(Craft::t('app', "“{$extension}” is not an allowed file extension."));
         }
 
         // Move the uploaded file to the temp folder


### PR DESCRIPTION
### Description
We’re currently only validating allowed extensions on `Elements->saveElement()` in the `src/validators/AssetLocationValidator.php`, which happens after the file has been moved to `storage/runtime/temp`. 

This PR ensures the extension is validated against a list of the allowed ones before the file gets moved to `storage/runtime/temp`.


### Related issues
#18015 
