### PR TITLE
check the actual query limit, not one adjusted for the folders count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where all plugin settings were being saved to the project config, rather than just posted settings. ([craftcms/commerce#4006](https://github.com/craftcms/commerce/issues/4006))
 - Fixed a bug where custom selects could be positioned incorrectly after the window was resized. ([#18179](https://github.com/craftcms/cms/issues/18179))
 - Fixed an error that could occur when logging a deprecation warning, if the backtrace contained any non-UTF-8-encoded strings. ([#18218](https://github.com/craftcms/cms/issues/18218))
+- Fixed a bug where it wasn’t possible to view assets if they had exactly 50 subfolders alongside them. ([#18213](https://github.com/craftcms/cms/issues/18213))
 - Fixed SSRF vulnerabilities. (GHSA-96pq-hxpw-rgh8, GHSA-m5r2-8p9x-hp5m, GHSA-8jr8-7hr4-vhfx)
 - Fixed a SQL injection vulnerability. (GHSA-2453-mppf-46cj)
 - Fixed an XSS vulnerability. (GHSA-9f5h-mmq6-2x78)

--- a/src/elements/Asset.php
+++ b/src/elements/Asset.php
@@ -643,6 +643,7 @@ class Asset extends Element
     protected static function indexElements(ElementQueryInterface $elementQuery, ?string $sourceKey): array
     {
         $assets = [];
+        $originalLimit = $elementQuery->limit;
 
         // Include folders in the results?
         /** @var AssetQuery $elementQuery */
@@ -726,7 +727,7 @@ class Asset extends Element
         // return the folders directly
         if (
             self::isFolderIndex() ||
-            count($assets) === (int)$elementQuery->limit
+            count($assets) === (int)$originalLimit
         ) {
             return $assets;
         }


### PR DESCRIPTION
### Description
Fixes an issue that occurred on the assets index page when the number of folders was exactly 50, and there were assets on the same level. In such a case, 50 folders were shown, but none of the assets. The pagination (and lazy loading for an assets index modal) is set to kick in at 100, but since the number of items shown on the screen is just 50, it won’t.

The original element query limit is set to 100. We first get the folders (50 in this case) and adjust the element query limit value by subtracting the number of folders. The new limit is now 50, which is what we want. However, a later check to see if we had hit the limit is now incorrectly met, causing us to only return the 50 folders.

If you added one more folder (or removed one), the assets started showing again, and pagination/lazy loading kicked in when going over 100.

### Related issues
#18213
