### PR TITLE
[6.x] Add Element validation tests

### DIFF
--- a/database/Factories/AddressFactory.php
+++ b/database/Factories/AddressFactory.php
@@ -23,4 +23,11 @@ final class AddressFactory extends Factory
             'dateUpdated' => $created,
         ];
     }
+
+    public function createElement(array $attributes = []): \CraftCms\Cms\Address\Elements\Address
+    {
+        $model = $this->create($attributes);
+
+        return \CraftCms\Cms\Address\Elements\Address::find()->id($model->id)->one();
+    }
 }

--- a/database/Factories/AssetFactory.php
+++ b/database/Factories/AssetFactory.php
@@ -27,6 +27,13 @@ final class AssetFactory extends Factory
         ];
     }
 
+    public function createElement(array $attributes = []): \CraftCms\Cms\Asset\Elements\Asset
+    {
+        $model = $this->create($attributes);
+
+        return \CraftCms\Cms\Asset\Elements\Asset::find()->id($model->id)->one();
+    }
+
     #[Override]
     public function configure(): self
     {

--- a/database/Factories/EntryFactory.php
+++ b/database/Factories/EntryFactory.php
@@ -89,4 +89,11 @@ final class EntryFactory extends Factory
                 : fake()->dateTimeBetween('+1 day', '+1 year'),
         ]);
     }
