### PR TITLE
multi-instance relation fields; empty/notempty querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where remove buttons within multi-select Selectize inputs weren’t working if the input wasn’t focusend and fully in view. ([#18079](https://github.com/craftcms/cms/issues/18079))
 - Fixed a bug where font icons weren’t hidden from screen readers. ([#18078](https://github.com/craftcms/cms/pull/18078))
+- Fixed a bug where relation fields weren’t handling `:empty:`/`:notempty:` element query params properly if the field had multiple instances within a field layout. ([#18092](https://github.com/craftcms/cms/pull/18092))
 
 ## 5.8.20 - 2025-11-18
 

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -34,6 +34,7 @@ use craft\elements\ElementCollection;
 use craft\errors\SiteNotFoundException;
 use craft\events\CancelableEvent;
 use craft\events\ElementCriteriaEvent;
+use craft\fieldlayoutelements\BaseField;
 use craft\fieldlayoutelements\CustomField;
 use craft\fields\conditions\RelationalFieldConditionRule;
 use craft\helpers\ArrayHelper;
@@ -140,8 +141,34 @@ abstract class BaseRelationField extends Field implements
         $conditions = [];
 
         if (isset($value[0]) && in_array($value[0], [':notempty:', ':empty:', 'not :empty:'])) {
-            $emptyCondition = array_shift($value);
-            if (in_array($emptyCondition, [':notempty:', 'not :empty:'])) {
+            $emptyParam = array_shift($value);
+
+            if (self::isQueryConditionFieldMultiInstance($instances)) {
+                // look at the JSON values rather than the `relations` table data
+                // (see https://github.com/craftcms/cms/issues/17290 + https://github.com/craftcms/cms/pull/18092)
+                if (in_array($emptyParam, [':notempty:', 'not :empty:'])) {
+                    $emptyCondition = ['or'];
+                    foreach ($instances as $instance) {
+                        $valueSql = $instance->getValueSql();
+                        $emptyCondition[] = [
+                            'and',
+                            ['not', [$valueSql => null]],
+                            ['not', [$valueSql => '[]']],
+                        ];
+                    }
+                } else {
+                    $emptyCondition = ['and'];
+                    foreach ($instances as $instance) {
+                        $valueSql = $instance->getValueSql();
+                        $emptyCondition[] = [
+                            'or',
+                            [$valueSql => null],
+                            [$valueSql => '[]'],
+                        ];
+                    }
+                }
+                $conditions[] = $emptyCondition;
+            } elseif (in_array($emptyParam, [':notempty:', 'not :empty:'])) {
                 $conditions[] = static::existsQueryCondition($field);
             } else {
                 $conditions[] = ['not', static::existsQueryCondition($field)];
@@ -172,6 +199,27 @@ abstract class BaseRelationField extends Field implements
     }
 
     /**
+     * @param self[] $instances
+     * @return bool
+     */
+    private static function isQueryConditionFieldMultiInstance(array $instances): bool
+    {
+        foreach ($instances as $instance) {
+            // See if this instance is used multiple times within its field layout
+            $allInstances = $instance->layoutElement?->getLayout()->getFields(fn(BaseField $field) => (
+                $field instanceof CustomField &&
+                $field->getFieldUid() === $instance->uid
+            ));
+
+            if ($allInstances && count($allInstances) > 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Returns a query builder-compatible condition for an element query,
      * limiting the results to only elements where the given relation field has a value.
      *
@@ -184,11 +232,6 @@ abstract class BaseRelationField extends Field implements
     public static function existsQueryCondition(self $field, bool $enabledOnly = true, bool $inTargetSiteOnly = true): array
     {
         $ns = sprintf('%s_%s', $field->handle, StringHelper::randomString(5));
-        $instanceQuery = [
-            'or',
-            [$field->getValueSql() => null],
-            ['not', [$field->getValueSql() => '[]']],
-        ];
 
         $query = (new Query())
             ->from(["relations_$ns" => DbTable::RELATIONS])
@@ -198,10 +241,8 @@ abstract class BaseRelationField extends Field implements
                 'and',
                 "[[relations_$ns.sourceId]] = [[elements.id]]",
                 [
-                    'and',
-                    ["relations_$ns.fieldId" => $field->id],
-                    $instanceQuery,
-                    ["elements_$ns.dateDeleted" => null],
+                    "relations_$ns.fieldId" => $field->id,
+                    "elements_$ns.dateDeleted" => null,
                 ],
                 [
                     'or',

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -184,6 +184,11 @@ abstract class BaseRelationField extends Field implements
     public static function existsQueryCondition(self $field, bool $enabledOnly = true, bool $inTargetSiteOnly = true): array
     {
         $ns = sprintf('%s_%s', $field->handle, StringHelper::randomString(5));
+        $instanceQuery = [
+            'and',
+            ['not', [$field->getValueSql() => null]],
+            ['not', [$field->getValueSql() => '[]']],
+        ];
 
         $query = (new Query())
             ->from(["relations_$ns" => DbTable::RELATIONS])
@@ -195,11 +200,7 @@ abstract class BaseRelationField extends Field implements
                 [
                     'and',
                     ["relations_$ns.fieldId" => $field->id],
-                    [
-                        'and',
-                        ['not', [$field->getValueSql() => null]],
-                        ['not', [$field->getValueSql() => '[]']],
-                    ],
+                    $instanceQuery,
                     ["elements_$ns.dateDeleted" => null],
                 ],
                 [

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -185,8 +185,8 @@ abstract class BaseRelationField extends Field implements
     {
         $ns = sprintf('%s_%s', $field->handle, StringHelper::randomString(5));
         $instanceQuery = [
-            'and',
-            ['not', [$field->getValueSql() => null]],
+            'or',
+            [$field->getValueSql() => null],
             ['not', [$field->getValueSql() => '[]']],
         ];
 

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -193,8 +193,14 @@ abstract class BaseRelationField extends Field implements
                 'and',
                 "[[relations_$ns.sourceId]] = [[elements.id]]",
                 [
-                    "relations_$ns.fieldId" => $field->id,
-                    "elements_$ns.dateDeleted" => null,
+                    'and',
+                    ["relations_$ns.fieldId" => $field->id],
+                    [
+                        'and',
+                        ['not', [$field->getValueSql() => null]],
+                        ['not', [$field->getValueSql() => '[]']],
+                    ],
+                    ["elements_$ns.dateDeleted" => null],
                 ],
                 [
                     'or',


### PR DESCRIPTION
### Description
When querying a multi-instance relation field with an `:empty:`/`:notempty:` value, the query results don’t limit the results to only the instance used in the query. The exists condition only takes into consideration the field ID, not the field instance UID.

**Steps to reproduce:**
- clean 5.8.20 installation
- create a local filesystem, a volume that uses it and an Assets field (handle `assets`)
- create a section with an entry type that pulls in the above Assets field twice (`assets` and `assets2`)
- in that section, create five entries; entries 1, 2 and 4 should have a value in the `assets` field; entry 3 should have a value in the `assets2` field
- create a template with the following code in it:
```
{% set results = craft.entries().section('<sectionHandle>').assets2(':empty:').all() %}
    {% if results|length == 0 %}
        <p>no matches</p>
    {% else %}
        {% for result in results %}
            <p>{{ result.title }}</p>
        {% endfor %}
    {% endif %}
```
- the result will be only entry 5, but it should be entries 1, 2, 4 and 5
- for `:notempty:`, the results will be entries 1, 2, 3, 4, but it should be entry 3
- if you switch to querying the `assets` field, the results will also be wrong



### Related issues
n/a, reported by @tommysvr
