### PR TITLE
order by credentialed users first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where Matrix fields’ Entry Types settings were partially interactive when admin changes were disallowed. ([#18145](https://github.com/craftcms/cms/pull/18145))
+- Fixed a bug where users could be unable to sign in if an inactive user account existed with the same email address. ([#18148](https://github.com/craftcms/cms/issues/18148))
 
 ## 5.8.21 - 2025-12-04
 

--- a/src/services/Users.php
+++ b/src/services/Users.php
@@ -294,6 +294,9 @@ class Users extends Component
                 ]);
         }
 
+        // order by credentialed users first
+        $query->orderBy(['users.active' => SORT_DESC, 'users.pending' => SORT_DESC]);
+
         /** @var User|null */
         return $query->one();
     }


### PR DESCRIPTION
### Description
The `Users::getUserByUsernameOrEmail()` method should prioritise the credentialed users.


### Related issues
#18148 
