### PR TITLE
Update the db/convert-charset collation argument docs

### DIFF
--- a/src/console/controllers/DbController.php
+++ b/src/console/controllers/DbController.php
@@ -423,7 +423,9 @@ class DbController extends Controller
      * @param string|null $charset The target character set, which honors `DbConfig::$charset`
      *                               or defaults to `utf8`.
      * @param string|null $collation The target collation, which honors `DbConfig::$collation`
-     *                               or defaults to `utf8_unicode_ci`.
+     *                               or defaults to `utf8mb4_0900_ai_ci` for MySQL 8.0+,
+     *                               otherwise, `utf8mb4_unicode_ci` for MariaDB and earlier
+     *                               MySQL versions.
      * @return int
      */
     public function actionConvertCharset(?string $charset = null, ?string $collation = null): int


### PR DESCRIPTION
### Description

The docs for the db/convert-charset command are no longer accurate. This PR updates `$collation` arguments docs to reflect the defaults here: https://github.com/craftcms/cms/blob/2f5149d4d64a5dafae9db99357823655422ba77d/src/helpers/Db.php#L1916-L1936

### Related issues

None.