### PR TITLE
Proposal: Craft core save optimization

### DIFF
--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -824,6 +824,9 @@ JS, [
 
         $elementIds = [];
         $sortOrder = 0;
+        $managerKey = isset($this->field)
+            ? sprintf('field:%s', (string)($this->field->uid ?? $this->field->handle ?? $this->field->id))
+            : sprintf('attribute:%s', (string)$this->attribute);
 
         $transaction = Craft::$app->getDb()->beginTransaction();
         try {
@@ -843,7 +846,17 @@ JS, [
                 }
 
                 $sortOrder++;
-                if ($saveAll || !$element->id || $element->forceSave) {
+                $shouldSave = $saveAll || !$element->id || $element->forceSave;
+
+                if (
+                    $shouldSave &&
+                    isset($element->id) &&
+                    !$elementsService->shouldSaveNestedElement($owner, $element, $managerKey, $sortOrder)
+                ) {
+                    $shouldSave = false;
+                }
+
+                if ($shouldSave) {
                     $element->setOwner($owner);
                     $element->setSortOrder($sortOrder);
                     $element->resaving = $owner->resaving;

--- a/src/services/ElementSaveOptimizationContext.php
+++ b/src/services/ElementSaveOptimizationContext.php
@@ -11,9 +11,6 @@ use craft\base\ElementInterface;
 
 /**
  * Request-scoped save optimization context.
- *
- * @internal
- * @since 5.8.0
  */
 final class ElementSaveOptimizationContext
 {

--- a/src/services/ElementSaveOptimizationContext.php
+++ b/src/services/ElementSaveOptimizationContext.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\services;
+
+use craft\base\ElementInterface;
+
+/**
+ * Request-scoped save optimization context.
+ *
+ * @internal
+ * @since 5.8.0
+ */
+final class ElementSaveOptimizationContext
+{
+    public int $depth = 0;
+
+    /**
+     * @var array<string,bool>
+     */
+    private array $cacheInvalidationKeys = [];
+
+    /**
+     * @var array<string,bool>
+     */
+    private array $changedAttributeKeys = [];
+
+    /**
+     * @var array<string,bool>
+     */
+    private array $changedFieldKeys = [];
+
+    /**
+     * @var array<string,bool>
+     */
+    private array $ownerSearchIndexKeys = [];
+
+    /**
+     * @var array<string,bool>
+     */
+    private array $nestedSaveKeys = [];
+
+    public function begin(): void
+    {
+        $this->depth++;
+    }
+
+    public function end(): bool
+    {
+        $this->depth--;
+        return $this->depth === 0;
+    }
+
+    public function rememberCacheInvalidation(ElementInterface $element): bool
+    {
+        if (!isset($element->id)) {
+            return true;
+        }
+
+        $key = sprintf('%s:%d', get_class($element), $element->id);
+
+        if (isset($this->cacheInvalidationKeys[$key])) {
+            return false;
+        }
+
+        $this->cacheInvalidationKeys[$key] = true;
+        return true;
+    }
+
+    public function rememberChangedAttribute(
+        int $elementId,
+        int $siteId,
+        string $attribute,
+        bool $propagated,
+        ?int $userId,
+    ): bool {
+        $key = sprintf('%d:%d:%s:%d:%d', $elementId, $siteId, $attribute, (int)$propagated, (int)$userId);
+
+        if (isset($this->changedAttributeKeys[$key])) {
+            return false;
+        }
+
+        $this->changedAttributeKeys[$key] = true;
+        return true;
+    }
+
+    public function rememberChangedField(
+        int $elementId,
+        int $siteId,
+        int $fieldId,
+        string $layoutElementUid,
+        bool $propagated,
+        ?int $userId,
+    ): bool {
+        $key = sprintf(
+            '%d:%d:%d:%s:%d:%d',
+            $elementId,
+            $siteId,
+            $fieldId,
+            $layoutElementUid,
+            (int)$propagated,
+            (int)$userId,
+        );
+
+        if (isset($this->changedFieldKeys[$key])) {
+            return false;
+        }
+
+        $this->changedFieldKeys[$key] = true;
+        return true;
+    }
+
+    public function rememberOwnerSearchIndex(int $ownerId, int $siteId, string $fieldHandle): bool
+    {
+        $key = sprintf('%d:%d:%s', $ownerId, $siteId, $fieldHandle);
+
+        if (isset($this->ownerSearchIndexKeys[$key])) {
+            return false;
+        }
+
+        $this->ownerSearchIndexKeys[$key] = true;
+        return true;
+    }
+
+    public function rememberNestedSave(
+        int $ownerId,
+        int $ownerSiteId,
+        string $managerKey,
+        int $nestedId,
+        int $sortOrder,
+    ): bool {
+        $key = sprintf('%d:%d:%s:%d:%d', $ownerId, $ownerSiteId, $managerKey, $nestedId, $sortOrder);
+
+        if (isset($this->nestedSaveKeys[$key])) {
+            return false;
+        }
+
+        $this->nestedSaveKeys[$key] = true;
+        return true;
+    }
+}

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -1265,8 +1265,10 @@ class Elements extends Component
     }
 
     /**
-     * @internal
-     * @since 5.8.0
+     * Returns whether a nested element save should run for the current save cycle.
+     *
+     * This prevents duplicate nested saves when the same owner, nested element,
+     * manager, and sort order have already been processed.
      */
     public function shouldSaveNestedElement(
         ElementInterface $owner,

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3976,234 +3976,234 @@ class Elements extends Component
                 $dirtyFields,
                 &$siteSettingsRecord,
             ) {
-            // Figure out whether we will be updating the search index (and memoize that for nested element saves)
-            $oldUpdateSearchIndex = $this->_updateSearchIndex;
-            $updateSearchIndex = $this->_updateSearchIndex = $updateSearchIndex ?? $this->_updateSearchIndex ?? true;
+                // Figure out whether we will be updating the search index (and memoize that for nested element saves)
+                $oldUpdateSearchIndex = $this->_updateSearchIndex;
+                $updateSearchIndex = $this->_updateSearchIndex = $updateSearchIndex ?? $this->_updateSearchIndex ?? true;
 
-            $newSiteIds = $element->newSiteIds;
-            $element->newSiteIds = [];
+                $newSiteIds = $element->newSiteIds;
+                $element->newSiteIds = [];
 
-            $transaction = Craft::$app->getDb()->beginTransaction();
+                $transaction = Craft::$app->getDb()->beginTransaction();
 
-            try {
-                // No need to save the element record multiple times
-                if (!$element->propagating) {
-                    // Get the element record
-                    if (!$isNewElement) {
-                        $elementRecord = ElementRecord::findOne($element->id);
+                try {
+                    // No need to save the element record multiple times
+                    if (!$element->propagating) {
+                        // Get the element record
+                        if (!$isNewElement) {
+                            $elementRecord = ElementRecord::findOne($element->id);
 
-                        if (!$elementRecord) {
-                            $element->firstSave = $originalFirstSave;
-                            $element->isNewForSite = $originalIsNewForSite;
-                            $element->propagateAll = $originalPropagateAll;
-                            throw new ElementNotFoundException("No element exists with the ID '$element->id'");
+                            if (!$elementRecord) {
+                                $element->firstSave = $originalFirstSave;
+                                $element->isNewForSite = $originalIsNewForSite;
+                                $element->propagateAll = $originalPropagateAll;
+                                throw new ElementNotFoundException("No element exists with the ID '$element->id'");
+                            }
+                        } else {
+                            $elementRecord = new ElementRecord();
+                            $elementRecord->type = get_class($element);
                         }
-                    } else {
-                        $elementRecord = new ElementRecord();
-                        $elementRecord->type = get_class($element);
-                    }
 
-                    // Set the attributes
-                    $elementRecord->uid = $element->uid;
-                    $canonicalId = $element->getCanonicalId();
-                    $elementRecord->canonicalId = $canonicalId !== $element->id ? $canonicalId : null;
-                    $elementRecord->draftId = (int)$element->draftId ?: null;
-                    $elementRecord->revisionId = (int)$element->revisionId ?: null;
-                    $elementRecord->fieldLayoutId = $element->fieldLayoutId = (int)($element->fieldLayoutId ?? $fieldLayout->id ?? 0) ?: null;
-                    $elementRecord->enabled = (bool)$element->enabled;
-                    $elementRecord->archived = (bool)$element->archived;
-                    $elementRecord->dateLastMerged = Db::prepareDateForDb($element->dateLastMerged);
-                    $elementRecord->dateDeleted = Db::prepareDateForDb($element->dateDeleted);
+                        // Set the attributes
+                        $elementRecord->uid = $element->uid;
+                        $canonicalId = $element->getCanonicalId();
+                        $elementRecord->canonicalId = $canonicalId !== $element->id ? $canonicalId : null;
+                        $elementRecord->draftId = (int)$element->draftId ?: null;
+                        $elementRecord->revisionId = (int)$element->revisionId ?: null;
+                        $elementRecord->fieldLayoutId = $element->fieldLayoutId = (int)($element->fieldLayoutId ?? $fieldLayout->id ?? 0) ?: null;
+                        $elementRecord->enabled = (bool)$element->enabled;
+                        $elementRecord->archived = (bool)$element->archived;
+                        $elementRecord->dateLastMerged = Db::prepareDateForDb($element->dateLastMerged);
+                        $elementRecord->dateDeleted = Db::prepareDateForDb($element->dateDeleted);
 
-                    if ($isNewElement) {
-                        if (isset($element->dateCreated)) {
-                            $elementRecord->dateCreated = Db::prepareValueForDb($element->dateCreated);
+                        if ($isNewElement) {
+                            if (isset($element->dateCreated)) {
+                                $elementRecord->dateCreated = Db::prepareValueForDb($element->dateCreated);
+                            }
+                            if (isset($element->dateUpdated)) {
+                                $elementRecord->dateUpdated = Db::prepareValueForDb($element->dateUpdated);
+                            }
+                        } elseif ($element->resaving && !$forceTouch) {
+                            // Prevent ActiveRecord::prepareForDb() from changing the dateUpdated
+                            $elementRecord->markAttributeDirty('dateUpdated');
+                        } else {
+                            // Force a new dateUpdated value
+                            $elementRecord->dateUpdated = Db::prepareValueForDb(DateTimeHelper::now());
                         }
-                        if (isset($element->dateUpdated)) {
-                            $elementRecord->dateUpdated = Db::prepareValueForDb($element->dateUpdated);
-                        }
-                    } elseif ($element->resaving && !$forceTouch) {
-                        // Prevent ActiveRecord::prepareForDb() from changing the dateUpdated
-                        $elementRecord->markAttributeDirty('dateUpdated');
-                    } else {
-                        // Force a new dateUpdated value
-                        $elementRecord->dateUpdated = Db::prepareValueForDb(DateTimeHelper::now());
-                    }
 
-                    // Update our list of dirty attributes
-                    if ($trackChanges) {
-                        array_push($dirtyAttributes, ...array_keys($elementRecord->getDirtyAttributes([
+                        // Update our list of dirty attributes
+                        if ($trackChanges) {
+                            array_push($dirtyAttributes, ...array_keys($elementRecord->getDirtyAttributes([
                             'fieldLayoutId',
                             'enabled',
                             'archived',
                         ])));
-                    }
+                        }
 
-                    // Save the element record
-                    $elementRecord->save(false);
+                        // Save the element record
+                        $elementRecord->save(false);
 
-                    $dateCreated = DateTimeHelper::toDateTime($elementRecord->dateCreated);
+                        $dateCreated = DateTimeHelper::toDateTime($elementRecord->dateCreated);
 
-                    if ($dateCreated === false) {
-                        $element->firstSave = $originalFirstSave;
-                        $element->isNewForSite = $originalIsNewForSite;
-                        $element->propagateAll = $originalPropagateAll;
-                        throw new Exception('There was a problem calculating dateCreated.');
-                    }
+                        if ($dateCreated === false) {
+                            $element->firstSave = $originalFirstSave;
+                            $element->isNewForSite = $originalIsNewForSite;
+                            $element->propagateAll = $originalPropagateAll;
+                            throw new Exception('There was a problem calculating dateCreated.');
+                        }
 
-                    $dateUpdated = DateTimeHelper::toDateTime($elementRecord->dateUpdated);
+                        $dateUpdated = DateTimeHelper::toDateTime($elementRecord->dateUpdated);
 
-                    if ($dateUpdated === false) {
-                        throw new Exception('There was a problem calculating dateUpdated.');
-                    }
+                        if ($dateUpdated === false) {
+                            throw new Exception('There was a problem calculating dateUpdated.');
+                        }
 
-                    // Save the new dateCreated and dateUpdated dates on the model
-                    $element->dateCreated = $dateCreated;
-                    $element->dateUpdated = $dateUpdated;
+                        // Save the new dateCreated and dateUpdated dates on the model
+                        $element->dateCreated = $dateCreated;
+                        $element->dateUpdated = $dateUpdated;
 
-                    if ($isNewElement) {
-                        // Save the element ID on the element model
-                        $element->id = $elementRecord->id;
+                        if ($isNewElement) {
+                            // Save the element ID on the element model
+                            $element->id = $elementRecord->id;
 
-                        // If there's a temp ID, update the URI
-                        if ($element->tempId && $element->uri) {
-                            $element->uri = str_replace($element->tempId, (string)$element->id, $element->uri);
-                            $element->tempId = null;
+                            // If there's a temp ID, update the URI
+                            if ($element->tempId && $element->uri) {
+                                $element->uri = str_replace($element->tempId, (string)$element->id, $element->uri);
+                                $element->tempId = null;
+                            }
                         }
                     }
-                }
 
-                // Save the element’s site settings record
-                if ($siteSettingsRecord === null) {
-                    // First time we've saved the element for this site
-                    $siteSettingsRecord = new Element_SiteSettingsRecord();
-                    $siteSettingsRecord->elementId = $element->id;
-                    $siteSettingsRecord->siteId = $element->siteId;
-                }
+                    // Save the element’s site settings record
+                    if ($siteSettingsRecord === null) {
+                        // First time we've saved the element for this site
+                        $siteSettingsRecord = new Element_SiteSettingsRecord();
+                        $siteSettingsRecord->elementId = $element->id;
+                        $siteSettingsRecord->siteId = $element->siteId;
+                    }
 
-                $title = $element::hasTitles() ? $element->title : null;
-                $siteSettingsRecord->title = $title !== null && $title !== '' ? $title : null;
-                $siteSettingsRecord->slug = $element->slug;
-                $siteSettingsRecord->uri = $element->uri;
+                    $title = $element::hasTitles() ? $element->title : null;
+                    $siteSettingsRecord->title = $title !== null && $title !== '' ? $title : null;
+                    $siteSettingsRecord->slug = $element->slug;
+                    $siteSettingsRecord->uri = $element->uri;
 
-                // Avoid `enabled` getting marked as dirty if it’s not really changing
-                $enabledForSite = $element->getEnabledForSite();
-                if ($siteSettingsRecord->getIsNewRecord() || $siteSettingsRecord->enabled != $enabledForSite) {
-                    $siteSettingsRecord->enabled = $enabledForSite;
-                }
+                    // Avoid `enabled` getting marked as dirty if it’s not really changing
+                    $enabledForSite = $element->getEnabledForSite();
+                    if ($siteSettingsRecord->getIsNewRecord() || $siteSettingsRecord->enabled != $enabledForSite) {
+                        $siteSettingsRecord->enabled = $enabledForSite;
+                    }
 
-                // Update our list of dirty attributes
-                if ($trackChanges && !$element->isNewForSite) {
-                    array_push($dirtyAttributes, ...array_keys($siteSettingsRecord->getDirtyAttributes([
+                    // Update our list of dirty attributes
+                    if ($trackChanges && !$element->isNewForSite) {
+                        array_push($dirtyAttributes, ...array_keys($siteSettingsRecord->getDirtyAttributes([
                         'slug',
                         'uri',
                     ])));
-                    if ($siteSettingsRecord->isAttributeChanged('enabled')) {
-                        $dirtyAttributes[] = 'enabledForSite';
-                    }
-                }
-
-                $saveContent = $saveContent || $element->isNewForSite;
-                if ($saveContent || !empty($dirtyFields) || !empty($generatedFields)) {
-                    $oldContent = $siteSettingsRecord->content ?? []; // we'll need that if we're not saving all the content
-                    if (is_string($oldContent)) {
-                        $oldContent = $oldContent !== '' ? Json::decode($oldContent) : [];
+                        if ($siteSettingsRecord->isAttributeChanged('enabled')) {
+                            $dirtyAttributes[] = 'enabledForSite';
+                        }
                     }
 
-                    $content = [];
+                    $saveContent = $saveContent || $element->isNewForSite;
+                    if ($saveContent || !empty($dirtyFields) || !empty($generatedFields)) {
+                        $oldContent = $siteSettingsRecord->content ?? []; // we'll need that if we're not saving all the content
+                        if (is_string($oldContent)) {
+                            $oldContent = $oldContent !== '' ? Json::decode($oldContent) : [];
+                        }
 
-                    if ($fieldLayout) {
-                        $validUids = [];
+                        $content = [];
 
-                        foreach ($customFields as $field) {
-                            $validUids[$field->layoutElement->uid] = true;
+                        if ($fieldLayout) {
+                            $validUids = [];
 
-                            if (($saveContent || in_array($field->handle, $dirtyFields)) && $field::dbType() !== null) {
-                                $value = $element->getFieldValue($field->handle);
-                                if ($element->isNewForSite && $field->isValueEmpty($value, $element)) {
-                                    // don't store empty values if element is new for site
-                                    // https://github.com/craftcms/cms/issues/16797
-                                    continue;
+                            foreach ($customFields as $field) {
+                                $validUids[$field->layoutElement->uid] = true;
+
+                                if (($saveContent || in_array($field->handle, $dirtyFields)) && $field::dbType() !== null) {
+                                    $value = $element->getFieldValue($field->handle);
+                                    if ($element->isNewForSite && $field->isValueEmpty($value, $element)) {
+                                        // don't store empty values if element is new for site
+                                        // https://github.com/craftcms/cms/issues/16797
+                                        continue;
+                                    }
+                                    $serializedValue = $field->serializeValueForDb($value, $element);
+                                    if ($serializedValue !== null) {
+                                        $content[$field->layoutElement->uid] = $serializedValue;
+                                    } elseif (!$saveContent) {
+                                        // if serialized value is null, and we're not saving all the content,
+                                        // we need to register the fact that the new value is empty
+                                        unset($oldContent[$field->layoutElement->uid]);
+                                    }
                                 }
-                                $serializedValue = $field->serializeValueForDb($value, $element);
-                                if ($serializedValue !== null) {
-                                    $content[$field->layoutElement->uid] = $serializedValue;
-                                } elseif (!$saveContent) {
-                                    // if serialized value is null, and we're not saving all the content,
-                                    // we need to register the fact that the new value is empty
-                                    unset($oldContent[$field->layoutElement->uid]);
+                            }
+
+                            if ($oldContent) {
+                                foreach ($generatedFields as $field) {
+                                    if (isset($oldContent[$field['uid']])) {
+                                        $content[$field['uid']] = $oldContent[$field['uid']];
+                                    }
                                 }
                             }
                         }
 
-                        if ($oldContent) {
-                            foreach ($generatedFields as $field) {
-                                if (isset($oldContent[$field['uid']])) {
-                                    $content[$field['uid']] = $oldContent[$field['uid']];
+                        // if we're only saving dirty fields, merge in the existing values,
+                        // excluding any UUIDs that are no longer valid (see https://github.com/craftcms/cms/issues/17768)
+                        if (!$saveContent && $oldContent) {
+                            foreach ($oldContent as $uid => $value) {
+                                if (!isset($content[$uid]) && isset($validUids[$uid])) {
+                                    $content[$uid] = $value;
                                 }
                             }
                         }
+
+                        $siteSettingsRecord->content = $content ?: null;
                     }
 
-                    // if we're only saving dirty fields, merge in the existing values,
-                    // excluding any UUIDs that are no longer valid (see https://github.com/craftcms/cms/issues/17768)
-                    if (!$saveContent && $oldContent) {
-                        foreach ($oldContent as $uid => $value) {
-                            if (!isset($content[$uid]) && isset($validUids[$uid])) {
-                                $content[$uid] = $value;
-                            }
-                        }
+                    // Save the site settings record
+                    if (!$siteSettingsRecord->save(false)) {
+                        $element->firstSave = $originalFirstSave;
+                        $element->isNewForSite = $originalIsNewForSite;
+                        $element->propagateAll = $originalPropagateAll;
+                        throw new Exception('Couldn’t save elements’ site settings record.');
                     }
 
-                    $siteSettingsRecord->content = $content ?: null;
-                }
+                    $element->siteSettingsId = $siteSettingsRecord->id;
 
-                // Save the site settings record
-                if (!$siteSettingsRecord->save(false)) {
-                    $element->firstSave = $originalFirstSave;
-                    $element->isNewForSite = $originalIsNewForSite;
-                    $element->propagateAll = $originalPropagateAll;
-                    throw new Exception('Couldn’t save elements’ site settings record.');
-                }
+                    // Set all of the dirty attributes on the element, in case an event listener wants to know
+                    if ($trackChanges) {
+                        array_push($dirtyAttributes, ...$element->getDirtyAttributes());
+                        $element->setDirtyAttributes($dirtyAttributes, false);
+                    }
 
-                $element->siteSettingsId = $siteSettingsRecord->id;
+                    // It is now officially saved
+                    $element->afterSave($isNewElement);
 
-                // Set all of the dirty attributes on the element, in case an event listener wants to know
-                if ($trackChanges) {
-                    array_push($dirtyAttributes, ...$element->getDirtyAttributes());
-                    $element->setDirtyAttributes($dirtyAttributes, false);
-                }
+                    // Update the list of dirty attributes
+                    $dirtyAttributes = $element->getDirtyAttributes();
 
-                // It is now officially saved
-                $element->afterSave($isNewElement);
+                    /** @var array<int,ElementInterface> $siteElements */
+                    $siteElements = [];
+                    /** @var array<int,Element_SiteSettingsRecord> $siteSettingsRecords */
+                    $siteSettingsRecords = [];
 
-                // Update the list of dirty attributes
-                $dirtyAttributes = $element->getDirtyAttributes();
+                    // Update the element across the other sites?
+                    if ($propagate) {
+                        $otherSiteIds = ArrayHelper::withoutValue(array_keys($supportedSites), $element->siteId);
 
-                /** @var array<int,ElementInterface> $siteElements */
-                $siteElements = [];
-                /** @var array<int,Element_SiteSettingsRecord> $siteSettingsRecords */
-                $siteSettingsRecords = [];
-
-                // Update the element across the other sites?
-                if ($propagate) {
-                    $otherSiteIds = ArrayHelper::withoutValue(array_keys($supportedSites), $element->siteId);
-
-                    if (!empty($otherSiteIds)) {
-                        if (!$isNewElement) {
-                            $siteElements = $this->_localizedElementQuery($element)
+                        if (!empty($otherSiteIds)) {
+                            if (!$isNewElement) {
+                                $siteElements = $this->_localizedElementQuery($element)
                                 ->siteId($otherSiteIds)
                                 ->status(null)
                                 ->indexBy('siteId')
                                 ->all();
-                        }
+                            }
 
-                        foreach (array_keys($supportedSites) as $siteId) {
-                            // Skip the initial site
-                            if ($siteId != $element->siteId) {
-                                $siteElement = $siteElements[$siteId] ?? false;
-                                $siteElementRecord = null;
-                                if (!$this->_propagateElement(
+                            foreach (array_keys($supportedSites) as $siteId) {
+                                // Skip the initial site
+                                if ($siteId != $element->siteId) {
+                                    $siteElement = $siteElements[$siteId] ?? false;
+                                    $siteElementRecord = null;
+                                    if (!$this->_propagateElement(
                                     $element,
                                     $supportedSites,
                                     $siteId,
@@ -4212,93 +4212,93 @@ class Elements extends Component
                                     customFields: $customFields,
                                     siteSettingsRecord: $siteElementRecord,
                                 )) {
-                                    throw new InvalidConfigException();
+                                        throw new InvalidConfigException();
+                                    }
+                                    $siteElements[$siteId] = $siteElement;
+                                    $siteSettingsRecords[$siteId] = $siteElementRecord;
                                 }
-                                $siteElements[$siteId] = $siteElement;
-                                $siteSettingsRecords[$siteId] = $siteElementRecord;
                             }
                         }
                     }
-                }
 
-                // Save the generated fields after the element has been fully propagated,
-                // so Matrix/CB/etc. have had a chance to save their data via afterElementPropagate()
-                // (see https://github.com/craftcms/cms/issues/17938)
-                if (!$element->propagating && !empty($generatedFields)) {
-                    $siteElements[$element->siteId] = $element;
-                    $siteSettingsRecords[$element->siteId] = $siteSettingsRecord;
+                    // Save the generated fields after the element has been fully propagated,
+                    // so Matrix/CB/etc. have had a chance to save their data via afterElementPropagate()
+                    // (see https://github.com/craftcms/cms/issues/17938)
+                    if (!$element->propagating && !empty($generatedFields)) {
+                        $siteElements[$element->siteId] = $element;
+                        $siteSettingsRecords[$element->siteId] = $siteSettingsRecord;
 
-                    $element->on(Element::EVENT_AFTER_PROPAGATE, function() use ($generatedFields, $siteElements, $siteSettingsRecords) {
-                        foreach ($siteElements as $siteId => $siteElement) {
-                            $siteSettingsRecord = $siteSettingsRecords[$siteId];
-                            $content = $siteSettingsRecord->content ?? [];
-                            if (is_string($content)) {
-                                $content = $content !== '' ? Json::decode($content) : [];
-                            }
-                            $view = Craft::$app->getView();
-                            $generatedFieldValues = [];
-                            $updated = false;
-
-                            foreach ($generatedFields as $field) {
-                                $value = $view->renderObjectTemplate($field['template'] ?? '', $siteElement);
-
-                                // handle 'true'/'false'/'null'/int/float values
-                                $value = App::normalizeValue($value) ?? '';
-
-                                if ($value !== ($content[$field['uid']] ?? '')) {
-                                    $updated = true;
+                        $element->on(Element::EVENT_AFTER_PROPAGATE, function() use ($generatedFields, $siteElements, $siteSettingsRecords) {
+                            foreach ($siteElements as $siteId => $siteElement) {
+                                $siteSettingsRecord = $siteSettingsRecords[$siteId];
+                                $content = $siteSettingsRecord->content ?? [];
+                                if (is_string($content)) {
+                                    $content = $content !== '' ? Json::decode($content) : [];
                                 }
-                                if ($value !== '') {
-                                    $content[$field['uid']] = $value;
-                                    if (($field['handle'] ?? '') !== '') {
-                                        $generatedFieldValues[$field['handle']] = $value;
+                                $view = Craft::$app->getView();
+                                $generatedFieldValues = [];
+                                $updated = false;
+
+                                foreach ($generatedFields as $field) {
+                                    $value = $view->renderObjectTemplate($field['template'] ?? '', $siteElement);
+
+                                    // handle 'true'/'false'/'null'/int/float values
+                                    $value = App::normalizeValue($value) ?? '';
+
+                                    if ($value !== ($content[$field['uid']] ?? '')) {
+                                        $updated = true;
                                     }
-                                } else {
-                                    unset($content[$field['uid']]);
+                                    if ($value !== '') {
+                                        $content[$field['uid']] = $value;
+                                        if (($field['handle'] ?? '') !== '') {
+                                            $generatedFieldValues[$field['handle']] = $value;
+                                        }
+                                    } else {
+                                        unset($content[$field['uid']]);
+                                    }
+                                }
+
+                                if ($updated) {
+                                    $siteSettingsRecord->content = $content;
+                                    $siteSettingsRecord->save(false, ['content']);
+                                    $siteElement->setGeneratedFieldValues($generatedFieldValues);
                                 }
                             }
+                        });
+                    }
 
-                            if ($updated) {
-                                $siteSettingsRecord->content = $content;
-                                $siteSettingsRecord->save(false, ['content']);
-                                $siteElement->setGeneratedFieldValues($generatedFieldValues);
-                            }
-                        }
-                    });
-                }
-
-                // It's now fully saved and propagated
-                if (
+                    // It's now fully saved and propagated
+                    if (
                     !$element->propagating &&
                     !$element->duplicateOf &&
                     !$element->mergingCanonicalChanges
                 ) {
-                    $element->afterPropagate($isNewElement);
+                        $element->afterPropagate($isNewElement);
 
-                    // Track this element in bulk operations
-                    $this->trackElementInBulkOps($element);
+                        // Track this element in bulk operations
+                        $this->trackElementInBulkOps($element);
+                    }
+
+                    $transaction->commit();
+                } catch (Throwable $e) {
+                    $transaction->rollBack();
+                    $element->firstSave = $originalFirstSave;
+                    $element->isNewForSite = $originalIsNewForSite;
+                    $element->propagateAll = $originalPropagateAll;
+                    $element->dateUpdated = $originalDateUpdated;
+                    if ($e instanceof InvalidConfigException) {
+                        return false;
+                    }
+                    throw $e;
+                } finally {
+                    $this->_updateSearchIndex = $oldUpdateSearchIndex;
+                    $element->newSiteIds = $newSiteIds;
                 }
 
-                $transaction->commit();
-            } catch (Throwable $e) {
-                $transaction->rollBack();
-                $element->firstSave = $originalFirstSave;
-                $element->isNewForSite = $originalIsNewForSite;
-                $element->propagateAll = $originalPropagateAll;
-                $element->dateUpdated = $originalDateUpdated;
-                if ($e instanceof InvalidConfigException) {
-                    return false;
-                }
-                throw $e;
-            } finally {
-                $this->_updateSearchIndex = $oldUpdateSearchIndex;
-                $element->newSiteIds = $newSiteIds;
-            }
-
-            if (!$element->propagating) {
-                // Delete the rows that don't need to be there anymore
-                if (!$isNewElement) {
-                    Db::deleteIfExists(
+                if (!$element->propagating) {
+                    // Delete the rows that don't need to be there anymore
+                    if (!$isNewElement) {
+                        Db::deleteIfExists(
                         Table::ELEMENTS_SITES,
                         [
                             'and',
@@ -4306,46 +4306,46 @@ class Elements extends Component
                             ['not', ['siteId' => array_keys($supportedSites)]],
                         ]
                     );
+                    }
+
+                    // Invalidate any caches involving this element
+                    $this->_invalidateCachesForElementOptimized($element);
                 }
 
-                // Invalidate any caches involving this element
-                $this->_invalidateCachesForElementOptimized($element);
-            }
-
-            // Update search index
-            if ($updateSearchIndex && !$element->getIsRevision() && !ElementHelper::isRevision($element)) {
-                $searchableDirtyFields = array_filter(
+                // Update search index
+                if ($updateSearchIndex && !$element->getIsRevision() && !ElementHelper::isRevision($element)) {
+                    $searchableDirtyFields = array_filter(
                     $dirtyFields,
                     fn(string $handle) => $fieldLayout?->getFieldByHandle($handle)?->searchable,
                 );
 
-                if (
+                    if (
                     !$trackChanges ||
                     !empty($searchableDirtyFields) ||
                     !empty(array_intersect($dirtyAttributes, ElementHelper::searchableAttributes($element)))
                 ) {
-                    // Fire a 'beforeUpdateSearchIndex' event
-                    if ($this->hasEventHandlers(self::EVENT_BEFORE_UPDATE_SEARCH_INDEX)) {
-                        $event = new ElementEvent(['element' => $element]);
-                        $this->trigger(self::EVENT_BEFORE_UPDATE_SEARCH_INDEX, $event);
-                        $isValid = $event->isValid;
-                    } else {
-                        $isValid = true;
-                    }
+                        // Fire a 'beforeUpdateSearchIndex' event
+                        if ($this->hasEventHandlers(self::EVENT_BEFORE_UPDATE_SEARCH_INDEX)) {
+                            $event = new ElementEvent(['element' => $element]);
+                            $this->trigger(self::EVENT_BEFORE_UPDATE_SEARCH_INDEX, $event);
+                            $isValid = $event->isValid;
+                        } else {
+                            $isValid = true;
+                        }
 
-                    if ($isValid) {
-                        $this->updateSearchIndex($element, $searchableDirtyFields, $propagate);
+                        if ($isValid) {
+                            $this->updateSearchIndex($element, $searchableDirtyFields, $propagate);
+                        }
                     }
                 }
-            }
 
-            // Update the changed attributes & fields
-            if ($trackChanges) {
-                $userId = Craft::$app->getUser()->getId();
-                $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
+                // Update the changed attributes & fields
+                if ($trackChanges) {
+                    $userId = Craft::$app->getUser()->getId();
+                    $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
 
-                foreach ($dirtyAttributes as $attributeName) {
-                    if (
+                    foreach ($dirtyAttributes as $attributeName) {
+                        if (
                         $this->_saveOptimizationContext !== null &&
                         !$this->_saveOptimizationContext->rememberChangedAttribute(
                             $element->id,
@@ -4355,10 +4355,10 @@ class Elements extends Component
                             $userId,
                         )
                     ) {
-                        continue;
-                    }
+                            continue;
+                        }
 
-                    Db::upsert(Table::CHANGEDATTRIBUTES, [
+                        Db::upsert(Table::CHANGEDATTRIBUTES, [
                         'elementId' => $element->id,
                         'siteId' => $element->siteId,
                         'attribute' => $attributeName,
@@ -4366,12 +4366,12 @@ class Elements extends Component
                         'propagated' => $element->propagating,
                         'userId' => $userId,
                     ]);
-                }
+                    }
 
-                if ($fieldLayout) {
-                    foreach ($dirtyFields as $fieldHandle) {
-                        if (($field = $fieldLayout->getFieldByHandle($fieldHandle)) !== null) {
-                            if (
+                    if ($fieldLayout) {
+                        foreach ($dirtyFields as $fieldHandle) {
+                            if (($field = $fieldLayout->getFieldByHandle($fieldHandle)) !== null) {
+                                if (
                                 $this->_saveOptimizationContext !== null &&
                                 !$this->_saveOptimizationContext->rememberChangedField(
                                     $element->id,
@@ -4382,10 +4382,10 @@ class Elements extends Component
                                     $userId,
                                 )
                             ) {
-                                continue;
-                            }
+                                    continue;
+                                }
 
-                            Db::upsert(Table::CHANGEDFIELDS, [
+                                Db::upsert(Table::CHANGEDFIELDS, [
                                 'elementId' => $element->id,
                                 'siteId' => $element->siteId,
                                 'fieldId' => $field->id,
@@ -4394,10 +4394,10 @@ class Elements extends Component
                                 'propagated' => $element->propagating,
                                 'userId' => $userId,
                             ]);
+                            }
                         }
                     }
                 }
-            }
             });
         } finally {
             $this->_endSaveOptimizationContext($saveOptimizationContext);

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -549,6 +549,11 @@ class Elements extends Component
     private ?bool $_updateSearchIndex = null;
 
     /**
+     * @var ElementSaveOptimizationContext|null
+     */
+    private ?ElementSaveOptimizationContext $_saveOptimizationContext = null;
+
+    /**
      * @inheritdoc
      */
     public function init()
@@ -1257,6 +1262,29 @@ class Elements extends Component
                 $this->endBulkOp($bulkKey);
             }
         }
+    }
+
+    /**
+     * @internal
+     * @since 5.8.0
+     */
+    public function shouldSaveNestedElement(
+        ElementInterface $owner,
+        NestedElementInterface $element,
+        string $managerKey,
+        int $sortOrder,
+    ): bool {
+        if (!isset($owner->id, $element->id) || $this->_saveOptimizationContext === null) {
+            return true;
+        }
+
+        return $this->_saveOptimizationContext->rememberNestedSave(
+            (int)$owner->id,
+            $owner->siteId,
+            $managerKey,
+            (int)$element->id,
+            $sortOrder,
+        );
     }
 
     // Saving Elements
@@ -3883,6 +3911,8 @@ class Elements extends Component
         }
 
         $fieldLayout = $element->getFieldLayout();
+        $customFields = $fieldLayout?->getCustomFields() ?? [];
+        $generatedFields = $fieldLayout?->getGeneratedFields() ?? [];
         $dirtyFields = $element->getDirtyFields();
 
         // Get the element's site record
@@ -3922,26 +3952,30 @@ class Elements extends Component
             }
         }
 
-        $this->ensureBulkOp(function() use (
-            $element,
-            $isNewElement,
-            $originalFirstSave,
-            $originalIsNewForSite,
-            $originalPropagateAll,
-            $forceTouch,
-            $saveContent,
-            $trackChanges,
-            $dirtyAttributes,
-            $updateSearchIndex,
-            $fieldLayout,
-            $propagate,
-            $supportedSites,
-            $crossSiteValidate,
-            $runValidation,
-            $originalDateUpdated,
-            $dirtyFields,
-            &$siteSettingsRecord,
-        ) {
+        $saveOptimizationContext = $this->_beginSaveOptimizationContext();
+        try {
+            $this->ensureBulkOp(function() use (
+                $element,
+                $isNewElement,
+                $originalFirstSave,
+                $originalIsNewForSite,
+                $originalPropagateAll,
+                $forceTouch,
+                $saveContent,
+                $trackChanges,
+                $dirtyAttributes,
+                $updateSearchIndex,
+                $fieldLayout,
+                $customFields,
+                $generatedFields,
+                $propagate,
+                $supportedSites,
+                $crossSiteValidate,
+                $runValidation,
+                $originalDateUpdated,
+                $dirtyFields,
+                &$siteSettingsRecord,
+            ) {
             // Figure out whether we will be updating the search index (and memoize that for nested element saves)
             $oldUpdateSearchIndex = $this->_updateSearchIndex;
             $updateSearchIndex = $this->_updateSearchIndex = $updateSearchIndex ?? $this->_updateSearchIndex ?? true;
@@ -4070,8 +4104,6 @@ class Elements extends Component
                 }
 
                 $saveContent = $saveContent || $element->isNewForSite;
-                $generatedFields = $fieldLayout?->getGeneratedFields() ?? [];
-
                 if ($saveContent || !empty($dirtyFields) || !empty($generatedFields)) {
                     $oldContent = $siteSettingsRecord->content ?? []; // we'll need that if we're not saving all the content
                     if (is_string($oldContent)) {
@@ -4083,7 +4115,7 @@ class Elements extends Component
                     if ($fieldLayout) {
                         $validUids = [];
 
-                        foreach ($fieldLayout->getCustomFields() as $field) {
+                        foreach ($customFields as $field) {
                             $validUids[$field->layoutElement->uid] = true;
 
                             if (($saveContent || in_array($field->handle, $dirtyFields)) && $field::dbType() !== null) {
@@ -4177,6 +4209,7 @@ class Elements extends Component
                                     $siteId,
                                     $siteElement,
                                     crossSiteValidate: $runValidation && $crossSiteValidate,
+                                    customFields: $customFields,
                                     siteSettingsRecord: $siteElementRecord,
                                 )) {
                                     throw new InvalidConfigException();
@@ -4276,7 +4309,7 @@ class Elements extends Component
                 }
 
                 // Invalidate any caches involving this element
-                $this->invalidateCachesForElement($element);
+                $this->_invalidateCachesForElementOptimized($element);
             }
 
             // Update search index
@@ -4312,6 +4345,19 @@ class Elements extends Component
                 $timestamp = Db::prepareDateForDb(DateTimeHelper::now());
 
                 foreach ($dirtyAttributes as $attributeName) {
+                    if (
+                        $this->_saveOptimizationContext !== null &&
+                        !$this->_saveOptimizationContext->rememberChangedAttribute(
+                            $element->id,
+                            $element->siteId,
+                            $attributeName,
+                            $element->propagating,
+                            $userId,
+                        )
+                    ) {
+                        continue;
+                    }
+
                     Db::upsert(Table::CHANGEDATTRIBUTES, [
                         'elementId' => $element->id,
                         'siteId' => $element->siteId,
@@ -4325,6 +4371,20 @@ class Elements extends Component
                 if ($fieldLayout) {
                     foreach ($dirtyFields as $fieldHandle) {
                         if (($field = $fieldLayout->getFieldByHandle($fieldHandle)) !== null) {
+                            if (
+                                $this->_saveOptimizationContext !== null &&
+                                !$this->_saveOptimizationContext->rememberChangedField(
+                                    $element->id,
+                                    $element->siteId,
+                                    $field->id,
+                                    $field->layoutElement->uid,
+                                    $element->propagating,
+                                    $userId,
+                                )
+                            ) {
+                                continue;
+                            }
+
                             Db::upsert(Table::CHANGEDFIELDS, [
                                 'elementId' => $element->id,
                                 'siteId' => $element->siteId,
@@ -4338,7 +4398,10 @@ class Elements extends Component
                     }
                 }
             }
-        });
+            });
+        } finally {
+            $this->_endSaveOptimizationContext($saveOptimizationContext);
+        }
 
         // Fire an 'afterSaveElement' event
         if ($this->hasEventHandlers(self::EVENT_AFTER_SAVE_ELEMENT)) {
@@ -4385,8 +4448,20 @@ class Elements extends Component
             /** @var NestedElementInterface $element */
             $owner = $element->getOwner();
             if ($owner) {
+                if (
+                    $this->_saveOptimizationContext !== null &&
+                    isset($owner->id) &&
+                    !$this->_saveOptimizationContext->rememberOwnerSearchIndex(
+                        (int)$owner->id,
+                        $owner->siteId,
+                        $field->handle,
+                    )
+                ) {
+                    return;
+                }
+
                 $this->updateSearchIndex($owner, [$field->handle], $propagate, true);
-                $this->invalidateCachesForElement($owner);
+                $this->_invalidateCachesForElementOptimized($owner);
             }
         }
     }
@@ -4412,6 +4487,7 @@ class Elements extends Component
         ElementInterface|false|null &$siteElement = null,
         bool $crossSiteValidate = false,
         bool $saveContent = true,
+        ?array $customFields = null,
         ?Element_SiteSettingsRecord &$siteSettingsRecord = null,
     ): bool {
         // Make sure the element actually supports the site it's being saved in
@@ -4528,9 +4604,10 @@ class Elements extends Component
                 $siteElement->setFieldValues($element->getFieldValues());
             } else {
                 $fieldLayout = $element->getFieldLayout();
+                $customFields ??= $fieldLayout?->getCustomFields() ?? [];
 
                 if ($fieldLayout !== null) {
-                    foreach ($fieldLayout->getCustomFields() as $field) {
+                    foreach ($customFields as $field) {
                         if (
                             $element->propagateAll ||
                             // If propagateRequired is set, is the field value invalid on the propagated site element?
@@ -4580,6 +4657,41 @@ class Elements extends Component
         }
 
         return true;
+    }
+
+    private function _beginSaveOptimizationContext(): ElementSaveOptimizationContext
+    {
+        $context = $this->_saveOptimizationContext ??= new ElementSaveOptimizationContext();
+        $wasInactive = $context->depth === 0;
+        $context->begin();
+
+        if ($wasInactive) {
+            Craft::$app->getSearch()->beginIndexQueueBatch();
+        }
+
+        return $context;
+    }
+
+    private function _endSaveOptimizationContext(ElementSaveOptimizationContext $context): void
+    {
+        if (!$context->end()) {
+            return;
+        }
+
+        $this->_saveOptimizationContext = null;
+        Craft::$app->getSearch()->endIndexQueueBatch();
+    }
+
+    private function _invalidateCachesForElementOptimized(ElementInterface $element): void
+    {
+        if (
+            $this->_saveOptimizationContext !== null &&
+            !$this->_saveOptimizationContext->rememberCacheInvalidation($element)
+        ) {
+            return;
+        }
+
+        $this->invalidateCachesForElement($element);
     }
 
     /**

--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -120,13 +120,15 @@ class Search extends Component
 
     /**
      * @var int
-     * @since 5.8.0
+     *
+     * Tracks nested queue-batch scope depth so callers can start/end batching safely.
      */
     private int $_indexQueueBatchDepth = 0;
 
     /**
      * @var array<string,array{element:ElementInterface,allFields:bool,fieldHandles:array<string,bool>}>
-     * @since 5.8.0
+     *
+     * Collects queued element/index requests within a batch and merges field handles per element/site.
      */
     private array $_queuedIndexElements = [];
 
@@ -264,7 +266,7 @@ class Search extends Component
     }
 
     /**
-     * @since 5.8.0
+     * Starts a queue-index batching scope.
      */
     public function beginIndexQueueBatch(): void
     {
@@ -272,7 +274,7 @@ class Search extends Component
     }
 
     /**
-     * @since 5.8.0
+     * Ends a queue-index batching scope and flushes merged requests when the outermost scope ends.
      */
     public function endIndexQueueBatch(): void
     {

--- a/src/services/Search.php
+++ b/src/services/Search.php
@@ -119,6 +119,18 @@ class Search extends Component
     public int $maxPostgresKeywordLength = 2450;
 
     /**
+     * @var int
+     * @since 5.8.0
+     */
+    private int $_indexQueueBatchDepth = 0;
+
+    /**
+     * @var array<string,array{element:ElementInterface,allFields:bool,fieldHandles:array<string,bool>}>
+     * @since 5.8.0
+     */
+    private array $_queuedIndexElements = [];
+
+    /**
      * @inheritdoc
      */
     public function init(): void
@@ -226,6 +238,65 @@ class Search extends Component
      * @since 5.7.0
      */
     public function queueIndexElement(ElementInterface $element, array $fieldHandles): void
+    {
+        if ($this->_indexQueueBatchDepth > 0) {
+            $key = sprintf('%s:%d:%d', get_class($element), $element->id, $element->siteId);
+            $queued = $this->_queuedIndexElements[$key] ?? [
+                'element' => $element,
+                'allFields' => false,
+                'fieldHandles' => [],
+            ];
+
+            if (empty($fieldHandles)) {
+                $queued['allFields'] = true;
+                $queued['fieldHandles'] = [];
+            } elseif (!$queued['allFields']) {
+                foreach ($fieldHandles as $fieldHandle) {
+                    $queued['fieldHandles'][$fieldHandle] = true;
+                }
+            }
+
+            $this->_queuedIndexElements[$key] = $queued;
+            return;
+        }
+
+        $this->_queueIndexElementNow($element, $fieldHandles);
+    }
+
+    /**
+     * @since 5.8.0
+     */
+    public function beginIndexQueueBatch(): void
+    {
+        $this->_indexQueueBatchDepth++;
+    }
+
+    /**
+     * @since 5.8.0
+     */
+    public function endIndexQueueBatch(): void
+    {
+        if ($this->_indexQueueBatchDepth === 0) {
+            return;
+        }
+
+        $this->_indexQueueBatchDepth--;
+
+        if ($this->_indexQueueBatchDepth !== 0 || empty($this->_queuedIndexElements)) {
+            return;
+        }
+
+        try {
+            foreach ($this->_queuedIndexElements as $queued) {
+                $fieldHandles = $queued['allFields'] ? [] : array_keys($queued['fieldHandles']);
+                $this->_queueIndexElementNow($queued['element'], $fieldHandles);
+            }
+        } finally {
+            $this->_queuedIndexElements = [];
+        }
+    }
+
+    private function _queueIndexElementNow(ElementInterface $element, array $fieldHandles): void
     {
         try {
             $this->createOrUpdateIndexJob($element, $fieldHandles);

--- a/tests/unit/services/SearchTest.php
+++ b/tests/unit/services/SearchTest.php
@@ -96,6 +96,57 @@ class SearchTest extends TestCase
         self::assertSame(' wilkerson ', $this->_getSearchIndexValueByAttribute('lastname', $searchIndex));
     }
 
+    public function testQueueIndexElementBatchMergesDuplicateFieldHandles(): void
+    {
+        $this->_clearSearchQueueTables();
+        $user = Craft::$app->getUsers()->getUserByUsernameOrEmail('user1');
+        self::assertNotNull($user);
+
+        $this->search->beginIndexQueueBatch();
+        $this->search->queueIndexElement($user, ['firstName']);
+        $this->search->queueIndexElement($user, ['lastName']);
+        $this->search->queueIndexElement($user, ['firstName']);
+        $this->search->endIndexQueueBatch();
+
+        $jobRows = (new Query())
+            ->from([Table::SEARCHINDEXQUEUE])
+            ->where(['elementId' => $user->id, 'siteId' => $user->siteId])
+            ->all();
+        self::assertCount(1, $jobRows);
+
+        $fieldRows = (new Query())
+            ->from([Table::SEARCHINDEXQUEUE_FIELDS])
+            ->where(['jobId' => $jobRows[0]['id']])
+            ->orderBy(['fieldHandle' => SORT_ASC])
+            ->column();
+        self::assertSame(['firstName', 'lastName'], $fieldRows);
+    }
+
+    public function testQueueIndexElementBatchPrefersAllFieldsWhenRequested(): void
+    {
+        $this->_clearSearchQueueTables();
+        $user = Craft::$app->getUsers()->getUserByUsernameOrEmail('user2');
+        self::assertNotNull($user);
+
+        $this->search->beginIndexQueueBatch();
+        $this->search->queueIndexElement($user, ['firstName']);
+        $this->search->queueIndexElement($user, []);
+        $this->search->queueIndexElement($user, ['lastName']);
+        $this->search->endIndexQueueBatch();
+
+        $jobRows = (new Query())
+            ->from([Table::SEARCHINDEXQUEUE])
+            ->where(['elementId' => $user->id, 'siteId' => $user->siteId])
+            ->all();
+        self::assertCount(1, $jobRows);
+
+        $fieldRows = (new Query())
+            ->from([Table::SEARCHINDEXQUEUE_FIELDS])
+            ->where(['jobId' => $jobRows[0]['id']])
+            ->all();
+        self::assertCount(0, $fieldRows);
+    }
+
     /**
      * Provide an array with input user names
      *
@@ -163,5 +214,13 @@ class SearchTest extends TestCase
         }
 
         return $scoreKeys;
+    }
+
+    private function _clearSearchQueueTables(): void
+    {
+        Craft::$app->getDb()->transaction(function() {
+            Craft::$app->getDb()->createCommand()->delete(Table::SEARCHINDEXQUEUE_FIELDS)->execute();
+            Craft::$app->getDb()->createCommand()->delete(Table::SEARCHINDEXQUEUE)->execute();
+        });
     }
 }

--- a/tests/unit/services/SearchTest.php
+++ b/tests/unit/services/SearchTest.php
@@ -115,6 +115,7 @@ class SearchTest extends TestCase
         self::assertCount(1, $jobRows);
 
         $fieldRows = (new Query())
+            ->select(['fieldHandle'])
             ->from([Table::SEARCHINDEXQUEUE_FIELDS])
             ->where(['jobId' => $jobRows[0]['id']])
             ->orderBy(['fieldHandle' => SORT_ASC])
@@ -141,6 +142,7 @@ class SearchTest extends TestCase
         self::assertCount(1, $jobRows);
 
         $fieldRows = (new Query())
+            ->select(['fieldHandle'])
             ->from([Table::SEARCHINDEXQUEUE_FIELDS])
             ->where(['jobId' => $jobRows[0]['id']])
             ->all();


### PR DESCRIPTION
### Issue

I have multiple multi-site installs where saving entries can take more than 30 seconds.

### Proposal

Implements synchronous save-path performance optimizations for multi-site element saves, including propagation-loop reuse, nested-save dedupe, search queue aggregation, and duplicate change-tracking/caching reduction.

### Related issues

-