### PR TITLE
Disallow non-Closure arrow functions

### DIFF
--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1240,7 +1240,7 @@ class GeneralConfig extends BaseConfig
      * @group Security
      * @since 4.17.0
      */
-    public bool $enableTwigSandbox = true;
+    public bool $enableTwigSandbox = false;
 
     /**
      * @var string The prefix that should be prepended to HTTP error status codes when determining the path to look for an error’s template.

--- a/src/config/GeneralConfig.php
+++ b/src/config/GeneralConfig.php
@@ -1225,6 +1225,24 @@ class GeneralConfig extends BaseConfig
     public bool $enableTemplateCaching = true;
 
     /**
+     * @var bool Whether all Twig templates should be sandboxed.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->enableTwigSandbox(false)
+     * ```
+     * ```shell Environment Override
+     * CRAFT_ENABLE_TWIG_SANDBOX=false
+     * ```
+     * :::
+     *
+     * @see enableTwigSandbox()
+     * @group Security
+     * @since 4.17.0
+     */
+    public bool $enableTwigSandbox = true;
+
+    /**
      * @var string The prefix that should be prepended to HTTP error status codes when determining the path to look for an error’s template.
      *
      * If set to `'_'` your site’s 404 template would live at `templates/_404.twig`, for example.
@@ -4561,6 +4579,25 @@ class GeneralConfig extends BaseConfig
     public function enableTemplateCaching(bool $value = true): self
     {
         $this->enableTemplateCaching = $value;
+        return $this;
+    }
+
+    /**
+     * Whether all Twig templates should be sandboxed.
+     *
+     * ```php
+     * ->enableTwigSandbox(false)
+     * ```
+     *
+     * @group Security
+     * @param bool $value
+     * @return self
+     * @see $enableTwigSandbox
+     * @since 4.17.0
+     */
+    public function enableTwigSandbox(bool $value = true): self
+    {
+        $this->enableTwigSandbox = $value;
         return $this;
     }
 

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -25,6 +25,7 @@ use craft\web\twig\Environment;
 use craft\web\twig\Extension;
 use craft\web\twig\FeExtension;
 use craft\web\twig\GlobalsExtension;
+use craft\web\twig\SecurityPolicy;
 use craft\web\twig\SinglePreloaderExtension;
 use craft\web\twig\TemplateLoader;
 use Illuminate\Support\Collection;
@@ -35,6 +36,7 @@ use Twig\Error\RuntimeError as TwigRuntimeError;
 use Twig\Error\SyntaxError as TwigSyntaxError;
 use Twig\Extension\CoreExtension;
 use Twig\Extension\ExtensionInterface;
+use Twig\Extension\SandboxExtension;
 use Twig\Extension\StringLoaderExtension;
 use Twig\Template as TwigTemplate;
 use Twig\TemplateWrapper;
@@ -394,6 +396,9 @@ class View extends \yii\web\View
         }
 
         $twig = new Environment(new TemplateLoader($this), $this->_getTwigOptions());
+
+        // Even an empty security policy will prevent non-closures from being allowed as arrow functions
+        $twig->addExtension(new SandboxExtension(new SecurityPolicy(), true));
 
         $twig->addExtension(new StringLoaderExtension());
         $twig->addExtension(new Extension($this, $twig));

--- a/src/web/View.php
+++ b/src/web/View.php
@@ -398,7 +398,7 @@ class View extends \yii\web\View
         $twig = new Environment(new TemplateLoader($this), $this->_getTwigOptions());
 
         // Even an empty security policy will prevent non-closures from being allowed as arrow functions
-        $twig->addExtension(new SandboxExtension(new SecurityPolicy(), true));
+        $twig->addExtension(new SandboxExtension(new SecurityPolicy(), Craft::$app->getConfig()->getGeneral()->enableTwigSandbox));
 
         $twig->addExtension(new StringLoaderExtension());
         $twig->addExtension(new Extension($this, $twig));

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -99,7 +99,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public static function arraySome(TwigEnvironment $env, $array, $arrow)
     {
-        self::checkArrowFunction($arrow, 'has some', 'operator');
+        CoreExtension::checkArrow($env, $arrow, 'has some', 'operator');
         return CoreExtension::arraySome($env, $array, $arrow);
     }
 
