### PR TITLE
respect readonly mode for matrix field settings entry type select field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where Matrix fields’ Entry Types settings were partially interactive when admin changes were disallowed. ([#18145](https://github.com/craftcms/cms/pull/18145))
+
 ## 5.8.21 - 2025-12-04
 
 - Improved the performance of saving nested elements on multi-site installs with a custom propagation method. ([#18126](https://github.com/craftcms/cms/issues/18126))

--- a/src/templates/_components/fieldtypes/Matrix/settings.twig
+++ b/src/templates/_components/fieldtypes/Matrix/settings.twig
@@ -4,6 +4,7 @@
   label: 'Entry Types'|t('app'),
   instructions: 'Choose the types of entries that can be created in this field.'|t('app'),
   id: 'entry-types',
+  disabled: readOnly,
 } %}
   {% block input %}
     {% import "_includes/forms" as forms %}
@@ -30,6 +31,7 @@
               id: "entry-type-select-#{random()}",
               values: entryTypes,
               includeGroupInValues: true,
+              disabled: readOnly,
             })) }}
           {% endtag %}
         {% endfor %}


### PR DESCRIPTION
### Description
The read-only mode was not respected by the Entry Types field on the Matrix field settings page.


### Related issues
#18140
