### PR TITLE
account for getEntryTypesByHandle returning an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an error that could occur if the `purgeStaleUserSessionDuration` config setting was set to a duration interval string. ([#18238](https://github.com/craftcms/cms/issues/18238))
 - Fixed a bug where image transforms weren’t getting regenerated on Local filesystems, if the transform params changed and the asset transform index had been cleared. ([#18249](https://github.com/craftcms/cms/issues/18249))
+- Fixed a bug where entry queries were executing extra database queries when the `type` param was used. ([#18223](https://github.com/craftcms/cms/issues/18223))
 - Fixed [low-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) XSS vulnerabilities. (GHSA-6j87-m5qx-9fqp, GHSA-3jh3-prx3-w6wc)
 - Fixed [moderate-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) SSRF vulnerabilities. (GHSA-gp2f-7wcm-5fhx, GHSA-v2gc-rm6g-wrw9)
 - Fixed a [moderate-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) TOCTOU vulnerability. (GHSA-6fx5-5cw5-4897)

--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -423,11 +423,41 @@ class EntryQuery extends ElementQuery
     {
         if (Db::normalizeParam($value, function($item) {
             if (is_string($item)) {
-                $item = Craft::$app->getSections()->getEntryTypesByHandle($item);
+                // multiple entry types can have the same handle, so $types is always an array
+                $types = Craft::$app->getSections()->getEntryTypesByHandle($item);
+
+                if (!empty($types)) {
+                    if (count($types) == 1) {
+                        return $types[0]->id;
+                    }
+
+                    return Collection::make($types)->pluck('id')->toArray();
+                }
+            } elseif ($item instanceof EntryType) {
+                // this will be the case if $value was an EntryType or array of those
+                return $item->id;
             }
-            return $item instanceof EntryType ? $item->id : null;
+
+            return null;
         })) {
-            $this->typeId = $value;
+            // if $value is a multidimensional array
+            if (is_array($value) && count($value) !== count($value, COUNT_RECURSIVE)) {
+                $ids = [];
+                // get all the IDs from it
+                foreach ($value as $key => $item) {
+                    if (is_array($item)) {
+                        $ids = array_merge($ids, $item);
+                        unset($value[$key]);
+                    } elseif (is_numeric($item)) {
+                        $ids[] = $item;
+                        unset($value[$key]);
+                    }
+                }
+                // and merge them with whatever's left in $values (e.g. 'not' keyword can still be there)
+                $this->typeId = array_merge($value, array_unique($ids));
+            } else {
+                $this->typeId = $value;
+            }
         } else {
             $this->typeId = (new Query())
                 ->select(['id'])

--- a/src/elements/db/EntryQuery.php
+++ b/src/elements/db/EntryQuery.php
@@ -427,11 +427,7 @@ class EntryQuery extends ElementQuery
                 $types = Craft::$app->getSections()->getEntryTypesByHandle($item);
 
                 if (!empty($types)) {
-                    if (count($types) == 1) {
-                        return $types[0]->id;
-                    }
-
-                    return Collection::make($types)->pluck('id')->toArray();
+                    return (count($types) == 1) ? $types[0]->id : Collection::make($types)->pluck('id')->toArray();
                 }
             } elseif ($item instanceof EntryType) {
                 // this will be the case if $value was an EntryType or array of those


### PR DESCRIPTION
### Description
In v3, we briefly dropped support for passing an array of entry types into the type param. It was then re-added in 3.7.40 via https://github.com/craftcms/cms/commit/54a3959cf6aaf88d40a3919507a09c3cd6ef804d (related issue: https://github.com/craftcms/cms/issues/11057).

However, up until and including v4, the `Sections->getEntryTypesByHandle()` method, which is used in the normalisation of the `EntryQuery->type()` param, only returns an array, which means that using it with anything other than an EntryType model always triggers a call to the database.

This PR takes into consideration that `Sections->getEntryTypesByHandle()` can return an array of entry types, and it does lower the number of DB queries, but I’m not 100% sure if it’s worth the extra code complexity.

This issue only affects v4, as in v5, entry type handles are globally unique.


### Related issues
#18223 
