### PR TITLE
Bugfix: Element source pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed an error that could occur when updating to Craft 5.9. ([#18309](https://github.com/craftcms/cms/issues/18309))
+- Fixed a bug where custom entry index pages that only contained native sources weren’t getting their own nav items. ([#18311](https://github.com/craftcms/cms/issues/18311))
 
 ## 5.9.0 - 2026-01-27
 

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -250,7 +250,7 @@ class ElementSources extends Component
 
         foreach ($pages as $key => $pageWithSources) {
             // Remove nav items that have no enabled native sources:
-            if (count(array_filter($pageWithSources, fn(array $source) => isset($source['disabled']) && $source['disabled'] === true)) == count($pageWithSources)) {
+            if (count(array_filter($pageWithSources, fn(array $source) => isset($source['disabled']) && $source['disabled'] === true)) === count($pageWithSources)) {
                 unset($pages[$key]);
             }
         }

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -248,12 +248,11 @@ class ElementSources extends Component
             }
         }
 
-        foreach ($pages as $key => $pageWithSources) {
-            // Remove nav items that have no enabled native sources:
-            if (count(array_filter($pageWithSources, fn(array $source) => isset($source['disabled']) && $source['disabled'] === true)) === count($pageWithSources)) {
-                unset($pages[$key]);
-            }
-        }
+        // Remove pages that only have disabled sources
+        $pages = array_filter(
+            $pages,
+            fn(array $sources) => ArrayHelper::contains($sources, fn(array $source) => !($source['disabled'] ?? false)),
+        );
 
         return array_keys($pages);
     }

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -249,7 +249,8 @@ class ElementSources extends Component
         }
 
         foreach ($pages as $key => $pageWithSources) {
-            if (count(array_filter($pageWithSources, fn(array $source) => !isset($source['disabled']) || $source['disabled'] === true)) == 0) {
+            // Remove nav items that have no enabled native sources:
+            if (count(array_filter($pageWithSources, fn(array $source) => isset($source['disabled']) && $source['disabled'] === true)) == count($pageWithSources)) {
                 unset($pages[$key]);
             }
         }


### PR DESCRIPTION
Our logic for determining when an element source page should show up in the nav mistakenly discards pages that have _any_ disabled native sources or _any_ custom sources, instead of only discarding them when _all_ of the nested sources are disabled.

&rarr; The absence of a `disabled` key is correlated with a `type` of `custom`; we could explicitly test for that, instead?

Should resolve #18311!