### PR TITLE
Fix parseBooleanEnv value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where the control panel requests could trigger an infinite browser redirect loop. ([#18420](https://github.com/craftcms/cms/issues/18420))
+- Fixed a bug where `craft\helpers\App::parseBooleanEnv()` wasn’t handling `false` values properly. ([#18418](https://github.com/craftcms/cms/issues/18418))
 
 ## 5.9.9 - 2026-02-11
 

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -235,7 +235,15 @@ class App
         $value = self::parseNestedEnv($value);
 
         // …/$VAR/…
-        $value = preg_replace_callback('/(?<=^|\/)\$(\w+)(?=$|\/)?/', fn($m) => static::env($m[1]), $value);
+        $value = preg_replace_callback('/(?<=^|\/)\$(\w+)(?=$|\/)?/', function($m) {
+            $result = self::env($m[1]);
+
+            if (is_bool($result)) {
+                return $result ? 'true' : 'false';
+            }
+
+            return (string)$result;
+        }, $value);
 
         if ($value === '') {
             return null;

--- a/tests/unit/helpers/AppHelperTest.php
+++ b/tests/unit/helpers/AppHelperTest.php
@@ -133,8 +133,12 @@ class AppHelperTest extends TestCase
      * @param bool|null $expected
      * @param mixed $value
      */
-    public function testParseBooleanEnv(?bool $expected, mixed $value): void
+    public function testParseBooleanEnv(?bool $expected, mixed $value, array $values = []): void
     {
+        foreach ($values as $name => $v) {
+            putenv("$name=$v");
+        }
+
         self::assertSame($expected, App::parseBooleanEnv($value));
     }
 
@@ -469,6 +473,16 @@ class AppHelperTest extends TestCase
             [false, 0],
             [null, 2],
             [null, '$TEST_MISSING'],
+            [
+                false,
+                '$TEST_FALSE',
+                ['TEST_FALSE' => 'false'],
+            ],
+            [
+                true,
+                '$TEST_TRUE',
+                ['TEST_TRUE' => 'true'],
+            ],
         ];
     }
 


### PR DESCRIPTION
Originally fixed in https://github.com/craftcms/cms/pull/18232 but I thought it was just a 6.x change. After seeing #18418 it's looking like the issue was introduced in [5.x](https://github.com/craftcms/cms/commit/397541cd2dddee915efa10e3c6caa9438f3aae3a#diff-8ddcc488c3dc025ab9e7d97a17dedba912ac12119f5f5f7a010e07b4bf981688R245) 

Fixes #18418 