### PR TITLE
“Change the author of other users’ entries” permissions

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,6 +1,7 @@
 # Release Notes for Craft CMS 4.17 (WIP)
 
 ### Administration
+- Added the “Change the author of other users’ entries” permission for channel and structure sections. ([#18298](https://github.com/craftcms/cms/pull/18298))
 - Added the “View user” GraphQL schema option for Craft Solo. ([#17863](https://github.com/craftcms/cms/pull/17863))
 - Composer package constraints in `composer.json` are now set with caret operators (e.g. `^1.2.3`). ([#18297](https://github.com/craftcms/cms/pull/18297))
 - The `clear-cache` command now accepts a space-delimited list of cache IDs that should be cleared.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Composer package constraints in `composer.json` are now set with caret operators (e.g. `^1.2.3`). ([#18297](https://github.com/craftcms/cms/pull/18297))
 - The `up` command now warns about any astray license issues before running migrations. ([#18297](https://github.com/craftcms/cms/pull/18297))
+- Added the “Change the author of other users’ entries” permission for channel and structure sections. ([#18298](https://github.com/craftcms/cms/pull/18298))
 - Fixed a [high-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) user account enumeration vulnerability. (GHSA-234q-vvw3-mrfq)
 
 ## 4.17.0-beta.1 - 2026-01-20

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '4.17.0-beta.1',
-    'schemaVersion' => '4.17.0.2',
+    'schemaVersion' => '4.17.0.3',
     'minVersionRequired' => '3.7.11',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -876,7 +876,7 @@ class Entry extends Element implements ExpirableElementInterface
         if (
             $authorId !== null &&
             $authorId !== $this->getAuthorId() &&
-            Craft::$app->getUser()->checkPermission(sprintf('viewPeerEntries:%s', $this->getSection()->uid))
+            $this->canChangeAuthor()
         ) {
             $this->setAuthorId($authorId);
         }
@@ -1759,8 +1759,8 @@ EOD;
 
         if ($section->type !== Section::TYPE_SINGLE) {
             // Author
-            if (Craft::$app->getEdition() === Craft::Pro && $user->can("viewPeerEntries:$section->uid")) {
-                $fields[] = (function() use ($static, $section) {
+            if (Craft::$app->getEdition() === Craft::Pro) {
+                $fields[] = (function() use ($static, $section, $user) {
                     $author = $this->getAuthor();
                     return Cp::elementSelectFieldHtml([
                         'status' => $this->getAttributeStatus('authorId'),
@@ -1774,7 +1774,7 @@ EOD;
                         ],
                         'single' => true,
                         'elements' => $author ? [$author] : null,
-                        'disabled' => $static,
+                        'disabled' => $static || !$this->canChangeAuthor($user),
                         'errors' => $this->getErrors('authorId'),
                     ]);
                 })();
@@ -1812,6 +1812,33 @@ EOD;
         $fields[] = parent::metaFieldsHtml($static);
 
         return implode("\n", $fields);
+    }
+
+    /**
+     * Returns whether the current user has permission to change this entry’s author.
+     */
+    private function canChangeAuthor(?User $user = null): bool
+    {
+        if (!$user) {
+            $user = Craft::$app->getUser()->getIdentity();
+            if (!$user) {
+                return false;
+            }
+        }
+
+        $section = $this->getSection();
+
+        if (!$user->can("viewPeerEntries:$section->uid")) {
+            return false;
+        }
+
+        $authorId = $this->getAuthorId();
+
+        return (
+            !$authorId ||
+            $authorId === $user->id ||
+            $user->can("changeAuthorForPeerEntries:$section->uid")
+        );
     }
 
     /**

--- a/src/migrations/m260125_233614_changeAuthorForPeerEntries_permission.php
+++ b/src/migrations/m260125_233614_changeAuthorForPeerEntries_permission.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace craft\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\db\Table;
+
+/**
+ * m260125_233614_changeAuthorForPeerEntries_permission migration.
+ */
+class m260125_233614_changeAuthorForPeerEntries_permission extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $projectConfig = Craft::$app->getProjectConfig();
+        $map = [];
+
+        foreach (Craft::$app->getSections()->getAllSections() as $section) {
+            $oldPermission = strtolower("savePeerEntries:$section->uid");
+            $newPermission = strtolower("changeAuthorForPeerEntries:$section->uid");
+            $map[$oldPermission] = $newPermission;
+        }
+
+        foreach ($map as $oldPermission => $newPermission) {
+            $userIds = (new Query())
+                ->select(['upu.userId'])
+                ->from(['upu' => Table::USERPERMISSIONS_USERS])
+                ->innerJoin(['up' => Table::USERPERMISSIONS], '[[up.id]] = [[upu.permissionId]]')
+                ->where(['up.name' => $oldPermission])
+                ->column($this->db);
+
+            $userIds = array_unique($userIds);
+
+            if (!empty($userIds)) {
+                $insert = [];
+
+                // delete the permission + user/group assignments if it already exists for some reason
+                $this->delete(Table::USERPERMISSIONS, [
+                    'name' => $newPermission,
+                ]);
+
+                $this->insert(Table::USERPERMISSIONS, [
+                    'name' => $newPermission,
+                ]);
+                $newPermissionId = $this->db->getLastInsertID(Table::USERPERMISSIONS);
+                foreach ($userIds as $userId) {
+                    $insert[] = [$newPermissionId, $userId];
+                }
+
+                $this->batchInsert(Table::USERPERMISSIONS_USERS, ['permissionId', 'userId'], $insert);
+            }
+        }
+
+        // Don't make the same config changes twice
+        $schemaVersion = $projectConfig->get('system.schemaVersion', true);
+
+        if (version_compare($schemaVersion, '4.17.0.3', '<')) {
+            foreach ($projectConfig->get('users.groups') ?? [] as $uid => $group) {
+                $groupPermissions = array_flip($group['permissions'] ?? []);
+                $save = false;
+
+                foreach ($map as $oldPermission => $newPermission) {
+                    if (isset($groupPermissions[$oldPermission])) {
+                        $groupPermissions[$newPermission] = true;
+                        $save = true;
+                    }
+                }
+
+                if ($save) {
+                    $projectConfig->set("users.groups.$uid.permissions", array_keys($groupPermissions));
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        return true;
+    }
+}

--- a/src/services/UserPermissions.php
+++ b/src/services/UserPermissions.php
@@ -573,6 +573,11 @@ class UserPermissions extends Component
                                 'nested' => [
                                     "savePeerEntries:$section->uid" => [
                                         'label' => StringHelper::upperCaseFirst(Craft::t('app', 'Save other users’ {type}', ['type' => $pluralType])),
+                                        'nested' => [
+                                            "changeAuthorForPeerEntries:$section->uid" => [
+                                                'label' => Craft::t('app', 'Change the author of other users’ entries'),
+                                            ],
+                                        ],
                                     ],
                                     "deletePeerEntries:$section->uid" => [
                                         'label' => Craft::t('app', 'Delete other users’ {type}', ['type' => $pluralType]),

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -243,6 +243,7 @@ return [
     'Change icon' => 'Change icon',
     'Change logo' => 'Change logo',
     'Change photo' => 'Change photo',
+    'Change the author of other users’ entries' => 'Change the author of other users’ entries',
     'Changelog' => 'Changelog',
     'Changes discarded.' => 'Changes discarded.',
     'Changing this may result in data loss.' => 'Changing this may result in data loss.',


### PR DESCRIPTION
Adds a “Change the author of other users’ entries” permission for each channel and structure section, nested under “Save other users’ entries”.

Previously, users with “Delete entries” and “Save other users’ entries” permissions for a section, but not “Delete other users’ entries”, could reassign an entry to themselves, save it, and then delete it. Now that’s only possible if the author also has the new permission.

To avoid a change in behavior, all users and user groups with “Save other users’ entries” permissions are automatically assigned the new permission as well.