### PR TITLE
Update `CpSidebar` for focus management

### DIFF
--- a/resources/js/components/CpSidebar.vue
+++ b/resources/js/components/CpSidebar.vue
@@ -3,21 +3,30 @@
   import MainNav from '@/components/MainNav.vue';
   import EditionInfo from '@/components/EditionInfo.vue';
   import DevModeIndicator from '@/components/DevModeIndicator.vue';
+  import {watch, computed, nextTick} from 'vue';
 
   const emit = defineEmits<{
     (e: 'close'): void;
     (e: 'dock'): void;
   }>();
-  withDefaults(
-    defineProps<{
-      mode: 'docked' | 'floating' | 'collapsed';
-      visibility: 'hidden' | 'visible';
-    }>(),
-    {
-      mode: 'floating',
-      visibility: 'hidden',
+
+  const { mode = 'floating', visibility = 'hidden' } = defineProps<{
+    mode: 'docked' | 'floating' | 'collapsed';
+    visibility: 'hidden' | 'visible';
+  }>();
+
+  const shouldManageFocus = computed(() => {
+    return mode === 'floating';
+  });
+
+  watch(() => visibility, async (newVal) => {
+    if (shouldManageFocus.value && newVal === 'visible') {
+      await nextTick();
+      const sidebar = document.querySelector('.cp-sidebar') as HTMLElement;
+      const firstFocusable = sidebar.querySelector('button, [href], [tabindex]:not([tabindex="-1"])') as HTMLElement;
+      firstFocusable?.focus();
     }
-  );
+  });
 </script>
 
 <template>

--- a/resources/js/components/CpSidebar.vue
+++ b/resources/js/components/CpSidebar.vue
@@ -22,22 +22,24 @@
 
 <template>
   <nav class="cp-sidebar" :data-visibility="visibility" :data-mode="mode">
-    <div class="cp-sidebar__header">
-      <div class="sidebar-header" v-if="mode !== 'docked'">
-        <SystemInfo />
-        <div class="ml-auto"></div>
-        <craft-button size="small" icon @click="emit('close')" type="button">
-          <craft-icon name="x" style="font-size: 0.7em"></craft-icon>
-        </craft-button>
+    <template v-if="visibility === 'visible'">
+      <div class="cp-sidebar__header">
+        <div class="sidebar-header" v-if="mode !== 'docked'">
+          <SystemInfo />
+          <div class="ml-auto"></div>
+          <craft-button size="small" icon @click="emit('close')" type="button">
+            <craft-icon name="x" style="font-size: 0.7em"></craft-icon>
+          </craft-button>
+        </div>
       </div>
-    </div>
-    <div class="cp-sidebar__body">
-      <MainNav />
-    </div>
-    <div class="cp-sidebar__footer">
-      <EditionInfo />
-      <DevModeIndicator />
-    </div>
+      <div class="cp-sidebar__body">
+        <MainNav />
+      </div>
+      <div class="cp-sidebar__footer">
+        <EditionInfo />
+        <DevModeIndicator />
+      </div>
+    </template>
   </nav>
 </template>
 

--- a/resources/js/layout/AppLayout.vue
+++ b/resources/js/layout/AppLayout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   import {t} from '@craftcms/cp';
   import SystemInfo from '@/components/SystemInfo.vue';
-  import {computed, reactive, ref, watch} from 'vue';
+  import {computed, reactive, ref, watch, useTemplateRef} from 'vue';
   import CpSidebar from '@/components/CpSidebar.vue';
   import {useMediaQuery} from '@vueuse/core';
   import {Head, usePage} from '@inertiajs/vue3';
@@ -30,6 +30,7 @@
   const errorFlash = computed(() => page.props.flash?.error);
   const successFlash = computed(() => page.props.flash?.success);
   const crumbs = computed(() => page.props.crumbs ?? null);
+  const sidebarToggle = useTemplateRef('sidebarToggle');
 
   const state = reactive<{
     sidebar: {
@@ -68,6 +69,11 @@
     }
   }
 
+  function closeSidebar() {
+    state.sidebar.visibility = 'hidden';
+    (sidebarToggle.value as HTMLButtonElement).focus();
+  }
+
   const sidebarIcon = computed(() => {
     return state.sidebar.visibility === 'visible' ? 'x' : 'bars';
   });
@@ -93,6 +99,7 @@
           appearance="plain"
           @click="toggleSidebar"
           v-if="!isLargeScreen"
+          ref="sidebarToggle"
         >
           <craft-icon :name="sidebarIcon"></craft-icon>
         </craft-button>
@@ -119,7 +126,7 @@
       <CpSidebar
         :mode="state.sidebar.mode"
         :visibility="state.sidebar.visibility"
-        @close="state.sidebar.visibility = 'hidden'"
+        @close="closeSidebar"
       />
     </div>
     <div class="cp__main">


### PR DESCRIPTION
### Description
To verify:
- [x] When the sidebar is collapsed, focusable children should not remain in the focus order
- [x] When the sidebar is opened, focus should move to the first focusable element
- [x] When the sidebar is collapsed, and keyboard focus is inside of it, focus should move back to the toggle button

### Related issues
Resolves ACC-8, ACC-7