### PR TITLE
[6.x] Maintenance mode

### DIFF
--- a/src/Database/Migrations/0000_00_00_000009_remove_maintenance_from_info.php
+++ b/src/Database/Migrations/0000_00_00_000009_remove_maintenance_from_info.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Database\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('info', 'maintenance')) {
+            return;
+        }
+
+        Schema::table('info', function (Blueprint $table) {
+            $table->dropColumn('maintenance');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('info', function (Blueprint $table) {
+            $table->boolean('maintenance')->default(false)->after('schemaVersion');
+        });
+    }
+};

--- a/src/Database/Migrations/Install.php
+++ b/src/Database/Migrations/Install.php
@@ -479,7 +479,6 @@ class Install extends Migration
             $table->integer('id', true);
             $table->string('version', 50);
             $table->string('schemaVersion', 15);
-            $table->boolean('maintenance')->default(false);
             $table->char('configVersion', 12)->default('000000000000');
             $table->dateTime('dateCreated');
             $table->dateTime('dateUpdated');
@@ -1063,7 +1062,6 @@ class Install extends Migration
                 'id' => 1,
                 'version' => Cms::VERSION,
                 'schemaVersion' => Cms::SCHEMA_VERSION,
-                'maintenance' => false,
                 'configVersion' => Str::random(12),
             ]);
         });

--- a/src/Http/Controllers/BaseUpdaterController.php
+++ b/src/Http/Controllers/BaseUpdaterController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http\Controllers;
 
-use Craft;
 use craft\web\Application;
 use craft\web\assets\updater\UpdaterAsset;
 use CraftCms\Cms\Config\GeneralConfig;