+
+    public function createElement(array $attributes = []): \CraftCms\Cms\Entry\Elements\Entry
+    {
+        $model = $this->create($attributes);
+
+        return \CraftCms\Cms\Entry\Elements\Entry::find()->id($model->id)->one();
+    }
 }

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -2978,12 +2978,6 @@ abstract class Element extends Component implements ElementInterface
 
             $rules[] = [
                 ['slug'],
-                'required',
-                'when' => fn () => (bool) preg_match('/\bslug\b/', $this->getUriFormat() ?? ''),
-                'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE],
-            ];
-            $rules[] = [
-                ['slug'],
                 SlugValidator::class,
                 'language' => $language,
                 'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE, self::SCENARIO_ESSENTIALS],
@@ -2993,6 +2987,12 @@ abstract class Element extends Component implements ElementInterface
                 'string',
                 'max' => 255,
                 'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE, self::SCENARIO_ESSENTIALS],
+            ];
+            $rules[] = [
+                ['slug'],
+                'required',
+                'when' => fn () => (bool) preg_match('/\bslug\b/', $this->getUriFormat() ?? ''),
+                'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE],
             ];
             $rules[] = [
                 ['uri'],

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -2978,6 +2978,12 @@ abstract class Element extends Component implements ElementInterface
 
             $rules[] = [
                 ['slug'],
+                'required',
+                'when' => fn () => (bool) preg_match('/\bslug\b/', $this->getUriFormat() ?? ''),
+                'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE],
+            ];
+            $rules[] = [
+                ['slug'],
                 SlugValidator::class,
                 'language' => $language,
                 'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE, self::SCENARIO_ESSENTIALS],
@@ -2987,12 +2993,6 @@ abstract class Element extends Component implements ElementInterface
                 'string',
                 'max' => 255,
                 'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE, self::SCENARIO_ESSENTIALS],
-            ];
-            $rules[] = [
-                ['slug'],
-                'required',
-                'when' => fn () => (bool) preg_match('/\bslug\b/', $this->getUriFormat() ?? ''),
-                'on' => [self::SCENARIO_DEFAULT, self::SCENARIO_LIVE],
             ];
             $rules[] = [
                 ['uri'],

--- a/src/Entry/EntryTypes.php
+++ b/src/Entry/EntryTypes.php
@@ -566,6 +566,9 @@ final class EntryTypes
     public function refreshEntryTypes(): void
     {
         $this->entryTypes = null;
+
+        // Sections cache entry types internally, so ensure those get refreshed as well.
+        Sections::refreshSections();
     }
 
     /**

--- a/tests/Address/Elements/AddressValidationTest.php
+++ b/tests/Address/Elements/AddressValidationTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Address\Elements\Address;
+use CraftCms\Cms\Address\Models\Address as AddressModel;
+use CraftCms\Cms\Cms;
+
+describe('Numeric field validation', function () {
+    test('integer fields accept valid integers', function (string $field) {
+        $address = AddressModel::factory()->createElement();
+        $address->{$field} = 1;
+
+        $address->validate([$field]);
+
+        expect($address->hasErrors($field))->toBeFalse();
+    })->with([
+        'fieldId accepts 1' => ['fieldId'],
+        'ownerId accepts 1' => ['ownerId'],
+        'primaryOwnerId accepts 1' => ['primaryOwnerId'],
+    ]);
+
+    test('integer fields accept null', function (string $field) {
+        $address = AddressModel::factory()->createElement();
+        $address->{$field} = null;
+
+        $address->validate([$field]);
+
+        expect($address->hasErrors($field))->toBeFalse();
+    })->with([
+        'fieldId accepts null' => ['fieldId'],
+        'ownerId accepts null' => ['ownerId'],
+        'primaryOwnerId accepts null' => ['primaryOwnerId'],
+    ]);
+});
+
+describe('Required countryCode validation', function () {
+    test('countryCode accepts valid values', function () {
+        $address = AddressModel::factory()->createElement();
+        $address->countryCode = 'US';
+
+        $address->validate(['countryCode']);
+
+        expect($address->hasErrors('countryCode'))->toBeFalse();
+    });
+});
+
+describe('Country code format validation', function () {
+    test('valid country codes are accepted', function (string $code) {
+        $address = AddressModel::factory()->createElement();
+        $address->countryCode = $code;
+
+        $address->validate(['countryCode']);
+
+        expect($address->hasErrors('countryCode'))->toBeFalse();
+    })->with([
+        ['US'],
+        ['BE'],
+        ['GB'],
+        ['DE'],
+        ['FR'],
+        ['NL'],
+        ['CA'],
+        ['AU'],
+    ]);
+
+    test('invalid country codes are rejected', function (string $code) {
+        $address = AddressModel::factory()->createElement(['countryCode' => 'US']);
+        $address->countryCode = $code;
+
+        $address->validate(['countryCode']);
+
+        expect($address->hasErrors('countryCode'))->toBeTrue();
+    })->with([
+        'XX is invalid' => ['XX'],
+        'lowercase us is invalid' => ['us'],
+    ]);
+});
+
+describe('String trimming validation', function () {
+    test('string fields are trimmed', function (string $field, string $input, string $expected, ?string $countryCode = null) {
+        $address = AddressModel::factory()->createElement(['countryCode' => $countryCode ?? 'US']);
+        $address->{$field} = $input;
+
+        $address->validate([$field]);
+
+        expect($address->{$field})->toBe($expected);
+    })->with([
+        'countryCode is trimmed' => ['countryCode', '  US  ', 'US'],
+        'addressLine1 is trimmed' => ['addressLine1', '  123 Main St  ', '123 Main St'],
+        'addressLine2 is trimmed' => ['addressLine2', '  Apt 4  ', 'Apt 4'],
+        'addressLine3 is trimmed' => ['addressLine3', '  Building C  ', 'Building C'],
+        'locality is trimmed' => ['locality', '  New York  ', 'New York'],
+        'administrativeArea is trimmed' => ['administrativeArea', '  NY  ', 'NY', 'US'],
+        'organization is trimmed' => ['organization', '  Acme Inc  ', 'Acme Inc'],
+        'fullName is trimmed' => ['fullName', '  John Doe  ', 'John Doe'],
+    ]);
+
+    test('postalCode is trimmed', function () {
+        $address = AddressModel::factory()->createElement(['countryCode' => 'US']);
+        $address->postalCode = '  10001  ';
+
+        $address->validate(['postalCode']);
+
+        expect($address->postalCode)->toBe('10001');
+    });
+});
+
+describe('String max length validation (255 chars)', function () {
+    test('string fields validate max length', function (string $field, string $char, int $length, bool $expectError) {
+        $address = AddressModel::factory()->createElement(['countryCode' => 'US']);
+        $address->{$field} = str_repeat($char, $length);
+
+        $address->validate([$field]);
+
+        expect($address->hasErrors($field))->toBe($expectError);
+    })->with([
+        'addressLine1 accepts 255 chars' => ['addressLine1', 'a', 255, false],
+        'addressLine1 rejects 256 chars' => ['addressLine1', 'a', 256, true],
+        'addressLine2 accepts 255 chars' => ['addressLine2', 'a', 255, false],
+        'addressLine2 rejects 256 chars' => ['addressLine2', 'a', 256, true],
+        'locality accepts 255 chars' => ['locality', 'a', 255, false],
+        'locality rejects 256 chars' => ['locality', 'a', 256, true],
+        'postalCode accepts 255 chars' => ['postalCode', '1', 255, false],
+        'postalCode rejects 256 chars' => ['postalCode', '1', 256, true],
+        'organization accepts 255 chars' => ['organization', 'a', 255, false],
+        'organization rejects 256 chars' => ['organization', 'a', 256, true],
+        'fullName accepts 255 chars' => ['fullName', 'a', 255, false],
+        'fullName rejects 256 chars' => ['fullName', 'a', 256, true],
+    ]);
+});
+
+describe('Latitude validation', function () {
+    test('latitude accepts valid values', function (mixed $value, bool $expectError) {
+        $address = AddressModel::factory()->createElement();
+        $address->latitude = $value;
+
+        $address->validate(['latitude']);
+
+        expect($address->hasErrors('latitude'))->toBe($expectError);
+    })->with([
+        'positive value 45.5 is valid' => ['45.5', false],
+        'negative value -45.5 is valid' => ['-45.5', false],
+        'zero is valid' => ['0', false],
+        'exactly 90 is valid' => ['90', false],
+        'exactly -90 is valid' => ['-90', false],
+        'greater than 90 is invalid' => ['91', true],
+        'less than -90 is invalid' => ['-91', true],
+        'null is valid' => [null, false],
+    ]);
+});
+
+describe('Longitude validation', function () {
+    test('longitude accepts valid values', function (mixed $value, bool $expectError) {
+        $address = AddressModel::factory()->createElement();
+        $address->longitude = $value;
+
+        $address->validate(['longitude']);
+
+        expect($address->hasErrors('longitude'))->toBe($expectError);
+    })->with([
+        'positive value 120.5 is valid' => ['120.5', false],
+        'negative value -120.5 is valid' => ['-120.5', false],
+        'zero is valid' => ['0', false],
+        'exactly 180 is valid' => ['180', false],
+        'exactly -180 is valid' => ['-180', false],
+        'greater than 180 is invalid' => ['181', true],
+        'less than -180 is invalid' => ['-181', true],
+        'null is valid' => [null, false],
+    ]);
+});
+
+describe('Country-specific required fields (SCENARIO_LIVE)', function () {
+    test('US address required fields on SCENARIO_LIVE', function (string $field, bool $expectError) {
+        $address = AddressModel::factory()->createElement(['countryCode' => 'US']);
+        $address->setScenario(Address::SCENARIO_LIVE);
+        $address->{$field} = null;
+
+        $address->validate([$field]);
+
+        expect($address->hasErrors($field))->toBe($expectError);
+    })->with([
+        'locality is required' => ['locality', true],
+        'administrativeArea is required' => ['administrativeArea', true],
+        'postalCode is required' => ['postalCode', true],
+        'addressLine1 is required' => ['addressLine1', true],
+    ]);
+
+    test('BE address required fields on SCENARIO_LIVE', function (string $field, bool $expectError) {
+        $address = AddressModel::factory()->createElement(['countryCode' => 'BE']);
+        $address->setScenario(Address::SCENARIO_LIVE);
+        $address->{$field} = null;
+
+        $address->validate([$field]);
+
+        expect($address->hasErrors($field))->toBe($expectError);
+    })->with([
+        'locality is required' => ['locality', true],
+        'postalCode is required' => ['postalCode', true],
+        'administrativeArea is not required' => ['administrativeArea', false],
+    ]);
+
+    test('fields not required by country pass validation on SCENARIO_LIVE', function () {
+        $address = AddressModel::factory()->createElement(['countryCode' => 'US']);
+        $address->setScenario(Address::SCENARIO_LIVE);
+        $address->dependentLocality = null;
+        $address->sortingCode = null;
+
+        $address->validate(['dependentLocality', 'sortingCode']);
+
+        expect($address->hasErrors('dependentLocality'))->toBeFalse();
+        expect($address->hasErrors('sortingCode'))->toBeFalse();
+    });
+
+    test('required fields are not required on default scenario', function () {
+        $address = AddressModel::factory()->createElement(['countryCode' => 'US']);
+        $address->locality = null;
+        $address->administrativeArea = null;
+        $address->postalCode = null;
+        $address->addressLine1 = null;
+
+        $address->validate(['locality', 'administrativeArea', 'postalCode', 'addressLine1']);
+
+        expect($address->hasErrors('locality'))->toBeFalse();
+        expect($address->hasErrors('administrativeArea'))->toBeFalse();
+        expect($address->hasErrors('postalCode'))->toBeFalse();
+        expect($address->hasErrors('addressLine1'))->toBeFalse();
+    });
+});
+
+describe('Safe attribute validation', function () {
+    test('safe attributes accept valid values', function (string $field, string $value) {
+        $address = AddressModel::factory()->createElement();
+        $address->{$field} = $value;
+
+        $address->validate([$field]);
+
+        expect($address->hasErrors($field))->toBeFalse();
+    })->with([
+        'addressLine1 accepts valid string' => ['addressLine1', '123 Main Street'],
+        'addressLine2 accepts valid string' => ['addressLine2', 'Apartment 4B'],
+        'addressLine3 accepts valid string' => ['addressLine3', 'Building C'],
+        'locality accepts valid string' => ['locality', 'New York'],
+        'administrativeArea accepts valid string' => ['administrativeArea', 'NY'],
+        'postalCode accepts valid string' => ['postalCode', '10001'],
+        'dependentLocality accepts valid string' => ['dependentLocality', 'Downtown'],
+        'sortingCode accepts valid string' => ['sortingCode', 'ABC123'],
+        'organization accepts valid string' => ['organization', 'Acme Corporation'],
+        'organizationTaxId accepts valid string' => ['organizationTaxId', 'TAX123456'],
+        'fullName accepts valid string' => ['fullName', 'John Doe'],
+    ]);
+
+    test('firstName is a safe attribute when config enabled', function () {
+        Cms::config()->showFirstAndLastNameFields = true;
+
+        $address = AddressModel::factory()->createElement();
+        $address->firstName = 'John';
+
+        $address->validate(['firstName']);
+
+        expect($address->hasErrors('firstName'))->toBeFalse();
+    });
+
+    test('lastName is a safe attribute when config enabled', function () {
+        Cms::config()->showFirstAndLastNameFields = true;
+
+        $address = AddressModel::factory()->createElement();
+        $address->lastName = 'Doe';
+
+        $address->validate(['lastName']);
+
+        expect($address->hasErrors('lastName'))->toBeFalse();
+    });
+});
+
+describe('Edge cases', function () {
+    test('null values are handled gracefully for all nullable fields', function () {
+        $address = AddressModel::factory()->createElement();
+        $address->addressLine1 = null;
+        $address->addressLine2 = null;
+        $address->addressLine3 = null;
+        $address->locality = null;
+        $address->administrativeArea = null;
+        $address->postalCode = null;
+        $address->dependentLocality = null;
+        $address->sortingCode = null;
+        $address->organization = null;
+        $address->organizationTaxId = null;
+        $address->fullName = null;
+        $address->latitude = null;
+        $address->longitude = null;
+
+        $address->validate([
+            'addressLine1', 'addressLine2', 'addressLine3',
+            'locality', 'administrativeArea', 'postalCode',
+            'dependentLocality', 'sortingCode',
+            'organization', 'organizationTaxId', 'fullName',
+            'latitude', 'longitude',
+        ]);
+
+        expect($address->hasErrors('addressLine1'))->toBeFalse();
+        expect($address->hasErrors('addressLine2'))->toBeFalse();
+        expect($address->hasErrors('addressLine3'))->toBeFalse();
+        expect($address->hasErrors('locality'))->toBeFalse();
+        expect($address->hasErrors('administrativeArea'))->toBeFalse();
+        expect($address->hasErrors('postalCode'))->toBeFalse();
+        expect($address->hasErrors('dependentLocality'))->toBeFalse();
+        expect($address->hasErrors('sortingCode'))->toBeFalse();
+        expect($address->hasErrors('organization'))->toBeFalse();
+        expect($address->hasErrors('organizationTaxId'))->toBeFalse();
+        expect($address->hasErrors('fullName'))->toBeFalse();
+        expect($address->hasErrors('latitude'))->toBeFalse();
+        expect($address->hasErrors('longitude'))->toBeFalse();
+    });
+
+    test('unicode characters are handled in address fields', function () {
+        $address = AddressModel::factory()->createElement();
+        $address->addressLine1 = '東京都渋谷区';
+        $address->locality = 'München';
+        $address->organization = 'Société Générale';
+
+        $address->validate(['addressLine1', 'locality', 'organization']);
+
+        expect($address->hasErrors('addressLine1'))->toBeFalse();
+        expect($address->hasErrors('locality'))->toBeFalse();
+        expect($address->hasErrors('organization'))->toBeFalse();
+    });
+
+    test('special characters in address fields', function () {
+        $address = AddressModel::factory()->createElement();
+        $address->addressLine1 = "123 O'Brien Street & Main Ave.";
+        $address->organization = 'Smith & Sons, Inc.';
+
+        $address->validate(['addressLine1', 'organization']);
+
+        expect($address->hasErrors('addressLine1'))->toBeFalse();
+        expect($address->hasErrors('organization'))->toBeFalse();
+    });
+
+    test('multiple validation errors can be collected', function () {
+        $address = AddressModel::factory()->createElement(['countryCode' => 'US']);
+        $address->countryCode = 'XX';
+        $address->latitude = '100';
+        $address->longitude = '200';
+
+        $address->validate(['countryCode', 'latitude', 'longitude']);
+
+        expect($address->hasErrors('countryCode'))->toBeTrue();
+        expect($address->hasErrors('latitude'))->toBeTrue();
+        expect($address->hasErrors('longitude'))->toBeTrue();
+    });
+
+    test('empty strings are handled for nullable string fields', function () {
+        $address = AddressModel::factory()->createElement();
+        $address->addressLine1 = '';
+        $address->locality = '';
+        $address->organization = '';
+
+        $address->validate(['addressLine1', 'locality', 'organization']);
+
+        expect($address->hasErrors('addressLine1'))->toBeFalse();
+        expect($address->hasErrors('locality'))->toBeFalse();
+        expect($address->hasErrors('organization'))->toBeFalse();
+    });
+});

--- a/tests/Address/Elements/AddressValidationTest.php
+++ b/tests/Address/Elements/AddressValidationTest.php
@@ -6,45 +6,6 @@ use CraftCms\Cms\Address\Elements\Address;
 use CraftCms\Cms\Address\Models\Address as AddressModel;
 use CraftCms\Cms\Cms;
 
-describe('Numeric field validation', function () {
-    test('integer fields accept valid integers', function (string $field) {
-        $address = AddressModel::factory()->createElement();
-        $address->{$field} = 1;
-
-        $address->validate([$field]);
-
-        expect($address->hasErrors($field))->toBeFalse();
-    })->with([
-        'fieldId accepts 1' => ['fieldId'],
-        'ownerId accepts 1' => ['ownerId'],
-        'primaryOwnerId accepts 1' => ['primaryOwnerId'],
-    ]);
-
-    test('integer fields accept null', function (string $field) {
-        $address = AddressModel::factory()->createElement();
-        $address->{$field} = null;
-
-        $address->validate([$field]);
-
-        expect($address->hasErrors($field))->toBeFalse();
-    })->with([
-        'fieldId accepts null' => ['fieldId'],
-        'ownerId accepts null' => ['ownerId'],
-        'primaryOwnerId accepts null' => ['primaryOwnerId'],
-    ]);
-});
-
-describe('Required countryCode validation', function () {
-    test('countryCode accepts valid values', function () {
-        $address = AddressModel::factory()->createElement();
-        $address->countryCode = 'US';
-
-        $address->validate(['countryCode']);
-
-        expect($address->hasErrors('countryCode'))->toBeFalse();
-    });
-});
-
 describe('Country code format validation', function () {
     test('valid country codes are accepted', function (string $code) {
         $address = AddressModel::factory()->createElement();
@@ -229,27 +190,6 @@ describe('Country-specific required fields (SCENARIO_LIVE)', function () {
 });
 
 describe('Safe attribute validation', function () {
-    test('safe attributes accept valid values', function (string $field, string $value) {
-        $address = AddressModel::factory()->createElement();
-        $address->{$field} = $value;
-
-        $address->validate([$field]);
-
-        expect($address->hasErrors($field))->toBeFalse();
-    })->with([
-        'addressLine1 accepts valid string' => ['addressLine1', '123 Main Street'],
-        'addressLine2 accepts valid string' => ['addressLine2', 'Apartment 4B'],
-        'addressLine3 accepts valid string' => ['addressLine3', 'Building C'],
-        'locality accepts valid string' => ['locality', 'New York'],
-        'administrativeArea accepts valid string' => ['administrativeArea', 'NY'],
-        'postalCode accepts valid string' => ['postalCode', '10001'],
-        'dependentLocality accepts valid string' => ['dependentLocality', 'Downtown'],
-        'sortingCode accepts valid string' => ['sortingCode', 'ABC123'],
-        'organization accepts valid string' => ['organization', 'Acme Corporation'],
-        'organizationTaxId accepts valid string' => ['organizationTaxId', 'TAX123456'],
-        'fullName accepts valid string' => ['fullName', 'John Doe'],
-    ]);
-
     test('firstName is a safe attribute when config enabled', function () {
         Cms::config()->showFirstAndLastNameFields = true;
 
@@ -274,45 +214,6 @@ describe('Safe attribute validation', function () {
 });
 
 describe('Edge cases', function () {
-    test('null values are handled gracefully for all nullable fields', function () {
-        $address = AddressModel::factory()->createElement();
-        $address->addressLine1 = null;
-        $address->addressLine2 = null;
-        $address->addressLine3 = null;
-        $address->locality = null;
-        $address->administrativeArea = null;
-        $address->postalCode = null;
-        $address->dependentLocality = null;
-        $address->sortingCode = null;
-        $address->organization = null;
-        $address->organizationTaxId = null;
-        $address->fullName = null;
-        $address->latitude = null;
-        $address->longitude = null;
-
-        $address->validate([
-            'addressLine1', 'addressLine2', 'addressLine3',
-            'locality', 'administrativeArea', 'postalCode',
-            'dependentLocality', 'sortingCode',
-            'organization', 'organizationTaxId', 'fullName',
-            'latitude', 'longitude',
-        ]);
-
-        expect($address->hasErrors('addressLine1'))->toBeFalse();
-        expect($address->hasErrors('addressLine2'))->toBeFalse();
-        expect($address->hasErrors('addressLine3'))->toBeFalse();
-        expect($address->hasErrors('locality'))->toBeFalse();
-        expect($address->hasErrors('administrativeArea'))->toBeFalse();
-        expect($address->hasErrors('postalCode'))->toBeFalse();
-        expect($address->hasErrors('dependentLocality'))->toBeFalse();
-        expect($address->hasErrors('sortingCode'))->toBeFalse();
-        expect($address->hasErrors('organization'))->toBeFalse();
-        expect($address->hasErrors('organizationTaxId'))->toBeFalse();
-        expect($address->hasErrors('fullName'))->toBeFalse();
-        expect($address->hasErrors('latitude'))->toBeFalse();
-        expect($address->hasErrors('longitude'))->toBeFalse();
-    });
-
     test('unicode characters are handled in address fields', function () {
         $address = AddressModel::factory()->createElement();
         $address->addressLine1 = '東京都渋谷区';

--- a/tests/Asset/Elements/AssetValidationTest.php
+++ b/tests/Asset/Elements/AssetValidationTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Asset\Elements\Asset;
+use CraftCms\Cms\Asset\Models\Asset as AssetModel;
+
+describe('Integer validation', function () {
+    test('integer fields accept valid values', function (string $field, int $value) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->{$field} = $value;
+
+        $asset->validate([$field]);
+
+        expect($asset->hasErrors($field))->toBeFalse();
+    })->with([
+        'volumeId accepts 1' => ['volumeId', 1],
+        'folderId accepts 1' => ['folderId', 1],
+        'width accepts 1920' => ['width', 1920],
+        'width accepts 0' => ['width', 0],
+        'height accepts 1080' => ['height', 1080],
+        'size accepts 1048576' => ['size', 1048576],
+    ]);
+
+    test('nullable integer fields accept null', function (string $field) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->{$field} = null;
+
+        $asset->validate([$field]);
+
+        expect($asset->hasErrors($field))->toBeFalse();
+    })->with([
+        'volumeId accepts null' => ['volumeId'],
+        'folderId accepts null' => ['folderId'],
+        'width accepts null' => ['width'],
+        'height accepts null' => ['height'],
+        'size accepts null' => ['size'],
+    ]);
+
+    test('integer fields accept zero', function () {
+        $asset = AssetModel::factory()->createElement();
+        $asset->width = 0;
+        $asset->height = 0;
+        $asset->size = 0;
+
+        $asset->validate(['width', 'height', 'size']);
+
+        expect($asset->hasErrors())->toBeFalse();
+    });
+});
+
+describe('DateTime validation', function () {
+    test('dateModified accepts valid values', function (mixed $value) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->dateModified = $value;
+
+        $asset->validate(['dateModified']);
+
+        expect($asset->hasErrors('dateModified'))->toBeFalse();
+    })->with([
+        'DateTime object' => [new DateTime],
+        'null' => [null],
+        'past date' => [new DateTime('2020-01-01')],
+        'future date' => [new DateTime('+1 year')],
+    ]);
+});
+
+describe('Required field validation', function () {
+    test('filename validation', function (string $value, bool $expectError) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->filename = $value;
+
+        $asset->validate(['filename']);
+
+        expect($asset->hasErrors('filename'))->toBe($expectError);
+    })->with([
+        'empty string is invalid' => ['', true],
+        'valid filename is valid' => ['valid-file.jpg', false],
+    ]);
+
+    test('kind validation', function (mixed $value, bool $expectError) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->kind = $value;
+
+        $asset->validate(['kind']);
+
+        expect($asset->hasErrors('kind'))->toBe($expectError);
+    })->with([
+        'null is invalid' => [null, true],
+        'empty string is invalid' => ['', true],
+        'KIND_IMAGE is valid' => [Asset::KIND_IMAGE, false],
+    ]);
+});
+
+describe('String length validation', function () {
+    test('kind length validation', function (int $length, bool $expectError) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->kind = str_repeat('a', $length);
+
+        $asset->validate(['kind']);
+
+        expect($asset->hasErrors('kind'))->toBe($expectError);
+    })->with([
+        '50 chars is valid' => [50, false],
+        '51 chars is invalid' => [51, true],
+    ]);
+});
+
+describe('Title validation on SCENARIO_CREATE', function () {
+    test('title length validation on create scenario', function (int $length, bool $expectError) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->title = str_repeat('a', $length);
+        $asset->setScenario(Asset::SCENARIO_CREATE);
+
+        $asset->validate(['title']);
+
+        expect($asset->hasErrors('title'))->toBe($expectError);
+    })->with([
+        '255 chars is valid' => [255, false],
+        '256 chars is invalid' => [256, true],
+    ]);
+});
+
+describe('Safe attribute validation', function () {
+    test('safe attributes accept valid values', function (string $field, mixed $value) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->{$field} = $value;
+
+        $asset->validate([$field]);
+
+        expect($asset->hasErrors($field))->toBeFalse();
+    })->with([
+        'filename accepts valid string' => ['filename', 'new-filename.jpg'],
+        'newFilename accepts valid string' => ['newFilename', 'renamed-file.jpg'],
+        'alt accepts string with special chars' => ['alt', 'Some alternative text with special characters: <>&"'],
+        'alt accepts null' => ['alt', null],
+        'alt accepts empty string' => ['alt', ''],
+    ]);
+});
+
+describe('Scenario-specific required validation', function () {
+    test('newLocation is required on specific scenarios', function (string $scenario, bool $expectError) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->setScenario($scenario);
+        $asset->newLocation = null;
+
+        $asset->validate(['newLocation']);
+
+        expect($asset->hasErrors('newLocation'))->toBe($expectError);
+    })->with([
+        'SCENARIO_CREATE requires newLocation' => [Asset::SCENARIO_CREATE, true],
+        'SCENARIO_MOVE requires newLocation' => [Asset::SCENARIO_MOVE, true],
+        'SCENARIO_FILEOPS requires newLocation' => [Asset::SCENARIO_FILEOPS, true],
+        'default scenario does not require newLocation' => [Asset::SCENARIO_DEFAULT, false],
+    ]);
+
+    test('tempFilePath is required on specific scenarios', function (string $scenario, bool $expectError) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->setScenario($scenario);
+        $asset->tempFilePath = null;
+
+        $asset->validate(['tempFilePath']);
+
+        expect($asset->hasErrors('tempFilePath'))->toBe($expectError);
+    })->with([
+        'SCENARIO_CREATE requires tempFilePath' => [Asset::SCENARIO_CREATE, true],
+        'SCENARIO_REPLACE requires tempFilePath' => [Asset::SCENARIO_REPLACE, true],
+        'default scenario does not require tempFilePath' => [Asset::SCENARIO_DEFAULT, false],
+        'SCENARIO_MOVE does not require tempFilePath' => [Asset::SCENARIO_MOVE, false],
+    ]);
+});
+
+describe('SCENARIO_INDEX validation', function () {
+    test('SCENARIO_INDEX has empty validation attributes', function () {
+        $asset = AssetModel::factory()->createElement();
+        $asset->setScenario(Asset::SCENARIO_INDEX);
+
+        $activeAttributes = $asset->activeAttributes();
+
+        expect($activeAttributes)->toBe([]);
+    });
+
+    test('validation passes with invalid values on SCENARIO_INDEX', function () {
+        $asset = AssetModel::factory()->createElement();
+        $asset->kind = '';
+        $asset->filename = '';
+        $asset->setScenario(Asset::SCENARIO_INDEX);
+
+        $asset->validate();
+
+        expect($asset->hasErrors())->toBeFalse();
+    });
+});
+
+describe('Edge cases', function () {
+    test('null values are handled gracefully for all nullable fields', function () {
+        $asset = AssetModel::factory()->createElement();
+        $asset->volumeId = null;
+        $asset->folderId = null;
+        $asset->width = null;
+        $asset->height = null;
+        $asset->size = null;
+        $asset->dateModified = null;
+        $asset->alt = null;
+
+        $asset->validate(['volumeId', 'folderId', 'width', 'height', 'size', 'dateModified', 'alt']);
+
+        expect($asset->hasErrors('volumeId'))->toBeFalse();
+        expect($asset->hasErrors('folderId'))->toBeFalse();
+        expect($asset->hasErrors('width'))->toBeFalse();
+        expect($asset->hasErrors('height'))->toBeFalse();
+        expect($asset->hasErrors('size'))->toBeFalse();
+        expect($asset->hasErrors('dateModified'))->toBeFalse();
+        expect($asset->hasErrors('alt'))->toBeFalse();
+    });
+
+    test('unicode characters are handled in alt text', function () {
+        $asset = AssetModel::factory()->createElement();
+        $asset->alt = 'Image of 山 mountain';
+
+        $asset->validate(['alt']);
+
+        expect($asset->hasErrors('alt'))->toBeFalse();
+    });
+
+    test('special characters in filenames', function () {
+        $asset = AssetModel::factory()->createElement();
+        $asset->filename = 'my-image_2024.01.jpg';
+
+        $asset->validate(['filename']);
+
+        expect($asset->hasErrors('filename'))->toBeFalse();
+    });
+
+    test('multiple validation errors can be collected', function () {
+        $asset = AssetModel::factory()->createElement();
+        $asset->filename = '';
+        $asset->kind = '';
+
+        $asset->validate(['filename', 'kind']);
+
+        expect($asset->hasErrors('filename'))->toBeTrue();
+        expect($asset->hasErrors('kind'))->toBeTrue();
+    });
+
+    test('all valid asset kinds are accepted', function (string $kind) {
+        $asset = AssetModel::factory()->createElement();
+        $asset->kind = $kind;
+
+        $asset->validate(['kind']);
+
+        expect($asset->hasErrors('kind'))->toBeFalse();
+    })->with([
+        'KIND_ACCESS' => [Asset::KIND_ACCESS],
+        'KIND_AUDIO' => [Asset::KIND_AUDIO],
+        'KIND_CAPTIONS_SUBTITLES' => [Asset::KIND_CAPTIONS_SUBTITLES],
+        'KIND_COMPRESSED' => [Asset::KIND_COMPRESSED],
+        'KIND_EXCEL' => [Asset::KIND_EXCEL],
+        'KIND_FLASH' => [Asset::KIND_FLASH],
+        'KIND_HTML' => [Asset::KIND_HTML],
+        'KIND_ILLUSTRATOR' => [Asset::KIND_ILLUSTRATOR],
+        'KIND_IMAGE' => [Asset::KIND_IMAGE],
+        'KIND_JAVASCRIPT' => [Asset::KIND_JAVASCRIPT],
+        'KIND_JSON' => [Asset::KIND_JSON],
+        'KIND_PDF' => [Asset::KIND_PDF],
+        'KIND_PHOTOSHOP' => [Asset::KIND_PHOTOSHOP],
+        'KIND_PHP' => [Asset::KIND_PHP],
+        'KIND_POWERPOINT' => [Asset::KIND_POWERPOINT],
+        'KIND_TEXT' => [Asset::KIND_TEXT],
+        'KIND_VIDEO' => [Asset::KIND_VIDEO],
+        'KIND_WORD' => [Asset::KIND_WORD],
+        'KIND_XML' => [Asset::KIND_XML],
+        'KIND_UNKNOWN' => [Asset::KIND_UNKNOWN],
+    ]);
+});

--- a/tests/Asset/Elements/AssetValidationTest.php
+++ b/tests/Asset/Elements/AssetValidationTest.php
@@ -5,66 +5,6 @@ declare(strict_types=1);
 use CraftCms\Cms\Asset\Elements\Asset;
 use CraftCms\Cms\Asset\Models\Asset as AssetModel;
 
-describe('Integer validation', function () {
-    test('integer fields accept valid values', function (string $field, int $value) {
-        $asset = AssetModel::factory()->createElement();
-        $asset->{$field} = $value;
-
-        $asset->validate([$field]);
-
-        expect($asset->hasErrors($field))->toBeFalse();
-    })->with([
-        'volumeId accepts 1' => ['volumeId', 1],
-        'folderId accepts 1' => ['folderId', 1],
-        'width accepts 1920' => ['width', 1920],
-        'width accepts 0' => ['width', 0],
-        'height accepts 1080' => ['height', 1080],
-        'size accepts 1048576' => ['size', 1048576],
-    ]);
-
-    test('nullable integer fields accept null', function (string $field) {
-        $asset = AssetModel::factory()->createElement();
-        $asset->{$field} = null;
-
-        $asset->validate([$field]);
-
-        expect($asset->hasErrors($field))->toBeFalse();
-    })->with([
-        'volumeId accepts null' => ['volumeId'],
-        'folderId accepts null' => ['folderId'],
-        'width accepts null' => ['width'],
-        'height accepts null' => ['height'],
-        'size accepts null' => ['size'],
-    ]);
-
-    test('integer fields accept zero', function () {
-        $asset = AssetModel::factory()->createElement();
-        $asset->width = 0;
-        $asset->height = 0;
-        $asset->size = 0;
-
-        $asset->validate(['width', 'height', 'size']);
-
-        expect($asset->hasErrors())->toBeFalse();
-    });
-});
-
-describe('DateTime validation', function () {
-    test('dateModified accepts valid values', function (mixed $value) {
-        $asset = AssetModel::factory()->createElement();
-        $asset->dateModified = $value;
-
-        $asset->validate(['dateModified']);
-
-        expect($asset->hasErrors('dateModified'))->toBeFalse();
-    })->with([
-        'DateTime object' => [new DateTime],
-        'null' => [null],
-        'past date' => [new DateTime('2020-01-01')],
-        'future date' => [new DateTime('+1 year')],
-    ]);
-});
-
 describe('Required field validation', function () {
     test('filename validation', function (string $value, bool $expectError) {
         $asset = AssetModel::factory()->createElement();
@@ -122,20 +62,14 @@ describe('Title validation on SCENARIO_CREATE', function () {
 });
 
 describe('Safe attribute validation', function () {
-    test('safe attributes accept valid values', function (string $field, mixed $value) {
+    test('alt accepts string with special chars', function () {
         $asset = AssetModel::factory()->createElement();
-        $asset->{$field} = $value;
+        $asset->alt = 'Some alternative text with special characters: <>&"';
 
-        $asset->validate([$field]);
+        $asset->validate(['alt']);
 
-        expect($asset->hasErrors($field))->toBeFalse();
-    })->with([
-        'filename accepts valid string' => ['filename', 'new-filename.jpg'],
-        'newFilename accepts valid string' => ['newFilename', 'renamed-file.jpg'],
-        'alt accepts string with special chars' => ['alt', 'Some alternative text with special characters: <>&"'],
-        'alt accepts null' => ['alt', null],
-        'alt accepts empty string' => ['alt', ''],
-    ]);
+        expect($asset->hasErrors('alt'))->toBeFalse();
+    });
 });
 
 describe('Scenario-specific required validation', function () {
@@ -193,27 +127,6 @@ describe('SCENARIO_INDEX validation', function () {
 });
 
 describe('Edge cases', function () {
-    test('null values are handled gracefully for all nullable fields', function () {
-        $asset = AssetModel::factory()->createElement();
-        $asset->volumeId = null;
-        $asset->folderId = null;
-        $asset->width = null;
-        $asset->height = null;
-        $asset->size = null;
-        $asset->dateModified = null;
-        $asset->alt = null;
-
-        $asset->validate(['volumeId', 'folderId', 'width', 'height', 'size', 'dateModified', 'alt']);
-
-        expect($asset->hasErrors('volumeId'))->toBeFalse();
-        expect($asset->hasErrors('folderId'))->toBeFalse();
-        expect($asset->hasErrors('width'))->toBeFalse();
-        expect($asset->hasErrors('height'))->toBeFalse();
-        expect($asset->hasErrors('size'))->toBeFalse();
-        expect($asset->hasErrors('dateModified'))->toBeFalse();
-        expect($asset->hasErrors('alt'))->toBeFalse();
-    });
-
     test('unicode characters are handled in alt text', function () {
         $asset = AssetModel::factory()->createElement();
         $asset->alt = 'Image of 山 mountain';

--- a/tests/Element/Elements/ElementValidationTest.php
+++ b/tests/Element/Elements/ElementValidationTest.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Edition;
+use CraftCms\Cms\Element\Element;
+use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Support\Facades\Sites;
+
+beforeEach(function () {
+    Edition::set(Edition::Pro);
+});
+
+describe('Integer validation for structure attributes', function () {
+    test('structure integer fields accept valid integers', function (string $field, int $value) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->{$field} = $value;
+
+        $entry->validate([$field]);
+
+        expect($entry->hasErrors($field))->toBeFalse();
+    })->with([
+        'id accepts 1' => ['id', 1],
+        'id accepts 999' => ['id', 999],
+        'parentId accepts 1' => ['parentId', 1],
+        'root accepts 1' => ['root', 1],
+        'lft accepts 1' => ['lft', 1],
+        'rgt accepts 2' => ['rgt', 2],
+        'level accepts 0' => ['level', 0],
+        'level accepts 5' => ['level', 5],
+    ]);
+
+    test('structure integer fields accept null', function (string $field) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->{$field} = null;
+
+        $entry->validate([$field]);
+
+        expect($entry->hasErrors($field))->toBeFalse();
+    })->with([
+        'id accepts null' => ['id'],
+        'parentId accepts null' => ['parentId'],
+        'root accepts null' => ['root'],
+        'lft accepts null' => ['lft'],
+        'rgt accepts null' => ['rgt'],
+        'level accepts null' => ['level'],
+    ]);
+
+});
+
+describe('Site ID validation', function () {
+    test('siteId accepts valid site ID', function () {
+        $entry = EntryModel::factory()->createElement();
+        $site = Sites::getPrimarySite();
+        $entry->siteId = $site->id;
+
+        $entry->validate(['siteId']);
+
+        expect($entry->hasErrors('siteId'))->toBeFalse();
+    });
+
+    test('siteId is validated on SCENARIO_DEFAULT', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_DEFAULT);
+        $site = Sites::getPrimarySite();
+        $entry->siteId = $site->id;
+
+        $entry->validate(['siteId']);
+
+        expect($entry->hasErrors('siteId'))->toBeFalse();
+    });
+
+    test('siteId is validated on SCENARIO_LIVE', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_LIVE);
+        $site = Sites::getPrimarySite();
+        $entry->siteId = $site->id;
+
+        $entry->validate(['siteId']);
+
+        expect($entry->hasErrors('siteId'))->toBeFalse();
+    });
+
+    test('siteId is validated on SCENARIO_ESSENTIALS', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_ESSENTIALS);
+        $site = Sites::getPrimarySite();
+        $entry->siteId = $site->id;
+
+        $entry->validate(['siteId']);
+
+        expect($entry->hasErrors('siteId'))->toBeFalse();
+    });
+});
+
+describe('DateTime validation', function () {
+    test('dateCreated and dateUpdated accept DateTime objects', function (string $field) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->{$field} = new DateTime;
+
+        $entry->validate([$field]);
+
+        expect($entry->hasErrors($field))->toBeFalse();
+    })->with([
+        'dateCreated accepts DateTime' => ['dateCreated'],
+        'dateUpdated accepts DateTime' => ['dateUpdated'],
+    ]);
+
+    test('dateCreated and dateUpdated accept null', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->dateCreated = null;
+        $entry->dateUpdated = null;
+
+        $entry->validate(['dateCreated', 'dateUpdated']);
+
+        expect($entry->hasErrors('dateCreated'))->toBeFalse();
+        expect($entry->hasErrors('dateUpdated'))->toBeFalse();
+    });
+
+    test('dateCreated and dateUpdated accept past dates', function (string $field) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->{$field} = new DateTime('-1 year');
+
+        $entry->validate([$field]);
+
+        expect($entry->hasErrors($field))->toBeFalse();
+    })->with([
+        'dateCreated accepts past date' => ['dateCreated'],
+        'dateUpdated accepts past date' => ['dateUpdated'],
+    ]);
+
+    test('dateCreated and dateUpdated accept future dates', function (string $field) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->{$field} = new DateTime('+1 year');
+
+        $entry->validate([$field]);
+
+        expect($entry->hasErrors($field))->toBeFalse();
+    })->with([
+        'dateCreated accepts future date' => ['dateCreated'],
+        'dateUpdated accepts future date' => ['dateUpdated'],
+    ]);
+});
+
+describe('Boolean validation', function () {
+    test('isFresh accepts boolean values', function (bool $value) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->isFresh = $value;
+
+        $entry->validate(['isFresh']);
+
+        expect($entry->hasErrors('isFresh'))->toBeFalse();
+    })->with([
+        'isFresh accepts true' => [true],
+        'isFresh accepts false' => [false],
+    ]);
+});
+
+describe('Title validation', function () {
+    test('title is trimmed of whitespace', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->title = '  Test Title  ';
+
+        $entry->validate(['title']);
+
+        expect($entry->title)->toBe('Test Title');
+    });
+
+    test('title accepts 255 characters', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->title = str_repeat('a', 255);
+
+        $entry->validate(['title']);
+
+        expect($entry->hasErrors('title'))->toBeFalse();
+    });
+
+    test('title rejects 256+ characters', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->title = str_repeat('a', 256);
+
+        $entry->validate(['title']);
+
+        expect($entry->hasErrors('title'))->toBeTrue();
+    });
+
+    test('title rejects 4-byte unicode (mb4) characters', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->title = 'Test 𝕋𝕚𝕥𝕝𝕖'; // Contains 4-byte unicode characters
+
+        $entry->validate(['title']);
+
+        expect($entry->hasErrors('title'))->toBeTrue();
+    });
+
+    test('title is required on SCENARIO_DEFAULT for elements with titles', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_DEFAULT);
+        $entry->title = '';
+
+        $entry->validate(['title']);
+
+        expect($entry->hasErrors('title'))->toBeTrue();
+    });
+
+    test('title is required on SCENARIO_LIVE for elements with titles', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_LIVE);
+        $entry->title = '';
+
+        $entry->validate(['title']);
+
+        expect($entry->hasErrors('title'))->toBeTrue();
+    });
+});
+
+describe('Slug validation', function () {
+    test('slug accepts valid characters', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->slug = 'valid-slug-123';
+
+        $entry->validate(['slug']);
+
+        expect($entry->hasErrors('slug'))->toBeFalse();
+    });
+
+    test('slug normalizes special characters', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->slug = 'Tëst Slüg';
+
+        $entry->validate(['slug']);
+
+        // Slug normalization happens but may not be lowercase depending on language
+        expect($entry->hasErrors('slug'))->toBeFalse();
+    });
+
+    test('slug accepts 255 characters', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->slug = str_repeat('a', 255);
+
+        $entry->validate(['slug']);
+
+        expect($entry->hasErrors('slug'))->toBeFalse();
+    });
+
+    test('slug rejects 256+ characters', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->slug = str_repeat('a', 256);
+
+        $entry->validate(['slug']);
+
+        expect($entry->hasErrors('slug'))->toBeTrue();
+    });
+
+    test('slug is validated on SCENARIO_ESSENTIALS', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_ESSENTIALS);
+        $entry->slug = str_repeat('a', 256);
+
+        $entry->validate(['slug']);
+
+        expect($entry->hasErrors('slug'))->toBeTrue();
+    });
+});
+
+describe('URI validation', function () {
+    test('uri passes validation for valid format', function () {
+        $entry = EntryModel::factory()->createElement();
+
+        $entry->validate(['uri']);
+
+        expect($entry->hasErrors('uri'))->toBeFalse();
+    });
+
+    test('uri is validated on SCENARIO_ESSENTIALS', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_ESSENTIALS);
+
+        $entry->validate(['uri']);
+
+        expect($entry->hasErrors('uri'))->toBeFalse();
+    });
+});
+
+describe('Scenario validation', function () {
+    test('SCENARIO_LIVE validates title when required', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_LIVE);
+        $entry->title = '';
+
+        $entry->validate(['title']);
+
+        expect($entry->hasErrors('title'))->toBeTrue();
+    });
+
+    test('SCENARIO_DEFAULT validates title when required', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_DEFAULT);
+        $entry->title = '';
+
+        $entry->validate(['title']);
+
+        expect($entry->hasErrors('title'))->toBeTrue();
+    });
+});
+
+describe('Edge cases', function () {
+    test('nullable fields accept null values', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->id = null;
+        $entry->parentId = null;
+        $entry->dateCreated = null;
+        $entry->dateUpdated = null;
+
+        $entry->validate(['id', 'parentId', 'dateCreated', 'dateUpdated']);
+
+        expect($entry->hasErrors('id'))->toBeFalse();
+        expect($entry->hasErrors('parentId'))->toBeFalse();
+        expect($entry->hasErrors('dateCreated'))->toBeFalse();
+        expect($entry->hasErrors('dateUpdated'))->toBeFalse();
+    });
+
+    test('unicode characters are handled in title', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->title = '日本語タイトル';
+
+        $entry->validate(['title']);
+
+        expect($entry->hasErrors('title'))->toBeFalse();
+    });
+
+    test('multiple validation errors can be collected', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->title = str_repeat('a', 256);
+        $entry->slug = str_repeat('b', 256);
+
+        $entry->validate(['title', 'slug']);
+
+        expect($entry->hasErrors('title'))->toBeTrue();
+        expect($entry->hasErrors('slug'))->toBeTrue();
+    });
+
+    test('validation with specific attribute names only validates those attributes', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->title = str_repeat('a', 256); // Invalid
+        $entry->slug = 'valid-slug'; // Valid
+
+        $entry->validate(['slug']);
+
+        expect($entry->hasErrors('slug'))->toBeFalse();
+        expect($entry->hasErrors('title'))->toBeFalse(); // Not validated
+    });
+
+    test('validation with clearErrors=false preserves existing errors', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->addError('title', 'Custom error');
+        $entry->slug = 'valid-slug';
+
+        $entry->validate(['slug'], false);
+
+        expect($entry->hasErrors('title'))->toBeTrue();
+        expect($entry->getErrors('title'))->toBe(['Custom error']);
+    });
+});

--- a/tests/Element/Elements/ElementValidationTest.php
+++ b/tests/Element/Elements/ElementValidationTest.php
@@ -6,6 +6,7 @@ use CraftCms\Cms\Edition;
 use CraftCms\Cms\Element\Element;
 use CraftCms\Cms\Entry\Models\Entry as EntryModel;
 use CraftCms\Cms\Support\Facades\Sites;
+use Illuminate\Support\Facades\DB;
 
 beforeEach(function () {
     Edition::set(Edition::Pro);
@@ -185,7 +186,7 @@ describe('Title validation', function () {
     });
 
     test('title rejects 4-byte unicode (mb4) characters', function () {
-        $this->markTestSkippedWhen(\Illuminate\Support\Facades\DB::getDriverName() === 'pgsql', 'PostgreSQL always supports 4-byte unicode characters');
+        $this->markTestSkippedWhen(DB::getDriverName() === 'pgsql', 'PostgreSQL always supports 4-byte unicode characters');
 
         $entry = EntryModel::factory()->createElement();
         $entry->title = 'Test 𝕋𝕚𝕥𝕝𝕖'; // Contains 4-byte unicode characters

--- a/tests/Element/Elements/ElementValidationTest.php
+++ b/tests/Element/Elements/ElementValidationTest.php
@@ -185,6 +185,8 @@ describe('Title validation', function () {
     });
 
     test('title rejects 4-byte unicode (mb4) characters', function () {
+        $this->markTestSkippedWhen(\Illuminate\Support\Facades\DB::getDriverName() === 'pgsql', 'PostgreSQL always supports 4-byte unicode characters');
+
         $entry = EntryModel::factory()->createElement();
         $entry->title = 'Test 𝕋𝕚𝕥𝕝𝕖'; // Contains 4-byte unicode characters
 

--- a/tests/Element/Elements/ElementValidationTest.php
+++ b/tests/Element/Elements/ElementValidationTest.php
@@ -12,43 +12,6 @@ beforeEach(function () {
     Edition::set(Edition::Pro);
 });
 
-describe('Integer validation for structure attributes', function () {
-    test('structure integer fields accept valid integers', function (string $field, int $value) {
-        $entry = EntryModel::factory()->createElement();
-        $entry->{$field} = $value;
-
-        $entry->validate([$field]);
-
-        expect($entry->hasErrors($field))->toBeFalse();
-    })->with([
-        'id accepts 1' => ['id', 1],
-        'id accepts 999' => ['id', 999],
-        'parentId accepts 1' => ['parentId', 1],
-        'root accepts 1' => ['root', 1],
-        'lft accepts 1' => ['lft', 1],
-        'rgt accepts 2' => ['rgt', 2],
-        'level accepts 0' => ['level', 0],
-        'level accepts 5' => ['level', 5],
-    ]);
-
-    test('structure integer fields accept null', function (string $field) {
-        $entry = EntryModel::factory()->createElement();
-        $entry->{$field} = null;
-
-        $entry->validate([$field]);
-
-        expect($entry->hasErrors($field))->toBeFalse();
-    })->with([
-        'id accepts null' => ['id'],
-        'parentId accepts null' => ['parentId'],
-        'root accepts null' => ['root'],
-        'lft accepts null' => ['lft'],
-        'rgt accepts null' => ['rgt'],
-        'level accepts null' => ['level'],
-    ]);
-
-});
-
 describe('Site ID validation', function () {
     test('siteId accepts valid site ID', function () {
         $entry = EntryModel::factory()->createElement();
@@ -92,69 +55,6 @@ describe('Site ID validation', function () {
 
         expect($entry->hasErrors('siteId'))->toBeFalse();
     });
-});
-
-describe('DateTime validation', function () {
-    test('dateCreated and dateUpdated accept DateTime objects', function (string $field) {
-        $entry = EntryModel::factory()->createElement();
-        $entry->{$field} = new DateTime;
-
-        $entry->validate([$field]);
-
-        expect($entry->hasErrors($field))->toBeFalse();
-    })->with([
-        'dateCreated accepts DateTime' => ['dateCreated'],
-        'dateUpdated accepts DateTime' => ['dateUpdated'],
-    ]);
-
-    test('dateCreated and dateUpdated accept null', function () {
-        $entry = EntryModel::factory()->createElement();
-        $entry->dateCreated = null;
-        $entry->dateUpdated = null;
-
-        $entry->validate(['dateCreated', 'dateUpdated']);
-
-        expect($entry->hasErrors('dateCreated'))->toBeFalse();
-        expect($entry->hasErrors('dateUpdated'))->toBeFalse();
-    });
-
-    test('dateCreated and dateUpdated accept past dates', function (string $field) {
-        $entry = EntryModel::factory()->createElement();
-        $entry->{$field} = new DateTime('-1 year');
-
-        $entry->validate([$field]);
-
-        expect($entry->hasErrors($field))->toBeFalse();
-    })->with([
-        'dateCreated accepts past date' => ['dateCreated'],
-        'dateUpdated accepts past date' => ['dateUpdated'],
-    ]);
-
-    test('dateCreated and dateUpdated accept future dates', function (string $field) {
-        $entry = EntryModel::factory()->createElement();
-        $entry->{$field} = new DateTime('+1 year');
-
-        $entry->validate([$field]);
-
-        expect($entry->hasErrors($field))->toBeFalse();
-    })->with([
-        'dateCreated accepts future date' => ['dateCreated'],
-        'dateUpdated accepts future date' => ['dateUpdated'],
-    ]);
-});
-
-describe('Boolean validation', function () {
-    test('isFresh accepts boolean values', function (bool $value) {
-        $entry = EntryModel::factory()->createElement();
-        $entry->isFresh = $value;
-
-        $entry->validate(['isFresh']);
-
-        expect($entry->hasErrors('isFresh'))->toBeFalse();
-    })->with([
-        'isFresh accepts true' => [true],
-        'isFresh accepts false' => [false],
-    ]);
 });
 
 describe('Title validation', function () {
@@ -308,21 +208,6 @@ describe('Scenario validation', function () {
 });
 
 describe('Edge cases', function () {
-    test('nullable fields accept null values', function () {
-        $entry = EntryModel::factory()->createElement();
-        $entry->id = null;
-        $entry->parentId = null;
-        $entry->dateCreated = null;
-        $entry->dateUpdated = null;
-
-        $entry->validate(['id', 'parentId', 'dateCreated', 'dateUpdated']);
-
-        expect($entry->hasErrors('id'))->toBeFalse();
-        expect($entry->hasErrors('parentId'))->toBeFalse();
-        expect($entry->hasErrors('dateCreated'))->toBeFalse();
-        expect($entry->hasErrors('dateUpdated'))->toBeFalse();
-    });
-
     test('unicode characters are handled in title', function () {
         $entry = EntryModel::factory()->createElement();
         $entry->title = '日本語タイトル';

--- a/tests/Entry/Elements/EntryValidationTest.php
+++ b/tests/Entry/Elements/EntryValidationTest.php
@@ -15,64 +15,6 @@ beforeEach(function () {
     Edition::set(Edition::Pro);
 });
 
-describe('Integer validation', function () {
-    test('integer fields accept valid integers', function (string $field, int $value, ?callable $setup = null) {
-        $entry = EntryModel::factory()->createElement();
-        $setup?->__invoke($entry);
-
-        $entry->{$field} = $value;
-        $entry->validate([$field]);
-
-        expect($entry->hasErrors($field))->toBeFalse();
-    })->with([
-        'sectionId accepts 1' => ['sectionId', 1],
-        'fieldId accepts 1' => ['fieldId', 1, fn ($entry) => $entry->sectionId = null],
-        'ownerId accepts 1' => ['ownerId', 1],
-        'primaryOwnerId accepts 1' => ['primaryOwnerId', 1],
-        'sortOrder accepts 1' => ['sortOrder', 1],
-        'sortOrder accepts 0' => ['sortOrder', 0],
-    ]);
-
-    test('typeId accepts valid integers from factory', function () {
-        $entry = EntryModel::factory()->createElement();
-
-        $entry->validate(['typeId']);
-
-        expect($entry->hasErrors('typeId'))->toBeFalse();
-    });
-
-    test('nullable integer fields accept null', function (string $field, ?callable $setup = null) {
-        $entry = EntryModel::factory()->createElement();
-        $setup?->__invoke($entry);
-
-        $entry->{$field} = null;
-        $entry->validate([$field]);
-
-        expect($entry->hasErrors($field))->toBeFalse();
-    })->with([
-        'sectionId accepts null when fieldId is set' => ['sectionId', fn ($entry) => $entry->fieldId = 1],
-        'fieldId accepts null' => ['fieldId'],
-        'ownerId accepts null' => ['ownerId'],
-        'primaryOwnerId accepts null' => ['primaryOwnerId'],
-        'sortOrder accepts null' => ['sortOrder'],
-    ]);
-});
-
-describe('authorIds array validation', function () {
-    test('authorIds accepts valid arrays', function (array $authorIds) {
-        $entry = EntryModel::factory()->createElement();
-        $entry->setAuthorIds($authorIds);
-
-        $entry->validate(['authorIds']);
-
-        expect($entry->hasErrors('authorIds'))->toBeFalse();
-    })->with([
-        'array of integers' => [[1, 2, 3]],
-        'empty array' => [[]],
-        'single integer in array' => [[1]],
-    ]);
-});
-
 describe('Safe attribute validation', function () {
     test('placeInStructure is a safe attribute', function (bool $value) {
         $entry = EntryModel::factory()->createElement();
@@ -108,6 +50,17 @@ describe('Required field validation', function () {
         expect($entry->hasErrors('sectionId'))->toBeFalse();
     });
 
+    test('fieldId and sectionId cannot both be set', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->fieldId = 1;
+
+        $entry->validate(['fieldId']);
+
+        expect($entry->hasErrors('fieldId'))->toBeTrue();
+        expect($entry->getFirstError('fieldId'))->toContain('sectionId');
+        expect($entry->getFirstError('fieldId'))->toContain('fieldId');
+    });
+
     test('typeId is required and cannot be empty', function () {
         $entry = EntryModel::factory()->createElement();
 
@@ -137,29 +90,6 @@ describe('Entry type validation', function () {
     });
 });
 
-describe('Mutual exclusion validation', function () {
-    test('fieldId and sectionId cannot both be set', function () {
-        $entry = EntryModel::factory()->createElement();
-        $entry->fieldId = 1;
-
-        $entry->validate(['fieldId']);
-
-        expect($entry->hasErrors('fieldId'))->toBeTrue();
-        expect($entry->getFirstError('fieldId'))->toContain('sectionId');
-        expect($entry->getFirstError('fieldId'))->toContain('fieldId');
-    });
-
-    test('fieldId without sectionId is valid', function () {
-        $entry = EntryModel::factory()->createElement();
-        $entry->sectionId = null;
-        $entry->fieldId = 1;
-
-        $entry->validate(['fieldId']);
-
-        expect($entry->hasErrors('fieldId'))->toBeFalse();
-    });
-});
-
 describe('DateTime validation', function () {
     test('date fields accept valid values', function (string $field, mixed $value) {
         $entry = EntryModel::factory()->createElement();
@@ -169,14 +99,8 @@ describe('DateTime validation', function () {
 
         expect($entry->hasErrors($field))->toBeFalse();
     })->with([
-        'postDate accepts DateTime' => ['postDate', new DateTime],
         'postDate accepts null' => ['postDate', null],
-        'postDate accepts past dates' => ['postDate', new DateTime('2020-01-01')],
-        'postDate accepts future dates' => ['postDate', new DateTime('+1 year')],
-        'expiryDate accepts DateTime' => ['expiryDate', new DateTime('+1 year')],
         'expiryDate accepts null' => ['expiryDate', null],
-        'expiryDate accepts past dates' => ['expiryDate', new DateTime('2020-01-01')],
-        'expiryDate accepts future dates' => ['expiryDate', new DateTime('+1 year')],
     ]);
 });
 
@@ -424,23 +348,6 @@ describe('Scenario-specific validation', function () {
 });
 
 describe('Edge cases', function () {
-    test('null values are handled gracefully for nullable fields', function () {
-        $entry = EntryModel::factory()->createElement();
-        $entry->fieldId = null;
-        $entry->ownerId = null;
-        $entry->primaryOwnerId = null;
-        $entry->sortOrder = null;
-        $entry->expiryDate = null;
-
-        $entry->validate(['fieldId', 'ownerId', 'primaryOwnerId', 'sortOrder', 'expiryDate']);
-
-        expect($entry->hasErrors('fieldId'))->toBeFalse();
-        expect($entry->hasErrors('ownerId'))->toBeFalse();
-        expect($entry->hasErrors('primaryOwnerId'))->toBeFalse();
-        expect($entry->hasErrors('sortOrder'))->toBeFalse();
-        expect($entry->hasErrors('expiryDate'))->toBeFalse();
-    });
-
     test('multiple validation errors can be collected', function () {
         $entry = EntryModel::factory()->createElement();
         $entry->sectionId = null;
@@ -449,15 +356,6 @@ describe('Edge cases', function () {
         $entry->validate(['sectionId']);
 
         expect($entry->hasErrors('sectionId'))->toBeTrue();
-    });
-
-    test('integer fields accept zero', function () {
-        $entry = EntryModel::factory()->createElement();
-        $entry->sortOrder = 0;
-
-        $entry->validate(['sortOrder']);
-
-        expect($entry->hasErrors('sortOrder'))->toBeFalse();
     });
 
     test('factory creates valid entry by default', function () {

--- a/tests/Entry/Elements/EntryValidationTest.php
+++ b/tests/Entry/Elements/EntryValidationTest.php
@@ -1,0 +1,470 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Edition;
+use CraftCms\Cms\Element\Element;
+use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Entry\Models\EntryType;
+use CraftCms\Cms\Section\Enums\SectionType;
+use CraftCms\Cms\Section\Models\Section;
+use CraftCms\Cms\User\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach(function () {
+    Edition::set(Edition::Pro);
+});
+
+describe('Integer validation', function () {
+    test('integer fields accept valid integers', function (string $field, int $value, ?callable $setup = null) {
+        $entry = EntryModel::factory()->createElement();
+        $setup?->__invoke($entry);
+
+        $entry->{$field} = $value;
+        $entry->validate([$field]);
+
+        expect($entry->hasErrors($field))->toBeFalse();
+    })->with([
+        'sectionId accepts 1' => ['sectionId', 1],
+        'fieldId accepts 1' => ['fieldId', 1, fn ($entry) => $entry->sectionId = null],
+        'ownerId accepts 1' => ['ownerId', 1],
+        'primaryOwnerId accepts 1' => ['primaryOwnerId', 1],
+        'sortOrder accepts 1' => ['sortOrder', 1],
+        'sortOrder accepts 0' => ['sortOrder', 0],
+    ]);
+
+    test('typeId accepts valid integers from factory', function () {
+        $entry = EntryModel::factory()->createElement();
+
+        $entry->validate(['typeId']);
+
+        expect($entry->hasErrors('typeId'))->toBeFalse();
+    });
+
+    test('nullable integer fields accept null', function (string $field, ?callable $setup = null) {
+        $entry = EntryModel::factory()->createElement();
+        $setup?->__invoke($entry);
+
+        $entry->{$field} = null;
+        $entry->validate([$field]);
+
+        expect($entry->hasErrors($field))->toBeFalse();
+    })->with([
+        'sectionId accepts null when fieldId is set' => ['sectionId', fn ($entry) => $entry->fieldId = 1],
+        'fieldId accepts null' => ['fieldId'],
+        'ownerId accepts null' => ['ownerId'],
+        'primaryOwnerId accepts null' => ['primaryOwnerId'],
+        'sortOrder accepts null' => ['sortOrder'],
+    ]);
+});
+
+describe('authorIds array validation', function () {
+    test('authorIds accepts valid arrays', function (array $authorIds) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setAuthorIds($authorIds);
+
+        $entry->validate(['authorIds']);
+
+        expect($entry->hasErrors('authorIds'))->toBeFalse();
+    })->with([
+        'array of integers' => [[1, 2, 3]],
+        'empty array' => [[]],
+        'single integer in array' => [[1]],
+    ]);
+});
+
+describe('Safe attribute validation', function () {
+    test('placeInStructure is a safe attribute', function (bool $value) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->placeInStructure = $value;
+
+        $entry->validate(['placeInStructure']);
+
+        expect($entry->hasErrors('placeInStructure'))->toBeFalse();
+    })->with([
+        'true' => [true],
+        'false' => [false],
+    ]);
+});
+
+describe('Required field validation', function () {
+    test('sectionId is required when fieldId is not set', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->sectionId = null;
+        $entry->fieldId = null;
+
+        $entry->validate(['sectionId']);
+
+        expect($entry->hasErrors('sectionId'))->toBeTrue();
+    });
+
+    test('sectionId is not required when fieldId is set', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->sectionId = null;
+        $entry->fieldId = 1;
+
+        $entry->validate(['sectionId']);
+
+        expect($entry->hasErrors('sectionId'))->toBeFalse();
+    });
+
+    test('typeId is required and cannot be empty', function () {
+        $entry = EntryModel::factory()->createElement();
+
+        $entry->validate(['typeId']);
+
+        expect($entry->hasErrors('typeId'))->toBeFalse();
+    });
+});
+
+describe('Entry type validation', function () {
+    test('typeId must be in available entry types', function () {
+        $entry = EntryModel::factory()->createElement();
+
+        $entry->validate(['typeId']);
+
+        expect($entry->hasErrors('typeId'))->toBeFalse();
+    });
+
+    test('typeId rejects entry type not in section', function () {
+        $entry = EntryModel::factory()->createElement();
+        $otherEntryType = EntryType::factory()->create();
+
+        $entry->typeId = $otherEntryType->id;
+        $entry->validate(['typeId']);
+
+        expect($entry->hasErrors('typeId'))->toBeTrue();
+    });
+});
+
+describe('Mutual exclusion validation', function () {
+    test('fieldId and sectionId cannot both be set', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->fieldId = 1;
+
+        $entry->validate(['fieldId']);
+
+        expect($entry->hasErrors('fieldId'))->toBeTrue();
+        expect($entry->getFirstError('fieldId'))->toContain('sectionId');
+        expect($entry->getFirstError('fieldId'))->toContain('fieldId');
+    });
+
+    test('fieldId without sectionId is valid', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->sectionId = null;
+        $entry->fieldId = 1;
+
+        $entry->validate(['fieldId']);
+
+        expect($entry->hasErrors('fieldId'))->toBeFalse();
+    });
+});
+
+describe('DateTime validation', function () {
+    test('date fields accept valid values', function (string $field, mixed $value) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->{$field} = $value;
+
+        $entry->validate([$field]);
+
+        expect($entry->hasErrors($field))->toBeFalse();
+    })->with([
+        'postDate accepts DateTime' => ['postDate', new DateTime],
+        'postDate accepts null' => ['postDate', null],
+        'postDate accepts past dates' => ['postDate', new DateTime('2020-01-01')],
+        'postDate accepts future dates' => ['postDate', new DateTime('+1 year')],
+        'expiryDate accepts DateTime' => ['expiryDate', new DateTime('+1 year')],
+        'expiryDate accepts null' => ['expiryDate', null],
+        'expiryDate accepts past dates' => ['expiryDate', new DateTime('2020-01-01')],
+        'expiryDate accepts future dates' => ['expiryDate', new DateTime('+1 year')],
+    ]);
+});
+
+describe('Date comparison validation', function () {
+    test('date comparison validation on SCENARIO_LIVE', function (
+        ?DateTime $postDate,
+        ?DateTime $expiryDate,
+        bool $expectError
+    ) {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_LIVE);
+        $entry->postDate = $postDate;
+        $entry->expiryDate = $expiryDate;
+
+        $entry->validate(['postDate']);
+
+        expect($entry->hasErrors('postDate'))->toBe($expectError);
+    })->with([
+        'postDate after expiryDate is invalid' => [new DateTime('2025-01-01'), new DateTime('2024-01-01'), true],
+        'postDate before expiryDate is valid' => [new DateTime('2024-01-01'), new DateTime('2025-01-01'), false],
+        'only postDate set is valid' => [new DateTime('2025-01-01'), null, false],
+        'only expiryDate set is valid' => [null, new DateTime('2025-01-01'), false],
+    ]);
+
+    test('date comparison does not apply on default scenario', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->postDate = new DateTime('2025-01-01');
+        $entry->expiryDate = new DateTime('2024-01-01');
+
+        $entry->validate(['postDate']);
+
+        expect($entry->hasErrors('postDate'))->toBeFalse();
+    });
+});
+
+describe('Author required validation', function () {
+    test('authorIds requirement varies by section type and scenario', function (
+        SectionType $sectionType,
+        bool $isLiveScenario,
+        int $maxAuthors,
+        bool $expectError
+    ) {
+        $section = Section::factory()->create([
+            'type' => $sectionType,
+            'maxAuthors' => $maxAuthors,
+        ]);
+        $entryType = EntryType::factory()->create();
+        $section->entryTypes()->attach($entryType, ['sortOrder' => 1]);
+
+        $entry = EntryModel::factory()->createElement([
+            'sectionId' => $section->id,
+            'typeId' => $entryType->id,
+        ]);
+
+        if ($isLiveScenario) {
+            $entry->setScenario(Element::SCENARIO_LIVE);
+        }
+
+        $entry->setAuthorIds([]);
+        $entry->validate(['authorIds']);
+
+        expect($entry->hasErrors('authorIds'))->toBe($expectError);
+    })->with([
+        'Channel with SCENARIO_LIVE requires authors' => [SectionType::Channel, true, 1, true],
+        'Structure with SCENARIO_LIVE requires authors' => [SectionType::Structure, true, 1, true],
+        'Single sections do not require authors' => [SectionType::Single, true, 1, false],
+        'Channel with maxAuthors 0 does not require authors' => [SectionType::Channel, true, 0, false],
+        'Channel on default scenario does not require authors' => [SectionType::Channel, false, 1, false],
+    ]);
+});
+
+describe('Author max count validation', function () {
+    test('authorIds validates author count against maxAuthors', function (
+        int $maxAuthors,
+        int $authorCount,
+        bool $expectError,
+        ?string $errorContains = null
+    ) {
+        $section = Section::factory()->create([
+            'type' => SectionType::Channel,
+            'maxAuthors' => $maxAuthors,
+        ]);
+        $entryType = EntryType::factory()->create();
+        $section->entryTypes()->attach($entryType, ['sortOrder' => 1]);
+
+        $users = [];
+        for ($i = 0; $i < $authorCount; $i++) {
+            $users[] = User::factory()->create(['admin' => true]);
+        }
+
+        $entry = EntryModel::factory()->createElement([
+            'sectionId' => $section->id,
+            'typeId' => $entryType->id,
+        ]);
+        $entry->setAuthorIds(array_map(fn ($u) => $u->id, $users));
+
+        $entry->validate(['authorIds']);
+
+        expect($entry->hasErrors('authorIds'))->toBe($expectError);
+
+        if ($errorContains !== null) {
+            expect($entry->getFirstError('authorIds'))->toContain($errorContains);
+        }
+    })->with([
+        'rejects more authors than maxAuthors allows (singular)' => [1, 2, true, 'Only one author'],
+        'accepts authors within maxAuthors limit' => [2, 2, false],
+        'error message uses plural for multiple allowed authors' => [3, 5, true, 'authors are'],
+    ]);
+});
+
+describe('Author permission validation', function () {
+    test('author must have viewEntries permission for the section', function () {
+        $section = Section::factory()->create([
+            'type' => SectionType::Channel,
+            'maxAuthors' => 1,
+        ]);
+        $entryType = EntryType::factory()->create();
+        $section->entryTypes()->attach($entryType, ['sortOrder' => 1]);
+
+        $user = User::factory()->create(['admin' => false]);
+
+        $entry = EntryModel::factory()->createElement([
+            'sectionId' => $section->id,
+            'typeId' => $entryType->id,
+        ]);
+        $entry->setAuthorIds([$user->id]);
+
+        $entry->validate(['authorIds']);
+
+        expect($entry->hasErrors('authorIds'))->toBeTrue();
+        expect($entry->getFirstError('authorIds'))->toContain('permission');
+    });
+
+    test('author with viewEntries permission is valid', function () {
+        $section = Section::factory()->create([
+            'type' => SectionType::Channel,
+            'maxAuthors' => 1,
+        ]);
+        $entryType = EntryType::factory()->create();
+        $section->entryTypes()->attach($entryType, ['sortOrder' => 1]);
+
+        $user = User::factory()->create(['admin' => false]);
+
+        Gate::before(function ($authUser, string $ability) use ($user, $section) {
+            if ($authUser->id === $user->id && $ability === "viewEntries:{$section->uid}") {
+                return true;
+            }
+
+            return null;
+        });
+
+        $entry = EntryModel::factory()->createElement([
+            'sectionId' => $section->id,
+            'typeId' => $entryType->id,
+        ]);
+        $entry->setAuthorIds([$user->id]);
+
+        $entry->validate(['authorIds']);
+
+        expect($entry->hasErrors('authorIds'))->toBeFalse();
+    });
+
+    test('admin user can be author without explicit permission', function () {
+        $section = Section::factory()->create([
+            'type' => SectionType::Channel,
+            'maxAuthors' => 1,
+        ]);
+        $entryType = EntryType::factory()->create();
+        $section->entryTypes()->attach($entryType, ['sortOrder' => 1]);
+
+        $adminUser = User::factory()->create(['admin' => true]);
+
+        $entry = EntryModel::factory()->createElement([
+            'sectionId' => $section->id,
+            'typeId' => $entryType->id,
+        ]);
+        $entry->setAuthorIds([$adminUser->id]);
+
+        $entry->validate(['authorIds']);
+
+        expect($entry->hasErrors('authorIds'))->toBeFalse();
+    });
+});
+
+describe('Scenario-specific validation', function () {
+    test('SCENARIO_LIVE validates date comparison', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->setScenario(Element::SCENARIO_LIVE);
+        $entry->postDate = new DateTime('2025-01-01');
+        $entry->expiryDate = new DateTime('2024-01-01');
+
+        $entry->validate(['postDate']);
+
+        expect($entry->hasErrors('postDate'))->toBeTrue();
+    });
+
+    test('default scenario skips date comparison validation', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->postDate = new DateTime('2025-01-01');
+        $entry->expiryDate = new DateTime('2024-01-01');
+
+        $entry->validate(['postDate']);
+
+        expect($entry->hasErrors('postDate'))->toBeFalse();
+    });
+
+    test('SCENARIO_LIVE validates author requirement', function () {
+        $section = Section::factory()->create([
+            'type' => SectionType::Channel,
+            'maxAuthors' => 1,
+        ]);
+        $entryType = EntryType::factory()->create();
+        $section->entryTypes()->attach($entryType, ['sortOrder' => 1]);
+
+        $entry = EntryModel::factory()->createElement([
+            'sectionId' => $section->id,
+            'typeId' => $entryType->id,
+        ]);
+        $entry->setScenario(Element::SCENARIO_LIVE);
+        $entry->setAuthorIds([]);
+
+        $entry->validate(['authorIds']);
+
+        expect($entry->hasErrors('authorIds'))->toBeTrue();
+    });
+
+    test('default scenario skips author requirement validation', function () {
+        $section = Section::factory()->create([
+            'type' => SectionType::Channel,
+            'maxAuthors' => 1,
+        ]);
+        $entryType = EntryType::factory()->create();
+        $section->entryTypes()->attach($entryType, ['sortOrder' => 1]);
+
+        $entry = EntryModel::factory()->createElement([
+            'sectionId' => $section->id,
+            'typeId' => $entryType->id,
+        ]);
+        $entry->setAuthorIds([]);
+
+        $entry->validate(['authorIds']);
+
+        expect($entry->hasErrors('authorIds'))->toBeFalse();
+    });
+});
+
+describe('Edge cases', function () {
+    test('null values are handled gracefully for nullable fields', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->fieldId = null;
+        $entry->ownerId = null;
+        $entry->primaryOwnerId = null;
+        $entry->sortOrder = null;
+        $entry->expiryDate = null;
+
+        $entry->validate(['fieldId', 'ownerId', 'primaryOwnerId', 'sortOrder', 'expiryDate']);
+
+        expect($entry->hasErrors('fieldId'))->toBeFalse();
+        expect($entry->hasErrors('ownerId'))->toBeFalse();
+        expect($entry->hasErrors('primaryOwnerId'))->toBeFalse();
+        expect($entry->hasErrors('sortOrder'))->toBeFalse();
+        expect($entry->hasErrors('expiryDate'))->toBeFalse();
+    });
+
+    test('multiple validation errors can be collected', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->sectionId = null;
+        $entry->fieldId = null;
+
+        $entry->validate(['sectionId']);
+
+        expect($entry->hasErrors('sectionId'))->toBeTrue();
+    });
+
+    test('integer fields accept zero', function () {
+        $entry = EntryModel::factory()->createElement();
+        $entry->sortOrder = 0;
+
+        $entry->validate(['sortOrder']);
+
+        expect($entry->hasErrors('sortOrder'))->toBeFalse();
+    });
+
+    test('factory creates valid entry by default', function () {
+        $entry = EntryModel::factory()->createElement();
+
+        $entry->validate();
+
+        expect($entry->hasErrors())->toBeFalse();
+    });
+});

--- a/tests/Field/Elements/ContentBlockValidationTest.php
+++ b/tests/Field/Elements/ContentBlockValidationTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Cms;
+use CraftCms\Cms\Field\ContentBlock as ContentBlockField;
+use CraftCms\Cms\Field\Elements\ContentBlock as ContentBlockElement;
+use CraftCms\Cms\Field\Models\Field;
+use CraftCms\Cms\Support\Facades\Fields;
+
+function createContentBlockElement(): ContentBlockElement
+{
+    $field = Field::factory()->create([
+        'type' => ContentBlockField::class,
+    ]);
+
+    Fields::refreshFields();
+
+    $contentBlock = new ContentBlockElement;
+    $contentBlock->fieldId = $field->id;
+
+    return $contentBlock;
+}
+
+describe('Integer validation', function () {
+    test('integer fields accept valid integers', function (string $field, ?callable $setup = null) {
+        $contentBlock = createContentBlockElement();
+        $setup?->__invoke($contentBlock);
+
+        $contentBlock->validate([$field]);
+
+        expect($contentBlock->hasErrors($field))->toBeFalse();
+    })->with([
+        'fieldId accepts valid integer' => ['fieldId'],
+        'ownerId accepts valid integer' => ['ownerId', fn ($cb) => $cb->setOwnerId(10)],
+        'primaryOwnerId accepts valid integer' => ['primaryOwnerId', fn ($cb) => $cb->setPrimaryOwnerId(10)],
+        'sortOrder accepts valid integer' => ['sortOrder', fn ($cb) => $cb->sortOrder = 3],
+    ]);
+
+    test('nullable integer fields accept null', function (string $field, callable $setup) {
+        $contentBlock = createContentBlockElement();
+        $setup($contentBlock);
+
+        $contentBlock->validate([$field]);
+
+        expect($contentBlock->hasErrors($field))->toBeFalse();
+    })->with([
+        'ownerId accepts null' => ['ownerId', fn ($cb) => $cb->setOwnerId(null)],
+        'primaryOwnerId accepts null' => ['primaryOwnerId', fn ($cb) => $cb->setPrimaryOwnerId(null)],
+        'sortOrder accepts null' => ['sortOrder', fn ($cb) => $cb->sortOrder = null],
+    ]);
+
+    test('fieldId accepts null when not installed', function () {
+        $contentBlock = createContentBlockElement();
+        Cms::setIsInstalled(false);
+        $contentBlock->fieldId = null;
+
+        try {
+            $contentBlock->validate(['fieldId']);
+        } finally {
+            Cms::setIsInstalled(true);
+        }
+
+        expect($contentBlock->hasErrors('fieldId'))->toBeFalse();
+    });
+});
+
+describe('Owner validation', function () {
+    test('ownerId accepts valid element IDs', function () {
+        $contentBlock = createContentBlockElement();
+        $contentBlock->setOwnerId(1);
+
+        $contentBlock->validate(['ownerId']);
+
+        expect($contentBlock->hasErrors('ownerId'))->toBeFalse();
+    });
+
+    test('primaryOwnerId accepts valid element IDs', function () {
+        $contentBlock = createContentBlockElement();
+        $contentBlock->setPrimaryOwnerId(1);
+
+        $contentBlock->validate(['primaryOwnerId']);
+
+        expect($contentBlock->hasErrors('primaryOwnerId'))->toBeFalse();
+    });
+
+    test('sortOrder accepts positive integers', function () {
+        $contentBlock = createContentBlockElement();
+        $contentBlock->sortOrder = 5;
+
+        $contentBlock->validate(['sortOrder']);
+
+        expect($contentBlock->hasErrors('sortOrder'))->toBeFalse();
+    });
+
+    test('sortOrder accepts zero', function () {
+        $contentBlock = createContentBlockElement();
+        $contentBlock->sortOrder = 0;
+
+        $contentBlock->validate(['sortOrder']);
+
+        expect($contentBlock->hasErrors('sortOrder'))->toBeFalse();
+    });
+});
+
+describe('Edge cases', function () {
+    test('nullable fields accept null values', function () {
+        $contentBlock = createContentBlockElement();
+        $contentBlock->setOwnerId(null);
+        $contentBlock->setPrimaryOwnerId(null);
+        $contentBlock->sortOrder = null;
+
+        $contentBlock->validate(['ownerId', 'primaryOwnerId', 'sortOrder']);
+
+        expect($contentBlock->hasErrors('ownerId'))->toBeFalse();
+        expect($contentBlock->hasErrors('primaryOwnerId'))->toBeFalse();
+        expect($contentBlock->hasErrors('sortOrder'))->toBeFalse();
+    });
+
+    test('validation runs for new unsaved content blocks', function () {
+        $contentBlock = createContentBlockElement();
+
+        $contentBlock->validate(['fieldId']);
+
+        expect($contentBlock->hasErrors('fieldId'))->toBeFalse();
+    });
+
+    test('multiple validation errors can be collected', function () {
+        $contentBlock = createContentBlockElement();
+        $contentBlock->sortOrder = -1;
+
+        $contentBlock->validate(['sortOrder']);
+
+        // sortOrder validation may not reject negative numbers
+        // Just verify validation runs without errors
+        expect(true)->toBeTrue();
+    });
+
+    test('inherited base Element validation works', function () {
+        $contentBlock = createContentBlockElement();
+        $contentBlock->title = str_repeat('a', 256);
+
+        $contentBlock->validate(['title']);
+
+        expect($contentBlock->hasErrors('title'))->toBeTrue();
+    });
+
+    test('dateCreated and dateUpdated validation inherited from Element', function () {
+        $contentBlock = createContentBlockElement();
+        $contentBlock->dateCreated = new DateTime;
+        $contentBlock->dateUpdated = new DateTime;
+
+        $contentBlock->validate(['dateCreated', 'dateUpdated']);
+
+        expect($contentBlock->hasErrors('dateCreated'))->toBeFalse();
+        expect($contentBlock->hasErrors('dateUpdated'))->toBeFalse();
+    });
+});

--- a/tests/Field/Elements/ContentBlockValidationTest.php
+++ b/tests/Field/Elements/ContentBlockValidationTest.php
@@ -22,34 +22,7 @@ function createContentBlockElement(): ContentBlockElement
     return $contentBlock;
 }
 
-describe('Integer validation', function () {
-    test('integer fields accept valid integers', function (string $field, ?callable $setup = null) {
-        $contentBlock = createContentBlockElement();
-        $setup?->__invoke($contentBlock);
-
-        $contentBlock->validate([$field]);
-
-        expect($contentBlock->hasErrors($field))->toBeFalse();
-    })->with([
-        'fieldId accepts valid integer' => ['fieldId'],
-        'ownerId accepts valid integer' => ['ownerId', fn ($cb) => $cb->setOwnerId(10)],
-        'primaryOwnerId accepts valid integer' => ['primaryOwnerId', fn ($cb) => $cb->setPrimaryOwnerId(10)],
-        'sortOrder accepts valid integer' => ['sortOrder', fn ($cb) => $cb->sortOrder = 3],
-    ]);
-
-    test('nullable integer fields accept null', function (string $field, callable $setup) {
-        $contentBlock = createContentBlockElement();
-        $setup($contentBlock);
-
-        $contentBlock->validate([$field]);
-
-        expect($contentBlock->hasErrors($field))->toBeFalse();
-    })->with([
-        'ownerId accepts null' => ['ownerId', fn ($cb) => $cb->setOwnerId(null)],
-        'primaryOwnerId accepts null' => ['primaryOwnerId', fn ($cb) => $cb->setPrimaryOwnerId(null)],
-        'sortOrder accepts null' => ['sortOrder', fn ($cb) => $cb->sortOrder = null],
-    ]);
-
+describe('Edge cases', function () {
     test('fieldId accepts null when not installed', function () {
         $contentBlock = createContentBlockElement();
         Cms::setIsInstalled(false);
@@ -63,78 +36,6 @@ describe('Integer validation', function () {
 
         expect($contentBlock->hasErrors('fieldId'))->toBeFalse();
     });
-});
-
-describe('Owner validation', function () {
-    test('ownerId accepts valid element IDs', function () {
-        $contentBlock = createContentBlockElement();
-        $contentBlock->setOwnerId(1);
-
-        $contentBlock->validate(['ownerId']);
-
-        expect($contentBlock->hasErrors('ownerId'))->toBeFalse();
-    });
-
-    test('primaryOwnerId accepts valid element IDs', function () {
-        $contentBlock = createContentBlockElement();
-        $contentBlock->setPrimaryOwnerId(1);
-
-        $contentBlock->validate(['primaryOwnerId']);
-
-        expect($contentBlock->hasErrors('primaryOwnerId'))->toBeFalse();
-    });
-
-    test('sortOrder accepts positive integers', function () {
-        $contentBlock = createContentBlockElement();
-        $contentBlock->sortOrder = 5;
-
-        $contentBlock->validate(['sortOrder']);
-
-        expect($contentBlock->hasErrors('sortOrder'))->toBeFalse();
-    });
-
-    test('sortOrder accepts zero', function () {
-        $contentBlock = createContentBlockElement();
-        $contentBlock->sortOrder = 0;
-
-        $contentBlock->validate(['sortOrder']);
-
-        expect($contentBlock->hasErrors('sortOrder'))->toBeFalse();
-    });
-});
-
-describe('Edge cases', function () {
-    test('nullable fields accept null values', function () {
-        $contentBlock = createContentBlockElement();
-        $contentBlock->setOwnerId(null);
-        $contentBlock->setPrimaryOwnerId(null);
-        $contentBlock->sortOrder = null;
-
-        $contentBlock->validate(['ownerId', 'primaryOwnerId', 'sortOrder']);
-
-        expect($contentBlock->hasErrors('ownerId'))->toBeFalse();
-        expect($contentBlock->hasErrors('primaryOwnerId'))->toBeFalse();
-        expect($contentBlock->hasErrors('sortOrder'))->toBeFalse();
-    });
-
-    test('validation runs for new unsaved content blocks', function () {
-        $contentBlock = createContentBlockElement();
-
-        $contentBlock->validate(['fieldId']);
-
-        expect($contentBlock->hasErrors('fieldId'))->toBeFalse();
-    });
-
-    test('multiple validation errors can be collected', function () {
-        $contentBlock = createContentBlockElement();
-        $contentBlock->sortOrder = -1;
-
-        $contentBlock->validate(['sortOrder']);
-
-        // sortOrder validation may not reject negative numbers
-        // Just verify validation runs without errors
-        expect(true)->toBeTrue();
-    });
 
     test('inherited base Element validation works', function () {
         $contentBlock = createContentBlockElement();
@@ -143,16 +44,5 @@ describe('Edge cases', function () {
         $contentBlock->validate(['title']);
 
         expect($contentBlock->hasErrors('title'))->toBeTrue();
-    });
-
-    test('dateCreated and dateUpdated validation inherited from Element', function () {
-        $contentBlock = createContentBlockElement();
-        $contentBlock->dateCreated = new DateTime;
-        $contentBlock->dateUpdated = new DateTime;
-
-        $contentBlock->validate(['dateCreated', 'dateUpdated']);
-
-        expect($contentBlock->hasErrors('dateCreated'))->toBeFalse();
-        expect($contentBlock->hasErrors('dateUpdated'))->toBeFalse();
     });
 });

--- a/tests/User/Elements/UserValidationTest.php
+++ b/tests/User/Elements/UserValidationTest.php
@@ -12,61 +12,6 @@ beforeEach(function () {
     Edition::set(Edition::Pro);
 });
 
-describe('DateTime validation', function () {
-    test('DateTime fields accept valid DateTime objects', function (string $field) {
-        $user = UserModel::factory()->createElement();
-        $user->{$field} = new DateTime;
-
-        $user->validate([$field]);
-
-        expect($user->hasErrors($field))->toBeFalse();
-    })->with([
-        'lastLoginDate accepts DateTime' => ['lastLoginDate'],
-        'lastInvalidLoginDate accepts DateTime' => ['lastInvalidLoginDate'],
-        'lockoutDate accepts DateTime' => ['lockoutDate'],
-        'lastPasswordChangeDate accepts DateTime' => ['lastPasswordChangeDate'],
-    ]);
-
-    test('DateTime fields accept null values', function () {
-        $user = UserModel::factory()->createElement();
-        $user->lastLoginDate = null;
-        $user->lastInvalidLoginDate = null;
-        $user->lockoutDate = null;
-        $user->lastPasswordChangeDate = null;
-
-        $user->validate(['lastLoginDate', 'lastInvalidLoginDate', 'lockoutDate', 'lastPasswordChangeDate']);
-
-        expect($user->hasErrors())->toBeFalse();
-    });
-});
-
-describe('Integer validation', function () {
-    test('integer fields accept valid values', function (string $field, int $value) {
-        $user = UserModel::factory()->createElement();
-        $user->{$field} = $value;
-
-        $user->validate([$field]);
-
-        expect($user->hasErrors($field))->toBeFalse();
-    })->with([
-        'invalidLoginCount accepts 5' => ['invalidLoginCount', 5],
-        'invalidLoginCount accepts 0' => ['invalidLoginCount', 0],
-        'photoId accepts 123' => ['photoId', 123],
-        'affiliatedSiteId accepts 1' => ['affiliatedSiteId', 1],
-    ]);
-
-    test('integer fields accept null values', function () {
-        $user = UserModel::factory()->createElement();
-        $user->invalidLoginCount = null;
-        $user->photoId = null;
-        $user->affiliatedSiteId = null;
-
-        $user->validate(['invalidLoginCount', 'photoId', 'affiliatedSiteId']);
-
-        expect($user->hasErrors())->toBeFalse();
-    });
-});
-
 describe('String trimming', function () {
     test('string fields are trimmed of whitespace', function (string $field, string $input, string $expected) {
         $user = UserModel::factory()->createElement();
@@ -514,23 +459,6 @@ describe('Scenario validation', function () {
 });
 
 describe('Edge cases', function () {
-    test('null values are handled gracefully for all string fields', function () {
-        $user = UserModel::factory()->createElement();
-        $user->fullName = null;
-        $user->firstName = null;
-        $user->lastName = null;
-        $user->unverifiedEmail = null;
-        $user->lastLoginAttemptIp = null;
-
-        $user->validate(['fullName', 'firstName', 'lastName', 'unverifiedEmail', 'lastLoginAttemptIp']);
-
-        expect($user->hasErrors('fullName'))->toBeFalse();
-        expect($user->hasErrors('firstName'))->toBeFalse();
-        expect($user->hasErrors('lastName'))->toBeFalse();
-        expect($user->hasErrors('unverifiedEmail'))->toBeFalse();
-        expect($user->hasErrors('lastLoginAttemptIp'))->toBeFalse();
-    });
-
     test('unicode characters are handled in name fields', function () {
         $user = UserModel::factory()->createElement();
         $user->fullName = '日本語名前';

--- a/tests/User/Elements/UserValidationTest.php
+++ b/tests/User/Elements/UserValidationTest.php
@@ -1,0 +1,581 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Cms;
+use CraftCms\Cms\Edition;
+use CraftCms\Cms\User\Elements\User;
+use CraftCms\Cms\User\Models\User as UserModel;
+use Illuminate\Support\Facades\Hash;
+
+beforeEach(function () {
+    Edition::set(Edition::Pro);
+});
+
+describe('DateTime validation', function () {
+    test('DateTime fields accept valid DateTime objects', function (string $field) {
+        $user = UserModel::factory()->createElement();
+        $user->{$field} = new DateTime;
+
+        $user->validate([$field]);
+
+        expect($user->hasErrors($field))->toBeFalse();
+    })->with([
+        'lastLoginDate accepts DateTime' => ['lastLoginDate'],
+        'lastInvalidLoginDate accepts DateTime' => ['lastInvalidLoginDate'],
+        'lockoutDate accepts DateTime' => ['lockoutDate'],
+        'lastPasswordChangeDate accepts DateTime' => ['lastPasswordChangeDate'],
+    ]);
+
+    test('DateTime fields accept null values', function () {
+        $user = UserModel::factory()->createElement();
+        $user->lastLoginDate = null;
+        $user->lastInvalidLoginDate = null;
+        $user->lockoutDate = null;
+        $user->lastPasswordChangeDate = null;
+
+        $user->validate(['lastLoginDate', 'lastInvalidLoginDate', 'lockoutDate', 'lastPasswordChangeDate']);
+
+        expect($user->hasErrors())->toBeFalse();
+    });
+});
+
+describe('Integer validation', function () {
+    test('integer fields accept valid values', function (string $field, int $value) {
+        $user = UserModel::factory()->createElement();
+        $user->{$field} = $value;
+
+        $user->validate([$field]);
+
+        expect($user->hasErrors($field))->toBeFalse();
+    })->with([
+        'invalidLoginCount accepts 5' => ['invalidLoginCount', 5],
+        'invalidLoginCount accepts 0' => ['invalidLoginCount', 0],
+        'photoId accepts 123' => ['photoId', 123],
+        'affiliatedSiteId accepts 1' => ['affiliatedSiteId', 1],
+    ]);
+
+    test('integer fields accept null values', function () {
+        $user = UserModel::factory()->createElement();
+        $user->invalidLoginCount = null;
+        $user->photoId = null;
+        $user->affiliatedSiteId = null;
+
+        $user->validate(['invalidLoginCount', 'photoId', 'affiliatedSiteId']);
+
+        expect($user->hasErrors())->toBeFalse();
+    });
+});
+
+describe('String trimming', function () {
+    test('string fields are trimmed of whitespace', function (string $field, string $input, string $expected) {
+        $user = UserModel::factory()->createElement();
+        $user->{$field} = $input;
+
+        $user->validate([$field]);
+
+        expect($user->{$field})->toBe($expected);
+    })->with([
+        'username is trimmed' => ['username', '  testuser  ', 'testuser'],
+        'email is trimmed' => ['email', '  test@example.com  ', 'test@example.com'],
+        'unverifiedEmail is trimmed' => ['unverifiedEmail', '  new@example.com  ', 'new@example.com'],
+        'fullName is trimmed' => ['fullName', '  John Doe  ', 'John Doe'],
+        'firstName is trimmed' => ['firstName', '  John  ', 'John'],
+        'lastName is trimmed' => ['lastName', '  Doe  ', 'Doe'],
+    ]);
+
+    test('trimming skips empty values', function () {
+        $user = UserModel::factory()->createElement();
+        $user->fullName = null;
+
+        $user->validate(['fullName']);
+
+        expect($user->fullName)->toBeNull();
+    });
+});
+
+describe('Email format validation', function () {
+    test('email validation', function (string $email, bool $expectError) {
+        $user = UserModel::factory()->createElement();
+        $user->email = $email;
+
+        $user->validate(['email']);
+
+        expect($user->hasErrors('email'))->toBe($expectError);
+    })->with([
+        'valid email is accepted' => ['valid@example.com', false],
+        'invalid email is rejected' => ['not-an-email', true],
+        'email without domain is rejected' => ['user@', true],
+        'email without local part is rejected' => ['@example.com', true],
+        'email with plus signs is accepted' => ['user+tag@example.com', false],
+    ]);
+
+    test('unverifiedEmail validation', function (string $email, bool $expectError) {
+        $user = UserModel::factory()->createElement();
+        $user->unverifiedEmail = $email;
+
+        $user->validate(['unverifiedEmail']);
+
+        expect($user->hasErrors('unverifiedEmail'))->toBe($expectError);
+    })->with([
+        'valid email is accepted' => ['newemail@example.com', false],
+        'invalid email is rejected' => ['invalid-email', true],
+    ]);
+});
+
+describe('String max length validation (255 chars)', function () {
+    test('string fields validate max length', function (string $field, int $length, bool $expectError) {
+        $user = UserModel::factory()->createElement();
+
+        $user->{$field} = match ($field) {
+            'email', 'unverifiedEmail' => str_repeat('a', 244).'@example.com',
+            default => str_repeat('a', $length),
+        };
+
+        $user->validate([$field]);
+
+        expect($user->hasErrors($field))->toBe($expectError);
+    })->with([
+        'email rejects 256+ chars' => ['email', 256, true],
+        'username accepts 255 chars' => ['username', 255, false],
+        'username rejects 256 chars' => ['username', 256, true],
+        'fullName accepts 255 chars' => ['fullName', 255, false],
+        'fullName rejects 256 chars' => ['fullName', 256, true],
+        'firstName rejects 256 chars' => ['firstName', 256, true],
+        'lastName rejects 256 chars' => ['lastName', 256, true],
+        'password rejects 256 chars' => ['password', 256, true],
+        'unverifiedEmail rejects 256+ chars' => ['unverifiedEmail', 256, true],
+    ]);
+});
+
+describe('Email required validation', function () {
+    test('email required validation', function (mixed $email, ?int $draftId, bool $expectError) {
+        $user = UserModel::factory()->createElement();
+        $user->email = $email;
+
+        if ($draftId !== null) {
+            $user->draftId = $draftId;
+        }
+
+        $user->validate(['email']);
+
+        expect($user->hasErrors('email'))->toBe($expectError);
+    })->with([
+        'null email is required when not draft' => [null, null, true],
+        'empty string email is required when not draft' => ['', null, true],
+        'email is not required for drafts' => [null, 123, false],
+    ]);
+});
+
+describe('IP address validation', function () {
+    test('lastLoginAttemptIp validation', function (mixed $value, bool $expectError) {
+        $user = UserModel::factory()->createElement();
+        $user->lastLoginAttemptIp = $value;
+
+        $user->validate(['lastLoginAttemptIp']);
+
+        expect($user->hasErrors('lastLoginAttemptIp'))->toBe($expectError);
+    })->with([
+        'valid IPv4 is accepted' => ['192.168.1.1', false],
+        'valid IPv6 is accepted' => ['2001:0db8:85a3:0000:0000:8a2e:0370:7334', false],
+        '45 chars is accepted' => [str_repeat('a', 45), false],
+        '46 chars is rejected' => [str_repeat('a', 46), true],
+        'null is accepted' => [null, false],
+    ]);
+});
+
+describe('Username validation', function () {
+    beforeEach(function () {
+        Cms::config()->useEmailAsUsername = false;
+    });
+
+    test('username whitespace validation', function (string $username, bool $expectError, ?string $errorContains = null) {
+        $user = UserModel::factory()->createElement();
+        $user->username = $username;
+
+        $user->validate(['username']);
+
+        expect($user->hasErrors('username'))->toBe($expectError);
+
+        if ($errorContains !== null) {
+            expect($user->getFirstError('username'))->toContain($errorContains);
+        }
+    })->with([
+        'spaces are rejected' => ['user name', true, 'cannot contain spaces'],
+        'tabs are rejected' => ["user\tname", true, null],
+        'newlines are rejected' => ["user\nname", true, null],
+        'valid username is accepted' => ['validusername', false, null],
+        'underscores are accepted' => ['valid_user_name', false, null],
+        'hyphens are accepted' => ['valid-user-name', false, null],
+    ]);
+
+    test('username is required for credentialed users', function (callable $factoryMethod, bool $expectError) {
+        $user = $factoryMethod()->createElement();
+        $user->username = null;
+
+        $user->validate(['username']);
+
+        expect($user->hasErrors('username'))->toBe($expectError);
+    })->with([
+        'active users require username' => [fn () => UserModel::factory()->active(), true],
+        'pending users require username' => [fn () => UserModel::factory()->pending(), true],
+    ]);
+});
+
+describe('Email uniqueness validation', function () {
+    test('email must be unique among active users', function () {
+        UserModel::factory()->active()->createElement(['email' => 'taken@example.com']);
+
+        $newUser = UserModel::factory()->active()->createElement(['email' => 'different@example.com']);
+        $newUser->email = 'taken@example.com';
+
+        $newUser->validate(['email']);
+
+        expect($newUser->hasErrors('email'))->toBeTrue();
+        expect($newUser->getFirstError('email'))->toContain('has already been taken');
+    });
+
+    test('email must be unique among pending users', function () {
+        UserModel::factory()->pending()->createElement(['email' => 'taken@example.com']);
+
+        $newUser = UserModel::factory()->pending()->createElement(['email' => 'different@example.com']);
+        $newUser->email = 'taken@example.com';
+
+        $newUser->validate(['email']);
+
+        expect($newUser->hasErrors('email'))->toBeTrue();
+    });
+
+    test('email uniqueness is case-insensitive', function () {
+        UserModel::factory()->active()->createElement(['email' => 'Test@Example.com']);
+
+        $newUser = UserModel::factory()->active()->createElement(['email' => 'different@example.com']);
+        $newUser->email = 'test@example.com';
+
+        $newUser->validate(['email']);
+
+        expect($newUser->hasErrors('email'))->toBeTrue();
+    });
+
+    test('email can duplicate inactive user email', function () {
+        UserModel::factory()->createElement([
+            'email' => 'inactive@example.com',
+            'active' => false,
+            'pending' => false,
+        ]);
+
+        $newUser = UserModel::factory()->active()->createElement(['email' => 'inactive@example.com']);
+
+        $newUser->validate(['email']);
+
+        expect($newUser->hasErrors('email'))->toBeFalse();
+    });
+
+    test('same user can keep their email on update', function () {
+        $user = UserModel::factory()->active()->createElement(['email' => 'user@example.com']);
+
+        $user->validate(['email']);
+
+        expect($user->hasErrors('email'))->toBeFalse();
+    });
+
+    test('email uniqueness not enforced for inactive users', function () {
+        UserModel::factory()->active()->createElement(['email' => 'shared@example.com']);
+
+        $inactiveUser = UserModel::factory()->createElement([
+            'email' => 'different@example.com',
+            'active' => false,
+            'pending' => false,
+        ]);
+        $inactiveUser->email = 'shared@example.com';
+
+        $inactiveUser->validate(['email']);
+
+        expect($inactiveUser->hasErrors('email'))->toBeFalse();
+    });
+});
+
+describe('Username uniqueness validation', function () {
+    beforeEach(function () {
+        Cms::config()->useEmailAsUsername = false;
+    });
+
+    test('username must be unique among active users', function () {
+        UserModel::factory()->active()->createElement(['username' => 'takenuser']);
+
+        $newUser = UserModel::factory()->active()->createElement(['username' => 'differentuser']);
+        $newUser->username = 'takenuser';
+
+        $newUser->validate(['username']);
+
+        expect($newUser->hasErrors('username'))->toBeTrue();
+    });
+
+    test('username must be unique among pending users', function () {
+        UserModel::factory()->pending()->createElement(['username' => 'takenuser']);
+
+        $newUser = UserModel::factory()->pending()->createElement(['username' => 'differentuser']);
+        $newUser->username = 'takenuser';
+
+        $newUser->validate(['username']);
+
+        expect($newUser->hasErrors('username'))->toBeTrue();
+    });
+
+    test('username uniqueness is case-insensitive', function () {
+        UserModel::factory()->active()->createElement(['username' => 'TestUser']);
+
+        $newUser = UserModel::factory()->active()->createElement(['username' => 'differentuser']);
+        $newUser->username = 'testuser';
+
+        $newUser->validate(['username']);
+
+        expect($newUser->hasErrors('username'))->toBeTrue();
+    });
+
+    test('username can duplicate inactive user username', function () {
+        UserModel::factory()->createElement([
+            'username' => 'inactiveuser',
+            'active' => false,
+            'pending' => false,
+        ]);
+
+        $newUser = UserModel::factory()->active()->createElement(['username' => 'inactiveuser']);
+
+        $newUser->validate(['username']);
+
+        expect($newUser->hasErrors('username'))->toBeFalse();
+    });
+
+    test('same user can keep their username on update', function () {
+        $user = UserModel::factory()->active()->createElement(['username' => 'myusername']);
+
+        $user->validate(['username']);
+
+        expect($user->hasErrors('username'))->toBeFalse();
+    });
+});
+
+describe('Unverified email uniqueness validation', function () {
+    test('unverifiedEmail must be unique among active users emails', function () {
+        UserModel::factory()->active()->createElement(['email' => 'taken@example.com']);
+
+        $user = UserModel::factory()->active()->createElement(['email' => 'different@example.com']);
+        $user->unverifiedEmail = 'taken@example.com';
+
+        $user->validate(['unverifiedEmail']);
+
+        expect($user->hasErrors('unverifiedEmail'))->toBeTrue();
+    });
+
+    test('unverifiedEmail must be unique among pending users emails', function () {
+        UserModel::factory()->pending()->createElement(['email' => 'taken@example.com']);
+
+        $user = UserModel::factory()->active()->createElement(['email' => 'different@example.com']);
+        $user->unverifiedEmail = 'taken@example.com';
+
+        $user->validate(['unverifiedEmail']);
+
+        expect($user->hasErrors('unverifiedEmail'))->toBeTrue();
+    });
+
+    test('unverifiedEmail uniqueness is case-insensitive', function () {
+        UserModel::factory()->active()->createElement(['email' => 'Test@Example.com']);
+
+        $user = UserModel::factory()->active()->createElement(['email' => 'different@example.com']);
+        $user->unverifiedEmail = 'test@example.com';
+
+        $user->validate(['unverifiedEmail']);
+
+        expect($user->hasErrors('unverifiedEmail'))->toBeTrue();
+    });
+
+    test('unverifiedEmail can duplicate inactive user email', function () {
+        UserModel::factory()->createElement([
+            'email' => 'inactive@example.com',
+            'active' => false,
+            'pending' => false,
+        ]);
+
+        $user = UserModel::factory()->active()->createElement(['email' => 'different@example.com']);
+        $user->unverifiedEmail = 'inactive@example.com';
+
+        $user->validate(['unverifiedEmail']);
+
+        expect($user->hasErrors('unverifiedEmail'))->toBeFalse();
+    });
+
+    test('unverifiedEmail can be the same as own current email', function () {
+        $user = UserModel::factory()->active()->createElement(['email' => 'user@example.com']);
+        $user->unverifiedEmail = 'user@example.com';
+
+        $user->validate(['unverifiedEmail']);
+
+        expect($user->hasErrors('unverifiedEmail'))->toBeFalse();
+    });
+});
+
+describe('Password validation', function () {
+    test('newPassword length validation', function (mixed $password, bool $expectError) {
+        $user = UserModel::factory()->createElement();
+        $user->newPassword = $password;
+
+        $user->validate(['newPassword']);
+
+        expect($user->hasErrors('newPassword'))->toBe($expectError);
+    })->with([
+        '5 chars is too short' => ['12345', true],
+        '6 chars is valid' => ['123456', false],
+        '160 chars is valid' => [str_repeat('a', 160), false],
+        '161 chars is too long' => [str_repeat('a', 161), true],
+        'null is valid' => [null, false],
+        'empty string is invalid' => ['', true],
+    ]);
+
+    test('newPassword must be different when passwordResetRequired is true', function () {
+        $user = UserModel::factory()->active()->createElement();
+
+        UserModel::findOrFail($user->id)->update([
+            'password' => Hash::make('oldpassword'),
+            'passwordResetRequired' => true,
+        ]);
+
+        $user = User::find()->id($user->id)->one();
+        $user->passwordResetRequired = true;
+        $user->newPassword = 'oldpassword';
+
+        $user->validate(['newPassword']);
+
+        expect($user->hasErrors('newPassword'))->toBeTrue();
+        expect($user->getFirstError('newPassword'))->toContain('must be set to a new password');
+    });
+});
+
+describe('URL injection prevention', function () {
+    test('fields reject URL protocols', function (string $field, string $value, bool $expectError) {
+        $user = UserModel::factory()->createElement();
+        $user->{$field} = $value;
+
+        $user->validate([$field]);
+
+        expect($user->hasErrors($field))->toBe($expectError);
+    })->with([
+        'fullName rejects http://' => ['fullName', 'http://malicious.com', true],
+        'fullName rejects https://' => ['fullName', 'https://malicious.com', true],
+        'fullName rejects ftp://' => ['fullName', 'ftp://files.com', true],
+        'firstName rejects http://' => ['firstName', 'http://malicious.com', true],
+        'lastName rejects https://' => ['lastName', 'https://malicious.com', true],
+        'username rejects http://' => ['username', 'http://malicious.com', true],
+        'fullName with colon but no slashes is allowed' => ['fullName', 'John: A Developer', false],
+        'fullName with single slash is allowed' => ['fullName', 'John/Jane Doe', false],
+        'fullName containing :// anywhere is rejected' => ['fullName', 'Check out ://example', true],
+    ]);
+});
+
+describe('Scenario validation', function () {
+    test('SCENARIO_PASSWORD only validates newPassword', function () {
+        $user = UserModel::factory()->createElement();
+        $user->setScenario(User::SCENARIO_PASSWORD);
+
+        expect($user->activeAttributes())->toBe(['newPassword']);
+    });
+
+    test('SCENARIO_REGISTRATION validates username email and newPassword', function () {
+        $user = UserModel::factory()->createElement();
+        $user->setScenario(User::SCENARIO_REGISTRATION);
+
+        $activeAttributes = $user->activeAttributes();
+
+        expect($activeAttributes)->toContain('username');
+        expect($activeAttributes)->toContain('email');
+        expect($activeAttributes)->toContain('newPassword');
+    });
+
+    test('SCENARIO_ACTIVATION validates username and email', function () {
+        $user = UserModel::factory()->createElement();
+        $user->setScenario(User::SCENARIO_ACTIVATION);
+
+        $activeAttributes = $user->activeAttributes();
+
+        expect($activeAttributes)->toContain('username');
+        expect($activeAttributes)->toContain('email');
+        expect($activeAttributes)->not()->toContain('newPassword');
+    });
+
+    test('treatAsActive returns correct value based on user status', function (callable $factoryMethod, bool $expected) {
+        $user = $factoryMethod();
+
+        expect($user->getIsCredentialed())->toBe($expected);
+    })->with([
+        'active users return true' => [fn () => UserModel::factory()->active()->createElement(), true],
+        'pending users return true' => [fn () => UserModel::factory()->pending()->createElement(), true],
+        'inactive users return false' => [fn () => UserModel::factory()->createElement(['active' => false, 'pending' => false]), false],
+    ]);
+});
+
+describe('Edge cases', function () {
+    test('null values are handled gracefully for all string fields', function () {
+        $user = UserModel::factory()->createElement();
+        $user->fullName = null;
+        $user->firstName = null;
+        $user->lastName = null;
+        $user->unverifiedEmail = null;
+        $user->lastLoginAttemptIp = null;
+
+        $user->validate(['fullName', 'firstName', 'lastName', 'unverifiedEmail', 'lastLoginAttemptIp']);
+
+        expect($user->hasErrors('fullName'))->toBeFalse();
+        expect($user->hasErrors('firstName'))->toBeFalse();
+        expect($user->hasErrors('lastName'))->toBeFalse();
+        expect($user->hasErrors('unverifiedEmail'))->toBeFalse();
+        expect($user->hasErrors('lastLoginAttemptIp'))->toBeFalse();
+    });
+
+    test('unicode characters are handled in name fields', function () {
+        $user = UserModel::factory()->createElement();
+        $user->fullName = '日本語名前';
+        $user->firstName = 'Müller';
+        $user->lastName = "O'Brien";
+
+        $user->validate(['fullName', 'firstName', 'lastName']);
+
+        expect($user->hasErrors('fullName'))->toBeFalse();
+        expect($user->hasErrors('firstName'))->toBeFalse();
+        expect($user->hasErrors('lastName'))->toBeFalse();
+    });
+
+    test('special characters in username are allowed except whitespace', function () {
+        Cms::config()->useEmailAsUsername = false;
+
+        $user = UserModel::factory()->createElement();
+        $user->username = 'user@name.test_123-abc';
+
+        $user->validate(['username']);
+
+        expect($user->hasErrors('username'))->toBeFalse();
+    });
+
+    test('validation runs for new unsaved users', function () {
+        $user = new User;
+        $user->email = 'test@example.com';
+        $user->username = 'testuser';
+
+        $user->validate(['email', 'username']);
+
+        expect($user->hasErrors('email'))->toBeFalse();
+        expect($user->hasErrors('username'))->toBeFalse();
+    });
+
+    test('multiple validation errors can be collected', function () {
+        $user = UserModel::factory()->createElement();
+        $user->email = 'invalid-email';
+        $user->username = 'user name with spaces';
+        $user->fullName = 'http://malicious.com';
+
+        $user->validate(['email', 'username', 'fullName']);
+
+        expect($user->hasErrors('email'))->toBeTrue();
+        expect($user->hasErrors('username'))->toBeTrue();
+        expect($user->hasErrors('fullName'))->toBeTrue();
+    });
+});


### PR DESCRIPTION
### Description

This PR adds comprehensive validation tests to the current validation of the Element classes, which we can then use to refactor the validation system to Laravel's, ensuring the behavior stays the same.
