### PR TITLE
Fix distribution of characters in `StringHelper::randomString()` when using extended character set

### DIFF
--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -1031,7 +1031,7 @@ class StringHelper extends \yii\helpers\StringHelper
     public static function randomString(int $length = 36, bool $extendedChars = false): string
     {
         if ($extendedChars) {
-            $validChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+[]\{}|;:\'",./<>?"';
+            $validChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+[]\{}|;:\'",./<>?';
         } else {
             $validChars = 'abcdefghijklmnopqrstuvwxyz';
         }


### PR DESCRIPTION
The double straight quote symbol appeared twice in the `$validChars` list, which means it is twice as likely to appear in a string:

```php
# Control:
substr_count(craft\helpers\StringHelper::randomString(100_000, true), 'a') / 100_000;
# → 1/96, over large samples ✔︎

# Test:
substr_count(craft\helpers\StringHelper::randomString(100_000, true), '"') / 100_000;
# → 2/96, over large samples ✘

```

With the fix applied, the probability of all characters is 1/95.

---

Targeting 5.9 due to the introduction of `randomString()` in Twig. I don't know how random distribution corrections are handled in semantic versioning! 😅