### PR TITLE
[6.x] Updates Matrix field and Matrix blocks to use group roles

### DIFF
--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1655,6 +1655,14 @@ JS,
         return $entryType;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function useFieldset(): bool
+    {
+        return true;
+    }
+
     // Events
     // -------------------------------------------------------------------------
 

--- a/src/templates/_components/fieldtypes/Matrix/block.twig
+++ b/src/templates/_components/fieldtypes/Matrix/block.twig
@@ -8,6 +8,7 @@
 {% set staticEntries = staticEntries ?? false %}
 
 {% set actionBtnLabel = "#{entryTypeName} #{'Actions'|t('app')}" %}
+{% set titleId = "matrixblock-title--#{entry.uid}" %}
 {% set actionMenuId = "matrixblock-action-menu--#{entry.uid}" %}
 
 {% set actionMenuItems = [
@@ -151,123 +152,127 @@
   }) %}
   {% set tabs = form.getTabMenu() %}
 {% endnamespace %}
-
-{% tag 'div' with {
-  class: [
-    'matrixblock',
-    'js-deletable',
-    not entry.enabled ? 'disabled-entry',
-    static ? 'static',
-  ]|filter,
-  style: {
-    '--custom-bg-color': entryType.color.cssVar(50) ?? null,
-    '--custom-text-color': entryType.color.cssVar(900) ?? null,
-    '--custom-titlebar-bg-color': entryType.color.cssVar(100) ?? null,
-    '--custom-border-color': entryType.color.cssVar(200) ?? null,
-  }|filter,
-  data: {
-    id: entry.id,
-    'draft-id': entry.isProvisionalDraft ? null : entry.draftId,
-    'revision-id': entry.revisionId,
-    'owner-id': entry.getOwnerId(),
-    'site-id': entry.siteId,
-    uid: entry.uid,
-    type: entryType.handle,
-    'type-name': entryTypeName,
-    collapsed: entry.collapsed,
-    'type-id': entry.typeId,
-    'field-layout-id': entry.getFieldLayout().id,
-    'visible-layout-elements': form.getVisibleElements(),
-    'base-input-name': baseInputName|namespaceInputName,
-  },
-  role: 'listitem',
-} %}
-  {% if not static %}
-    {{ hiddenInput("#{name}[sortOrder][]", entry.uid) }}
-    {# only register a delta name for this entry if it’s not new #}
-    {% if entry.id and not entry.getIsUnpublishedDraft() %}
-      {% do view.registerDeltaName(baseInputName) %}
-    {% endif %}
-    {{ hiddenInput("#{baseInputName}[type]", entryType.handle) }}
-    {{ hiddenInput("#{baseInputName}[enabled]", entry.enabled ? '1' : '') }}
-    {% if isFresh ?? false %}
-      {{ hiddenInput("#{baseInputName}[fresh]", '1') }}
-    {% endif %}
-  {% endif %}
-
+<div role="listitem">
   {% tag 'div' with {
-    class: 'titlebar',
+    class: [
+      'matrixblock',
+      'js-deletable',
+      not entry.enabled ? 'disabled-entry',
+      static ? 'static',
+    ]|filter,
+    style: {
+      '--custom-bg-color': entryType.color.cssVar(50) ?? null,
+      '--custom-text-color': entryType.color.cssVar(900) ?? null,
+      '--custom-titlebar-bg-color': entryType.color.cssVar(100) ?? null,
+      '--custom-border-color': entryType.color.cssVar(200) ?? null,
+    }|filter,
+    data: {
+      id: entry.id,
+      'draft-id': entry.isProvisionalDraft ? null : entry.draftId,
+      'revision-id': entry.revisionId,
+      'owner-id': entry.getOwnerId(),
+      'site-id': entry.siteId,
+      uid: entry.uid,
+      type: entryType.handle,
+      'type-name': entryTypeName,
+      collapsed: entry.collapsed,
+      'type-id': entry.typeId,
+      'field-layout-id': entry.getFieldLayout().id,
+      'visible-layout-elements': form.getVisibleElements(),
+      'base-input-name': baseInputName|namespaceInputName,
+    },
+    role: 'group',
+    aria: {
+      labelledby: titleId,
+    }
   } %}
+    {% if not static %}
+      {{ hiddenInput("#{name}[sortOrder][]", entry.uid) }}
+      {# only register a delta name for this entry if it’s not new #}
+      {% if entry.id and not entry.getIsUnpublishedDraft() %}
+        {% do view.registerDeltaName(baseInputName) %}
+      {% endif %}
+      {{ hiddenInput("#{baseInputName}[type]", entryType.handle) }}
+      {{ hiddenInput("#{baseInputName}[enabled]", entry.enabled ? '1' : '') }}
+      {% if isFresh ?? false %}
+        {{ hiddenInput("#{baseInputName}[fresh]", '1') }}
+      {% endif %}
+    {% endif %}
+
     {% tag 'div' with {
-      class: {
-        blocktype: true,
-        flex: true,
-        'flex-nowrap': true,
-        'flex-gap-xs': true,
-        error: not static and entry.hasErrors(),
-      }|filter|keys,
+      class: 'titlebar',
     } %}
-      {% if entryType.icon %}
-        {{ tag('div', {
-          class: ['cp-icon', 'small', entryType.color.value ?? null]|filter,
-          html: iconSvg(entryType.icon),
+      {% tag 'div' with {
+        class: {
+          blocktype: true,
+          flex: true,
+          'flex-nowrap': true,
+          'flex-gap-xs': true,
+          error: not static and entry.hasErrors(),
+        }|filter|keys,
+      } %}
+        {% if entryType.icon %}
+          {{ tag('div', {
+            class: ['cp-icon', 'small', entryType.color.value ?? null]|filter,
+            html: iconSvg(entryType.icon),
+          }) }}
+        {% endif %}
+        <div id="{{ titleId }}">{{ entryTypeName }}</div>
+        {% if not static and entry.hasErrors() %}<span data-icon="alert" aria-label="{{ 'Error'|t('app') }}"></span>{% endif %}
+      {% endtag %}
+      <div class="preview"></div>
+      {% tag 'div' with {
+        class: ['matrixblock-tabs'],
+        style: {
+          '--custom-sel-tab-shadow-color': entryType.color.cssVar(200) ?? null,
+        }|filter,
+      } %}
+        {% if tabs|length > 1 %}
+          {% namespace baseInputName %}
+            {% include '_includes/tabs.twig' %}
+          {% endnamespace %}
+        {% endif %}
+      {% endtag %}
+    {% endtag %}{# /.titlebar #}
+
+    <div class="actions">
+      <div class="status off" title="{{ 'Disabled'|t('app') }}">
+        {{ tag('span', {
+          class: 'visually-hidden',
+          html: 'Disabled'|t('app'),
+        }) }}
+      </div>
+
+      {% if actionMenuItems is not empty %}
+        <div class="checkbox" title="{{ 'Select'|t('app') }}" aria-label="{{ 'Select'|t('app') }}" tabindex="0" role="checkbox" aria-checked="false"></div>
+        {{ disclosureMenu(actionMenuItems, {
+          hiddenLabel: 'Actions'|t('app'),
+          buttonAttributes: {
+            class: ['action-btn', 'small'],
+            title: 'Actions'|t('app'),
+            data: {
+              'disclosure-trigger': true,
+            },
+          },
         }) }}
       {% endif %}
-      <div>{{ entryTypeName }}</div>
-      {% if not static and entry.hasErrors() %}<span data-icon="alert" aria-label="{{ 'Error'|t('app') }}"></span>{% endif %}
-    {% endtag %}
-    <div class="preview"></div>
-    {% tag 'div' with {
-      class: ['matrixblock-tabs'],
-      style: {
-        '--custom-sel-tab-shadow-color': entryType.color.cssVar(200) ?? null,
-      }|filter,
-    } %}
-      {% if tabs|length > 1 %}
-        {% namespace baseInputName %}
-          {% include '_includes/tabs.twig' %}
-        {% endnamespace %}
-      {% endif %}
-    {% endtag %}
-  {% endtag %}{# /.titlebar #}
-
-  <div class="actions">
-    <div class="status off" title="{{ 'Disabled'|t('app') }}">
-      {{ tag('span', {
-        class: 'visually-hidden',
-        html: 'Disabled'|t('app'),
-      }) }}
-    </div>
-
-    {% if actionMenuItems is not empty %}
-      <div class="checkbox" title="{{ 'Select'|t('app') }}" aria-label="{{ 'Select'|t('app') }}" tabindex="0" role="checkbox" aria-checked="false"></div>
-      {{ disclosureMenu(actionMenuItems, {
-        hiddenLabel: 'Actions'|t('app'),
-        buttonAttributes: {
-          class: ['action-btn', 'small'],
-          title: 'Actions'|t('app'),
-          data: {
-            'disclosure-trigger': true,
+      {% if not static %}
+        {{ button({
+          class: ['chromeless', 'small', 'move-btn'],
+          icon: 'move',
+          attributes: {
+            title: 'Reorder'|t('app'),
+            aria: {label: 'Reorder'|t('app')},
+            role: 'none',
+            tabindex: '-1',
           },
-        },
-      }) }}
-    {% endif %}
-    {% if not static %}
-      {{ button({
-        class: ['chromeless', 'small', 'move-btn'],
-        icon: 'move',
-        attributes: {
-          title: 'Reorder'|t('app'),
-          aria: {label: 'Reorder'|t('app')},
-          role: 'none',
-          tabindex: '-1',
-        },
-      }) }}
-    {% endif %}
-  </div>
-  <div class="fields">
-    {% namespace baseInputName %}
-      {{ form.render()|raw }}
-    {% endnamespace %}
-  </div>
-{% endtag %}{# /.matrixblock #}
+        }) }}
+      {% endif %}
+    </div>
+    <div class="fields">
+      {% namespace baseInputName %}
+        {{ form.render()|raw }}
+      {% endnamespace %}
+    </div>
+  {% endtag %}{# /.matrixblock #}
+</div>


### PR DESCRIPTION
### Description

- Updates markup for matrix blocks so that the `.matrixblock` container uses a `group` role, and wraps the block inside of an element with a `listitem` role
- Matrix field returns `true` for `useFieldset()`


### Related issues
Resolves PT-2235

