### PR TITLE
[6.x] Add `cms` to path

### DIFF
--- a/yii2-adapter/bootstrap/bootstrap.php
+++ b/yii2-adapter/bootstrap/bootstrap.php
@@ -102,6 +102,7 @@ Craft::setAlias('@translations', Env::get('CRAFT_TRANSLATIONS_PATH', $app->langP
 Craft::setAlias('@tests', Env::get('CRAFT_TESTS_PATH', $app->basePath('tests')));
 Craft::setAlias('@assetBundles', Arr::join([
     dirname(__DIR__, 2),
+    'cms',
     'resources',
     'build',
     'legacy',


### PR DESCRIPTION
I think this _really_ fixes the asset issue. 

Previously, I had symlinks on my local DDEV that didn't match the folder structure you end up with when installing from Composer. 

From Composer, because `cms` and `yii2-adapter` are separate packages, you'll end up with them side by side:

```
vendor/craftcms/cms
vendor/craftcms/yii2-adapter
```

but locally because the yii2-adapter is in the main repo and I just symlinked the main folder, my folder structure ended up as:

```
vendor/craftcms/craft6
vendor/craftcms/craft6/yii2-adapter
```

Rather than add some logic into the application, I've adjusted my symlinks locally to match the Composer structure which required this change. 

I'm not sure what this means for Herd (cc @riasvdv) but for DDEV you'll have to adjust your `docker-compose.local.yaml` to something more like:

```yaml
services:
  web:
    volumes:
      - ~/path/to/craft6:/tmp/packages/cms
      - ~/path/to/craft6/yii2-adapter:/tmp/packages/yii2-adapter
```