### PR TITLE
element sources can be null

### DIFF
--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -241,7 +241,7 @@ class ElementSources extends Component
     {
         $pages = [];
 
-        foreach ($this->_sourceConfigs($elementType) as $source) {
+        foreach ($this->_sourceConfigs($elementType) ?? [] as $source) {
             // divide all sources into pages
             if (isset($source['page'])) {
                 $pages[$source['page']][] = $source;


### PR DESCRIPTION
### Description
Safeguard against element sources that are stored in the project config being `null`. This will be the case if you never customised your sources.

Thanks @nfourtythree for reporting!

### Related issues
#18286
