### PR TITLE
Normalize generated field values

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -57,6 +57,7 @@
 - Element cards and table views can now include fields nested within Content Block fields. ([#18206](https://github.com/craftcms/cms/pull/18206), [#18252](https://github.com/craftcms/cms/pull/18252))
 - Element table views can now include generated fields. ([#18253](https://github.com/craftcms/cms/pull/18253))
 - Element indexes can now be sorted by generated fields. ([#18253](https://github.com/craftcms/cms/pull/18253))
+- Generated fields now normalize `true`/`false`/`null`/integer/float values to the appropriate types. ([#18267](https://github.com/craftcms/cms/pull/18267))
 - Money fields’ icons now indicate their selected currency, for common currencies.
 
 ### Development

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -54,6 +54,7 @@ use craft\events\MultiElementActionEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\fieldlayoutelements\CustomField;
 use craft\fields\BaseRelationField;
+use craft\helpers\App;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Component as ComponentHelper;
 use craft\helpers\DateTimeHelper;
@@ -4207,6 +4208,10 @@ class Elements extends Component
 
                             foreach ($generatedFields as $field) {
                                 $value = $view->renderObjectTemplate($field['template'] ?? '', $siteElement);
+
+                                // handle 'true'/'false'/'null'/int/float values
+                                $value = App::normalizeValue($value) ?? '';
+
                                 if ($value !== ($content[$field['uid']] ?? '')) {
                                     $updated = true;
                                 }


### PR DESCRIPTION
### Description

Normalizes generated field values, so they’re stored as the appropriate type in the database:

- `'true'`/`'false'` values are stored as booleans
- integer and float values are stored as… integers and floats
- `'null'` values are omitted

### Related issues

- #18189