### PR TITLE
[5.9] Add EVENT_DEFINE_BASEPATHS

### DIFF
--- a/src/events/DefineBasePathsEvent.php
+++ b/src/events/DefineBasePathsEvent.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+use craft\base\Event;
+
+/**
+ * Define basePaths event class.
+ */
+class DefineBasePathsEvent extends Event
+{
+    /**
+     * @var array The component definitions
+     */
+    public array $basePaths = [];
+}

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\ElementInterface;
 use craft\events\AssetBundleEvent;
 use craft\events\CreateTwigEvent;
+use craft\events\DefineBasePathsEvent;
 use craft\events\RegisterTemplateRootsEvent;
 use craft\events\TemplateEvent;
 use craft\helpers\App;
@@ -107,6 +108,12 @@ class View extends \yii\web\View
      * @since 4.5.0
      */
     public const EVENT_AFTER_REGISTER_ASSET_BUNDLE = 'afterRegisterAssetBundle';
+
+    /**
+     * @event DefineBasepaths The event that is triggered when base paths are defined before resolving templates
+     * @since 5.9.0
+     */
+    public const EVENT_DEFINE_BASEPATHS = 'defineBasePaths';
 
     /**
      * @const TEMPLATE_MODE_CP
@@ -991,6 +998,15 @@ class View extends \yii\web\View
         }
 
         $basePaths[] = $this->_templatesPath;
+
+        if ($this->hasEventHandlers(self::EVENT_DEFINE_BASEPATHS)) {
+            $event = new DefineBasePathsEvent([
+                'basePaths' => $basePaths
+            ]);
+
+            $this->trigger(self::EVENT_DEFINE_BASEPATHS, $event);
+            $basePaths = $event->basePaths;
+        }
 
         foreach ($basePaths as $basePath) {
             if (($path = $this->_resolveTemplate($basePath, $name, $publicOnly)) !== null) {


### PR DESCRIPTION
### Description

This PR adds a new event to the `craft\web\View` class named `EVENT_DEFINE_BASEPATHS`.
The event is triggered right before Craft resolves a template via `_resolveTemplate()`, and exposes the array of base template paths that Craft will search when locating templates.

#### Why this event is needed
Craft currently provides no way for modules or plugins to modify the base template paths that are used during template resolution. All template lookup logic is fixed in `TemplateLoader`, which means:

- You cannot inject additional template roots dynamically
- You cannot reorder lookup priorities
- You cannot introduce theme-based overrides without modifying core behavior
- Template fallback patterns cannot be implemented cleanly

This PR introduces an officially supported extension point that allows developers to define custom template path strategies using a simple event listener.

#### What this enables

With `EVENT_DEFINE_BASEPATHS`, a developer can intercept and modify the list of base paths Craft uses to find templates. This makes it possible to create more flexible, DRY, and maintainable template architectures.

For example, a project may support a theme system where templates should be resolved in the following order:
1. /templates/{theme}/
2. /templates/base/
3. /templates/

Using the event, a listener can detect the current theme (via project config, environment settings, user preferences, etc.) and dynamically inject or reorder basepaths before template resolution takes place.

This enables a “theme override” mechanism similar to what many CMS platforms provide, while preserving full compatibility with Craft’s existing template loader.

#### How it works
The event listener receives an array of basepaths and is free to:
- Add new paths
- Remove unwanted paths
- Reorder paths to change lookup priority

Craft then proceeds to resolve the requested template using the modified basepath list.

This approach gives developers complete control over template resolution strategy, without requiring changes to the loader, Twig environment, or existing Craft configuration.

#### Example use case
```
Event::on(
    View::class,
    View::EVENT_DEFINE_BASEPATHS,
    function (Event $event) {
        $basePaths = [];
        $site = Craft::$app->getSites()->getCurrentSite();
        $globals = \craft\elements\GlobalSet::find()->site($site)->one();
        if ($globals->theme) {
            $basePaths[] = Craft::getAlias('@templates') . DIRECTORY_SEPARATOR . $globals->theme;
        }
        
        $basePaths[] = Craft::getAlias('@templates') . DIRECTORY_SEPARATOR . 'base';
        $event->basePaths = array_merge($basePaths, $event->basePaths);
    }
);
```