### PR TITLE
get value of the json expression before casting

### DIFF
--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -898,7 +898,7 @@ JS, [
         // see https://github.com/craftcms/cms/issues/15609
         $db = Craft::$app->getDb();
         if ($db->getIsMysql() && is_string($dbType) && DbHelper::parseColumnType($dbType) === Schema::TYPE_TEXT) {
-            $orderBy = "CAST($orderBy AS CHAR(255))";
+            $orderBy = "CAST({$orderBy->getValue(DB::getQueryGrammar())} AS CHAR(255))";
         }
 
         // The attribute name should match the table attribute name,

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -898,7 +898,7 @@ JS, [
         // see https://github.com/craftcms/cms/issues/15609
         $db = Craft::$app->getDb();
         if ($db->getIsMysql() && is_string($dbType) && DbHelper::parseColumnType($dbType) === Schema::TYPE_TEXT) {
-            $orderBy = "CAST({$orderBy->getValue(DB::getQueryGrammar())} AS CHAR(255))";
+            $orderBy = new Cast($orderBy, 'CHAR(255)');
         }
 
         // The attribute name should match the table attribute name,


### PR DESCRIPTION
### Description
`$orderBy` is a `JsonExtract` expression, which means we can’t use it as is when casting for MySQL.

This was causing an issue where the table on the Entries index page wasn’t loading any data when using MySQL. All worked as expected with PostgreSQL (and still does). 


### Related issues
n/a