@@ -200,7 +199,7 @@ abstract class BaseUpdaterController
     public function finish(): Response
     {
         // Disable maintenance mode
-        Craft::$app->disableMaintenanceMode();
+        app()->maintenanceMode()->deactivate();
 
         return $this->send([
             'finished' => true,

--- a/src/Http/Controllers/MigrateController.php
+++ b/src/Http/Controllers/MigrateController.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\ProjectConfig\Exceptions\BusyResourceException;
 use CraftCms\Cms\ProjectConfig\Exceptions\StaleResourceException;
 use CraftCms\Cms\ProjectConfig\ProjectConfig;
 use CraftCms\Cms\Updates\Updates;
+use Illuminate\Foundation\MaintenanceModeManager;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -27,7 +28,7 @@ final class MigrateController
      * services (like [DeployBot](https://deploybot.com/) or [DeployPlace](https://deployplace.com/)) to minimize site
      * downtime after a deployment.
      */
-    public function __invoke(Request $request, GeneralConfig $generalConfig, Updates $updates, ProjectConfig $projectConfig)
+    public function __invoke(Request $request, GeneralConfig $generalConfig, Updates $updates, ProjectConfig $projectConfig, MaintenanceModeManager $maintenance)
     {
         $handles = $updates->pendingMigrationHandles(true);
         $runMigrations = ! empty($handles);
@@ -42,19 +43,19 @@ final class MigrateController
         }
 
         // Bail if Craft is already in maintenance mode
-        if (Craft::$app->getIsInMaintenanceMode()) {
+        if (app()->isDownForMaintenance()) {
             throw new ServiceUnavailableHttpException('Craft is already being updated.');
         }
 
         // Enable maintenance mode
-        Craft::$app->enableMaintenanceMode();
+        $maintenance->activate([]);
 
         // Backup the DB?
         if ($generalConfig->getBackupOnUpdate()) {
             try {
                 $backupPath = Craft::$app->getDb()->backup();
             } catch (Throwable $e) {
-                Craft::$app->disableMaintenanceMode();
+                $maintenance->deactivate();
                 throw new HttpException(500, 'Error backing up the database.', $e);
             }
         }
@@ -103,12 +104,12 @@ final class MigrateController
                 default => ' The database has not been restored.',
             };
 
-            Craft::$app->disableMaintenanceMode();
+            $maintenance->deactivate();
 
             throw new HttpException(500, $error, $e);
         }
 
-        Craft::$app->disableMaintenanceMode();
+        $maintenance->deactivate();
 
         return response()->noContent();
     }

--- a/src/Http/Controllers/Updates/UpdaterController.php
+++ b/src/Http/Controllers/Updates/UpdaterController.php
@@ -237,7 +237,7 @@ final class UpdaterController extends BaseUpdaterController
         }
 
         // Is Craft already in Maintenance Mode?
-        if (! $force && Craft::$app->getIsInMaintenanceMode()) {
+        if (! $force && app()->isDownForMaintenance()) {
             // Bail if Craft is already in maintenance mode
             return [
                 'error' => str_replace(['<br>', '<br/>'], "\n\n", t('It looks like someone is currently performing a system update.<br>Only continue if you’re sure that’s not the case.')),
@@ -253,7 +253,7 @@ final class UpdaterController extends BaseUpdaterController
         }
 
         // Enable maintenance mode
-        Craft::$app->enableMaintenanceMode();
+        app()->maintenanceMode()->activate([]);
 
         if (! empty($this->data['install'])) {
             $nextAction = self::ACTION_COMPOSER_INSTALL;
@@ -304,7 +304,7 @@ final class UpdaterController extends BaseUpdaterController
     protected function sendFinished(array $state = []): Response
     {
         // Disable maintenance mode
-        Craft::$app->disableMaintenanceMode();
+        app()->maintenanceMode()->deactivate();
 
         return parent::sendFinished($state);
     }

--- a/src/Plugin/Plugins.php
+++ b/src/Plugin/Plugins.php
@@ -224,7 +224,7 @@ final class Plugins
             }
 
             // If we're not updating, check if the plugin’s version number changed, but not its schema version.
-            if (! app('Craft')->getIsInMaintenanceMode() && $hasVersionChanged && ! $this->isPluginUpdatePending($plugin)) {
+            if (! app()->isDownForMaintenance() && $hasVersionChanged && ! $this->isPluginUpdatePending($plugin)) {
                 // Update our record of the plugin’s version number
                 DB::table(Table::PLUGINS)
                     ->where('id', $row['id'])

--- a/src/Route/RouteServiceProvider.php
+++ b/src/Route/RouteServiceProvider.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Route;
 
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Http\Controllers\ConfigSyncController;
+use CraftCms\Cms\Http\Controllers\MigrateController;
+use CraftCms\Cms\Http\Controllers\PluginStore\InstallController as PluginStoreInstallController;
+use CraftCms\Cms\Http\Controllers\PluginStore\RemoveController as PluginStoreRemoveController;
+use CraftCms\Cms\Http\Controllers\Updates\UpdaterController;
 use CraftCms\Cms\Http\Middleware\AddLogContext;
 use CraftCms\Cms\Http\Middleware\CheckForUpdates;
 use CraftCms\Cms\Http\Middleware\CheckRequirements;
@@ -25,6 +30,7 @@ use CraftCms\Cms\Route\Data\Route;
 use CraftCms\Cms\Site\Events\SiteDeleted;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Routing\Router;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Support\Facades\Event;
@@ -55,6 +61,7 @@ final class RouteServiceProvider extends ServiceProvider
 
         $this->bootMiddleware($router);
         $this->loadRoutesFrom(dirname(__DIR__).'/../routes/routes.php');
+        $this->bootMaintenanceModeExceptions();
 
         $this->app->booted(function () use ($routes, $router): void {
             if (! Cms::isInstalled()) {
@@ -73,6 +80,22 @@ final class RouteServiceProvider extends ServiceProvider
 
             $routes->handleDeletedSite($event);
         });
+    }
+
+    /**
+     * Register routes that should remain accessible during maintenance mode.
+     */
+    private function bootMaintenanceModeExceptions(): void
+    {
+        PreventRequestsDuringMaintenance::except([
+            action([UpdaterController::class, 'finish']),
+            action([UpdaterController::class, 'backup']),
+            action([UpdaterController::class, 'serverCheck']),
+            action([ConfigSyncController::class, 'finish']),
+            action([PluginStoreInstallController::class, 'finish']),
+            action([PluginStoreRemoveController::class, 'finish']),
+            action(MigrateController::class),
+        ]);
     }
 
     private function bootMiddleware(Router $router): void

--- a/src/Shared/Models/Info.php
+++ b/src/Shared/Models/Info.php
@@ -23,17 +23,8 @@ final class Info extends BaseModel
      */
     protected $attributes = [
         'schemaVersion' => '0',
-        'maintenance' => false,
         'configVersion' => '000000000000',
     ];
-
-    #[\Override]
-    protected function casts(): array
-    {
-        return [
-            'maintenance' => 'bool',
-        ];
-    }
 
     #[\Override]
     protected static function booted(): void

--- a/tests/Feature/Http/Controllers/MigrateControllerTest.php
+++ b/tests/Feature/Http/Controllers/MigrateControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Http\Controllers\MigrateController;
+use CraftCms\Cms\Updates\Updates;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Auth;
 
@@ -17,10 +18,7 @@ beforeEach(function () {
 test('can be invoked without authentication for deployment hooks', function () {
     Auth::logout();
 
-    $response = post(action(MigrateController::class));
-
-    // Should work (returns 204 when nothing to do, or 503 if in maintenance mode)
-    expect($response->status())->toBeIn([204, 503]);
+    post(action(MigrateController::class))->assertNoContent();
 });
 
 test('returns no content when no migrations or config changes pending', function () {
@@ -29,14 +27,14 @@ test('returns no content when no migrations or config changes pending', function
     ]);
 
     // Should return 204 No Content when there's nothing to do
-    expect($response->status())->toBeIn([204, 503]);
+    expect($response->status())->toBe(204);
 });
 
 test('returns no content when migrations complete successfully', function () {
     $response = postJson(action(MigrateController::class));
 
     // Should complete without error
-    expect($response->status())->toBeIn([204, 503, 500]);
+    expect($response->status())->toBe(204);
 });
 
 test('handles applyProjectConfigChanges parameter', function () {
@@ -45,33 +43,34 @@ test('handles applyProjectConfigChanges parameter', function () {
     ]);
 
     // Should handle the parameter
-    expect($response->status())->toBeIn([204, 500, 503]);
+    expect($response->status())->toBe(204);
 });
 
 test('handles maintenance mode correctly', function () {
-    // Ensure maintenance mode is off initially
-    Craft::$app->disableMaintenanceMode();
+    postJson(action(MigrateController::class))->assertNoContent();
 
     // Enable maintenance mode
-    Craft::$app->enableMaintenanceMode();
+    app()->maintenanceMode()->activate([]);
 
-    $response = postJson(action(MigrateController::class));
+    // Nothing to migrate
+    postJson(action(MigrateController::class))->assertNoContent();
 
-    // Should either reject (503) or complete (204) depending on implementation details
-    expect($response->status())->toBeIn([204, 503]);
+    $this->mock(Updates::class)
+        ->shouldReceive('isCraftUpdatePending')->andReturn(true)
+        ->shouldReceive('isCraftSchemaVersionCompatible')->andReturn(true)
+        ->shouldReceive('pendingMigrationHandles')->andReturn(['foo']);
 
-    // Clean up - ensure maintenance mode is disabled
-    Craft::$app->disableMaintenanceMode();
+    postJson(action(MigrateController::class))->assertServiceUnavailable();
 });
 
 test('disables maintenance mode after completion', function () {
     // Ensure maintenance mode is off before test
-    Craft::$app->disableMaintenanceMode();
+    app()->maintenanceMode()->deactivate();
 
     postJson(action(MigrateController::class));
 
     // Verify maintenance mode is off after operation
-    expect(Craft::$app->getIsInMaintenanceMode())->toBeFalse();
+    expect(app()->isDownForMaintenance())->toBeFalse();
 });
 
 test('handles empty request body', function () {

--- a/tests/Feature/Http/Middleware/MaintenanceModeExceptionsTest.php
+++ b/tests/Feature/Http/Middleware/MaintenanceModeExceptionsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Cms;
+use CraftCms\Cms\User\Elements\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+use function Pest\Laravel\postJson;
+
+beforeEach(function () {
+    actingAs(User::findOne());
+    app()->maintenanceMode()->activate([]);
+});
+
+afterEach(function () {
+    app()->maintenanceMode()->deactivate();
+});
+
+test('non-exempted routes return 503 during maintenance mode', function () {
+    $cpTrigger = Cms::config()->cpTrigger;
+    $actionTrigger = Cms::config()->actionTrigger;
+
+    $response = postJson("/{$cpTrigger}/{$actionTrigger}/app/api-headers");
+
+    expect($response->status())->toBe(503);
+});
+
+test('migrate action route is accessible during maintenance mode', function () {
+    $actionTrigger = Cms::config()->actionTrigger;
+
+    $response = post("/{$actionTrigger}/migrate");
+
+    expect($response->status())->not->toBe(503);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,6 +51,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         app()->setLocale('en-US');
+        app()->maintenanceMode()->deactivate();
 
         // Reset timezone to a consistent value for tests
         // This is needed because AppServiceProvider::setTimezone() runs during boot,

--- a/yii2-adapter/legacy/base/ApplicationTrait.php
+++ b/yii2-adapter/legacy/base/ApplicationTrait.php
@@ -601,7 +601,7 @@ trait ApplicationTrait
      */
     public function getIsInMaintenanceMode(): bool
     {
-        return \CraftCms\Cms\Shared\Models\Info::fetch()->maintenance;
+        return app()->isDownForMaintenance();
     }
 
     /**
@@ -612,7 +612,9 @@ trait ApplicationTrait
      */
     public function enableMaintenanceMode(): bool
     {
-        return $this->_setMaintenanceMode(true);
+        app()->maintenanceMode()->activate([]);
+
+        return true;
     }
 
     /**
@@ -623,7 +625,9 @@ trait ApplicationTrait
      */
     public function disableMaintenanceMode(): bool
     {
-        return $this->_setMaintenanceMode(false);
+        app()->maintenanceMode()->deactivate();
+
+        return true;
     }
 
     /**
@@ -1363,20 +1367,6 @@ trait ApplicationTrait
         if ($this->hasEventHandlers(WebApplication::EVENT_INIT)) {
             $this->trigger(WebApplication::EVENT_INIT);
         }
-    }
-
-    /**
-     * Enables or disables Maintenance Mode
-     */
-    private function _setMaintenanceMode(bool $value): bool
-    {
-        $info = \CraftCms\Cms\Shared\Models\Info::fetch();
-        if ($info->maintenance === $value) {
-            return true;
-        }
-        $info->maintenance = $value;
-
-        return $info->save();
     }
 
     /**


### PR DESCRIPTION
Replaces the "hard" maintenance mode (the one stored on Info) with Laravel's implementation

Craft's "live" status is unaffected and different from this more global one.