### PR TITLE
Support including nested content block fields in table views

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -53,7 +53,7 @@
 - Drag-and-drop icons are now longer shown for devices that don’t support pointer events. ([#18067](https://github.com/craftcms/cms/pull/18067))
 - The Caches utility now keeps track of which options were previously selected. ([#9447](https://github.com/craftcms/cms/discussions/9447))
 - Field layouts can now set editability conditions on custom fields, based on the edited element. ([#18181](https://github.com/craftcms/cms/discussions/18181))
-- Element cards can now include fields nested within Content Block fields. ([#18206](https://github.com/craftcms/cms/pull/18206))
+- Element cards and table views can now include fields nested within Content Block fields. ([#18206](https://github.com/craftcms/cms/pull/18206), [#18252](https://github.com/craftcms/cms/pull/18252))
 - Money fields’ icons now indicate their selected currency, for common currencies.
 
 ### Development

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -72,6 +72,7 @@ use craft\events\SetEagerLoadedElementsEvent;
 use craft\events\SetElementRouteEvent;
 use craft\fieldlayoutelements\BaseField;
 use craft\fieldlayoutelements\CustomField;
+use craft\fields\ContentBlock as ContentBlockField;
 use craft\gql\interfaces\Element as ElementGqlType;
 use craft\helpers\App;
 use craft\helpers\ArrayHelper;
@@ -5885,6 +5886,10 @@ JS, [
      */
     protected function attributeHtml(string $attribute): string
     {
+        if (str_starts_with($attribute, 'contentBlock:')) {
+            return $this->contentBlockAttributeHtml($attribute);
+        }
+
         switch ($attribute) {
             case 'id':
                 return (string)$this->getCanonicalId();
@@ -6049,6 +6054,30 @@ JS, [
 
                 return ElementHelper::attributeHtml($this->$attribute);
         }
+    }
+
+    private function contentBlockAttributeHtml(string $attribute): string
+    {
+        $parts = explode('.', $attribute);
+        $uid = StringHelper::removeLeft(array_shift($parts), 'contentBlock:');
+        $layoutElement = $this->getFieldLayout()?->getElementByUid($uid);
+
+        if (!$layoutElement instanceof CustomField) {
+            return '';
+        }
+
+        try {
+            $field = $layoutElement->getField();
+        } catch (FieldNotFoundException) {
+            return '';
+        }
+
+        if (!$field instanceof ContentBlockField) {
+            return '';
+        }
+
+        $block = $this->getFieldValue($field->handle);
+        return $block->getAttributeHtml(implode('.', $parts));
     }
 
     /**

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -19,6 +19,7 @@ use craft\errors\SiteNotFoundException;
 use craft\events\DefineSourceSortOptionsEvent;
 use craft\events\DefineSourceTableAttributesEvent;
 use craft\fieldlayoutelements\CustomField;
+use craft\fields\ContentBlock;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
 use craft\helpers\StringHelper;
@@ -619,10 +620,14 @@ class ElementSources extends Component
                     }
 
                     if (
-                        $field instanceof PreviewableFieldInterface &&
+                        ($field instanceof PreviewableFieldInterface || $field instanceof ContentBlock) &&
                         (!$user || $user->admin || ($layoutElement->getUserCondition()?->matchElement($user) ?? true))
                     ) {
-                        if ($layoutElement->handle === null) {
+                        if ($field instanceof ContentBlock) {
+                            foreach ($this->getTableAttributesForFieldLayouts([$field->getFieldLayout()]) as $key => $attribute) {
+                                $attributes["contentBlock:{$field->layoutElement->uid}.$key"] = $attribute;
+                            }
+                        } elseif ($layoutElement->handle === null) {
                             // The handle wasn't overridden, so combine it with any other instances (from other layouts)
                             // where the handle also wasn't overridden
                             $groupedFieldElements[$field->id][] = $layoutElement;


### PR DESCRIPTION
### Description

Makes it possible to select fields nested within Content Block fields, for inclusion within element table views.

### Related issues

- #17507
- #17528