### PR TITLE
[6.x] Replace Validator property with MessageBag to fix serialization

### DIFF
--- a/src/Dashboard/Widgets/Feed.php
+++ b/src/Dashboard/Widgets/Feed.php
@@ -41,7 +41,7 @@ final class Feed extends Widget
      * {@inheritdoc}
      */
     #[\Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [
             'title' => ['required'],

--- a/src/Dashboard/Widgets/MyDrafts.php
+++ b/src/Dashboard/Widgets/MyDrafts.php
@@ -48,7 +48,7 @@ final class MyDrafts extends Widget
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [
             'limit' => ['required', 'integer', 'min:1'],

--- a/src/Dashboard/Widgets/QuickPost.php
+++ b/src/Dashboard/Widgets/QuickPost.php
@@ -92,7 +92,7 @@ final class QuickPost extends Widget
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [
             'section' => ['required', 'integer'],

--- a/src/Dashboard/Widgets/RecentEntries.php
+++ b/src/Dashboard/Widgets/RecentEntries.php
@@ -59,7 +59,7 @@ final class RecentEntries extends Widget
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [
             'siteId' => ['nullable', 'integer'],

--- a/src/Field/Addresses.php
+++ b/src/Field/Addresses.php
@@ -184,7 +184,7 @@ final class Addresses extends Field implements EagerLoadingFieldInterface, Eleme
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         $rules = parent::getRules();
 

--- a/src/Field/Assets.php
+++ b/src/Field/Assets.php
@@ -235,7 +235,7 @@ final class Assets extends BaseRelationField
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'restrictFiles' => 'boolean',

--- a/src/Field/BaseOptionsField.php
+++ b/src/Field/BaseOptionsField.php
@@ -188,7 +188,7 @@ abstract class BaseOptionsField extends Field implements CrossSiteCopyableFieldI
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'options' => ['array'],

--- a/src/Field/BaseRelationField.php
+++ b/src/Field/BaseRelationField.php
@@ -455,7 +455,7 @@ abstract class BaseRelationField extends Field implements CrossSiteCopyableField
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'minRelations' => ['nullable', 'integer'],

--- a/src/Field/Color.php
+++ b/src/Field/Color.php
@@ -220,7 +220,7 @@ final class Color extends Field implements CrossSiteCopyableFieldInterface, Inli
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'allowCustomColors' => ['required', 'boolean'],
@@ -231,7 +231,7 @@ final class Color extends Field implements CrossSiteCopyableFieldInterface, Inli
         ]);
     }
 
