### PR TITLE
Table field with static rows and no defaults - php error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > [!WARNING]  
 > Relational condition rules’ element ID templates are now rendered in a sandboxed Twig environment, when `enableTwigSandbox` is enabled.
 
+- Fixed an error that could occur when editing an element with a Table field. ([#18408](https://github.com/craftcms/cms/pull/18408))
 - Fixed a [high-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) RCE vulnerability. (GHSA-fp5j-j7j4-mcxc)
 
 ## 4.17.3 - 2026-02-09

--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -504,7 +504,7 @@ class Table extends Field
 
         if ($this->staticRows) {
             // get the order of the default rows
-            $order = ArrayHelper::getColumn($this->defaults, 'rowId');
+            $order = ArrayHelper::getColumn($this->defaults ?? [], 'rowId');
             $missingValueRowIds = null;
 
             if (!empty($order)) {


### PR DESCRIPTION
### Description
Fixes an error that occurred when viewing, e.g. an entry edit page that contains a Table field with static rows and no default rows.

This error was not directly mentioned by OP and occurs in v4 and v5. 

### Related issues
#18407
