### PR TITLE
Fix `Env::parseBoolean` return

### DIFF
--- a/src/Support/Env.php
+++ b/src/Support/Env.php
@@ -81,7 +81,20 @@ final class Env extends \Illuminate\Support\Env
         // …/$VAR/…
         $value = preg_replace_callback(
             '/(?<=^|\/)\$(\w+)(?=$|\/)?/',
-            fn ($m) => self::get($m[1]), $value
+            function ($m) {
+                $result = self::get($m[1]);
+
+                if ($result === null) {
+                    return $m[0]; // keep original if not set
+                }
+
+                if (is_bool($result)) {
+                    return $result ? 'true' : 'false';
+                }
+
+                return (string) $result;
+            },
+            $value
         );
 
         if ($value === '') {

--- a/src/Support/Env.php
+++ b/src/Support/Env.php
@@ -84,10 +84,6 @@ final class Env extends \Illuminate\Support\Env
             function ($m) {
                 $result = self::get($m[1]);
 
-                if ($result === null) {
-                    return $m[0]; // keep original if not set
-                }
-
                 if (is_bool($result)) {
                     return $result ? 'true' : 'false';
                 }

--- a/tests/Support/EnvTest.php
+++ b/tests/Support/EnvTest.php
@@ -151,13 +151,13 @@ test('parseBoolean', function (?bool $expected, mixed $value, array $values = []
     [null, '$TEST_MISSING'],
     [
         false,
-        '$FALSY_VALUE',
-        ['FALSY_VALUE' => 'false'],
+        '$TEST_FALSE',
+        ['TEST_FALSE' => 'false'],
     ],
     [
         true,
-        '$TRUTHY_VALUE',
-        ['TRUTHY_VALUE' => 'true'],
+        '$TEST_TRUE',
+        ['TEST_TRUE' => 'true'],
     ],
 ]);
 

--- a/tests/Support/EnvTest.php
+++ b/tests/Support/EnvTest.php
@@ -127,7 +127,10 @@ test('parse', function () {
     }
 });
 
-test('parseBoolean', function (?bool $expected, mixed $value) {
+test('parseBoolean', function (?bool $expected, mixed $value, array $values = []) {
+    foreach ($values as $name => $v) {
+        putenv("$name=$v");
+    }
     expect(Env::parseBoolean($value))->toBe($expected);
 })->with([
     [true, true],
@@ -146,6 +149,16 @@ test('parseBoolean', function (?bool $expected, mixed $value) {
     [false, 0],
     [null, 2],
     [null, '$TEST_MISSING'],
+    [
+        false,
+        '$FALSY_VALUE',
+        ['FALSY_VALUE' => 'false'],
+    ],
+    [
+        true,
+        '$TRUTHY_VALUE',
+        ['TRUTHY_VALUE' => 'true'],
+    ],
 ]);
 
 test('config', function (mixed $expected, string $paramName, string $overrideName, mixed $overrideValue) {


### PR DESCRIPTION
Updates `Env::parseBoolean` to match what was previously returned by `App::parseBooleanEnv`. In Craft 5, `App::parseBooleanEnv` would return `false` for something like `$FALSY_VALUE=false` but `Env::parseBoolean` was returning `null` because `preg_replace_callback` will coerse `false` into `''` which then gets returned as `null` on L#100. 

I'm totally open to a better fix, but this seems to work. 