-    public static function getMessages(): array
+    public function getMessages(): array
     {
         return [
             'palette.required_if' => t('Palette cannot be blank if custom colors aren’t allowed.'),
@@ -295,7 +295,7 @@ final class Color extends Field implements CrossSiteCopyableFieldInterface, Inli
         return $value;
     }
 
-    #[\Override]
+    #[Override]
     public function getElementRules(ElementInterface $element): array
     {
         return [

--- a/src/Field/Date.php
+++ b/src/Field/Date.php
@@ -173,7 +173,7 @@ final class Date extends Field implements CrossSiteCopyableFieldInterface, Inlin
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'showDate' => 'boolean',

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -514,7 +514,7 @@ abstract class Field implements Actionable, Arrayable, FieldInterface, Iconic, S
         ];
     }
 
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [
             'name' => ['required'],

--- a/src/Field/Link.php
+++ b/src/Field/Link.php
@@ -227,7 +227,7 @@ final class Link extends Field implements CrossSiteCopyableFieldInterface, Inlin
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'types' => ['required', 'array'],

--- a/src/Field/Matrix.php
+++ b/src/Field/Matrix.php
@@ -353,7 +353,7 @@ final class Matrix extends Field implements EagerLoadingFieldInterface, ElementC
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'entryTypes' => ['array', 'min:1'],

--- a/src/Field/Money.php
+++ b/src/Field/Money.php
@@ -137,7 +137,7 @@ final class Money extends Field implements CrossSiteCopyableFieldInterface, Inli
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'defaultValue' => ['nullable', 'numeric'],

--- a/src/Field/Number.php
+++ b/src/Field/Number.php
@@ -160,7 +160,7 @@ final class Number extends Field implements CrossSiteCopyableFieldInterface, Inl
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         $conditionalInteger = Rule::when(fn ($input) => ! $input->decimals, 'integer', 'numeric');
 

--- a/src/Field/PlainText.php
+++ b/src/Field/PlainText.php
@@ -117,7 +117,7 @@ final class PlainText extends Field implements CrossSiteCopyableFieldInterface, 
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'initialRows' => ['nullable', 'integer', 'min:1'],

--- a/src/Field/Range.php
+++ b/src/Field/Range.php
@@ -116,7 +116,7 @@ final class Range extends Field implements InlineEditableFieldInterface, Mergeab
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'min' => ['nullable', 'numeric'],

--- a/src/Field/Table.php
+++ b/src/Field/Table.php
@@ -209,7 +209,7 @@ final class Table extends Field implements CrossSiteCopyableFieldInterface
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'minRows' => ['nullable', Rule::when(fn ($input) => $input->maxRows > 0, ['lte:maxRows']), 'integer', 'min:0'],

--- a/src/Field/Time.php
+++ b/src/Field/Time.php
@@ -111,7 +111,7 @@ final class Time extends Field implements CrossSiteCopyableFieldInterface, Inlin
     }
 
     #[Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return array_merge(parent::getRules(), [
             'minuteIncrement' => ['nullable', 'integer', 'min:1', 'max:60'],

--- a/src/Http/Controllers/Dashboard/WidgetsController.php
+++ b/src/Http/Controllers/Dashboard/WidgetsController.php
@@ -71,7 +71,7 @@ final readonly class WidgetsController
         // Create a new widget model with the new settings
         $settings = $request->input("widget{$widget->id}-settings");
 
-        Validator::validate($settings, $widget::getRules());
+        Validator::validate($settings, $widget->getRules());
 
         $widget = $this->dashboard->createWidget([
             'id' => $widget->id,

--- a/src/Validation/Concerns/InteractsWithValidator.php
+++ b/src/Validation/Concerns/InteractsWithValidator.php
@@ -14,9 +14,9 @@ use Illuminate\Validation\Validator;
  */
 trait InteractsWithValidator
 {
-    private ?Validator $validator = null;
+    private ?MessageBag $errors = null;
 
-    abstract protected function getValidator(): Validator;
+    abstract protected function getValidator(?array $attributeNames = null): Validator;
 
     public function beforeValidate(): bool
     {
@@ -36,7 +36,7 @@ trait InteractsWithValidator
 
     public function errors(): MessageBag
     {
-        return $this->getValidator()->errors();
+        return $this->errors ??= new MessageBag;
     }
 
     /**
@@ -48,19 +48,20 @@ trait InteractsWithValidator
      */
     public function validate($attributeNames = null, $clearErrors = true): bool
     {
-        $previousErrors = ! $clearErrors && isset($this->validator)
-            ? $this->errors()->getMessages()
-            : [];
+        if ($clearErrors) {
+            $this->errors = new MessageBag;
+        }
 
         if ($this instanceof ValidatableWithRuleset) {
             $this->getRuleset()->prepareForValidation($attributeNames);
         }
 
-        $result = $this->getValidator($attributeNames, fresh: $clearErrors)
-            ->after(fn ($validator) => $this->afterValidate($validator))
-            ->passes();
+        $validator = $this->getValidator($attributeNames)
+            ->after(fn ($validator) => $this->afterValidate($validator));
 
-        $this->errors()->merge($previousErrors);
+        $result = $validator->passes();
+
+        $this->errors()->merge($validator->errors()->getMessages());
 
         return $result && $this->errors()->isEmpty();
     }

--- a/src/Validation/Concerns/Validates.php
+++ b/src/Validation/Concerns/Validates.php
@@ -24,13 +24,9 @@ trait Validates
         return [];
     }
 
-    protected function getValidator(?array $attributeNames = null, bool $fresh = false): Validator
+    protected function getValidator(?array $attributeNames = null): Validator
     {
-        if ($fresh || ! isset($this->validator)) {
-            $this->validator = ValidatorFacade::make([], []);
-        }
-
-        return $this->validator
+        return ValidatorFacade::make([], [])
             ->setData($this->getAttributes())
             ->setCustomMessages(static::getMessages())
             ->setAttributeNames($this->attributeLabels())

--- a/src/Validation/Concerns/Validates.php
+++ b/src/Validation/Concerns/Validates.php
@@ -14,12 +14,12 @@ trait Validates
 {
     use InteractsWithValidator;
 
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [];
     }
 
-    public static function getMessages(): array
+    public function getMessages(): array
     {
         return [];
     }
@@ -28,11 +28,11 @@ trait Validates
     {
         return ValidatorFacade::make([], [])
             ->setData($this->getAttributes())
-            ->setCustomMessages(static::getMessages())
+            ->setCustomMessages($this->getMessages())
             ->setAttributeNames($this->attributeLabels())
             ->setRules(is_null($attributeNames)
-                ? static::getRules()
-                : Arr::only(static::getRules(), $attributeNames)
+                ? $this->getRules()
+                : Arr::only($this->getRules(), $attributeNames)
             );
     }
 

--- a/src/Validation/Concerns/ValidatesWithRuleset.php
+++ b/src/Validation/Concerns/ValidatesWithRuleset.php
@@ -44,15 +44,11 @@ trait ValidatesWithRuleset
         return $this->ruleset = app()->make($class, ['component' => $this]);
     }
 
-    protected function getValidator(?array $attributeNames = null, bool $fresh = false): Validator
+    protected function getValidator(?array $attributeNames = null): Validator
     {
-        if ($fresh || ! isset($this->validator)) {
-            $this->validator = ValidatorFacade::make([], []);
-        }
-
         $ruleset = $this->getRuleset();
 
-        return $this->validator
+        return ValidatorFacade::make([], [])
             ->setData($this->getAttributes())
             ->setCustomMessages($ruleset->messages())
             ->setAttributeNames($ruleset->attributes())

--- a/src/Validation/Contracts/Validatable.php
+++ b/src/Validation/Contracts/Validatable.php
@@ -13,14 +13,14 @@ interface Validatable
      *
      * @return array<string, mixed>
      */
-    public static function getRules(): array;
+    public function getRules(): array;
 
     /**
      * Returns custom error messages for validation rules.
      *
      * @return array<string, string>
      */
-    public static function getMessages(): array;
+    public function getMessages(): array;
 
     // /**
     //  * This method is invoked before validation starts.

--- a/tests/TestClasses/TestPluginSettings.php
+++ b/tests/TestClasses/TestPluginSettings.php
@@ -11,7 +11,7 @@ final class TestPluginSettings extends PluginSettings
     public ?string $foo = null;
 
     #[\Override]
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [
             'foo' => 'required',

--- a/tests/Validation/RulesetTest.php
+++ b/tests/Validation/RulesetTest.php
@@ -59,12 +59,12 @@ function createTestComponent(array $scenarios = []): ValidatableWithRuleset
             return $this->testScenarios;
         }
 
-        public static function getRules(): array
+        public function getRules(): array
         {
             return [];
         }
 
-        public static function getMessages(): array
+        public function getMessages(): array
         {
             return [];
         }

--- a/tests/Validation/ValidatesWithRulesetTest.php
+++ b/tests/Validation/ValidatesWithRulesetTest.php
@@ -23,12 +23,12 @@ function createValidatableComponent(array $attributes, ?string $rulesetClass = n
             $this->rulesetClass = $rulesetClass ?? TestRuleset::class;
         }
 
-        public static function getRules(): array
+        public function getRules(): array
         {
             return [];
         }
 
-        public static function getMessages(): array
+        public function getMessages(): array
         {
             return [];
         }
@@ -128,12 +128,12 @@ describe('getRuleset', function () {
         {
             use ValidatesWithRuleset;
 
-            public static function getRules(): array
+            public function getRules(): array
             {
                 return [];
             }
 
-            public static function getMessages(): array
+            public function getMessages(): array
             {
                 return [];
             }

--- a/yii2-adapter/legacy/base/Model.php
+++ b/yii2-adapter/legacy/base/Model.php
@@ -406,7 +406,7 @@ abstract class Model extends \yii\base\Model implements ModelInterface, Validata
     /**
      * Legacy models are validated differently
      */
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [];
     }
@@ -414,7 +414,7 @@ abstract class Model extends \yii\base\Model implements ModelInterface, Validata
     /**
      * Legacy models are validated differently
      */
-    public static function getMessages(): array
+    public function getMessages(): array
     {
         return [];
     }

--- a/yii2-adapter/legacy/base/Widget.php
+++ b/yii2-adapter/legacy/base/Widget.php
@@ -24,7 +24,7 @@ abstract class Widget extends SavableComponent implements \CraftCms\Cms\Dashboar
     /**
      * Old widgets will get validated by calling the ->validate() method.
      */
-    public static function getRules(): array
+    public function getRules(): array
     {
         return [];
     }

--- a/yii2-adapter/legacy/gql/base/ElementMutationResolver.php
+++ b/yii2-adapter/legacy/gql/base/ElementMutationResolver.php
@@ -177,7 +177,7 @@ abstract class ElementMutationResolver extends MutationResolver
             }
         }
 
-        if ($element->errors()->isNotEmpty()) {
+        if ($element->hasErrors()) {
             $validationErrors = [];
 
             foreach ($element->getFirstErrors() as $errorMessage) {


### PR DESCRIPTION
## Summary

Replaced the `$validator` property with a `MessageBag` property to fix serialization issues in the `InteractsWithValidator` trait.

### Changes Made

**1. `src/Validation/Concerns/InteractsWithValidator.php`**
- Replaced `private ?Validator $validator` with `private ?MessageBag $errors`
- `errors()` now returns a persistent mutable `MessageBag` instance
- `validate()` creates a fresh validator each time and merges errors into the stored bag
- When `clearErrors: false`, existing errors are preserved by not resetting the bag

**2. `src/Validation/Concerns/Validates.php` & `ValidatesWithRuleset.php`**
- Removed the `$fresh` parameter from `getValidator()`
- Removed validator caching logic — always creates fresh validator instance
- Simplified implementation