### PR TITLE
table columns for multi instance fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed a bug where custom fields’ checkboxes weren’t getting removed from field layouts’ “Card Attributes” lists when removed from the layout.
 - Fixed a bug where consecutive hyphens (`-`) within Link fields’ “Class Name” values were getting removed. ([#18201](https://github.com/craftcms/cms/issues/18201))
 - Fixed an error that could occur when saving a recursively-nested element. ([#18164](https://github.com/craftcms/cms/issues/18164))
+- Fixed a bug where element indexes could show muliple table columns for the same field/label/handle combinations. ([#18209](https://github.com/craftcms/cms/issues/18209))
 - Fixed SSRF vulnerabilities. (GHSA-96pq-hxpw-rgh8, GHSA-m5r2-8p9x-hp5m, GHSA-8jr8-7hr4-vhfx)
 - Fixed an XSS vulnerability. (GHSA-7pr4-wx9w-mqwr)
 - Fixed a SQL injection vulnerability. (GHSA-2453-mppf-46cj)

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -6030,7 +6030,7 @@ JS, [
                             } catch (FieldNotFoundException) {
                             }
                         }
-                        $field = $field ?? $this->_getFieldFromAlternativeLayouts($uid) ?? null;
+                        $field ??= $this->_getFieldFromAlternativeLayouts($uid) ?? null;
                     }
 
                     if ($field instanceof PreviewableFieldInterface) {
@@ -6123,7 +6123,7 @@ JS, [
                 }
             }
 
-            $field = $field ?? $this->_getFieldFromAlternativeLayouts($instanceUid) ?? null;
+            $field ??= $this->_getFieldFromAlternativeLayouts($instanceUid) ?? null;
         }
 
         if ($field !== null) {

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -6030,7 +6030,7 @@ JS, [
                             } catch (FieldNotFoundException) {
                             }
                         }
-                        $field ??= null;
+                        $field = $field ?? $this->_getFieldFromAlternativeLayouts($uid) ?? null;
                     }
 
                     if ($field instanceof PreviewableFieldInterface) {
@@ -6057,6 +6057,48 @@ JS, [
     }
 
     /**
+     * Find field instance that matches the instance UID from another layout.
+     *
+     * @param $layoutElementUid
+     * @return FieldInterface|null
+     */
+    private function _getFieldFromAlternativeLayouts($layoutElementUid): ?FieldInterface
+    {
+        $currentLayout = $this->getFieldLayout();
+
+        // get all field layouts for this element type sans the layout used by this element
+        $fieldLayouts = Collection::make(Craft::$app->getFields()->getLayoutsByType(static::class))
+            ->filter(fn($fieldLayout) => $fieldLayout->uid !== $currentLayout?->uid);
+
+        if ($fieldLayouts->isEmpty()) {
+            return null;
+        }
+
+        // find the layout that has this element UID and get its handle
+        $handle = null;
+        foreach ($fieldLayouts as $fieldLayout) {
+            foreach ($fieldLayout->getCustomFields() as $field) {
+                if ($field->layoutElement->uid === $layoutElementUid) {
+                    // get its handle
+                    $handle = $field->layoutElement->handle;
+                    break 2;
+                }
+            }
+        }
+
+        // and now find the layout element by handle in this element's layout
+        if ($handle) {
+            foreach ($currentLayout->getCustomFields() as $field) {
+                if ($field->layoutElement->handle === $handle) {
+                    return $field;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Returns the HTML that should be shown for a given attribute’s inline input.
      *
      * @param string $attribute The attribute name.
@@ -6080,6 +6122,8 @@ JS, [
                 } catch (FieldNotFoundException) {
                 }
             }
+
+            $field = $field ?? $this->_getFieldFromAlternativeLayouts($instanceUid) ?? null;
         }
 
         if ($field !== null) {

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -432,6 +432,7 @@ class ElementSources extends Component
         $attributes = [];
         /** @var CustomField[][] $groupedFieldElements */
         $groupedFieldElements = [];
+        $groupedFieldInstances = [];
 
         foreach ($fieldLayouts as $fieldLayout) {
             foreach ($fieldLayout->getTabs() as $tab) {
@@ -460,10 +461,13 @@ class ElementSources extends Component
                             // where the handle also wasn't overridden
                             $groupedFieldElements[$field->id][] = $layoutElement;
                         } else {
-                            // The handle was overridden, so it gets its own table attribute
-                            $attributes["fieldInstance:$layoutElement->uid"] = [
-                                'label' => Craft::t('site', $layoutElement->label()),
-                            ];
+                            // The handle was overridden, so we'll use a key consisting of
+                            // the global field uid and layout element label and handle
+                            // to check if a new table attribute should be added to the list
+                            $key = $field->uid . " - " . $layoutElement->label() . " - " . $layoutElement->handle;
+                            if (!isset($groupedFieldInstances[$key])) {
+                                $groupedFieldInstances[$key] = $layoutElement;
+                            }
                         }
                     }
                 }
@@ -475,6 +479,12 @@ class ElementSources extends Component
             $labels = array_unique(array_map(fn(CustomField $layoutElement) => $layoutElement->label(), $fieldElements));
             $attributes["field:$field->uid"] = [
                 'label' => count($labels) === 1 ? $labels[0] : Craft::t('site', $field->name),
+            ];
+        }
+
+        foreach ($groupedFieldInstances as $layoutElement) {
+            $attributes["fieldInstance:$layoutElement->uid"] = [
+                'label' => Craft::t('site', $layoutElement->label()),
             ];
         }
 


### PR DESCRIPTION
### Description
**Steps to reproduce:**
- clean 5.8.21 installation
- create a field called “Plain Text” with a handle of `plainText`; 
- create two entry types: `et1` and `et2`
- to each, you add this `plainText` field 3 times: 
	- once in its original form - you don’t override the label or the handle, 
	- the second one’s handle is automatically overridden (handles have to be unique per layout), and you change the label to “headline”, 
	- the third one’s handle is also automatically overridden, and you change the label to “topline”;
- create three sections (can be any type, but let's stick with Singles as in the GH issue): “Single 1” with `et1`, “Single 2” with `et2` and “Single 3” with `et1`
- edit each entry and fill out the text of each of those fields with the label and handle, e.g. “plain text => plainText”, “headline => plainText2”, “topline => plainText3”

If you go to the entry index page, to the “Singles” source and click the “View” button next to the search input, you can see that the “Plain text” checkbox appears only once, since its handle is not overridden and “headline” and “topline” each show twice

**How it currently works:**
If you add the same field to a field layout more than once, each of those field instances gets its own checkbox in the Table Columns list, because it has an overwritten handle: https://github.com/craftcms/cms/blob/5.8.21/src/services/ElementSources.php#L458-L467; If you are adding the same field twice, it‘s safe to assume that you‘d want the label of that field to be different for each case, just like you have: “text”, “headline”, “topline”, so it all looks and works as expected.

The same rule applies when you‘re viewing a source that has multiple field layouts. If each of your singles uses a different entry type, then each field is a different instance and therefore shows as a separate checkbox.


We had a similar report for the condition builder functionality, and the most recent work was done here: https://github.com/craftcms/cms/pull/15781. In that case, we‘ll only show duplicate names of the same field if the name is the same, but the handle is different. Additionally, if the user has ‘showFieldHandles’ turned on, we‘ll show the field handles.

**This PR:**
This PR makes the table column checkboxes and actual table columns follow the same logic as the condition builder. Each combination of the field uid (actual global field uid), field layout element label and field layout element handle is the same - only show one checkbox table columns checkbox and only show one column for it in the table. This affects the element index table view (and inline editing), the “table columns” checkboxes under the “View” button, and the “Customize Sources” modal. 


Before:
<img width="1846" height="512" alt="Screenshot 2026-01-07 at 15 03 03" src="https://github.com/user-attachments/assets/d3063c1a-0bc6-4a71-8b92-9d0edee6ed2d" />
<img width="492" height="770" alt="Screenshot 2026-01-07 at 15 07 27" src="https://github.com/user-attachments/assets/86e6cff7-9afd-4102-aa51-8d30a985b40f" />


After:
<img width="1848" height="446" alt="Screenshot 2026-01-07 at 15 03 18" src="https://github.com/user-attachments/assets/a65e3f41-6f70-4fd7-b5b9-bff03167fcc6" />
<img width="434" height="719" alt="Screenshot 2026-01-07 at 15 07 40" src="https://github.com/user-attachments/assets/bd15a899-a8c0-43d1-89f3-8d000fecf38f" />


### Related issues
#18209 
