### PR TITLE
Drop the searchindexqueue.elementId FK (Craft 4)

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -10,6 +10,7 @@
 - Added the `uuid()` Twig function.
 
 ### Extensibility
+- Added `craft\services\Search::deleteOrphanedIndexJobs()`.
 - Added `craft\web\GqlResponseFormatter`.
 - Added `craft\web\Response::FORMAT_GQL`.
 - Added `craft\web\twig\nodes\BaseNode`.
@@ -24,3 +25,4 @@
 - Global set queries no longer register cache tags.
 - Updated Twig to 3.19. ([#17603](https://github.com/craftcms/cms/discussions/17603))
 - Fixed a bug where Table fields with the “Static Rows” setting enabled would lose track of which values belonged to which row headings, if the “Default Values” table was reordered. ([#17090](https://github.com/craftcms/cms/issues/17090))
+- Fixed a bug where deadlocks could occur when updating elements’ search indexes. ([#18139](https://github.com/craftcms/cms/pull/18139))

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '4.16.17',
-    'schemaVersion' => '4.15.0.0',
+    'schemaVersion' => '4.17.0.0',
     'minVersionRequired' => '3.7.11',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1077,7 +1077,6 @@ class Install extends Migration
         $this->addForeignKey(null, Table::RELATIONS, ['sourceSiteId'], Table::SITES, ['id'], 'CASCADE', 'CASCADE');
         $this->addForeignKey(null, Table::REVISIONS, ['creatorId'], Table::USERS, ['id'], 'SET NULL', null);
         $this->addForeignKey(null, Table::REVISIONS, ['canonicalId'], Table::ELEMENTS, ['id'], 'CASCADE', null);
-        $this->addForeignKey(null, Table::SEARCHINDEXQUEUE, 'elementId', Table::ELEMENTS, 'id', 'CASCADE', null);
         $this->addForeignKey(null, Table::SEARCHINDEXQUEUE_FIELDS, 'jobId', Table::SEARCHINDEXQUEUE, 'id', 'CASCADE', null);
         $this->addForeignKey(null, Table::SECTIONS, ['structureId'], Table::STRUCTURES, ['id'], 'SET NULL', null);
         $this->addForeignKey(null, Table::SECTIONS_SITES, ['siteId'], Table::SITES, ['id'], 'CASCADE', 'CASCADE');

--- a/src/migrations/m251205_190131_drop_searchindexqueue_fk.php
+++ b/src/migrations/m251205_190131_drop_searchindexqueue_fk.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m251205_190131_drop_searchindexqueue_fk migration.
+ */
+class m251205_190131_drop_searchindexqueue_fk extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->dropForeignKeyIfExists(Table::SEARCHINDEXQUEUE, 'elementId');
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->addForeignKey(null, Table::SEARCHINDEXQUEUE, 'elementId', Table::ELEMENTS, 'id', 'CASCADE', null);
+        return true;
+    }
+}

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -156,6 +156,7 @@ class Gc extends Component
 
         $this->_deleteOrphanedDraftsAndRevisions();
         $this->_deleteOrphanedSearchIndexes();
+        $this->_deleteOrphanedSearchIndexJobs();
         $this->_deleteOrphanedRelations();
         $this->_deleteOrphanedStructureElements();
         $this->_deleteOrphanedFkRows();
@@ -494,6 +495,13 @@ class Gc extends Component
     {
         $this->_stdout('    > deleting orphaned search indexes ... ');
         Craft::$app->getSearch()->deleteOrphanedIndexes();
+        $this->_stdout("done\n", Console::FG_GREEN);
+    }
+
+    private function _deleteOrphanedSearchIndexJobs(): void
+    {
+        $this->_stdout('    > deleting orphaned search index jobs ... ');
+        Craft::$app->getSearch()->deleteOrphanedIndexJobs();
         $this->_stdout("done\n", Console::FG_GREEN);
     }
 

--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -297,22 +297,9 @@ class Search extends Component
         }
 
         try {
-            for ($try = 0; $try < 3; $try++) {
-                try {
-                    if (!Db::update(Table::SEARCHINDEXQUEUE, ['reserved' => true], ['id' => $jobId])) {
-                        // another process must be handling the same job
-                        return;
-                    }
-                    break;
-                } catch (DbException $e) {
-                    if (str_contains($e->getPrevious()?->getMessage(), 'deadlock')) {
-                        // A gap lock was probably hit. Try again in one second
-                        // https://github.com/craftcms/cms/issues/17318
-                        sleep(1);
-                    } else {
-                        throw $e;
-                    }
-                }
+            if (!Db::update(Table::SEARCHINDEXQUEUE, ['reserved' => true], ['id' => $jobId])) {
+                // another process must be handling the same job
+                return;
             }
         } finally {
             $mutex->release($lockName);
@@ -594,6 +581,35 @@ DELETE FROM $searchIndexTable s
 WHERE NOT EXISTS (
     SELECT * FROM $elementsTable
     WHERE id = s."elementId"
+)
+SQL;
+        }
+        $db->createCommand($sql)->execute();
+    }
+
+    /**
+     * Deletes any search indexes that belong to elements that don’t exist anymore.
+     *
+     * @since 4.17.0
+     */
+    public function deleteOrphanedIndexJobs(): void
+    {
+        $db = Craft::$app->getDb();
+        $searchIndexQueueTable = Table::SEARCHINDEXQUEUE;
+        $elementsTable = Table::ELEMENTS;
+
+        if ($db->getIsMysql()) {
+            $sql = <<<SQL
+DELETE q.* FROM $searchIndexQueueTable q
+LEFT JOIN $elementsTable e ON e.id = q.elementId
+WHERE e.id IS NULL
+SQL;
+        } else {
+            $sql = <<<SQL
+DELETE FROM $searchIndexQueueTable q
+WHERE NOT EXISTS (
+    SELECT * FROM $elementsTable
+    WHERE id = q."elementId"
 )
 SQL;
         }


### PR DESCRIPTION
### Description

Removes the FK on `searchindexqueue.elementId`, to avoid a deadlock that could occur when an element’s search indexes were being updated at the same time that another request was trying to delete the element.

### Related issues

- #17318