### PR TITLE
don't assume defaults is an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 > Relational condition rules’ element ID templates are now rendered in a sandboxed Twig environment, when `enableTwigSandbox` is enabled.
 
 - Fixed an error that could occur when editing an element with a Table field. ([#18408](https://github.com/craftcms/cms/pull/18408))
+- Fixed an error that occurred when editing a Table field with no default rows. ([#18407](https://github.com/craftcms/cms/issues/18407))
 - Fixed a [high-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) RCE vulnerability. (GHSA-fp5j-j7j4-mcxc)
 
 ## 5.9.8 - 2026-02-10

--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -399,7 +399,7 @@ class Table extends Field implements CrossSiteCopyableFieldInterface
                 // make sure the row has a UUID
                 $row['rowId'] ??= StringHelper::uuid();
                 return $row;
-            }, $this->defaults),
+            }, $this->defaults ?? []),
             'initJs' => false,
             'static' => $readOnly,
             'includeRowId' => true,


### PR DESCRIPTION
### Description
Fixes an error that occurred when trying to save a Table field with nothing under the default values (not even an empty row).

This error only affects v5.
There's a complimentary PR for this that affects v4 and v5: https://github.com/craftcms/cms/pull/18408

### Related issues
#18407
