### PR TITLE
ensure there's no field layouts with the same uid too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- The `utils/fix-field-layout-uids` command now checks for duplicate top-level field layout UUIDs. ([#18193](https://github.com/craftcms/cms/pull/18193))
 - Fixed a bug where all plugin settings were being saved to the project config, rather than just posted settings. ([craftcms/commerce#4006](https://github.com/craftcms/commerce/issues/4006))
 - Fixed a bug where custom selects could be positioned incorrectly after the window was resized. ([#18179](https://github.com/craftcms/cms/issues/18179))
 


### PR DESCRIPTION
### Description
The `utils/fix-field-layout-uids` command fixes duplicate or missing UUIDs that are found inside of given field layout.

This PR builds on top of that to ensure that all field layouts themselves also have unique UUIDs.

**Background:**
As issue was reported via support, where an upgrade from v4 to v5 caused some content to go missing. 
Digging into it, I found that when entrifying matrix blocks, three blocks were converted to an entry type with wrong fields - fields that belonged to a different block in a different matrix field. When two field layouts have the same UID, a wrong one can be grabbed here: https://github.com/craftcms/cms/blob/5.8.21/src/migrations/m230617_070415_entrify_matrix_blocks.php#L107, leading to the described problem.


### Related issues
n/a; reported by @olivierbon 
