### PR TITLE
don't redirect if it's the same path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where the Entries index page could trigger an infinite browser redirect loop. ([#18400](https://github.com/craftcms/cms/issues/18400))
+
 ## 5.9.7 - 2026-02-09
 
 - Nested entries’ edit screens now have a “Field settings” action menu item.

--- a/src/templates/entries/index.twig
+++ b/src/templates/entries/index.twig
@@ -4,7 +4,7 @@
 {% if not page or not craft.app.elementSources.pageExists("craft\\elements\\Entry", page) %}
   {% if sectionHandle is defined %}
     {% set redirect = craft.app.entries.getSectionByHandle(sectionHandle).getCpIndexUri() ?? null %}
-    {% if redirect %}
+    {% if redirect and redirect != craft.app.request.getPathInfo() %}
       {% redirect redirect %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
### Description
The following actions can lead to an infinite redirection loop if the pages are not saved against sources via customise sources modal.

- visit an entry that belongs to a section and then click on the section’s name in the breadcrumbs
- visit an entry that belongs to a section and press the browser’s back button
- in a multisite setup, go to the entries index page, click on one of the sources and then switch to another site


### Related issues
#18400 
