### PR TITLE
purgeStaleUserSessionDuration can be more than just an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed an error that could occur if the `purgeStaleUserSessionDuration` config setting was set to a duration interval string. ([#18238](https://github.com/craftcms/cms/issues/18238))
 - Fixed XSS vulnerabilities. (GHSA-6j87-m5qx-9fqp, GHSA-3jh3-prx3-w6wc)
 - Fixed SSRF vulnerabilities. (GHSA-gp2f-7wcm-5fhx, GHSA-v2gc-rm6g-wrw9)
 

--- a/src/services/Gc.php
+++ b/src/services/Gc.php
@@ -396,7 +396,7 @@ class Gc extends Component
         }
 
         $this->_stdout('    > deleting stale user sessions ... ');
-        $interval = DateTimeHelper::secondsToInterval($this->_generalConfig->purgeStaleUserSessionDuration);
+        $interval = DateTimeHelper::toDateInterval($this->_generalConfig->purgeStaleUserSessionDuration);
         $expire = DateTimeHelper::currentUTCDateTime();
         $pastTime = $expire->sub($interval);
         Db::delete(Table::SESSIONS, ['<', 'dateUpdated', Db::prepareDateForDb($pastTime)]);


### PR DESCRIPTION
### Description
The values [`purgeStaleUserSessionDuration`](https://craftcms.com/docs/5.x/reference/config/general.html#purgestaleusersessionduration) general config setting accepts are: integer, string (a duration interval), `DateInterval` object and empty value, but the `Gc` service relies on it being an integer (number of seconds).

This PR switches from using `DateTimeHelper::secondsToInterval()` to `DateTimeHelper::toDateInterval()` method so that all possible values are accounted for when creating an actual `DateInterval` object.

BTW, it’s not related to 5.8.22.

### Related issues
#18238 
