### PR TITLE
check if extension is allowed before saving as temp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where remove buttons within multi-select Selectize inputs weren’t working if the input wasn’t focusend and fully in view. ([#18079](https://github.com/craftcms/cms/issues/18079))
 - Fixed an error that could occur when executing a GraphQL mutation when the `lazyGqlTypes` config setting was enabled. ([#18014](https://github.com/craftcms/cms/issues/18014))
 - Fixed a PHP error that could occur when creating a username that began or ended with an `@`. ([#18123](https://github.com/craftcms/cms/pull/18123))
+- Fixed a bug where assets with disallowed file extensions could be stored in the system’s temp directory. ([#18049](https://github.com/craftcms/cms/pull/18049))
 
 ## 4.16.16 - 2025-11-18
 

--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\ElementInterface;
 use craft\db\Table;
 use craft\elements\Asset as AssetElement;
+use craft\errors\AssetDisallowedExtensionException;
 use craft\events\ReplaceAssetEvent;
 use craft\gql\base\ElementMutationResolver;
 use craft\helpers\Assets as AssetsHelper;
@@ -199,6 +200,8 @@ class Asset extends ElementMutationResolver
         $tempPath = null;
         $filename = null;
 
+        $allowedExtensions = Craft::$app->getConfig()->getGeneral()->allowedFileExtensions;
+
         if (!empty($fileInformation['fileData'])) {
             $dataString = $fileInformation['fileData'];
             $fileData = null;
@@ -224,7 +227,11 @@ class Asset extends ElementMutationResolver
                     $filename = 'Upload.' . $extension;
                 } else {
                     $filename = AssetsHelper::prepareAssetName($fileInformation['filename']);
-                    $extension = pathinfo($filename, PATHINFO_EXTENSION);
+                    $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+                }
+
+                if (is_array($allowedExtensions) && !in_array($extension, $allowedExtensions, true)) {
+                    throw new AssetDisallowedExtensionException(Craft::t('app', "“{$extension}” is not an allowed file extension."));
                 }
 
                 $tempPath = AssetsHelper::tempFilePath($extension);
@@ -241,7 +248,10 @@ class Asset extends ElementMutationResolver
                 $filename = AssetsHelper::prepareAssetName($fileInformation['filename']);
             }
 
-            $extension = pathinfo($filename, PATHINFO_EXTENSION);
+            $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+            if (is_array($allowedExtensions) && !in_array($extension, $allowedExtensions, true)) {
+                throw new AssetDisallowedExtensionException(Craft::t('app', "“{$extension}” is not an allowed file extension."));
+            }
 
             // Download the file
             $tempPath = AssetsHelper::tempFilePath($extension);


### PR DESCRIPTION
### Description
Continuation of https://github.com/craftcms/cms/pull/18049.
When uploading an asset via GQL mutation, validate the target file against a list of allowed extensions early, before saving the file in the temp directory.


### Related issues
n/a
