### PR TITLE
Add option to hard delete elements via GraphQL mutations

### DIFF
--- a/src/gql/mutations/Asset.php
+++ b/src/gql/mutations/Asset.php
@@ -59,7 +59,10 @@ class Asset extends Mutation
         if ($createDeleteMutation) {
             $mutationList['deleteAsset'] = [
                 'name' => 'deleteAsset',
-                'args' => ['id' => Type::nonNull(Type::int())],
+                'args' => [
+                    'id' => Type::nonNull(Type::int()),
+                    'hardDelete' => Type::boolean(),
+                ],
                 'resolve' => [Craft::createObject(AssetResolver::class), 'deleteAsset'],
                 'description' => 'Delete an asset.',
                 'type' => Type::boolean(),

--- a/src/gql/mutations/Category.php
+++ b/src/gql/mutations/Category.php
@@ -58,7 +58,10 @@ class Category extends Mutation
         if ($createDeleteMutation) {
             $mutationList['deleteCategory'] = [
                 'name' => 'deleteCategory',
-                'args' => ['id' => Type::nonNull(Type::int())],
+                'args' => [
+                    'id' => Type::nonNull(Type::int()),
+                    'hardDelete' => Type::boolean(),
+                ],
                 'resolve' => [Craft::createObject(CategoryResolver::class), 'deleteCategory'],
                 'description' => 'Delete a category.',
                 'type' => Type::boolean(),

--- a/src/gql/mutations/Entry.php
+++ b/src/gql/mutations/Entry.php
@@ -102,6 +102,7 @@ class Entry extends Mutation
                     'args' => [
                         'id' => Type::nonNull(Type::int()),
                         'siteId' => Type::int(),
+                        'hardDelete' => Type::boolean(),
                     ],
                     'resolve' => [$resolver, 'deleteEntry'],
                     'description' => 'Delete an entry.',

--- a/src/gql/mutations/Tag.php
+++ b/src/gql/mutations/Tag.php
@@ -57,7 +57,10 @@ class Tag extends Mutation
         if ($createDeleteMutation) {
             $mutationList['deleteTag'] = [
                 'name' => 'deleteTag',
-                'args' => ['id' => Type::nonNull(Type::int())],
+                'args' => [
+                    'id' => Type::nonNull(Type::int()),
+                    'hardDelete' => Type::boolean(),
+                ],
                 'resolve' => [Craft::createObject(TagResolver::class), 'deleteTag'],
                 'description' => 'Delete a tag.',
                 'type' => Type::boolean(),

--- a/src/gql/resolvers/mutations/Asset.php
+++ b/src/gql/resolvers/mutations/Asset.php
@@ -155,6 +155,7 @@ class Asset extends ElementMutationResolver
     public function deleteAsset(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): bool
     {
         $assetId = $arguments['id'];
+        $hardDelete = $arguments['hardDelete'] ?? false;
 
         $elementService = Craft::$app->getElements();
         /** @var AssetElement|null $asset */
@@ -167,7 +168,7 @@ class Asset extends ElementMutationResolver
         $volumeUid = Db::uidById(Table::VOLUMES, $asset->getVolumeId());
         $this->requireSchemaAction('volumes.' . $volumeUid, 'delete');
 
-        return $elementService->deleteElementById($assetId);
+        return $elementService->deleteElementById($assetId, hardDelete: $hardDelete);
     }
 
     /**

--- a/src/gql/resolvers/mutations/Category.php
+++ b/src/gql/resolvers/mutations/Category.php
@@ -90,6 +90,7 @@ class Category extends ElementMutationResolver
     public function deleteCategory(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): bool
     {
         $categoryId = $arguments['id'];
+        $hardDelete = $arguments['hardDelete'] ?? false;
 
         $elementService = Craft::$app->getElements();
         $category = $elementService->getElementById($categoryId, CategoryElement::class);
@@ -101,6 +102,6 @@ class Category extends ElementMutationResolver
         $categoryGroupUid = Db::uidById(Table::CATEGORYGROUPS, $category->groupId);
         $this->requireSchemaAction('categorygroups.' . $categoryGroupUid, 'delete');
 
-        return $elementService->deleteElementById($categoryId);
+        return $elementService->deleteElementById($categoryId, hardDelete: $hardDelete);
     }
 }

--- a/src/gql/resolvers/mutations/Entry.php
+++ b/src/gql/resolvers/mutations/Entry.php
@@ -136,6 +136,7 @@ class Entry extends ElementMutationResolver
     {
         $entryId = $arguments['id'];
         $siteId = $arguments['siteId'] ?? null;
+        $hardDelete = $arguments['hardDelete'] ?? false;
 
         $elementService = Craft::$app->getElements();
         /** @var EntryElement|null $entry */
@@ -148,7 +149,7 @@ class Entry extends ElementMutationResolver
         $section = $entry->getSection();
         $this->requireSchemaAction("sections.$section->uid", 'delete');
 
-        return $elementService->deleteElementById($entryId);
+        return $elementService->deleteElementById($entryId, hardDelete: $hardDelete);
     }
 
     /**

--- a/src/gql/resolvers/mutations/Tag.php
+++ b/src/gql/resolvers/mutations/Tag.php
@@ -84,6 +84,7 @@ class Tag extends ElementMutationResolver
     public function deleteTag(mixed $source, array $arguments, mixed $context, ResolveInfo $resolveInfo): bool
     {
         $tagId = $arguments['id'];
+        $hardDelete = $arguments['hardDelete'] ?? false;
 
         $elementService = Craft::$app->getElements();
         $tag = $elementService->getElementById($tagId, TagElement::class);
@@ -95,6 +96,6 @@ class Tag extends ElementMutationResolver
         $tagGroupUid = Db::uidById(Table::TAGGROUPS, $tag->groupId);
         $this->requireSchemaAction('taggroups.' . $tagGroupUid, 'delete');
 
-        return $elementService->deleteElementById($tagId);
+        return $elementService->deleteElementById($tagId, hardDelete: $hardDelete);
     }
 }


### PR DESCRIPTION
### Description
There is currently no way to specify if elements should be hard deleted via GraphQL mutations.

This PR adds a `hardDelete` option to delete mutations for Entries, Assets, Categories and Tags. Here is an example of a query using the new parameter:

```graphql
mutation HardDeleteEntry {
  deleteEntry(id: 12345, hardDelete: true)
}
```

I could not find any tests related to these parameters, but let me know if there are any, and I will update the PR.