### PR TITLE
ensure we can handle non-utf8 string arg values in the deprecator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The `utils/fix-field-layout-uids` command now checks for duplicate top-level field layout UUIDs. ([#18193](https://github.com/craftcms/cms/pull/18193))
 - Fixed a bug where all plugin settings were being saved to the project config, rather than just posted settings. ([craftcms/commerce#4006](https://github.com/craftcms/commerce/issues/4006))
 - Fixed a bug where custom selects could be positioned incorrectly after the window was resized. ([#18179](https://github.com/craftcms/cms/issues/18179))
+- Fixed an error that could occur when logging a deprecation warning, if the backtrace contained any non-UTF-8-encoded strings. ([#18218](https://github.com/craftcms/cms/issues/18218))
 - Fixed SSRF vulnerabilities. (GHSA-96pq-hxpw-rgh8, GHSA-m5r2-8p9x-hp5m, GHSA-8jr8-7hr4-vhfx)
 - Fixed a SQL injection vulnerability. (GHSA-2453-mppf-46cj)
 - Fixed an XSS vulnerability. (GHSA-9f5h-mmq6-2x78)

--- a/src/services/Deprecator.php
+++ b/src/services/Deprecator.php
@@ -451,6 +451,7 @@ class Deprecator extends Component
                 } else {
                     $strValue = '"' . $value . '"';
                 }
+                $strValue = mb_convert_encoding($strValue, 'UTF-8');
             } elseif (is_array($value)) {
                 $strValue = '[' . $this->_argsToString($value) . ']';
             } elseif ($value === null) {


### PR DESCRIPTION
### Description
**Steps to reproduce:**
- clean 4.16.19 or 5.8.21 install
- create a custom module or plugin with a console controller and a service
- in the console controller, add a method like so:
  ```
  public function actionTest(): int
  {
      $t1 = "test \200 me";
      Plugin::getInstance()->myService->test($t1);
      return ExitCode::OK;
  }
  ```
- in the service, add the following method:
  ```
  public function test(string $param1) {
      Craft::$app->getDeprecator()->log(__METHOD__, 'some message');
  }
  ```
- hit that console controller method, e.g. `ddev craft test-plugin/default/test`
- observe the error

It can also be achieved if `$t1` is set to e.g. `random_string(5)`.

Technically, this can also be reproduced by calling `Json::encode()` on a string that contains non-UTF8 chars.


**Fix:**
Running the stack trace string-type argument values via `mb_convert_encoding()` ensures the stack trace can be properly saved in the database.

### Related issues
#18218 
