### PR TITLE
@username@ fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed a bug where remove buttons within multi-select Selectize inputs weren’t working if the input wasn’t focusend and fully in view. ([#18079](https://github.com/craftcms/cms/issues/18079))
 - Fixed an error that could occur when executing a GraphQL mutation when the `lazyGqlTypes` config setting was enabled. ([#18014](https://github.com/craftcms/cms/issues/18014))
-- Fixed a PHP error that could occur when creating a username that began or ended with an `@` when running PHP 8.4+.
+- Fixed a PHP error that could occur when creating a username that began or ended with an `@`. ([#18123](https://github.com/craftcms/cms/pull/18123))
 
 ## 4.16.16 - 2025-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where remove buttons within multi-select Selectize inputs weren’t working if the input wasn’t focusend and fully in view. ([#18079](https://github.com/craftcms/cms/issues/18079))
 - Fixed an error that could occur when executing a GraphQL mutation when the `lazyGqlTypes` config setting was enabled. ([#18014](https://github.com/craftcms/cms/issues/18014))
+- Fixed a PHP error that could occur when creating a username that began or ended with an `@` when running PHP 8.4+.
 
 ## 4.16.16 - 2025-11-18
 

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -1810,10 +1810,10 @@ class StringHelper extends \yii\helpers\StringHelper
 
         // Remove inner-word punctuation
         $handle = preg_replace('/[\'"‘’“”ʻ\[\]\(\)\{\}:]/', '', $handle);
-    
+
         // Make it lowercase
         $handle = static::toLowerCase($handle);
-    
+
         // Convert extended ASCII characters to basic ASCII
         $handle = static::toAscii($handle);
 
@@ -1939,7 +1939,7 @@ class StringHelper extends \yii\helpers\StringHelper
 
         $parts = explode('@', $email, 2);
         foreach ($parts as &$part) {
-            if (($part = idn_to_utf8($part, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46)) === false) {
+            if (!empty($part) && ($part = idn_to_utf8($part, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46)) === false) {
                 return $email;
             }
         }


### PR DESCRIPTION
Fixed a PHP error that could occur when creating a username that began or ended with an `@` when running PHP 8.4+.

Should be merged into 5.x.