### PR TITLE
when element is a revision, query the content block element revisions too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where Matrix fields’ Entry Types settings were partially interactive when admin changes were disallowed. ([#18145](https://github.com/craftcms/cms/pull/18145))
 - Fixed a bug where users could be unable to sign in if an inactive user account existed with the same email address. ([#18148](https://github.com/craftcms/cms/issues/18148))
+- Fixed a bug where Content Block fields could appear to be missing their content when viewing a revision. ([#18149](https://github.com/craftcms/cms/issues/18149))
 
 ## 5.8.21 - 2025-12-04
 

--- a/src/fields/ContentBlock.php
+++ b/src/fields/ContentBlock.php
@@ -497,12 +497,17 @@ class ContentBlock extends Field implements
                 ->all();
 
             if (count($sameSiteElements) > 1) {
-                $contentBlocks = ContentBlockElement::find()
+                $query = ContentBlockElement::find()
                     ->fieldId($this->id)
                     ->ownerId(array_map(fn(ElementInterface $e) => $e->id, $sameSiteElements))
                     ->siteId($element->siteId)
-                    ->indexBy('ownerId')
-                    ->collect();
+                    ->indexBy('ownerId');
+
+                if ($element->getIsRevision()) {
+                    $query->revisions();
+                }
+
+                $contentBlocks = $query->collect();
 
                 foreach ($sameSiteElements as $e) {
                     $contentBlock = $contentBlocks[$e->id] ?? null;

--- a/src/fields/ContentBlock.php
+++ b/src/fields/ContentBlock.php
@@ -497,17 +497,15 @@ class ContentBlock extends Field implements
                 ->all();
 
             if (count($sameSiteElements) > 1) {
-                $query = ContentBlockElement::find()
+                $contentBlocks = ContentBlockElement::find()
                     ->fieldId($this->id)
                     ->ownerId(array_map(fn(ElementInterface $e) => $e->id, $sameSiteElements))
                     ->siteId($element->siteId)
-                    ->indexBy('ownerId');
-
-                if ($element->getIsRevision()) {
-                    $query->revisions();
-                }
-
-                $contentBlocks = $query->collect();
+                    // explicitly fetch revisions if the owner element is a revision
+                    // (see https://github.com/craftcms/cms/pull/18161)
+                    ->revisions($element->getIsRevision())
+                    ->indexBy('ownerId')
+                    ->collect();
 
                 foreach ($sameSiteElements as $e) {
                     $contentBlock = $contentBlocks[$e->id] ?? null;


### PR DESCRIPTION
### Description
If you have a Content Block field that’s inside of a Matrix field in the inline-editable blocks view mode and there are at least two “blocks” in that Matrix field, the Content Block elements are not retrieved correctly.


**Steps to reproduce:**
- clean 5.8.21 install with one site
- create a content block field `myContentBlock` with a plain text field in it `plainText`
- create a matrix field `myMatrix` with entry type `withContentBlock`, add `myContentBlock` field to it; view mode: inline-editable blocks; revisions: can be on or off - same results in both cases
- create a section `mySection` with entry type `myEntryType`, add `myMatrix` field to it (all default settings)
- create an entry in `mySection`, fill out the title, add two blocks to `myMatrix`, fill out the `plainText` field and fully save
- edit the first block, change the `plainText` field value and fully save
- view the first revision from the top - the `plainText` field in both blocks shows as empty


**Fix:** when the element is a revision, query for content block revisions.


### Related issues
#18149 
