### PR TITLE
[6.x] Use Laravel Gate authorization for permissions

### DIFF
--- a/src/Field/Assets.php
+++ b/src/Field/Assets.php
@@ -36,6 +36,7 @@ use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Html;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 use Override;
 
@@ -694,7 +695,7 @@ final class Assets extends BaseRelationField
                 // (Use restrictedLocationSource here because the actual folder could belong to a temp volume)
                 $volume = $this->_volumeBySourceKey($this->restrictedLocationSource);
 
-                if (! $volume || ! Craft::$app->getUser()->checkPermission("viewAssets:$volume->uid")) {
+                if (! $volume || ! Gate::check("viewAssets:$volume->uid")) {
                     return [];
                 }
             }
@@ -724,11 +725,10 @@ final class Assets extends BaseRelationField
 
         // Now enforce the showUnpermittedVolumes setting
         if (! $this->showUnpermittedVolumes && ! empty($sources)) {
-            $userService = Craft::$app->getUser();
             $volumesService = Craft::$app->getVolumes();
 
             return Collection::make($sources)
-                ->filter(function (string $source) use ($volumesService, $userService) {
+                ->filter(function (string $source) use ($volumesService) {
                     // If it’s not a volume folder, let it through
                     if (! str_starts_with($source, 'volume:')) {
                         return true;
@@ -736,7 +736,7 @@ final class Assets extends BaseRelationField
 
                     // Only show it if they have permission to view it, or if it's the temp volume
                     $volumeUid = explode(':', $source)[1];
-                    if ($userService->checkPermission("viewAssets:$volumeUid")) {
+                    if (Gate::check("viewAssets:$volumeUid")) {
                         return true;
                     }
 
@@ -767,7 +767,7 @@ final class Assets extends BaseRelationField
             $this->allowUploads &&
             $uploadVolume &&
             $uploadFs &&
-            Craft::$app->getUser()->checkPermission("saveAssets:$uploadVolume->uid")
+            Gate::check("saveAssets:$uploadVolume->uid")
         );
         $variables['defaultFieldLayoutId'] = $uploadVolume->fieldLayoutId ?? null;
 

--- a/src/Field/LinkTypes/Asset.php
+++ b/src/Field/LinkTypes/Asset.php
@@ -12,6 +12,7 @@ use craft\helpers\Cp;
 use craft\models\Volume;
 use CraftCms\Cms\Field\Link;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
 
 use function CraftCms\Cms\t;
 
@@ -91,8 +92,7 @@ final class Asset extends BaseElementLinkType
             ->filter(fn (Volume $volume) => $volume->getFs()->hasUrls);
 
         if (! $this->showUnpermittedVolumes) {
-            $userService = Craft::$app->getUser();
-            $volumes = $volumes->filter(fn (Volume $volume) => $userService->checkPermission("viewAssets:$volume->uid"));
+            $volumes = $volumes->filter(fn (Volume $volume) => Gate::check("viewAssets:$volume->uid"));
         }
 
         return $volumes
@@ -126,9 +126,8 @@ final class Asset extends BaseElementLinkType
             $sourceKeys = $this->sources ?? Collection::make($this->availableSources())
                 ->map(fn (array $source) => $source['key'])
                 ->all();
-            $userService = Craft::$app->getUser();
             $config['sources'] = Collection::make($sourceKeys)
-                ->filter(function (string $source) use ($userService) {
+                ->filter(function (string $source) {
                     // If it’s not a volume folder, let it through
                     if (! str_starts_with($source, 'volume:')) {
                         return true;
@@ -136,7 +135,7 @@ final class Asset extends BaseElementLinkType
                     // Only show it if they have permission to view it, or if it's the temp volume
                     $volumeUid = explode(':', $source)[1];
 
-                    return $userService->checkPermission("viewAssets:$volumeUid");
+                    return Gate::check("viewAssets:$volumeUid");
                 })
                 ->all();
         }

--- a/src/Translation/I18N.php
+++ b/src/Translation/I18N.php
@@ -13,6 +13,7 @@ use CraftCms\Cms\Support\Json;
 use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 use ResourceBundle;
 use Stringable;
@@ -254,7 +255,7 @@ final class I18N
             return $this->getSiteLocales();
         }
 
-        return $this->getSiteLocales()->filter(fn (Locale $locale) => Craft::$app->getUser()->checkPermission('editLocale:'.$locale->id));
+        return $this->getSiteLocales()->filter(fn (Locale $locale) => Gate::check('editLocale:'.$locale->id));
     }
 
     /**

--- a/src/User/Models/User.php
+++ b/src/User/Models/User.php
@@ -12,7 +12,6 @@ use CraftCms\Cms\Shared\BaseModel;
 use CraftCms\Cms\Site\Models\Site;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\UserGroups;
-use CraftCms\Cms\Support\Facades\UserPermissions;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\MustVerifyEmail;
 use Illuminate\Auth\Passwords\CanResetPassword;
@@ -82,30 +81,6 @@ class User extends BaseModel implements AuthenticatableContract, AuthorizableCon
                     ->whereColumn(Table::USERS.'.id', Table::ELEMENTS.'.id')
                     ->whereNull(Table::ELEMENTS.'.dateDeleted')
             );
-    }
-
-    /**
-     * Returns whether the user has permission to perform a given action.
-     *
-     * @param  string  $abilities
-     *
-     * @todo Permissions to Laravel Gates
-     */
-    #[Override]
-    public function can($abilities, $arguments = []): bool
-    {
-        if (
-            $this->admin ||
-            Edition::get() === Edition::Solo
-        ) {
-            return true;
-        }
-
-        if (! isset($this->id)) {
-            return false;
-        }
-
-        return UserPermissions::doesUserHavePermission($this->id, $abilities);
     }
 
     public function asElement(): \CraftCms\Cms\User\Elements\User

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -19,10 +19,11 @@ use CraftCms\Cms\User\Models\User;
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Override;
 
 final class UserServiceProvider extends ServiceProvider
 {
-    #[\Override]
+    #[Override]
     public function register(): void
     {
         /**
@@ -45,7 +46,7 @@ final class UserServiceProvider extends ServiceProvider
                 return null;
             }
 
-            if (! (new UserPermissions)->doesUserHavePermission($user->id, $ability)) {
+            if (! app(UserPermissions::class)->doesUserHavePermission($user->id, $ability)) {
                 return null;
             }
 

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -31,7 +31,7 @@ final class UserServiceProvider extends ServiceProvider
          * Laravel's Gate authorization system
          */
         Gate::before(function (Authorizable $user, string $ability) {
-            if (! $user instanceof User) {
+            if (! $user instanceof User && ! $user instanceof \craft\elements\User) {
                 return null;
             }
 

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\User;
 
+use CraftCms\Cms\Edition;
 use CraftCms\Cms\User\Commands\ActivationUrlCommand;
 use CraftCms\Cms\User\Commands\CreateCommand;
 use CraftCms\Cms\User\Commands\DeleteCommand;
@@ -14,10 +15,44 @@ use CraftCms\Cms\User\Commands\PasswordResetUrlCommand;
 use CraftCms\Cms\User\Commands\Remove2faCommand;
 use CraftCms\Cms\User\Commands\SetPasswordCommand;
 use CraftCms\Cms\User\Commands\UnlockCommand;
+use CraftCms\Cms\User\Models\User;
+use Illuminate\Contracts\Auth\Access\Authorizable;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 final class UserServiceProvider extends ServiceProvider
 {
+    #[\Override]
+    public function register(): void
+    {
+        /**
+         * This hooks our permission system into
+         * Laravel's Gate authorization system
+         */
+        Gate::before(function (Authorizable $user, string $ability) {
+            if (! $user instanceof User) {
+                return null;
+            }
+
+            if (
+                $user->admin ||
+                Edition::get() === Edition::Solo
+            ) {
+                return true;
+            }
+
+            if (! isset($user->id)) {
+                return null;
+            }
+
+            if (! (new UserPermissions)->doesUserHavePermission($user->id, $ability)) {
+                return null;
+            }
+
+            return true;
+        });
+    }
+
     public function boot(): void
     {
         $this->commands([

--- a/yii2-adapter/legacy/controllers/AppController.php
+++ b/yii2-adapter/legacy/controllers/AppController.php
@@ -37,6 +37,7 @@ use CraftCms\DependencyAwareCache\Dependency\FileDependency;
 use CraftCms\DependencyAwareCache\Facades\DependencyCache;
 use DateInterval;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Http;
 use InvalidArgumentException;
 use yii\base\InvalidConfigException;
@@ -76,7 +77,7 @@ class AppController extends Controller
                 'class' => UtilityAccess::class,
                 'utility' => UpdatesUtility::class,
                 'only' => ['check-for-updates', 'cache-updates'],
-                'when' => fn() => !Craft::$app->getUser()->checkPermission('performUpdates'),
+                'when' => fn() => !Gate::check('performUpdates'),
             ],
         ]);
     }

--- a/yii2-adapter/legacy/controllers/GlobalsController.php
+++ b/yii2-adapter/legacy/controllers/GlobalsController.php
@@ -15,6 +15,7 @@ use craft\web\Controller;
 use CraftCms\Cms\Field\Fields;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Json;
+use Illuminate\Support\Facades\Gate;
 use yii\web\BadRequestHttpException;
 use yii\web\ForbiddenHttpException;
 use yii\web\NotFoundHttpException;
@@ -161,7 +162,7 @@ class GlobalsController extends Controller
             ->all();
 
         foreach ($globalSets as $thisGlobalSet) {
-            if (Craft::$app->getUser()->checkPermission('editGlobalSet:' . $thisGlobalSet->uid)) {
+            if (Gate::check('editGlobalSet:' . $thisGlobalSet->uid)) {
                 $editableGlobalSets[$thisGlobalSet->handle] = $thisGlobalSet;
             }
         }

--- a/yii2-adapter/legacy/controllers/UsersController.php
+++ b/yii2-adapter/legacy/controllers/UsersController.php
@@ -61,6 +61,7 @@ use CraftCms\Cms\User\Events\AssigningGroupsAndPermissions;
 use CraftCms\Cms\User\Events\DefineEditUserScreens;
 use CraftCms\Cms\User\Events\GroupsAndPermissionsAssigned;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Gate;
 use Throwable;
 use yii\base\Exception;
 use yii\base\InvalidArgumentException;
@@ -522,7 +523,7 @@ class UsersController extends Controller
         $loginName = null;
 
         // If someone's logged in and they're allowed to edit other users, then see if a userId was submitted
-        if (Craft::$app->getUser()->checkPermission('editUsers')) {
+        if (Gate::check('editUsers')) {
             $userId = $this->request->getBodyParam('userId');
 
             if ($userId) {
@@ -1053,10 +1054,9 @@ class UsersController extends Controller
         $response = $this->asEditUserScreen($user, self::SCREEN_ADDRESSES);
 
         $response->contentHtml(function() use ($user) {
-            $canEditUsers = Craft::$app->getUser()->checkPermission('editUsers');
             $config = [
                 'showInGrid' => true,
-                'canCreate' => $canEditUsers,
+                'canCreate' => Gate::check('editUsers'),
             ];
 
             // Use an element index view if there's more than 50 addresses

--- a/yii2-adapter/legacy/elements/Asset.php
+++ b/yii2-adapter/legacy/elements/Asset.php
@@ -79,6 +79,7 @@ use DateTime;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB as DbFacade;
+use Illuminate\Support\Facades\Gate;
 use Throwable;
 use Twig\Markup;
 use yii\base\ErrorHandler;
@@ -503,7 +504,7 @@ class Asset extends Element
             $actions[] = DownloadAssetFile::class;
 
             $userSession = Craft::$app->getUser();
-            if ($isTemp || $userSession->checkPermission("replaceFiles:$volume->uid")) {
+            if ($isTemp || Gate::check("replaceFiles:$volume->uid")) {
                 // Rename/Replace File
                 $actions[] = RenameFile::class;
                 $actions[] = ReplaceFile::class;
@@ -530,7 +531,7 @@ class Asset extends Element
             $actions[] = CopyReferenceTag::class;
 
             // Edit Image
-            if ($isTemp || $userSession->checkPermission("editImages:$volume->uid")) {
+            if ($isTemp || Gate::check("editImages:$volume->uid")) {
                 $actions[] = EditImage::class;
             }
 
@@ -544,7 +545,7 @@ class Asset extends Element
             ];
 
             // Delete
-            if ($userSession->checkPermission("deletePeerAssets:$volume->uid")) {
+            if (Gate::check("deletePeerAssets:$volume->uid")) {
                 $actions[] = DeleteAssets::class;
             }
         }
@@ -998,12 +999,12 @@ class Asset extends Element
         }
 
         $userSession = Craft::$app->getUser();
-        $canUpload = $userSession->checkPermission("saveAssets:$volume->uid");
-        $canMoveTo = $canUpload && $userSession->checkPermission("deleteAssets:$volume->uid");
+        $canUpload = Gate::check("saveAssets:$volume->uid");
+        $canMoveTo = $canUpload && Gate::check("deleteAssets:$volume->uid");
         $canMovePeerFilesTo = (
             $canMoveTo &&
-            $userSession->checkPermission("savePeerAssets:$volume->uid") &&
-            $userSession->checkPermission("deletePeerAssets:$volume->uid")
+            Gate::check("savePeerAssets:$volume->uid") &&
+            Gate::check("deletePeerAssets:$volume->uid")
         );
 
         $sourcePathInfo = $folder->getSourcePathInfo();
@@ -1794,8 +1795,8 @@ JS, [
         // Image editor
         if (
             $this->getSupportsImageEditor() &&
-            $userSession->checkPermission("editImages:$volume->uid") &&
-            ($userSession->getId() == $this->uploaderId || $userSession->checkPermission("editPeerImages:$volume->uid"))
+            Gate::check("editImages:$volume->uid") &&
+            ($userSession->getId() == $this->uploaderId || Gate::check("editPeerImages:$volume->uid"))
         ) {
             $editImageId = sprintf('action-image-edit-%s', mt_rand());
             $items[] = [
@@ -2851,8 +2852,8 @@ JS,[
             $previewable = Craft::$app->getAssets()->getAssetPreviewHandler($this) !== null;
             $editable = (
                 $this->getSupportsImageEditor() &&
-                $userSession->checkPermission("editImages:$volume->uid") &&
-                ($userSession->getId() == $this->uploaderId || $userSession->checkPermission("editPeerImages:$volume->uid"))
+                Gate::check("editImages:$volume->uid") &&
+                ($userSession->getId() == $this->uploaderId || Gate::check("editPeerImages:$volume->uid"))
             );
 
             switch ($this->kind) {
@@ -3409,8 +3410,8 @@ JS;
             $userSession = Craft::$app->getUser();
 
             if (
-                $userSession->checkPermission("savePeerAssets:$volume->uid") &&
-                $userSession->checkPermission("deletePeerAssets:$volume->uid")
+                Gate::check("savePeerAssets:$volume->uid") &&
+                Gate::check("deletePeerAssets:$volume->uid")
             ) {
                 $attributes['data']['movable'] = true;
             }
@@ -3450,13 +3451,13 @@ JS;
         } else {
             $attributes['data']['peer-file'] = true;
             $movable = (
-                $userSession->checkPermission("savePeerAssets:$volume->uid") &&
-                $userSession->checkPermission("deletePeerAssets:$volume->uid")
+                Gate::check("savePeerAssets:$volume->uid") &&
+                Gate::check("deletePeerAssets:$volume->uid")
             );
-            $replaceable = $userSession->checkPermission("replacePeerFiles:$volume->uid");
+            $replaceable = Gate::check("replacePeerFiles:$volume->uid");
             $imageEditable = (
                 $imageEditable &&
-                ($userSession->checkPermission("editPeerImages:$volume->uid"))
+                (Gate::check("editPeerImages:$volume->uid"))
             );
         }
 

--- a/yii2-adapter/legacy/elements/Category.php
+++ b/yii2-adapter/legacy/elements/Category.php
@@ -34,6 +34,7 @@ use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\Support\Str;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
 use function CraftCms\Cms\t;
@@ -202,7 +203,7 @@ class Category extends Element
                 'data' => ['handle' => $group->handle],
                 'criteria' => ['groupId' => $group->id],
                 'structureId' => $group->structureId,
-                'structureEditable' => Craft::$app->getRequest()->getIsConsoleRequest() || Craft::$app->getUser()->checkPermission("viewCategories:$group->uid"),
+                'structureEditable' => app()->runningInConsole() || Gate::check("viewCategories:$group->uid"),
             ];
         }
 

--- a/yii2-adapter/legacy/elements/User.php
+++ b/yii2-adapter/legacy/elements/User.php
@@ -62,6 +62,8 @@ use CraftCms\Cms\User\Models\User as UserModel;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
@@ -101,8 +103,9 @@ use function CraftCms\Cms\t;
  *
  * @since 3.0.0
  */
-class User extends Element implements IdentityInterface
+class User extends Element implements IdentityInterface, AuthorizableContract
 {
+    use Authorizable;
     use NameTrait;
 
     /**
@@ -1822,14 +1825,6 @@ XML;
         }
 
         return Auth::user()?->id === $this->id;
-    }
-
-    /**
-     * Returns whether the user has permission to perform a given action.
-     */
-    public function can(string $permission): bool
-    {
-        return Gate::check($permission);
     }
 
     /**

--- a/yii2-adapter/legacy/elements/User.php
+++ b/yii2-adapter/legacy/elements/User.php
@@ -66,6 +66,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB as DbFacade;
+use Illuminate\Support\Facades\Gate;
 use Throwable;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use yii\base\ErrorHandler;
@@ -406,7 +407,7 @@ class User extends Element implements IdentityInterface
     {
         $actions = [];
 
-        if (Craft::$app->getUser()->checkPermission('moderateUsers')) {
+        if (Gate::check('moderateUsers')) {
             // Suspend
             $actions[] = SuspendUsers::class;
 
@@ -414,7 +415,7 @@ class User extends Element implements IdentityInterface
             $actions[] = UnsuspendUsers::class;
         }
 
-        if (Craft::$app->getUser()->checkPermission('deleteUsers')) {
+        if (Gate::check('deleteUsers')) {
             // Delete
             $actions[] = DeleteUsers::class;
         }
@@ -909,7 +910,7 @@ class User extends Element implements IdentityInterface
     {
         if (
             Edition::get() === Edition::Solo ||
-            !Craft::$app->getUser()->checkPermission('editUsers')
+            !Gate::check('editUsers')
         ) {
             return null;
         }
@@ -1113,11 +1114,11 @@ class User extends Element implements IdentityInterface
 
             if ($this->email !== null) {
                 // are they allowed to set the email?
-                if ($this->getIsCurrent() || $userSession->checkPermission('administrateUsers')) {
+                if ($this->getIsCurrent() || Gate::check('administrateUsers')) {
                     if (
                         Edition::get()->value >= Edition::Pro->value &&
                         app(ProjectConfig::class)->get('users.requireEmailVerification') &&
-                        !$userSession->checkPermission('administrateUsers')
+                        !Gate::check('administrateUsers')
                     ) {
                         // set it as the unverified email instead, and
                         $values['unverifiedEmail'] = Arr::pull($values, 'email');
@@ -1828,18 +1829,7 @@ XML;
      */
     public function can(string $permission): bool
     {
-        if (
-            $this->admin ||
-            Edition::get() === Edition::Solo
-        ) {
-            return true;
-        }
-
-        if (!isset($this->id)) {
-            return false;
-        }
-
-        return Craft::$app->getUserPermissions()->doesUserHavePermission($this->id, $permission);
+        return Gate::check($permission);
     }
 
     /**
@@ -2045,7 +2035,7 @@ XML;
                         }
                     }
 
-                    if (!$isCurrentUser && $userSession->checkPermission('editUsers')) {
+                    if (!$isCurrentUser && Gate::check('editUsers')) {
                         $statusItems[] = [
                             'icon' => 'paperplane',
                             'label' => t('Send password reset email'),

--- a/yii2-adapter/legacy/elements/User.php
+++ b/yii2-adapter/legacy/elements/User.php
@@ -1762,6 +1762,11 @@ XML;
     {
         return Craft::createObject(self::class);
     }
+    
+    public function getKey(): ?int
+    {
+        return $this->id;
+    }
 
     /**
      * {@inheritdoc}

--- a/yii2-adapter/legacy/fieldlayoutelements/users/EmailField.php
+++ b/yii2-adapter/legacy/fieldlayoutelements/users/EmailField.php
@@ -13,6 +13,7 @@ use craft\elements\User;
 use craft\fieldlayoutelements\TextField;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\ProjectConfig\ProjectConfig;
+use Illuminate\Support\Facades\Gate;
 use yii\base\InvalidArgumentException;
 use function CraftCms\Cms\t;
 
@@ -99,7 +100,7 @@ class EmailField extends TextField
             Edition::get()->value >= Edition::Pro->value &&
             app(ProjectConfig::class)->get('users.requireEmailVerification') &&
             !$element->getIsDraft() &&
-            !Craft::$app->getUser()->checkPermission('administrateUsers')
+            !Gate::check('administrateUsers')
         ) {
             return t('New email addresses must be verified before taking effect.');
         }
@@ -120,7 +121,7 @@ class EmailField extends TextField
             if (
                 !$element->getIsCurrent() &&
                 !$element->getIsDraft() &&
-                !Craft::$app->getUser()->checkPermission('administrateUsers')
+                !Gate::check('administrateUsers')
             ) {
                 return null;
             }

--- a/yii2-adapter/legacy/models/VolumeFolder.php
+++ b/yii2-adapter/legacy/models/VolumeFolder.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\FsInterface;
 use craft\base\Model;
 use CraftCms\Cms\Support\Html;
+use Illuminate\Support\Facades\Gate;
 use yii\base\InvalidConfigException;
 use function CraftCms\Cms\t;
 
@@ -146,11 +147,10 @@ class VolumeFolder extends Model
         }
 
         $volume = $this->getVolume();
-        $userSession = Craft::$app->getUser();
-        $canView = $userSession->checkPermission("viewAssets:$volume->uid");
-        $canCreate = $userSession->checkPermission("createFolders:$volume->uid");
-        $canDelete = $userSession->checkPermission("deletePeerAssets:$volume->uid");
-        $canMove = $canDelete && $userSession->checkPermission("savePeerAssets:$volume->uid");
+        $canView = Gate::check("viewAssets:$volume->uid");
+        $canCreate = Gate::check("createFolders:$volume->uid");
+        $canDelete = Gate::check("deletePeerAssets:$volume->uid");
+        $canMove = $canDelete && Gate::check("savePeerAssets:$volume->uid");
 
         $info = [
             'uri' => sprintf('assets/%s%s', $volume->handle, $this->path ? sprintf('/%s', trim($this->path, '/')) : ''),
@@ -172,7 +172,7 @@ class VolumeFolder extends Model
                 'handle' => $volume->handle,
             ];
         } else {
-            $canRename = $canCreate && $userSession->checkPermission("deleteAssets:$volume->uid");
+            $canRename = $canCreate && Gate::check("deleteAssets:$volume->uid");
 
             $info += [
                 'key' => "folder:$this->uid",

--- a/yii2-adapter/legacy/services/Globals.php
+++ b/yii2-adapter/legacy/services/Globals.php
@@ -23,6 +23,7 @@ use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Throwable;
 use yii\base\Component;
 
@@ -149,10 +150,8 @@ class Globals extends Component
         $currentSiteId = Sites::getCurrentSite()->id;
 
         if (!isset($this->_editableGlobalSets[$currentSiteId])) {
-            $session = Craft::$app->getUser();
-
             $this->_editableGlobalSets[$currentSiteId] = Collection::make($this->_allSets($currentSiteId))
-                ->filter(fn(GlobalSet $globalSet) => $session->checkPermission("editGlobalSet:$globalSet->uid"))
+                ->filter(fn(GlobalSet $globalSet) => Gate::check("editGlobalSet:$globalSet->uid"))
                 ->values()
                 ->all();
         }

--- a/yii2-adapter/legacy/services/Volumes.php
+++ b/yii2-adapter/legacy/services/Volumes.php
@@ -27,6 +27,7 @@ use CraftCms\Cms\Support\Str;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Throwable;
 use yii\base\Component;
 use yii\base\InvalidArgumentException;
@@ -126,14 +127,12 @@ class Volumes extends Component
      */
     public function getViewableVolumes(): array
     {
-        if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+        if (app()->runningInConsole()) {
             return $this->getAllVolumes();
         }
 
-        $userSession = Craft::$app->getUser();
-
         return Collection::make($this->getAllVolumes())
-            ->filter(fn(Volume $volume) => $userSession->checkPermission("viewAssets:$volume->uid"))
+            ->filter(fn(Volume $volume) => Gate::check("viewAssets:$volume->uid"))
             ->values()
             ->all();
     }

--- a/yii2-adapter/legacy/web/Application.php
+++ b/yii2-adapter/legacy/web/Application.php
@@ -32,6 +32,7 @@ use CraftCms\Cms\Support\Json;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
 use IntlDateFormatter;
 use IntlException;
 use ReflectionClass;
@@ -50,7 +51,6 @@ use yii\debug\panels\MailPanel;
 use yii\debug\panels\ProfilingPanel;
 use yii\debug\panels\RouterPanel;
 use yii\web\BadRequestHttpException;
-use yii\web\ForbiddenHttpException;
 use yii\web\NotFoundHttpException;
 use yii\web\Response as BaseResponse;
 use yii\web\UnauthorizedHttpException;
@@ -245,9 +245,8 @@ class Application extends \yii\web\Application
                     if ($userSession->getIsGuest()) {
                         return $userSession->loginRequired();
                     }
-                    if (!$userSession->checkPermission('accessPlugin-' . $plugin->handle)) {
-                        throw new ForbiddenHttpException();
-                    }
+
+                    Gate::authorize('accessPlugin-' . $plugin->handle);
                 }
 
                 if (!$userSession->getIsGuest()) {

--- a/yii2-adapter/legacy/web/Controller.php
+++ b/yii2-adapter/legacy/web/Controller.php
@@ -506,7 +506,6 @@ abstract class Controller extends \yii\web\Controller
      * Checks whether the current user has a given permission, and ends the request with a 403 error if they don’t.
      *
      * @param string $permissionName The name of the permission.
-     * @throws ForbiddenHttpException if the current user doesn’t have the required permission
      */
     public function requirePermission(string $permissionName): void
     {

--- a/yii2-adapter/legacy/web/Controller.php
+++ b/yii2-adapter/legacy/web/Controller.php
@@ -16,6 +16,7 @@ use CraftCms\Cms\Cms;
 use CraftCms\Cms\Component\Contracts\Chippable;
 use CraftCms\Cms\Component\Contracts\Identifiable;
 use CraftCms\Cms\ProjectConfig\ProjectConfig;
+use Illuminate\Support\Facades\Gate;
 use yii\base\Action;
 use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
@@ -223,7 +224,7 @@ abstract class Controller extends \yii\web\Controller
             // If the system is offline, make sure they have permission to access the control panel/site
             if (!$isLive) {
                 $permission = $this->request->getIsCpRequest() ? 'accessCpWhenSystemIsOff' : 'accessSiteWhenSystemIsOff';
-                if (!Craft::$app->getUser()->checkPermission($permission)) {
+                if (!Gate::check($permission)) {
                     $error = $this->request->getIsCpRequest()
                         ? t('Your account doesn’t have permission to access the control panel when the system is offline.')
                         : t('Your account doesn’t have permission to access the site when the system is offline.');
@@ -509,9 +510,7 @@ abstract class Controller extends \yii\web\Controller
      */
     public function requirePermission(string $permissionName): void
     {
-        if (!Craft::$app->getUser()->checkPermission($permissionName)) {
-            throw new ForbiddenHttpException('User is not authorized to perform this action.');
-        }
+        Gate::authorize($permissionName);
     }
 
     /**

--- a/yii2-adapter/legacy/web/User.php
+++ b/yii2-adapter/legacy/web/User.php
@@ -17,6 +17,7 @@ use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Support\Config;
 use CraftCms\Cms\Support\Str;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use yii\web\Cookie;
 use yii\web\ForbiddenHttpException;
 use yii\web\IdentityInterface;

--- a/yii2-adapter/legacy/web/User.php
+++ b/yii2-adapter/legacy/web/User.php
@@ -147,7 +147,7 @@ class User extends \CraftCms\Yii2Adapter\Web\User
     public function getDefaultReturnUrl(): string
     {
         // Is this a control panel request and can they access the control panel?
-        if (Craft::$app->getRequest()->getIsCpRequest() && $this->checkPermission('accessCp')) {
+        if (Craft::$app->getRequest()->getIsCpRequest() && Gate::check('accessCp')) {
             return UrlHelper::cpUrl(Cms::config()->getPostCpLoginRedirect());
         }
 
@@ -223,6 +223,8 @@ class User extends \CraftCms\Yii2Adapter\Web\User
      *   </a>
      * {% endif %}
      * ```
+     *
+     * @deprecated 6.0.0 use {@see \Illuminate\Support\Facades\Auth::guest()} instead.
      */
     public function getIsGuest(): bool
     {
@@ -341,6 +343,7 @@ class User extends \CraftCms\Yii2Adapter\Web\User
      *
      * @param string $permissionName The name of the permission.
      * @return bool Whether the current user has the permission.
+     * @deprecated 6.0.0 use {@see Gate::check} instead.
      */
     public function checkPermission(string $permissionName): bool
     {

--- a/yii2-adapter/legacy/web/twig/variables/Cp.php
+++ b/yii2-adapter/legacy/web/twig/variables/Cp.php
@@ -41,6 +41,7 @@ use DateTime;
 use DateTimeZone;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
 use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -274,7 +275,7 @@ class Cp extends Component
 
         if (
             Edition::get() !== Edition::Solo &&
-            Craft::$app->getUser()->checkPermission('viewUsers')
+            Gate::check('viewUsers')
         ) {
             $navItems[] = [
                 'label' => t('Users'),
@@ -289,7 +290,7 @@ class Cp extends Component
         foreach ($plugins as $plugin) {
             if (
                 $plugin->hasCpSection &&
-                Craft::$app->getUser()->checkPermission('accessPlugin-' . $plugin->handle) &&
+                Gate::check('accessPlugin-' . $plugin->handle) &&
                 ($pluginNavItem = $plugin->getCpNavItem()) !== null
             ) {
                 $navItems[] = $pluginNavItem;


### PR DESCRIPTION
This adds the Craft permissions system to Laravel's [Gates](https://laravel.com/docs/12.x/authorization#gates), this allows for checks using the `Gate::` Facade, but also using the Laravel authorization middleware and any other authorization functionality Laravel provides.

If the user passed into the check is not a Craft User object (currently still the model but in a future PR it should be an Element) we return `null` from the check so any other callbacks or authorization checks in the Laravel application can still pick it up.

This PR also replaces all permission checks through the User object to the Gate helper.