### PR TITLE
generated fields and `EVENT_AFTER_PROPAGATE` for new elements

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -4198,6 +4198,14 @@ class Elements extends Component
                     $element->on(Element::EVENT_AFTER_PROPAGATE, function() use ($generatedFields, $siteElements, $siteSettingsRecords) {
                         foreach ($siteElements as $siteId => $siteElement) {
                             $siteSettingsRecord = $siteSettingsRecords[$siteId];
+                            // this will be the case if we're creating a new entry
+                            // see PR #18392 for details
+                            if ($siteSettingsRecord === null) {
+                                $siteSettingsRecord = Element_SiteSettingsRecord::findOne([
+                                    'id' => $siteElement->siteSettingsId,
+                                    'siteId' => $siteElement->siteId,
+                                ]);
+                            }
                             $content = $siteSettingsRecord->content ?? [];
                             if (is_string($content)) {
                                 $content = $content !== '' ? Json::decode($content) : [];

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -4199,7 +4199,7 @@ class Elements extends Component
                         foreach ($siteElements as $siteId => $siteElement) {
                             $siteSettingsRecord = $siteSettingsRecords[$siteId];
                             // this will be the case if we're creating a new entry
-                            // see PR #18392 for details
+                            // see PR #18393 for details
                             if ($siteSettingsRecord === null) {
                                 $siteSettingsRecord = Element_SiteSettingsRecord::findOne([
                                     'id' => $siteElement->siteSettingsId,


### PR DESCRIPTION
### Description
**Issue:**
In a multisite setup, you can’t create a new entry from the entries index page if the entry type contains a generated field.

**Steps to reproduce:**
- clean 5.9.6 install (this started happening in 5.9.0)
- have at least two sites
- create an entry type (`et`) with all the default settings and add at least one generated field; it can be as simple as name: gen1, handle: gen1, template: test
- create a section (`myChannel`) with all default settings and the entry type from the previous step; make sure it’s enabled for both sites
- go to Entries > My Channel and press the “New entry” button
- observe that the entry edit form doesn’t load, and there’s an error in the console

This can also happen if the section’s propagation is set to “Let each entry choose which sites it should be saved to” and you’re enabling an entry for a site (regardless of whether the current entry is new or has already been fully saved). 

**Cause of the issue:**
In https://github.com/craftcms/cms/commit/5f474b2d9aab4899e8b63f1ecd1d87892ddaa38d we added this bit which sets the `$siteElementRecord` to `null` before calling `Elements::_propagateElement()` ([link](https://github.com/craftcms/cms/blob/5.9.6/src/services/Elements.php#L4173)).

We then added an event after propagate listener that’s only triggered when we have generated fields ([link](https://github.com/craftcms/cms/blob/5.9.6/src/services/Elements.php#L4198-L4235)), which assumes we’ll definitely have a site element record.

But that’s not always the case and causes an error when trying to set the `content` property on a `$siteSettingsRecord` that’s been set to `null` ([link](https://github.com/craftcms/cms/blob/5.9.6/src/services/Elements.php#L4229)).

**Solution:**
If we still don’t have a `$siteSettingsRecord` for a site element when handling the after propagate, try to get it from the database one last time.


### Related issues
n/a; found while checking something else
