### PR TITLE
Feature/meta fields event

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -79,10 +79,12 @@
 - Added `craft\base\ElementTrait::$hasProvisionalChanges`. ([#17915](https://github.com/craftcms/cms/pull/17915))
 - Added `craft\base\ElementTrait::$propagateRequired`.
 - Added `craft\base\FieldInterface::propagateValue()`.
+- Added `craft\elements\Entry::EVENT_DEFINE_META_FIELDS`. ([#17996](https://github.com/craftcms/cms/pull/17996))
 - Added `craft\elements\User::isInGroups()`. ([#17989](https://github.com/craftcms/cms/discussions/17989))
 - Added `craft\elements\conditions\HintableConditionRuleTrait`. ([#17909](https://github.com/craftcms/cms/pull/17909))
 - Added `craft\events\DefineFieldActionsEvent`.
 - Added `craft\events\DefineGqlArgumentsEvent`.
+- Added `craft\events\DefineMetaFields`. ([#17996](https://github.com/craftcms/cms/pull/17996))
 - Added `craft\events\RegisterElementCardAttributesEvent::$fieldLayout`. ([#17920](https://github.com/craftcms/cms/pull/17920))
 - Added `craft\fieldlayoutelements\BaseField::EVENT_DEFINE_ACTION_MENU_ITEMS`. ([#18037](https://github.com/craftcms/cms/issues/18037))
 - Added `craft\fieldlayoutelements\BaseField::copyAttributeAction()`. ([#18114](https://github.com/craftcms/cms/pull/18114))

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -44,8 +44,8 @@ use craft\elements\db\EntryQuery;
 use craft\enums\CmsEdition;
 use craft\enums\Color;
 use craft\enums\PropagationMethod;
-use craft\events\DefineEntryMetaFields;
 use craft\events\DefineEntryTypesEvent;
+use craft\events\DefineMetaFields;
 use craft\events\ElementCriteriaEvent;
 use craft\fieldlayoutelements\entries\EntryTitleField;
 use craft\fields\Matrix;
@@ -120,9 +120,9 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
     public const EVENT_DEFINE_PARENT_SELECTION_CRITERIA = 'defineParentSelectionCriteria';
 
     /**
-     * @event DefineEntryMetaFields The event that is triggered when defining the meta fields.
+     * @event DefineMetaFields The event that is triggered when defining the meta fields.
      * @see metaFieldsHtml()
-     * @since 5.8.18
+     * @since 5.9.0
      */
     public const EVENT_DEFINE_META_FIELDS = 'defineEntryMetaFields';
 
@@ -2539,7 +2539,7 @@ JS, [
         $this->_applyActionBtnEntryTypeCompatibility();
 
         // Type
-        $fields[] = (function() use ($static) {
+        $fields['type'] = (function() use ($static) {
             $entryTypes = $this->getAvailableEntryTypes();
             if (!ArrayHelper::contains($entryTypes, fn(EntryType $entryType) => $entryType->id === $this->typeId)) {
                 $entryTypes[] = $this->getType();
@@ -2569,12 +2569,12 @@ JS, [
 
         // Slug
         if ($this->getType()->showSlugField) {
-            $fields[] = $this->slugFieldHtml($static);
+            $fields['slug'] = $this->slugFieldHtml($static);
         }
 
         // Parent
         if ($section?->type === Section::TYPE_STRUCTURE && $section->maxLevels !== 1) {
-            $fields[] = (function() use ($static, $section) {
+            $fields['parent'] = (function() use ($static, $section) {
                 if ($parentId = $this->getParentId()) {
                     $parent = Craft::$app->getEntries()->getEntryById($parentId, $this->siteId, [
                         'drafts' => null,
@@ -2617,7 +2617,7 @@ JS, [
                 Craft::$app->edition !== CmsEdition::Solo &&
                 $user->can("viewPeerEntries:$section->uid")
             ) {
-                $fields[] = (function() use ($static, $section) {
+                $fields['authors'] = (function() use ($static, $section) {
                     $authors = $this->getAuthors();
                     $html = Cp::elementSelectFieldHtml([
                         'status' => $this->getAttributeStatus('authorIds'),
@@ -2648,7 +2648,7 @@ JS, [
             $view->setIsDeltaRegistrationActive($isDeltaRegistrationActive);
 
             // Post Date
-            $fields[] = Cp::dateTimeFieldHtml([
+            $fields['postDate'] = Cp::dateTimeFieldHtml([
                 'status' => $this->getAttributeStatus('postDate'),
                 'label' => Craft::t('app', 'Post Date'),
                 'id' => 'postDate',
@@ -2659,7 +2659,7 @@ JS, [
             ]);
 
             // Expiry Date
-            $fields[] = Cp::dateTimeFieldHtml([
+            $fields['expiryDate'] = Cp::dateTimeFieldHtml([
                 'status' => $this->getAttributeStatus('expiryDate'),
                 'label' => Craft::t('app', 'Expiry Date'),
                 'id' => 'expiryDate',
@@ -2672,16 +2672,15 @@ JS, [
 
         $fields[] = parent::metaFieldsHtml($static);
 
-         // Fire a 'defineEntryMetaFields' event
+        // Fire a 'defineEntryMetaFields' event
         if ($this->hasEventHandlers(self::EVENT_DEFINE_META_FIELDS)) {
-            $event = new DefineEntryMetaFields([
-                'entry' => $this,
+            $event = new DefineMetaFields([
+                'element' => $this,
                 'static' => $static,
-                'fields' => $fields
+                'fields' => $fields,
             ]);
             $this->trigger(self::EVENT_DEFINE_META_FIELDS, $event);
-            
-            return implode("\n", $event->fields);
+            $fields = $event->fields;
         }
 
         return implode("\n", $fields);

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -44,6 +44,7 @@ use craft\elements\db\EntryQuery;
 use craft\enums\CmsEdition;
 use craft\enums\Color;
 use craft\enums\PropagationMethod;
+use craft\events\DefineEntryMetaFields;
 use craft\events\DefineEntryTypesEvent;
 use craft\events\ElementCriteriaEvent;
 use craft\fieldlayoutelements\entries\EntryTitleField;
@@ -116,6 +117,13 @@ class Entry extends Element implements NestedElementInterface, ExpirableElementI
      * @since 4.4.0
      */
     public const EVENT_DEFINE_PARENT_SELECTION_CRITERIA = 'defineParentSelectionCriteria';
+
+    /**
+     * @event DefineEntryMetaFields The event that is triggered when defining the meta fields.
+     * @see metaFieldsHtml()
+     * @since 5.8.18
+     */
+    public const EVENT_DEFINE_META_FIELDS = 'defineEntryMetaFields';
 
     /**
      * @inheritdoc
@@ -2566,6 +2574,18 @@ JS, [
         }
 
         $fields[] = parent::metaFieldsHtml($static);
+
+         // Fire a 'defineEntryMetaFields' event
+        if ($this->hasEventHandlers(self::EVENT_DEFINE_META_FIELDS)) {
+            $event = new DefineEntryMetaFields([
+                'entry' => $this,
+                'static' => $static,
+                'fields' => $fields
+            ]);
+            $this->trigger(self::EVENT_DEFINE_META_FIELDS, $event);
+            
+            return implode("\n", $event->fields);
+        }
 
         return implode("\n", $fields);
     }

--- a/src/events/DefineEntryMetaFields.php
+++ b/src/events/DefineEntryMetaFields.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\events;
+
+
+use craft\elements\Entry;
+use craft\base\Event;
+
+/**
+ * class DefineEntryMetaFields
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.8.18
+ */
+
+class DefineEntryMetaFields extends Event
+{
+    /**
+     * @var Entry The current entry
+     */
+    public Entry $entry;
+
+    /**
+     * @var bool Whether the fields should be static (non-interactive)
+     */
+    public bool $static;
+
+    /**
+     * @var array array of all meta fields
+     */
+    public array $fields;
+}

--- a/src/events/DefineMetaFields.php
+++ b/src/events/DefineMetaFields.php
@@ -8,23 +8,22 @@
 
 namespace craft\events;
 
-
-use craft\elements\Entry;
+use craft\base\ElementInterface;
 use craft\base\Event;
 
 /**
  * class DefineEntryMetaFields
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
- * @since 5.8.18
+ * @since 5.9.0
  */
 
-class DefineEntryMetaFields extends Event
+class DefineMetaFields extends Event
 {
     /**
-     * @var Entry The current entry
+     * @var ElementInterface The element the meta fields are for
      */
-    public Entry $entry;
+    public ElementInterface $element;
 
     /**
      * @var bool Whether the fields should be static (non-interactive)
@@ -32,7 +31,7 @@ class DefineEntryMetaFields extends Event
     public bool $static;
 
     /**
-     * @var array array of all meta fields
+     * @var array The meta fields
      */
     public array $fields;
 }


### PR DESCRIPTION
### Description

Adds a new `EVENT_DEFINE_META_FIELDS` event to entries, making it possible for plugins/modules to add/remove meta fields from entry edit forms’ sidebars.

### Related issues

- #17642
- #17996
