### PR TITLE
Return `null` duration instead of default from stopCollectingCacheInfo

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -691,16 +691,6 @@ class Elements extends Component
             return [null, null];
         }
 
-        // Only use the duration if it's less than the cacheDuration config setting
-        $generalConfig = Craft::$app->getConfig()->getGeneral();
-        if ($generalConfig->cacheDuration) {
-            if ($duration) {
-                $duration = min($duration, $generalConfig->cacheDuration);
-            } else {
-                $duration = $generalConfig->cacheDuration;
-            }
-        }
-
         $dep = new TagDependency([
             'tags' => array_keys($tags),
         ]);

--- a/src/services/TemplateCaches.php
+++ b/src/services/TemplateCaches.php
@@ -156,6 +156,8 @@ class TemplateCaches extends Component
         }
 
         [$dep, $maxDuration] = Craft::$app->getElements()->stopCollectingCacheInfo();
+        $defaultDuration = Craft::$app->getConfig()->getGeneral()->cacheDuration;
+        $maxDuration = min($maxDuration, $defaultDuration);
 
         if ($withResources) {
             $view = Craft::$app->getView();
@@ -174,21 +176,18 @@ class TemplateCaches extends Component
         $saveCache = !StringHelper::contains(stripslashes($body), 'assets/generate-transform');
 
         if ($saveCache) {
-            if (!$dep) {
-                $dep = new TagDependency();
-            }
+            $dep = $dep ?? new TagDependency();
 
             // Always add a `template` tag
             $dep->tags[] = 'template';
 
+            $cacheInfo = [
+                'tags' => $dep->tags,
+            ];
+
             if ($maxDuration) {
                 $expiryDate = DateTimeHelper::now()->modify("+$maxDuration seconds");
-                $cacheInfo = [
-                    'tags' => $dep->tags,
-                    'expiryDate' => DateTimeHelper::toIso8601($expiryDate),
-                ];
-            } else {
-                $cacheInfo = $dep->tags;
+                $cacheInfo['expiryDate'] = DateTimeHelper::toIso8601($expiryDate);
             }
 
             $cacheValue = [$body, $cacheInfo];


### PR DESCRIPTION
### Description
If something calls `stopCollectingCacheInfo`, there is no way to know if the elements had a duration, or if the default duration from config was used.

This moves the application of the default to `\craft\services\TemplateCaches::endTemplateCache`.

## Use-case

Craft Cloud uses `\craft\services\Elements::stopCollectingCacheInfo` to collect tags and expiry for static cache. It has it's own default for static cache (1 year), but because a duration is always returned (even if it is just the default config fallback), there isn't a way to know if it actually came from an element.

## Notes

To avoid this kind of thing, future versions should separate cache duration settings by use-case, e.g. `templateCacheDuration`, instead of sharing one config value.