### PR TITLE
Bugfix/legacy element namespace and bugs

### DIFF
--- a/resources/templates/assets/_index.twig
+++ b/resources/templates/assets/_index.twig
@@ -1,6 +1,6 @@
 {% extends '_layouts/elementindex.twig' %}
 {% set title = "Assets"|t('app') %}
-{% set elementType = 'CraftCms\\Cms\\Entry\\Elements\\Asset' %}
+{% set elementType = 'CraftCms\\Cms\\Asset\\Elements\\Asset' %}
 
 {% do view.registerAssetBundle("craft\\web\\assets\\fileupload\\FileUploadAsset") %}
 {% do view.registerAssetBundle("craft\\web\\assets\\prismjs\\PrismJsAsset") %}

--- a/resources/templates/assets/_index.twig
+++ b/resources/templates/assets/_index.twig
@@ -1,6 +1,6 @@
 {% extends '_layouts/elementindex.twig' %}
 {% set title = "Assets"|t('app') %}
-{% set elementType = 'craft\\elements\\Asset' %}
+{% set elementType = 'CraftCms\\Cms\\Entry\\Elements\\Asset' %}
 
 {% do view.registerAssetBundle("craft\\web\\assets\\fileupload\\FileUploadAsset") %}
 {% do view.registerAssetBundle("craft\\web\\assets\\prismjs\\PrismJsAsset") %}

--- a/resources/templates/entries/index.twig
+++ b/resources/templates/entries/index.twig
@@ -1,14 +1,14 @@
 {% extends "_layouts/elementindex" %}
 
-{% if page is defined and not craft.elementSources.pageExists("craft\\elements\\Entry", page) %}
-  {% set firstPage = craft.elementSources.getFirstPage("craft\\elements\\Entry") %}
+{% if page is defined and not craft.elementSources.pageExists("CraftCms\\Cms\\Entry\\Elements\\Entry", page) %}
+  {% set firstPage = craft.elementSources.getFirstPage("CraftCms\\Cms\\Entry\\Elements\\Entry") %}
   {% if firstPage or (not firstPage and page != 'entries') %}
     {% redirect 'content/' ~ (firstPage ? firstPage|kebab : 'entries') %}
   {% endif %}
 {% endif %}
 
 {% set title = "Entries"|t('app') %}
-{% set elementType = 'craft\\elements\\Entry' %}
+{% set elementType = 'CraftCms\\Cms\\Entry\\Elements\\Entry' %}
 
 {% if sectionHandle is defined %}
   {% js %}

--- a/resources/templates/settings/users/fields.twig
+++ b/resources/templates/settings/users/fields.twig
@@ -16,7 +16,7 @@
 
         {{ forms.fieldLayoutDesignerField({
             first: true,
-            fieldLayout: fieldLayout ?? craft.fields.getLayoutByType('craft\\elements\\User'),
+            fieldLayout: fieldLayout ?? craft.fields.getLayoutByType('CraftCms\\Cms\\Entry\\Elements\\User'),
             withGeneratedFields: true,
             withCardViewDesigner: true,
             disabled: readOnly,

--- a/resources/templates/settings/users/fields.twig
+++ b/resources/templates/settings/users/fields.twig
@@ -16,7 +16,7 @@
 
         {{ forms.fieldLayoutDesignerField({
             first: true,
-            fieldLayout: fieldLayout ?? craft.fields.getLayoutByType('CraftCms\\Cms\\Entry\\Elements\\User'),
+            fieldLayout: fieldLayout ?? craft.fields.getLayoutByType('CraftCms\\Cms\\User\\Elements\\User'),
             withGeneratedFields: true,
             withCardViewDesigner: true,
             disabled: readOnly,

--- a/resources/templates/users/_index.twig
+++ b/resources/templates/users/_index.twig
@@ -3,7 +3,7 @@
 {% endif %}
 
 {% extends "_layouts/elementindex" %}
-{% set elementType = 'craft\\elements\\User' %}
+{% set elementType = 'CraftCms\\Cms\\Entry\\Elements\\User' %}
 
 {% set canHaveDrafts = craft.users().drafts().draftOf(false).savedDraftsOnly().exists() %}
 

--- a/resources/templates/users/_index.twig
+++ b/resources/templates/users/_index.twig
@@ -3,7 +3,7 @@
 {% endif %}
 
 {% extends "_layouts/elementindex" %}
-{% set elementType = 'CraftCms\\Cms\\Entry\\Elements\\User' %}
+{% set elementType = 'CraftCms\\Cms\\User\\Elements\\User' %}
 
 {% set canHaveDrafts = craft.users().drafts().draftOf(false).savedDraftsOnly().exists() %}
 

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -4461,7 +4461,7 @@ JS, [
     public function setEnabledForSite(array|bool $enabledForSite): void
     {
         if (is_array($enabledForSite)) {
-            $this->_enabledForSite = array_map(fn ($value) => (bool) $value, $enabledForSite);
+            $this->_enabledForSite = array_map(fn (bool $value) => $value, $enabledForSite);
         } else {
             $this->_enabledForSite = $enabledForSite;
         }

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -4461,7 +4461,7 @@ JS, [
     public function setEnabledForSite(array|bool $enabledForSite): void
     {
         if (is_array($enabledForSite)) {
-            $this->_enabledForSite = array_map(fn ($value) => $value, $enabledForSite);
+            $this->_enabledForSite = array_map(fn ($value) => (bool) $value, $enabledForSite);
         } else {
             $this->_enabledForSite = $enabledForSite;
         }

--- a/yii2-adapter/legacy/helpers/ElementHelper.php
+++ b/yii2-adapter/legacy/helpers/ElementHelper.php
@@ -385,7 +385,7 @@ class ElementHelper
             ->status(null)
             ->trashed(null)
             ->asArray()
-            ->select(['elements_sites.siteId', 'elements_sites.enabled'])
+            ->select(['siteId', 'enabled'])
             ->pluck('enabled', 'siteId')
             ->map(fn($enabled) => (bool)$enabled)
             ->all();


### PR DESCRIPTION
### Description
The first commit replaces the old element namespaces with new ones in the twig files. 
With the old namespaces, the wrong element type was set in the [`ElementIndexesController::beforeAction()`](https://github.com/craftcms/cms/blob/56f1e361c2693a1e1ff0b320b571faeb0d7e4a16/yii2-adapter/legacy/controllers/ElementIndexesController.php#L103). This caused errors on e.g. entry index page. Trying to view entries in a section caused the “Move to section is only available for Entries” error, the “New entry” button was not loading when the “All entries” source was selected, etc.

The second commit fixes an issue where it was not possible to create a new entry or edit an existing one due to an `Undefined property: stdClass::$siteId` error.

The third commit fixes an issue where it was not possible to save a new nested entry due to `CraftCms\Cms\Element\Element::getEnabledForSite(): Return value must be of type ?bool, string returned` error.


### Related issues
n/a
