### PR TITLE
Add conditional registration for Twig SandboxExtension

### DIFF
--- a/src/web/View.php
+++ b/src/web/View.php
@@ -452,19 +452,22 @@ class View extends \yii\web\View
         }
 
         // Only register the SandboxExtension if something else hasn't already
-        if (!$twig->hasExtension(SandboxExtension::class)) {
-            $sandboxConfig = ArrayHelper::merge(
-                require Craft::getAlias('@app/config/twig-sandbox.php'),
-                Craft::$app->getConfig()->getConfigFromFile('twig-sandbox'),
-            );
-            $twig->addExtension(new SandboxExtension(new SecurityPolicy(
-                $sandboxConfig['allowedTags'],
-                $sandboxConfig['allowedFilters'],
-                $sandboxConfig['allowedFunctions'],
-                $sandboxConfig['allowedMethods'],
-                $sandboxConfig['allowedProperties'],
-                $sandboxConfig['allowedClasses'],
-            )));
+        // and the enableTwigSandbox is set to true
+        if (Craft::$app->getConfig()->getGeneral()->enableTwigSandbox) {
+            if (!$twig->hasExtension(SandboxExtension::class)) {
+                $sandboxConfig = ArrayHelper::merge(
+                    require Craft::getAlias('@app/config/twig-sandbox.php'),
+                    Craft::$app->getConfig()->getConfigFromFile('twig-sandbox'),
+                );
+                $twig->addExtension(new SandboxExtension(new SecurityPolicy(
+                    $sandboxConfig['allowedTags'],
+                    $sandboxConfig['allowedFilters'],
+                    $sandboxConfig['allowedFunctions'],
+                    $sandboxConfig['allowedMethods'],
+                    $sandboxConfig['allowedProperties'],
+                    $sandboxConfig['allowedClasses'],
+                )));
+            }
         }
 
         // Set our timezone


### PR DESCRIPTION
### Description

In #18208, the Twig Sandbox was added conditionally to all places it's used, controlled by `enableTwigSandbox` [(commit)](https://github.com/craftcms/cms/pull/18208/changes/acd83072d490d67c554ea1316c55a98197234e7a#diff-8a3b4e5060318a461c465cc3ee7ae599aec16da92400781a9eae4377230a2f1f).

In #18216, the View class was updated [(commit)](https://github.com/craftcms/cms/pull/18216/changes/42a0fb86f377cb9e2a4c915be4a43a5094c7aa52#diff-8a3b4e5060318a461c465cc3ee7ae599aec16da92400781a9eae4377230a2f1f), but the conditional check for `enableTwigSandbox` was not applied to the SandboxExtension registration in `createTwig()`.  As I understand it, , this means SandboxExtension is always added to Twig, even when `enableTwigSandbox` is `false`.

(I've been looking into this in circles for hours, so my apologies if I've missed something here)

### Related issues

This seemingly breaks the craft-nocache plugin - https://github.com/ttempleton/craft-nocache/issues/42

When nocache compiles templates, they include `$this->sandbox->ensureToStringAllowed()` calls because SandboxExtension is present. However, `$this->sandbox` is null during rendering because sandbox mode isn't actually enabled (since `enableTwigSandbox` is `false`). This causes fatal errors with no way to resolve other than stripping all `$this->sandbox` references from compiled templates via regex, so I think it better to fix upstream, apologies if this all sounds unrelated.

This fix ensures SandboxExtension is only registered when `enableTwigSandbox` is explicitly set to `true`, resolving the craft-nocache issue. I have tested this by setting `->enableTwigSandbox(false)` and the issue with nocache is resolved. If I set it to `->enableTwigSandbox(true)`, their bug resurfaces, indicating that sandbox was always on.