### PR TITLE
don't mess with ownership when resaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where font icons weren’t hidden from screen readers. ([#18078](https://github.com/craftcms/cms/pull/18078))
 - Fixed a bug where relation fields weren’t handling `:empty:`/`:notempty:` element query params properly if the field had multiple instances within a field layout. ([#18092](https://github.com/craftcms/cms/pull/18092))
 - Fixed a bug where user preferences were being respected for users who formerly had access to the control panel.
+- Fixed a bug where nested entries could be reordered when their owner element was resaved programmatically. ([#18121](https://github.com/craftcms/cms/pull/18121))
 
 ## 5.8.20 - 2025-11-18
 

--- a/src/base/NestedElementTrait.php
+++ b/src/base/NestedElementTrait.php
@@ -464,7 +464,7 @@ trait NestedElementTrait
      */
     private function saveOwnership(bool $isNew, string $elementTable, string $fieldIdColumn = 'fieldId'): void
     {
-        if (!$this->saveOwnership || !isset($this->fieldId)) {
+        if (!$this->saveOwnership || !isset($this->fieldId) || $this->resaving) {
             return;
         }
         

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -803,6 +803,7 @@ JS, [
                 if ($saveAll || !$element->id || $element->forceSave) {
                     $element->setOwner($owner);
                     $element->setSortOrder($sortOrder);
+                    $element->resaving = $owner->resaving;
                     $elementsService->saveElement($element, false);
 
                     // If this element's primary owner is $owner, and it’s a draft of another element whose owner is


### PR DESCRIPTION
### Description
Don’t attempt to adjust element ownership when resaving.

The `ResaveElements` job, triggered by the `Entries::handleChangedSection()` method, has the extra criteria (like `provisionalDrafts`) because it fixes this [propagation issue](https://github.com/craftcms/cms/issues/10634).

The issue described under #18109 looks to be caused by [this code](https://github.com/craftcms/cms/blob/5.8.20/src/base/NestedElementTrait.php#L516-L534), which causes the order of the nested entries for the primary owner to be replaced by the order of the nested entries for the owner (e.g. provisional or regular draft).


### Related issues
#18109 
