### PR TITLE
fix: condition logic for (not) empty operator

### DIFF
--- a/src/base/conditions/BaseMultiSelectConditionRule.php
+++ b/src/base/conditions/BaseMultiSelectConditionRule.php
@@ -181,6 +181,13 @@ abstract class BaseMultiSelectConditionRule extends BaseConditionRule
      */
     protected function matchValue(array|string|null $value): bool
     {
+        if (in_array($this->operator, [self::OPERATOR_EMPTY, self::OPERATOR_NOT_EMPTY])) {
+            return match ($this->operator) {
+                self::OPERATOR_EMPTY => empty($value),
+                self::OPERATOR_NOT_EMPTY => !empty($value),
+            };
+        }
+        
         if (!$this->_values) {
             return true;
         }
@@ -194,8 +201,6 @@ abstract class BaseMultiSelectConditionRule extends BaseConditionRule
         return match ($this->operator) {
             self::OPERATOR_IN => !empty(array_intersect($value, $this->_values)),
             self::OPERATOR_NOT_IN => empty(array_intersect($value, $this->_values)),
-            self::OPERATOR_NOT_EMPTY => !empty($value),
-            self::OPERATOR_EMPTY => empty($value),
             default => throw new InvalidConfigException("Invalid operator: $this->operator"),
         };
     }


### PR DESCRIPTION
### Description
Fixes conditional logic for the **(not) empty** operator on dropdown fields. Previously, conditions using **(not) empty** always evaluated to true because `$this->_values` was checked first. That check is only relevant for **(not) in** conditions.

### Steps to reproduce the fixed issue
1. Create an entry for an entry type that includes a Title field and a Dropdown field.
2. Add a Visibility Condition to the Title field using an Entry Condition where the Dropdown field is set to **(not) empty**.
3. Observe that the Title is always visible, regardless of whether the dropdown field had a value.
