### PR TITLE
Allow line breaks in entry titles

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -29,6 +29,7 @@
 - It’s now possible to divide entry sources into multiple index pages, via the Customize Sources modal. ([#17779](https://github.com/craftcms/cms/pull/17779))
 - The Customize Sources modal now supports mobile devices. ([#18067](https://github.com/craftcms/cms/pull/18067))
 - Added the “UI Label Format” entry type setting. ([#18044](https://github.com/craftcms/cms/pull/18044))
+- Added the “Allow line breaks in titles” entry type setting. ([#18265](https://github.com/craftcms/cms/pull/18265))
 - Added the “View user” GraphQL schema option for Craft Solo. ([#17863](https://github.com/craftcms/cms/pull/17863))
 - Users’ User Groups settings now show a component select input, and support inline group editing/creation on environments that allow administrative changes.
 - Address labels can now be made optional. ([#11410](https://github.com/craftcms/cms/discussions/11410))
@@ -103,6 +104,7 @@
 - Added `craft\helpers\Assets::resolveSubpath()`. ([#18103](https://github.com/craftcms/cms/pull/18103))
 - Added `craft\helpers\Cp::cardPreviewOptions()`.
 - Added `craft\helpers\ElementHelper::loadProvisionalChanges()`. ([#17915](https://github.com/craftcms/cms/pull/17915))
+- Added `craft\helpers\StringHelper::convertLineBreaks()`.
 - Added `craft\helpers\UrlHelper::cpReferralUrl()`.
 - Added `craft\i18n\Locale::getDefaultCurrency()`.
 - Added `craft\models\EntryType::$uiLabelFormat`.

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2941,6 +2941,12 @@ abstract class Element extends Component implements ElementInterface
             'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE],
             'when' => fn() => $this->shouldValidateTitle(),
         ];
+        $rules[] = [
+            ['title'],
+            function() {
+                $this->title = StringHelper::convertLineBreaks($this->title);
+            },
+        ];
 
         if (static::hasUris()) {
             try {

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '5.8.22',
-    'schemaVersion' => '5.9.0.6',
+    'schemaVersion' => '5.9.0.7',
     'minVersionRequired' => '4.5.0',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/controllers/EntryTypesController.php
+++ b/src/controllers/EntryTypesController.php
@@ -229,6 +229,7 @@ class EntryTypesController extends Controller
         $entryType->titleTranslationMethod = $this->request->getBodyParam('titleTranslationMethod', $entryType->titleTranslationMethod);
         $entryType->titleTranslationKeyFormat = $this->request->getBodyParam('titleTranslationKeyFormat', $entryType->titleTranslationKeyFormat);
         $entryType->titleFormat = $this->request->getBodyParam('titleFormat', $entryType->titleFormat);
+        $entryType->allowLineBreaksInTitles = $this->request->getBodyParam('allowLineBreaksInTitles', $entryType->allowLineBreaksInTitles);
         $entryType->showSlugField = $this->request->getBodyParam('showSlugField', $entryType->showSlugField);
         $entryType->slugTranslationMethod = $this->request->getBodyParam('slugTranslationMethod', $entryType->slugTranslationMethod);
         $entryType->slugTranslationKeyFormat = $this->request->getBodyParam('slugTranslationKeyFormat', $entryType->slugTranslationKeyFormat);

--- a/src/fieldlayoutelements/entries/EntryTitleField.php
+++ b/src/fieldlayoutelements/entries/EntryTitleField.php
@@ -12,6 +12,7 @@ use craft\base\Field;
 use craft\elements\Entry;
 use craft\fieldlayoutelements\TitleField;
 use craft\helpers\ArrayHelper;
+use craft\helpers\Cp;
 use craft\helpers\ElementHelper;
 use yii\base\InvalidArgumentException;
 
@@ -87,8 +88,28 @@ class EntryTitleField extends TitleField
             throw new InvalidArgumentException(sprintf('%s can only be used in entry field layouts.', self::class));
         }
 
-        if (!$element->getType()->hasTitleField) {
+        $entryType = $element->getType();
+
+        if (!$entryType->hasTitleField) {
             return null;
+        }
+
+        if ($entryType->allowLineBreaksInTitles) {
+            return Cp::textareaHtml([
+                'class' => 'nicetext',
+                'id' => $this->id(),
+                'describedBy' => $this->describedBy($element, $static),
+                'rows' => 2,
+                'name' => $this->name ?? $this->attribute(),
+                'value' => $this->value($element),
+                'maxlength' => $this->maxlength,
+                'autofocus' => $this->autofocus,
+                'disabled' => $static || $this->disabled,
+                'readonly' => $this->readonly,
+                'required' => !$static && $this->required,
+                'title' => $this->title,
+                'placeholder' => $this->placeholder,
+            ]);
         }
 
         return parent::inputHtml($element, $static);

--- a/src/fields/PlainText.php
+++ b/src/fields/PlainText.php
@@ -183,7 +183,7 @@ class PlainText extends Field implements InlineEditableFieldInterface, SortableF
                 $value = StringHelper::unescapeShortcodes(StringHelper::shortcodesToEmoji($value));
             }
 
-            $value = trim(preg_replace('/\R/u', "\n", $value));
+            $value = trim(StringHelper::convertLineBreaks($value));
         }
 
         return $value !== '' ? $value : null;

--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -787,7 +787,7 @@ class Table extends Field implements CrossSiteCopyableFieldInterface
                     if (!$fromRequest) {
                         $value = StringHelper::unescapeShortcodes(StringHelper::shortcodesToEmoji($value));
                     }
-                    return trim(preg_replace('/\R/u', "\n", $value));
+                    return trim(StringHelper::convertLineBreaks($value));
                 }
                 // no break
             case 'date':

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -446,6 +446,18 @@ class StringHelper extends \yii\helpers\StringHelper
     }
 
     /**
+     * Converts line breaks to Unix line breaks (LF) within the given string.
+     *
+     * @param string $str
+     * @return string
+     * @since 5.9.0
+     */
+    public static function convertLineBreaks(string $str): string
+    {
+        return preg_replace('/\R/u', "\n", $str);
+    }
+
+    /**
      * Returns the length of the string, implementing the countable interface.
      *
      * @param string $str The string to count.

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -452,6 +452,7 @@ class Install extends Migration
             'titleTranslationMethod' => $this->string()->notNull()->defaultValue(Field::TRANSLATION_METHOD_SITE),
             'titleTranslationKeyFormat' => $this->text(),
             'titleFormat' => $this->string(),
+            'allowLineBreaksInTitles' => $this->boolean()->notNull()->defaultValue(false),
             'showSlugField' => $this->boolean()->defaultValue(true),
             'slugTranslationMethod' => $this->string()->notNull()->defaultValue(Field::TRANSLATION_METHOD_SITE),
             'slugTranslationKeyFormat' => $this->text(),

--- a/src/migrations/m260120_120907_line_breaks_in_titles.php
+++ b/src/migrations/m260120_120907_line_breaks_in_titles.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m260120_120907_line_breaks_in_titles migration.
+ */
+class m260120_120907_line_breaks_in_titles extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        if (!$this->db->columnExists(Table::ENTRYTYPES, 'allowLineBreaksInTitles')) {
+            $this->addColumn(Table::ENTRYTYPES, 'allowLineBreaksInTitles', $this->boolean()->notNull()->defaultValue(false));
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        if ($this->db->columnExists(Table::ENTRYTYPES, 'allowLineBreaksInTitles')) {
+            $this->dropColumn(Table::ENTRYTYPES, 'allowLineBreaksInTitles');
+        }
+
+        return true;
+    }
+}

--- a/src/models/EntryType.php
+++ b/src/models/EntryType.php
@@ -124,6 +124,12 @@ class EntryType extends Model implements
     public ?string $titleFormat = null;
 
     /**
+     * @var bool Whether line breaks should be allowed in titles
+     * @since 5.9.0
+     */
+    public bool $allowLineBreaksInTitles = false;
+
+    /**
      * @var bool Whether to show the Slug field
      * @since 5.0.0
      */
@@ -462,6 +468,7 @@ JS, [
             'titleTranslationMethod' => $this->titleTranslationMethod,
             'titleTranslationKeyFormat' => $this->titleTranslationKeyFormat ?: null,
             'titleFormat' => $this->titleFormat ?: null,
+            'allowLineBreaksInTitles' => $this->allowLineBreaksInTitles,
             'showSlugField' => $this->showSlugField,
             'slugTranslationMethod' => $this->slugTranslationMethod,
             'slugTranslationKeyFormat' => $this->slugTranslationKeyFormat ?: null,

--- a/src/records/EntryType.php
+++ b/src/records/EntryType.php
@@ -28,6 +28,7 @@ use yii2tech\ar\softdelete\SoftDeleteBehavior;
  * @property string $titleTranslationMethod Title translation method
  * @property string|null $titleTranslationKeyFormat Title translation key format
  * @property string|null $titleFormat Title format
+ * @property bool $allowLineBreaksInTitles Allow line breaks in titles
  * @property bool $showSlugField Whether to show the Slug field
  * @property string $slugTranslationMethod Slug translation method
  * @property string|null $slugTranslationKeyFormat Slug translation key format

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -1455,6 +1455,9 @@ SQL)->execute();
         if ($db->columnExists(Table::ENTRYTYPES, 'uiLabelFormat')) {
             $query->addSelect('uiLabelFormat');
         }
+        if ($db->columnExists(Table::ENTRYTYPES, 'allowLineBreaksInTitles')) {
+            $query->addSelect('allowLineBreaksInTitles');
+        }
 
         return $query;
     }
@@ -1669,6 +1672,7 @@ SQL)->execute();
             $entryTypeRecord->titleTranslationMethod = $data['titleTranslationMethod'] ?? '';
             $entryTypeRecord->titleTranslationKeyFormat = $data['titleTranslationKeyFormat'] ?? null;
             $entryTypeRecord->titleFormat = $data['titleFormat'];
+            $entryTypeRecord->allowLineBreaksInTitles = $data['allowLineBreaksInTitles'] ?? false;
             $entryTypeRecord->showSlugField = $data['showSlugField'] ?? true;
             $entryTypeRecord->slugTranslationMethod = $data['slugTranslationMethod'] ?? Field::TRANSLATION_METHOD_SITE;
             $entryTypeRecord->slugTranslationKeyFormat = $data['slugTranslationKeyFormat'] ?? null;

--- a/src/templates/settings/entry-types/_edit.twig
+++ b/src/templates/settings/entry-types/_edit.twig
@@ -141,6 +141,13 @@
 }) }}
 
 {{ forms.lightswitchField({
+  label: 'Allow line breaks in titles'|t('app'),
+  name: 'allowLineBreaksInTitles',
+  on: entryType.allowLineBreaksInTitles,
+  disabled: readOnly,
+}) }}
+
+{{ forms.lightswitchField({
     label: "Show the Slug field"|t('app'),
     name: 'showSlugField',
     toggle: 'slug-container',

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -103,6 +103,7 @@ return [
     'Allow custom URL schemes' => 'Allow custom URL schemes',
     'Allow custom colors' => 'Allow custom colors',
     'Allow custom options' => 'Allow custom options',
+    'Allow line breaks in titles' => 'Allow line breaks in titles',
     'Allow line breaks' => 'Allow line breaks',
     'Allow public registration' => 'Allow public registration',
     'Allow root-relative URLs' => 'Allow root-relative URLs',

--- a/tests/unit/helpers/StringHelperTest.php
+++ b/tests/unit/helpers/StringHelperTest.php
@@ -250,6 +250,17 @@ class StringHelperTest extends TestCase
     }
 
     /**
+     * @dataProvider convertLineBreaksDataProvider
+     * @param string $expected
+     * @param string $string
+     */
+    public function testConvertLineBreaks(string $expected, string $string): void
+    {
+        $actual = StringHelper::convertLineBreaks($string);
+        self::assertSame($expected, $actual);
+    }
+
+    /**
      *
      */
     public function testCount(): void
@@ -1973,6 +1984,19 @@ class StringHelperTest extends TestCase
             ['😂😁', '😂😁'],
             ['Foo © bar 𝌆 baz ☃ qux', 'Foo © bar 𝌆 baz ☃ qux'],
             ['İnanç Esasları" shown as "Ä°nanÃ§ EsaslarÄ±', 'İnanç Esasları" shown as "Ä°nanÃ§ EsaslarÄ±'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public static function convertLineBreaksDataProvider(): array
+    {
+        return [
+            ['foo bar', 'foo bar'],
+            ["foo\nbar", "foo\nbar"],
+            ["foo\nbar", "foo\rbar"],
+            ["foo\nbar", "foo\r\nbar"],
         ];
     }
 


### PR DESCRIPTION
### Description

Adds an “Allow line breaks in titles” setting to entry types. When enabled, the Title field will use a multi-line textarea instead of a single-line text input, allowing authors to create multi-line titles.

### Related issues

- #8939