### PR TITLE
Support including generated fields in table views

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -54,6 +54,8 @@
 - The Caches utility now keeps track of which options were previously selected. ([#9447](https://github.com/craftcms/cms/discussions/9447))
 - Field layouts can now set editability conditions on custom fields, based on the edited element. ([#18181](https://github.com/craftcms/cms/discussions/18181))
 - Element cards and table views can now include fields nested within Content Block fields. ([#18206](https://github.com/craftcms/cms/pull/18206), [#18252](https://github.com/craftcms/cms/pull/18252))
+- Element table views can now include generated fields. ([#18253](https://github.com/craftcms/cms/pull/18253))
+- Element indexes can now be sorted by generated fields. ([#18253](https://github.com/craftcms/cms/pull/18253))
 - Money fields’ icons now indicate their selected currency, for common currencies.
 
 ### Development

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -5890,6 +5890,10 @@ JS, [
             return $this->contentBlockAttributeHtml($attribute);
         }
 
+        if (str_starts_with($attribute, 'generatedField:')) {
+            return $this->generatedFieldAttributeHtml($attribute);
+        }
+
         switch ($attribute) {
             case 'id':
                 return (string)$this->getCanonicalId();
@@ -6078,6 +6082,12 @@ JS, [
 
         $block = $this->getFieldValue($field->handle);
         return $block->getAttributeHtml(implode('.', $parts));
+    }
+
+    private function generatedFieldAttributeHtml(string $attribute): string
+    {
+        $uid = StringHelper::removeLeft($attribute, 'generatedField:');
+        return $this->getGeneratedFieldValues()[$uid] ?? '';
     }
 
     /**

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -643,6 +643,14 @@ class ElementSources extends Component
                     }
                 }
             }
+
+            foreach ($fieldLayout->getGeneratedFields() as $field) {
+                if (($field['name'] ?? '') !== '') {
+                    $attributes["generatedField:{$field['uid']}"] = [
+                        'label' => Craft::t('site', $field['name']),
+                    ];
+                }
+            }
         }
 
         foreach ($groupedFieldElements as $fieldElements) {

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -535,6 +535,7 @@ class ElementSources extends Component
     public function getSortOptionsForFieldLayouts(array $fieldLayouts): array
     {
         $sortOptions = [];
+        $qb = null;
 
         foreach ($fieldLayouts as $fieldLayout) {
             foreach ($fieldLayout->getCustomFieldElements() as $layoutElement) {
@@ -548,6 +549,17 @@ class ElementSources extends Component
                         $sortOption['defaultDir'] = 'asc';
                     }
                     $sortOptions[] = $sortOption;
+                }
+            }
+
+            foreach ($fieldLayout->getGeneratedFields() as $field) {
+                if (($field['name'] ?? '') !== '') {
+                    $qb ??= Craft::$app->getDb()->getQueryBuilder();
+                    $sortOptions[] = [
+                        'label' => Craft::t('site', $field['name']),
+                        'attribute' => "generatedField:{$field['uid']}",
+                        'orderBy' => $qb->jsonExtract('elements_sites.content', [$field['uid']]),
+                    ];
                 }
             }
         }


### PR DESCRIPTION
### Description

Makes it possible to select generated fields for inclusion within element table views, as well as makes generated fields available as sort options.

### Related issues

- #17507