### PR TITLE
Add SensitiveParameter attributes to Security methods

### DIFF
--- a/src/services/Security.php
+++ b/src/services/Security.php
@@ -67,7 +67,7 @@ class Security extends \yii\base\Security
      * validation fails.
      * @return string The hash.
      */
-    public function hashPassword(string $password, bool $validateHash = false): string
+    public function hashPassword(#[\SensitiveParameter] string $password, bool $validateHash = false): string
     {
         $hash = $this->generatePasswordHash($password, $this->_blowFishHashCost);
 
@@ -93,7 +93,7 @@ class Security extends \yii\base\Security
      * @see hkdf()
      * @see pbkdf2()
      */
-    public function hashData($data, $key = null, $rawHash = false): string
+    public function hashData(#[\SensitiveParameter] $data, #[\SensitiveParameter] $key = null, $rawHash = false): string
     {
         if ($key === null) {
             $key = Craft::$app->getConfig()->getGeneral()->securityKey;
@@ -118,7 +118,7 @@ class Security extends \yii\base\Security
      * @throws InvalidConfigException when HMAC generation fails.
      * @see hashData()
      */
-    public function validateData($data, $key = null, $rawHash = false): string|false
+    public function validateData($data, #[\SensitiveParameter] $key = null, $rawHash = false): string|false
     {
         if ($key === null) {
             $key = Craft::$app->getConfig()->getGeneral()->securityKey;
@@ -138,7 +138,7 @@ class Security extends \yii\base\Security
      * @see decryptByKey()
      * @see encryptByPassword()
      */
-    public function encryptByKey($data, $inputKey = null, $info = null): string
+    public function encryptByKey(#[\SensitiveParameter] $data, #[\SensitiveParameter] $inputKey = null, $info = null): string
     {
         if ($inputKey === null) {
             $inputKey = Craft::$app->getConfig()->getGeneral()->securityKey;
@@ -157,7 +157,7 @@ class Security extends \yii\base\Security
      * @throws Exception on OpenSSL error
      * @see encryptByKey()
      */
-    public function decryptByKey($data, $inputKey = null, $info = null): string|false
+    public function decryptByKey($data, #[\SensitiveParameter] $inputKey = null, $info = null): string|false
     {
         if ($inputKey === null) {
             $inputKey = Craft::$app->getConfig()->getGeneral()->securityKey;
@@ -185,7 +185,7 @@ class Security extends \yii\base\Security
      * @param mixed $value
      * @return mixed The possibly-redacted value
      */
-    public function redactIfSensitive(string $key, mixed $value): mixed
+    public function redactIfSensitive(string $key, #[\SensitiveParameter] mixed $value): mixed
     {
         if (is_array($value)) {
             foreach ($value as $n => &$v) {


### PR DESCRIPTION
### Description

Mark sensitive parameters in password hashing, data encryption, and validation methods with the #[\SensitiveParameter] attribute. This improves security by preventing sensitive data from being exposed in error messages, stack traces, and debugging output.

### Related issues

N/A