@@ -108,36 +108,8 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public static function arrayEvery(TwigEnvironment $env, $array, $arrow)
     {
-        self::checkArrowFunction($arrow, 'has every', 'operator');
+        CoreExtension::checkArrow($env, $arrow, 'has every', 'operator');
         return CoreExtension::arrayEvery($env, $array, $arrow);
-    }
-
-    /**
-     * Called by:
-     * - has every (operator)
-     * - has some (operator)
-     * - |filter
-     * - |find
-     * - |map
-     * - |reduce
-     * - |sort
-     */
-    private static function checkArrowFunction(mixed $arrow, string $thing, string $type): void
-    {
-        if (
-            is_string($arrow) &&
-            in_array(ltrim(strtolower($arrow), '\\'), [
-                'system',
-                'passthru',
-                'exec',
-                'file_get_contents',
-                'file_put_contents',
-                'popen',
-                'call_user_func',
-            ])
-        ) {
-            throw new RuntimeError(sprintf('The "%s" %s does not support passing "%s".', $thing, $type, $arrow));
-        }
     }
 
     /**
@@ -253,7 +225,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('filesize', [$this, 'filesizeFilter']),
             new TwigFilter('filter', [$this, 'filterFilter'], ['needs_environment' => true]),
             new TwigFilter('filterByValue', [ArrayHelper::class, 'where'], ['deprecation_info' => new DeprecatedCallableInfo('craftcms/cms', '3.5.0', 'where')]),
-            new TwigFilter('group', [$this, 'groupFilter']),
+            new TwigFilter('group', [$this, 'groupFilter'], ['needs_environment' => true]),
             new TwigFilter('hash', [$security, 'hashData']),
             new TwigFilter('httpdate', [$this, 'httpdateFilter'], ['needs_environment' => true]),
             new TwigFilter('id', [Html::class, 'id']),
@@ -565,7 +537,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public function sortFilter(TwigEnvironment $env, iterable $array, string|callable|null $arrow = null): array
     {
-        self::checkArrowFunction($arrow, 'sort', 'filter');
+        CoreExtension::checkArrow($env, $arrow, 'sort', 'filter');
         return CoreExtension::sort($env, $array, $arrow);
     }
 
@@ -582,7 +554,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public function reduceFilter(TwigEnvironment $env, mixed $array, mixed $arrow, mixed $initial = null): mixed
     {
-        self::checkArrowFunction($arrow, 'reduce', 'filter');
+        CoreExtension::checkArrow($env, $arrow, 'reduce', 'filter');
         return CoreExtension::reduce($env, $array, $arrow, $initial);
     }
 
@@ -598,7 +570,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public function mapFilter(TwigEnvironment $env, mixed $array, mixed $arrow = null): array
     {
-        self::checkArrowFunction($arrow, 'map', 'filter');
+        CoreExtension::checkArrow($env, $arrow, 'map', 'filter');
         return CoreExtension::map($env, $array, $arrow);
     }
 
@@ -723,7 +695,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public function findFilter(TwigEnvironment $env, $array, $arrow): mixed
     {
-        self::checkArrowFunction($arrow, 'find', 'filter');
+        CoreExtension::checkArrow($env, $arrow, 'find', 'filter');
         return CoreExtension::find($env, $array, $arrow);
     }
 
@@ -1202,7 +1174,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
      */
     public function filterFilter(TwigEnvironment $env, iterable $arr, ?callable $arrow = null): array
     {
-        self::checkArrowFunction($arrow, 'filter', 'filter');
+        CoreExtension::checkArrow($env, $arrow, 'filter', 'filter');
 
         /** @var array|Traversable $arr */
         if ($arrow === null) {
@@ -1224,14 +1196,15 @@ class Extension extends AbstractExtension implements GlobalsInterface
     /**
      * Groups an array by the results of an arrow function, or value of a property.
      *
+     * @param TwigEnvironment $env
      * @param iterable $arr
      * @param callable|string $arrow The arrow function or property name that determines the group the item should be grouped in
      * @return array[] The grouped items
      * @throws RuntimeError if $arr is not of type array or Traversable
      */
-    public function groupFilter(iterable $arr, callable|string $arrow): array
+    public function groupFilter(TwigEnvironment $env, iterable $arr, callable|string $arrow): array
     {
-        self::checkArrowFunction($arrow, 'group', 'filter');
+        CoreExtension::checkArrow($env, $arrow, 'group', 'filter');
 
         $groups = [];
 

--- a/src/web/twig/SecurityPolicy.php
+++ b/src/web/twig/SecurityPolicy.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\web\twig;
+
+use Twig\Sandbox\SecurityPolicyInterface;
+
+/**
+ * Security policy
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.17.0
+ */
+class SecurityPolicy implements SecurityPolicyInterface
+{
+    public function checkSecurity($tags, $filters, $functions): void
+    {
+    }
+
+    public function checkMethodAllowed($obj, $method): void
+    {
+    }
+
+    public function checkPropertyAllowed($obj, $property): void
+    {
+    }
+}


### PR DESCRIPTION
Adds a new `enableTwigSandbox` config setting, which when enabled, configures Twig with the [Sandbox extension](https://twig.symfony.com/doc/3.x/sandbox.html) with a custom security policy that doesn’t block any tags, filers, methods, or properties. However by simply being enabled, Twig will [block all non-Closure arrow functions](https://github.com/twigphp/Twig/blob/946ddeafa3c9f4ce279d1f34051af041db0e16f2/src/Extension/CoreExtension.php#L2092-L2094), fixing several security issues.

```twig
{# no longer works #}
{% set names = names|map('ucfirst') %}

{# do this instead #}
{% set names = names|map(n => n|capitalize) %}
```

The config setting is `false` by default in core, but will be enabled by default for new `craftcms/craft`-based projects.

Support for calling non-Closure arrow functions is [deprecated](https://github.com/twigphp/Twig/blob/946ddeafa3c9f4ce279d1f34051af041db0e16f2/src/Extension/CoreExtension.php#L2096) and will be removed in a future version of Twig, so updating templates and enabling the setting should be encouraged.
