### PR TITLE
`--to-default` option

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -5,11 +5,13 @@
 
 ### Administration
 - Newlines in system message bodies are now replaced with `<br>` tags. ([#18058](https://github.com/craftcms/cms/discussions/18058))
+- Added the `--to-default` option to `resave` commands. ([#18522](https://github.com/craftcms/cms/pull/18522))
 
 ### Development
 - `delete` GraphQL queries now have a `hardDelete` argument. ([#18511](https://github.com/craftcms/cms/pull/18511))
 
 ### Extensibility
+- Added `craft\base\DefaultableFieldInterface`. ([#18522](https://github.com/craftcms/cms/pull/18522))
 - Added `craft\elements\PopulateElementEvent::$content`.
 - `craft\elements\PopulateElementEvent::$row` no longer includes `fieldValues` or `generatedFieldValues` keys.
 

--- a/src/base/DefaultableFieldInterface.php
+++ b/src/base/DefaultableFieldInterface.php
@@ -21,7 +21,6 @@ interface DefaultableFieldInterface extends FieldInterface
      * Returns the default value that should be set on existing elements.
      *
      * @return mixed
-     * @since 5.10.0
      */
     public function getDefaultValue(): mixed;
 }

--- a/src/base/DefaultableFieldInterface.php
+++ b/src/base/DefaultableFieldInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\base;
+
+/**
+ * PreviewableFieldInterface defines the common interface to be implemented by field classes
+ * that wish to be previewable in element table and card views.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.10.0
+ * @mixin Field
+ */
+interface DefaultableFieldInterface extends FieldInterface
+{
+    /**
+     * Returns the default value that should be set on existing elements.
+     *
+     * @return mixed
+     * @since 5.10.0
+     */
+    public function getDefaultValue(): mixed;
+}

--- a/src/console/controllers/ResaveController.php
+++ b/src/console/controllers/ResaveController.php
@@ -8,8 +8,10 @@
 namespace craft\console\controllers;
 
 use Craft;
+use craft\base\DefaultableFieldInterface;
 use craft\base\Element;
 use craft\base\ElementInterface;
+use craft\base\FieldInterface;
 use craft\console\Controller;
 use craft\elements\Address;
 use craft\elements\Asset;
@@ -217,7 +219,7 @@ class ResaveController extends Controller
     public ?string $countryCode = null;
 
     /**
-     * @var string[] Only resave elements that have custom fields with these global field handles.
+     * @var string[]|FieldInterface[] Only resave elements that have custom fields with these global field handles.
      * @since 5.5.0
      */
     public array $withFields = [];
@@ -247,6 +249,12 @@ class ResaveController extends Controller
      * @since 3.7.29
      */
     public ?string $to = null;
+
+    /**
+     * @var bool Sets the specified fields to their default values.
+     * @since 5.10.0
+     */
+    public bool $toDefault = false;
 
     /**
      * @var bool Whether the `--set` attribute should only be set if it doesn’t have a value.
@@ -313,6 +321,7 @@ class ResaveController extends Controller
 
         $options[] = 'set';
         $options[] = 'to';
+        $options[] = 'toDefault';
         $options[] = 'ifEmpty';
         $options[] = 'ifInvalid';
 
@@ -357,9 +366,49 @@ class ResaveController extends Controller
             }
         }
 
-        if (isset($this->set) && !isset($this->to)) {
-            $this->stderr('--to is required when using --set.' . PHP_EOL, Console::FG_RED);
+        if (isset($this->set) && !isset($this->to) && !isset($this->toDefault)) {
+            $this->stderr('--to or --to-default is required when using --set.' . PHP_EOL, Console::FG_RED);
             return false;
+        }
+
+        if (isset($this->withFields)) {
+            $fieldsService = Craft::$app->getFields();
+
+            foreach ($this->withFields as $i => $field) {
+                if (!$field instanceof FieldInterface) {
+                    $handle = $field;
+                    $field = $fieldsService->getFieldByHandle($handle);
+                    if (!$field) {
+                        $this->stderr("Invalid field: `$handle`" . PHP_EOL, Console::FG_RED);
+                        return false;
+                    }
+                }
+                $this->withFields[$i] = $field;
+            }
+        }
+
+        if (isset($this->toDefault)) {
+            if (!isset($this->withFields) && !isset($this->set)) {
+                $this->stderr('--with-fields or --set is required when using --to-default.' . PHP_EOL, Console::FG_RED);
+                return false;
+            }
+
+            $fieldsService = Craft::$app->getFields();
+
+            if (isset($this->set)) {
+                $field = $fieldsService->getFieldByHandle($this->set);
+                if (!$field) {
+                    $this->stderr("Invalid field handle: $this->set", Console::FG_RED);
+                    return false;
+                }
+            } else {
+                foreach ($this->withFields as $field) {
+                    if (!$field instanceof DefaultableFieldInterface) {
+                        $this->stderr("$field->handle doesn’t support --to-default." . PHP_EOL, Console::FG_RED);
+                        return false;
+                    }
+                }
+            }
         }
 
         return true;
@@ -631,10 +680,8 @@ class ResaveController extends Controller
      */
     public function hasTheFields(FieldLayout $fieldLayout): bool
     {
-        $fieldsService = Craft::$app->getFields();
-        foreach ($this->withFields as $handle) {
-            $field = $fieldsService->getFieldByHandle($handle);
-            if ($field && $fieldLayout->getFieldByUid($field->uid)) {
+        foreach ($this->withFields as $field) {
+            if ($fieldLayout->getFieldByUid($field->uid)) {
                 return true;
             }
         }
@@ -655,8 +702,10 @@ class ResaveController extends Controller
             Queue::push(new ResaveElements([
                 'elementType' => $elementType,
                 'criteria' => $criteria,
+                'withFields' => array_map(fn(FieldInterface $field) => $field->handle, $this->withFields),
                 'set' => $this->set,
                 'to' => $this->to,
+                'toDefault' => $this->toDefault,
                 'ifEmpty' => $this->ifEmpty,
                 'ifInvalid' => $this->ifInvalid,
                 'touch' => $this->touch,
@@ -785,7 +834,37 @@ class ResaveController extends Controller
                     }
 
                     try {
-                        if (isset($this->set)) {
+                        if ($this->toDefault) {
+                            if ($this->set) {
+                                $fields = [$element->getFieldLayout()?->getFieldByHandle($this->set)];
+                            } else {
+                                $fields = array_map(
+                                    fn(FieldInterface $field) => $element->getFieldLayout()?->getFieldByUid($field->uid),
+                                    $this->withFields,
+                                );
+                            }
+
+                            $fields = array_filter($fields, fn(?FieldInterface $field) => $field instanceof DefaultableFieldInterface);
+
+                            foreach ($fields as $field) {
+                                $set = true;
+                                if ($this->ifEmpty) {
+                                    if (!ElementHelper::isAttributeEmpty($element, $field->handle)) {
+                                        $set = false;
+                                    }
+                                } elseif ($this->ifInvalid) {
+                                    $element->setScenario(Element::SCENARIO_LIVE);
+                                    if ($element->validate("field:$field->handle")) {
+                                        $set = false;
+                                    }
+                                }
+
+                                if ($set) {
+                                    /** @var DefaultableFieldInterface $field */
+                                    $element->setFieldValue($field->handle, $field->getDefaultValue());
+                                }
+                            }
+                        } elseif (isset($this->set)) {
                             $set = true;
                             if ($this->ifEmpty) {
                                 if (!ElementHelper::isAttributeEmpty($element, $this->set)) {

--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -9,6 +9,7 @@ namespace craft\fields;
 
 use Craft;
 use craft\base\CrossSiteCopyableFieldInterface;
+use craft\base\DefaultableFieldInterface;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\MergeableFieldInterface;
@@ -37,7 +38,11 @@ use yii\db\Schema;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
-abstract class BaseOptionsField extends Field implements PreviewableFieldInterface, MergeableFieldInterface, CrossSiteCopyableFieldInterface
+abstract class BaseOptionsField extends Field implements
+    PreviewableFieldInterface,
+    MergeableFieldInterface,
+    CrossSiteCopyableFieldInterface,
+    DefaultableFieldInterface
 {
     /**
      * @event DefineInputOptionsEvent Event triggered when defining the options for the field's input.
@@ -346,6 +351,14 @@ abstract class BaseOptionsField extends Field implements PreviewableFieldInterfa
         }
 
         return $html;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultValue(): array|string|null
+    {
+        return $this->defaultValue();
     }
 
     /**

--- a/src/fields/Color.php
+++ b/src/fields/Color.php
@@ -9,6 +9,7 @@ namespace craft\fields;
 
 use Craft;
 use craft\base\CrossSiteCopyableFieldInterface;
+use craft\base\DefaultableFieldInterface;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\InlineEditableFieldInterface;
@@ -30,7 +31,11 @@ use yii\db\Schema;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
-class Color extends Field implements InlineEditableFieldInterface, MergeableFieldInterface, CrossSiteCopyableFieldInterface
+class Color extends Field implements
+    InlineEditableFieldInterface,
+    MergeableFieldInterface,
+    CrossSiteCopyableFieldInterface,
+    DefaultableFieldInterface
 {
     /**
      * @inheritdoc
@@ -114,8 +119,17 @@ class Color extends Field implements InlineEditableFieldInterface, MergeableFiel
      *
      * @return string|null
      * @since 5.6.0
+     * @deprecated in 5.10.0. [[getDefaultValue()]] should be used instead.
      */
     public function getDefaultColor(): ?string
+    {
+        return $this->getDefaultValue();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultValue(): ?string
     {
         $color = Arr::first($this->palette, fn(array $color) => $color['default'] ?? false);
         return $color ? $color['color'] : null;
@@ -279,7 +293,7 @@ class Color extends Field implements InlineEditableFieldInterface, MergeableFiel
 
         // If this is a new entry, look for any default options
         if ($value === null && $this->isFresh($element)) {
-            $defaultColor = $this->getDefaultColor();
+            $defaultColor = $this->getDefaultValue();
             if ($defaultColor) {
                 $value = $defaultColor;
             }

--- a/src/fields/Lightswitch.php
+++ b/src/fields/Lightswitch.php
@@ -9,6 +9,7 @@ namespace craft\fields;
 
 use Craft;
 use craft\base\CrossSiteCopyableFieldInterface;
+use craft\base\DefaultableFieldInterface;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\InlineEditableFieldInterface;
@@ -30,7 +31,12 @@ use yii\db\Schema;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
-class Lightswitch extends Field implements InlineEditableFieldInterface, SortableFieldInterface, MergeableFieldInterface, CrossSiteCopyableFieldInterface
+class Lightswitch extends Field implements
+    InlineEditableFieldInterface,
+    SortableFieldInterface,
+    MergeableFieldInterface,
+    CrossSiteCopyableFieldInterface,
+    DefaultableFieldInterface
 {
     /**
      * @inheritdoc
@@ -175,6 +181,14 @@ class Lightswitch extends Field implements InlineEditableFieldInterface, Sortabl
                 'on' => $this->showLabelsInCards,
                 'disabled' => $readOnly,
             ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultValue(): bool
+    {
+        return $this->default;
     }
 
     /**

--- a/src/fields/Money.php
+++ b/src/fields/Money.php
@@ -9,6 +9,7 @@ namespace craft\fields;
 
 use Craft;
 use craft\base\CrossSiteCopyableFieldInterface;
+use craft\base\DefaultableFieldInterface;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\InlineEditableFieldInterface;
@@ -39,7 +40,12 @@ use yii\db\Schema;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.0.0
  */
-class Money extends Field implements InlineEditableFieldInterface, SortableFieldInterface, MergeableFieldInterface, CrossSiteCopyableFieldInterface
+class Money extends Field implements
+    InlineEditableFieldInterface,
+    SortableFieldInterface,
+    MergeableFieldInterface,
+    CrossSiteCopyableFieldInterface,
+    DefaultableFieldInterface
 {
     /**
      * @inheritdoc
@@ -214,6 +220,14 @@ class Money extends Field implements InlineEditableFieldInterface, SortableField
     {
         $valueSql = static::valueSql($instances);
         return Db::parseMoneyParam($valueSql, $instances[0]->currency, $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultValue(): float|int|null
+    {
+        return $this->defaultValue;
     }
 
     /**

--- a/src/fields/Number.php
+++ b/src/fields/Number.php
@@ -9,6 +9,7 @@ namespace craft\fields;
 
 use Craft;
 use craft\base\CrossSiteCopyableFieldInterface;
+use craft\base\DefaultableFieldInterface;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\InlineEditableFieldInterface;
@@ -33,7 +34,12 @@ use yii\helpers\Markdown;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
-class Number extends Field implements InlineEditableFieldInterface, SortableFieldInterface, MergeableFieldInterface, CrossSiteCopyableFieldInterface
+class Number extends Field implements
+    InlineEditableFieldInterface,
+    SortableFieldInterface,
+    MergeableFieldInterface,
+    CrossSiteCopyableFieldInterface,
+    DefaultableFieldInterface
 {
     /**
      * @since 3.5.11
@@ -214,6 +220,14 @@ class Number extends Field implements InlineEditableFieldInterface, SortableFiel
             'field' => $this,
             'readOnly' => $readOnly,
         ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultValue(): int|null|float
+    {
+        return $this->defaultValue;
     }
 
     /**

--- a/src/fields/Range.php
+++ b/src/fields/Range.php
@@ -8,6 +8,7 @@
 namespace craft\fields;
 
 use Craft;
+use craft\base\DefaultableFieldInterface;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\base\InlineEditableFieldInterface;
@@ -28,7 +29,11 @@ use yii\db\Schema;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 5.5.0
  */
-class Range extends Field implements InlineEditableFieldInterface, SortableFieldInterface, MergeableFieldInterface
+class Range extends Field implements
+    InlineEditableFieldInterface,
+    SortableFieldInterface,
+    MergeableFieldInterface,
+    DefaultableFieldInterface
 {
     /**
      * @inheritdoc
@@ -161,6 +166,14 @@ class Range extends Field implements InlineEditableFieldInterface, SortableField
     public function useFieldset(): bool
     {
         return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultValue(): int|float|null
+    {
+        return $this->defaultValue;
     }
 
     /**

--- a/src/fields/Table.php
+++ b/src/fields/Table.php
@@ -9,6 +9,7 @@ namespace craft\fields;
 
 use Craft;
 use craft\base\CrossSiteCopyableFieldInterface;
+use craft\base\DefaultableFieldInterface;
 use craft\base\ElementInterface;
 use craft\base\Field;
 use craft\fields\data\ColorData;
@@ -39,7 +40,7 @@ use yii\validators\EmailValidator;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
-class Table extends Field implements CrossSiteCopyableFieldInterface
+class Table extends Field implements CrossSiteCopyableFieldInterface, DefaultableFieldInterface
 {
     private static array $typeOptions;
 
@@ -438,6 +439,14 @@ class Table extends Field implements CrossSiteCopyableFieldInterface
     public function useFieldset(): bool
     {
         return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultValue(): ?array
+    {
+        return $this->defaults;
     }
 
     /**

--- a/src/queue/jobs/ResaveElements.php
+++ b/src/queue/jobs/ResaveElements.php
@@ -9,8 +9,10 @@ namespace craft\queue\jobs;
 
 use Craft;
 use craft\base\Batchable;
+use craft\base\DefaultableFieldInterface;
 use craft\base\Element;
 use craft\base\ElementInterface;
+use craft\base\FieldInterface;
 use craft\console\controllers\ResaveController;
 use craft\db\QueryBatcher;
 use craft\helpers\ElementHelper;
@@ -43,6 +45,12 @@ class ResaveElements extends BaseBatchedElementJob
     public bool $updateSearchIndex = false;
 
     /**
+     * @var string[] Only resave elements that have custom fields with these global field handles.
+     * @since 5.10.0
+     */
+    public array $withFields = [];
+
+    /**
      * @var string|null An attribute name that should be set for each of the elements. The value will be determined by [[to]].
      * @since 4.2.6
      */
@@ -53,6 +61,12 @@ class ResaveElements extends BaseBatchedElementJob
      * @since 4.2.6
      */
     public ?string $to = null;
+
+    /**
+     * @var bool Sets the specified fields to their default values.
+     * @since 5.10.0
+     */
+    public bool $toDefault = false;
 
     /**
      * @var bool Whether the [[set]] attribute should only be set if it doesn’t have a value.
@@ -92,7 +106,52 @@ class ResaveElements extends BaseBatchedElementJob
      */
     protected function processItem(mixed $item): void
     {
-        if (isset($this->set)) {
+        if ($this->toDefault) {
+            if ($this->set) {
+                /** @var ElementInterface $item */
+                $fields = [$item->getFieldLayout()?->getFieldByHandle($this->set)];
+            } else {
+                $fieldsService = Craft::$app->getFields();
+                $fields = array_map(
+                    function(string $handle) use ($fieldsService, $item) {
+                        $field = $fieldsService->getFieldByHandle($handle);
+                        if (!$field) {
+                            return null;
+                        }
+                        /** @var ElementInterface $item */
+                        return $item->getFieldLayout()?->getFieldByUid($field->uid);
+                    },
+                    $this->withFields,
+                );
+            }
+
+            $fields = array_filter($fields, fn(?FieldInterface $field) => $field instanceof DefaultableFieldInterface);
+
+            foreach ($fields as $field) {
+                $set = true;
+                if ($this->ifEmpty) {
+                    /** @var ElementInterface $item */
+                    if (!ElementHelper::isAttributeEmpty($item, $field->handle)) {
+                        $set = false;
+                    }
+                } elseif ($this->ifInvalid) {
+                    /** @var ElementInterface $item */
+                    $item->setScenario(Element::SCENARIO_LIVE);
+                    if ($item->validate("field:$field->handle")) {
+                        $set = false;
+                    }
+                }
+
+                if ($set) {
+                    /** @var ElementInterface $item */
+                    /** @var DefaultableFieldInterface $field */
+                    $defaultValue = $field->getDefaultValue();
+                    if ($defaultValue !== null) {
+                        $item->setFieldValue($field->handle, $defaultValue);
+                    }
+                }
+            }
+        } elseif (isset($this->set)) {
             $set = true;
             if ($this->ifEmpty) {
                 if (!ElementHelper::isAttributeEmpty($item, $this->set)) {


### PR DESCRIPTION
### Description

Adds a new `--to-default` option to `resave` commands. When present, the field(s) specified by either `--set` or `--with-fields` will be set to their default values, when possible.

For example, after setting a default value for a Dropdown field, that default value could be added to all elements that A) have that field; ad B) don’t have a value yet, with the following command:

```sh
php craft resave/all --with-field=myDropdownField --to-default --if-empty
```

This is made possible by a new `DefaultableFieldInterface`, which is implemented by the following built-in field types:

- Button Group
- Checkboxes
- Color
- Dropdown
- Lightswitch
- Money
- Multi-select
- Number
- Radio Buttons
- Range
- Table

### Related issues

- #18489