### PR TITLE
multi-instance relation fields; empty/notempty querying - part2

### DIFF
--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -142,9 +142,9 @@ abstract class BaseRelationField extends Field implements
         if (isset($value[0]) && in_array($value[0], [':notempty:', ':empty:', 'not :empty:'])) {
             $emptyCondition = array_shift($value);
             if (in_array($emptyCondition, [':notempty:', 'not :empty:'])) {
-                $conditions[] = static::existsQueryCondition($field);
+                $conditions[] = static::existsQueryCondition($field, instances: $instances);
             } else {
-                $conditions[] = ['not', static::existsQueryCondition($field)];
+                $conditions[] = ['not', static::existsQueryCondition($field, instances: $instances)];
             }
         }
 
@@ -181,9 +181,27 @@ abstract class BaseRelationField extends Field implements
      * @return array
      * @since 5.2.0
      */
-    public static function existsQueryCondition(self $field, bool $enabledOnly = true, bool $inTargetSiteOnly = true): array
+    public static function existsQueryCondition(self $field, bool $enabledOnly = true, bool $inTargetSiteOnly = true, array $instances = []): array
     {
         $ns = sprintf('%s_%s', $field->handle, StringHelper::randomString(5));
+
+        if (count($instances) > 1) {
+            $instanceQuery = [];
+            foreach ($instances as $instance) {
+                $instanceQuery[] = [
+                    'and',
+                    ['not', [$instance->getValueSql() => null]],
+                    ['not', [$instance->getValueSql() => '[]']],
+                ];
+            }
+            array_unshift($instanceQuery, 'or');
+        } else {
+            $instanceQuery = [
+                'and',
+                ['not', [$field->getValueSql() => null]],
+                ['not', [$field->getValueSql() => '[]']],
+            ];
+        }
 
         $query = (new Query())
             ->from(["relations_$ns" => DbTable::RELATIONS])
@@ -193,8 +211,10 @@ abstract class BaseRelationField extends Field implements
                 'and',
                 "[[relations_$ns.sourceId]] = [[elements.id]]",
                 [
-                    "relations_$ns.fieldId" => $field->id,
-                    "elements_$ns.dateDeleted" => null,
+                    'and',
+                    ["relations_$ns.fieldId" => $field->id],
+                    $instanceQuery,
+                    ["elements_$ns.dateDeleted" => null],
                 ],
                 [
                     'or',


### PR DESCRIPTION
### Description
Follow-up to #18092. It requires a signature change in the `BaseRelationField::existsQueryCondition()` method, hence targeting 5.9.

PR #18092 resolves an issue with querying an instance of the same field in a single field layout. 
This PR takes that further and improves querying an instance of the same field (with the same handle) across multiple field layouts.

Steps to reproduce:
- follow the steps from #18092, but add a second entry type to the section; the entry type should pull in the `assets` field (don’t override the handle)
- add an entry using this second entry type and fill out the field
- query `assets` field for `:empty:`
    - on `5.x` branch, only entry 5 is returned
    - on `bugfix/multi-instance-relation-field-empty-notempty-querying` branch, entries 3, 5, 6 are returned
    - correct result (result with this PR): entries 3, 5 returned
- now query for `:notempty:`
    - on `5.x` branch, entries 1, 2, 3, 4, 6 are returned
    - on `bugfix/multi-instance-relation-field-empty-notempty-querying` branch, entries 1, 2, 4 are returned
    - correct result (result with this PR): entries 1, 2, 4, 6 returned


### Related issues
n/a
