### PR TITLE
selectize, multi select and items not being removed when the field is not fully in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where remove buttons within multi-select Selectize inputs weren’t working if the input wasn’t focusend and fully in view. ([#18079](https://github.com/craftcms/cms/issues/18079))
+
 ## 4.16.16 - 2025-11-18
 
 - Fixed a bug where assets with disallowed file extensions could still be uploaded to the system’s temp directory. ([#18015](https://github.com/craftcms/cms/issues/18015))

--- a/src/templates/_includes/forms/selectize.twig
+++ b/src/templates/_includes/forms/selectize.twig
@@ -194,6 +194,9 @@
         },
         onChange: onChange,
         onInitialize: function () {
+            {% if multi %}
+                this.$control.off('mousedown');
+            {% endif %}
             // Copy all ARIA attributes from initial select to selectize
             [...$select[0].attributes]
                 .filter(attr => /^aria-/.test(attr.name))

--- a/src/templates/_includes/forms/selectize.twig
+++ b/src/templates/_includes/forms/selectize.twig
@@ -194,9 +194,12 @@
         },
         onChange: onChange,
         onInitialize: function () {
+            // this is needed so that you can delete selected item when the field is not fully in viewport
+            // see https://github.com/craftcms/cms/issues/18079 for details
             {% if multi %}
-                this.$control.off('mousedown');
+                this.isFocused = true;
             {% endif %}
+
             // Copy all ARIA attributes from initial select to selectize
             [...$select[0].attributes]
                 .filter(attr => /^aria-/.test(attr.name))


### PR DESCRIPTION
### Description
If you have a multi-select field (selectize) with at least a few options selected, that field is positioned so that at least the last row of selected options is below the viewport and the field is not focused, if you try to delete one of the options (you even click precisely in the middle of the “x” icon), the option won’t get deleted. If you still have multiple unselected options, one of them might be added instead of the deletion you wanted. If you first focus on the field, this issue won’t occur.

It’s easiest to test with the example from OP:
1. create a discount in Commerce, in the Conditions tab, under “Match Shipping Address”, create a “Country is one of” rule, add at least 2 rows of options to it and save
2. edit the discount again, go to that rule, and make a note of the last option in that field 
3. resize the browser window so that the last row of selected options is not visible
4. try to delete an option from the first row
5. the page will jump, the selectize dropdown will show, and the option you just tried to delete won’t be deleted
6. the last option in the field will now be different to the one you made a note of in step 2

It’s also possible to reproduce it in core by creating a multi-select field with enough options to fill at least 2 rows, adding it to an entry type used by a section, going to the entries index page and adding a filter condition “<your multi-select field> is one of” and then following steps 3-4 from the Commerce example above. Step 6 is only reproducible if you have multiple unselected options left in the field.

And, it’s also possible to reproduce this issue on Selectize’s Remove Button [demo page](https://selectize.dev/docs/plugins/remove-button).

The cause:
It looks to be caused by the `focus()` being triggered twice. [Once](https://github.com/selectize/selectize.js/blob/master/src/selectize.js#L436) from the `onMouseDown` handler and then from [the call](https://github.com/selectize/selectize.js/blob/master/src/selectize.js#L436) to the `open()` method (which also calls `focus()`). 

The fix:
When initialising selectize in a multi-select mode, set `isFocused` to `true` so that the `focus()` method is only called once.


### Related issues
#18079 
