### PR TITLE
[6.x] Move deprecated methods & properties into legacy config class

### DIFF
--- a/config/general.php
+++ b/config/general.php
@@ -15,8 +15,6 @@ use CraftCms\Cms\Config\GeneralConfig;
 return GeneralConfig::create()
     // Set the default week start day for date pickers (0 = Sunday, 1 = Monday, etc.)
     ->defaultWeekStartDay(1)
-    // Prevent generated URLs from including "index.php"
-    // ->omitScriptNameInUrls()
     // Preload Single entries as Twig variables
     ->preloadSingles()
     // Prevent user enumeration attacks

--- a/src/Config/GeneralConfig.php
+++ b/src/Config/GeneralConfig.php
@@ -15,8 +15,6 @@ use CraftCms\Cms\Support\Facades\I18N;
 use CraftCms\Cms\Support\PHP;
 use DateInterval;
 use Deprecated;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
-use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Traits\Conditionable;
@@ -182,31 +180,6 @@ class GeneralConfig extends BaseConfig
      * @group System
      */
     public bool $allowAdminChanges = true;
-
-    /**
-     * @var string[]|null|false The Ajax origins that should be allowed to access the GraphQL API, if enabled.
-     *
-     * If this is set to an array, then `graphql/api` requests will only include the current request’s [[\yii\web\Request::getOrigin()|origin]]
-     * in the `Access-Control-Allow-Origin` response header if it’s listed here.
-     *
-     * If this is set to `false`, then the `Access-Control-Allow-Origin` response header will never be sent.
-     *
-     * ::: code
-     * ```php Static Config
-     * ->allowedGraphqlOrigins(false)
-     * ```
-     * ```shell Environment Override
-     * CRAFT_ALLOW_GRAPHQL_ORIGINS=false
-     * ```
-     * :::
-     *
-     * @group GraphQL
-     *
-     * @since 3.5.0
-     * @deprecated in 4.11.0. [[\craft\filters\Cors]] should be used instead.
-     * @see https://www.yiiframework.com/doc/api/2.0/yii-filters-cors
-     */
-    public array|null|false $allowedGraphqlOrigins = null;
 
     /**
      * @var bool Whether Craft should allow system and plugin updates in the control panel, and plugin installation from the Plugin Store.
@@ -389,27 +362,6 @@ class GeneralConfig extends BaseConfig
     public bool $autoLoginAfterAccountActivation = false;
 
     /**
-     * @var bool Whether drafts should be saved automatically as they are edited.
-     *
-     * Note that drafts *will* be autosaved while Live Preview is open, regardless of this setting.
-     *
-     * ::: code
-     *  ```php Static Config
-     *  ->autosaveDrafts(false)
-     *  ```
-     * ```shell Environment Override
-     * CRAFT_AUTOSAVE_DRAFTS=false
-     * ```
-     * :::
-     *
-     * @group System
-     *
-     * @since 3.5.6
-     * @deprecated in 4.0.0
-     */
-    public bool $autosaveDrafts = true;
-
-    /**
      * @var string|null The base URL Craft should use when generating control panel URLs.
      *
      * It will be determined automatically if left blank.
@@ -502,33 +454,6 @@ class GeneralConfig extends BaseConfig
      * @group Environment
      */
     public ?string $backupCommandFormat = null;
-
-    /**
-     * @var int The higher the cost value, the longer it takes to generate a password hash and to verify against it.
-     *
-     * Therefore, higher cost slows down a brute-force attack.
-     *
-     * For best protection against brute force attacks, set it to the highest value that is tolerable on production servers.
-     *
-     * The time taken to compute the hash doubles for every increment by one for this value.
-     *
-     * For example, if the hash takes 1 second to compute when the value is 14 then the compute time varies as
-     * 2^(value - 14) seconds.
-     *
-     * ::: code
-     * ```php Static Config
-     * ->blowfishHashCost(15)
-     * ```
-     * ```shell Environment Override
-     * CRAFT_BLOWFISH_HASH_COST=15
-     * ```
-     * :::
-     *
-     * @group Security
-     *
-     * @deprecated 6.0.0. Set hashing.bcrypt.rounds or BCRYPT_ROUNDS environment variable instead.
-     */
-    public int $blowfishHashCost = 13;
 
     /**
      * @var string|null The server path to an image file that should be sent when responding to an image request with a
@@ -1041,30 +966,6 @@ class GeneralConfig extends BaseConfig
      * @group System
      */
     public bool $disallowRobots = false;
-
-    /**
-     * @var bool Whether the `@transform` directive should be disabled for the GraphQL API.
-     *
-     * ::: code
-     * ```php Static Config
-     * ->disableGraphqlTransformDirective(true)
-     * ```
-     * ```shell Environment Override
-     * CRAFT_DISABLE_GRAPHQL_TRANSFORM_DIRECTIVE=true
-     * ```
-     * :::
-     *
-     * ::: tip
-     * As of Craft 5.9.0, the `@transform` directive can be optionally included for each GraphQL schema,
-     * unless this setting is set to `true`.
-     * :::
-     *
-     * @group GraphQL
-     *
-     * @since 3.6.0
-     * @deprecated in 5.9.0
-     */
-    public bool $disableGraphqlTransformDirective = false;
 
     /**
      * @var bool Whether CSRF values should be injected via JavaScript for greater cache-ability. This setting can be overridden by passing an `async` option into the `csrfInput()` function.
@@ -2092,25 +1993,6 @@ class GeneralConfig extends BaseConfig
     public ?string $pathParam = null;
 
     /**
-     * @var string|null The `Permissions-Policy` header that should be sent for site responses.
-     *
-     * ::: code
-     * ```php Static Config
-     * ->permissionsPolicyHeader('Permissions-Policy: geolocation=(self)')
-     * ```
-     * ```shell Environment Override
-     * CRAFT_PERMISSIONS_POLICY_HEADER=Permissions-Policy: geolocation=(self)
-     * ```
-     * :::
-     *
-     * @group System
-     *
-     * @since 3.6.14
-     * @deprecated in 4.11.0. [[\craft\filters\Headers]] should be used instead.
-     */
-    public ?string $permissionsPolicyHeader = null;
-
-    /**
      * @var string|null The maximum amount of memory Craft will try to reserve during memory-intensive operations such as zipping,
      *                  unzipping and updating. Defaults to an empty string, which means it will use as much memory as it can.
      *
@@ -2128,26 +2010,6 @@ class GeneralConfig extends BaseConfig
      * @group System
      */
     public ?string $phpMaxMemoryLimit = null;
-
-    /**
-     * @var string The name of the PHP session cookie.
-     *
-     * ::: code
-     * ```php Static Config
-     * ->phpSessionName(null)
-     * ```
-     * ```shell Environment Override
-     * CRAFT_PHP_SESSION_NAME=
-     * ```
-     * :::
-     *
-     * @see https://php.net/manual/en/function.session-name.php
-     *
-     * @group Session
-     *
-     * @deprecated 6.0.0 configure sessions using Laravel's session config instead.
-     */
-    public string $phpSessionName = 'CraftSessionId';
 
     /**
      * @var mixed The path users should be redirected to after logging into the control panel.
@@ -2439,33 +2301,6 @@ class GeneralConfig extends BaseConfig
     public mixed $purgeUnsavedDraftsDuration = 2592000;
 
     /**
-     * @var mixed The amount of time to wait before Craft purges stale user sessions from the sessions table in the database.
-     *
-     * Set to `0` to disable this feature.
-     *
-     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
-     *
-     * ::: code
-     * ```php Static Config
-     * // 1 week
-     * ->purgeStaleUserSessionDuration(604800)
-     * ```
-     * ```shell Environment Override
-     * # 1 week
-     * CRAFT_PURGE_STALE_USER_SESSION_DURATION=604800
-     * ```
-     * :::
-     *
-     * @group Garbage Collection
-     *
-     * @defaultAlt 90 days
-     *
-     * @since 3.3.0
-     * @deprecated 6.0.0 configure sessions using Laravel's session config instead.
-     */
-    public mixed $purgeStaleUserSessionDuration = 7776000;
-
-    /**
      * @var bool Whether SVG thumbnails should be rasterized.
      *
      * This will only work if ImageMagick is installed, and <config5:imageDriver> is set to either `auto` or `imagick`.
@@ -2526,42 +2361,6 @@ class GeneralConfig extends BaseConfig
      * @defaultAlt 14 days
      */
     public mixed $rememberedUserSessionDuration = 1209600;
-
-    /**
-     * @var bool Whether Craft should require a matching user agent string when restoring a user session from a cookie.
-     *
-     * ::: code
-     * ```php Static Config
-     * ->requireMatchingUserAgentForSession(false)
-     * ```
-     * ```shell Environment Override
-     * CRAFT_REQUIRE_MATCHING_USER_AGENT_FOR_SESSION=false
-     * ```
-     * :::
-     *
-     * @group Session
-     *
-     * @deprecated 6.0.0
-     */
-    public bool $requireMatchingUserAgentForSession = true;
-
-    /**
-     * @var bool Whether Craft should require the existence of a user agent string and IP address when creating a new user session.
-     *
-     * ::: code
-     * ```php Static Config
-     * ->requireUserAgentAndIpForSession(false)
-     * ```
-     * ```shell Environment Override
-     * CRAFT_REQUIRE_USER_AGENT_AND_IP_FOR_SESSION=false
-     * ```
-     * :::
-     *
-     * @group Session
-     *
-     * @deprecated 6.0.0
-     */
-    public bool $requireUserAgentAndIpForSession = true;
 
     /**
      * @var string The path to the root directory that should store published control panel resources.
@@ -3136,26 +2935,6 @@ class GeneralConfig extends BaseConfig
 
     /**
     /**
-     * @var string|null The timezone of the site. If set, it will take precedence over the Timezone setting in Settings → General.
-     *
-     * This can be set to one of PHP’s [supported timezones](https://php.net/manual/en/timezones.php).
-     *
-     * ::: code
-     * ```php Static Config
-     * ->timezone('Europe/London')
-     * ```
-     * ```shell Environment Override
-     * CRAFT_TIMEZONE=Europe/London
-     * ```
-     * :::
-     *
-     * @group System
-     *
-     * @deprecated in 6.0.0. Laravel's `app.timezone` config variable should be used instead.
-     */
-    public ?string $timezone = null;
-
-    /**
      * @var bool Whether GIF files should be cleansed/transformed.
      *
      * ::: code
@@ -3403,32 +3182,6 @@ class GeneralConfig extends BaseConfig
      * @group Routing
      */
     public string|bool $useSslOnTokenizedUrls = 'auto';
-
-    /**
-     * @var mixed The amount of time before a user will get logged out due to inactivity.
-     *
-     * Set to `0` if you want users to stay logged in as long as their browser is open rather than a predetermined amount of time.
-     *
-     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
-     *
-     * ::: code
-     * ```php Static Config
-     * // 3 hours
-     * ->userSessionDuration(10800)
-     * ```
-     * ```shell Environment Override
-     * # 3 hours
-     * CRAFT_USER_SESSION_DURATION=10800
-     * ```
-     * :::
-     *
-     * @group Session
-     *
-     * @defaultAlt 1 hour
-     *
-     * @deprecated 6.0.0
-     */
-    public mixed $userSessionDuration = 3600;
 
     /**
      * @var bool|null Whether to grab an exclusive lock on a file when writing to it by using the `LOCK_EX` flag.
@@ -3746,32 +3499,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * The Ajax origins that should be allowed to access the GraphQL API, if enabled.
-     *
-     * If this is set to an array, then `graphql/api` requests will only include the current request’s [[\yii\web\Request::getOrigin()|origin]]
-     * in the `Access-Control-Allow-Origin` response header if it’s listed here.
-     *
-     * If this is set to `false`, then the `Access-Control-Allow-Origin` response header will never be sent.
-     *
-     * ```php
-     * ->allowedGraphqlOrigins(false)
-     * ```
-     *
-     * @group GraphQL
-     *
-     * @see $allowedGraphqlOrigins
-     * @since 4.2.0
-     * @see https://www.yiiframework.com/doc/api/2.0/yii-filters-cors
-     */
-    #[Deprecated(message: 'in 4.11.0. [[\craft\filters\Cors]] should be used instead.')]
-    public function allowedGraphqlOrigins(array|null|false $value): self
-    {
-        $this->allowedGraphqlOrigins = $value;
-
-        return $this;
-    }
-
-    /**
      * Whether users should be allowed to create similarly-named tags.
      *
      * ```php
@@ -3918,40 +3645,6 @@ class GeneralConfig extends BaseConfig
     public function backupCommandFormat(string $value): self
     {
         $this->backupCommandFormat = $value;
-
-        return $this;
-    }
-
-    /**
-     * The higher the cost value, the longer it takes to generate a password hash and to verify against it.
-     *
-     * Therefore, higher cost slows down a brute-force attack.
-     *
-     * For best protection against brute force attacks, set it to the highest value that is tolerable on production servers.
-     *
-     * The time taken to compute the hash doubles for every increment by one for this value.
-     *
-     * For example, if the hash takes 1 second to compute when the value is 14 then the compute time varies as
-     * 2^(value - 14) seconds.
-     *
-     * ```php
-     * ->blowfishHashCost(15)
-     * ```
-     *
-     * @group Security
-     *
-     * @see $blowfishHashCost
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. Set hashing.bcrypt.rounds or BCRYPT_ROUNDS environment variable instead.')]
-    public function blowfishHashCost(int $value): self
-    {
-        app()->booting(function () use ($value) {
-            Config::set('hashing.bcrypt.rounds', $value);
-            Deprecator::log('generalConfig.blowfishHashCost', 'blowfishHashCost is deprecated. Set hashing.bcrypt.rounds or BCRYPT_ROUNDS instead.');
-        });
-
-        $this->blowfishHashCost = $value;
 
         return $this;
     }
@@ -4127,29 +3820,6 @@ class GeneralConfig extends BaseConfig
     public function cpTrigger(?string $value): self
     {
         $this->cpTrigger = $value;
-
-        return $this;
-    }
-
-    /**
-     * The name of CSRF token used for CSRF validation if <config5:enableCsrfProtection> is set to `true`.
-     *
-     * ```php
-     * ->csrfTokenName('MY_CSRF')
-     * ```
-     *
-     * @group Security
-     *
-     * @see $csrfTokenName
-     * @see enableCsrfProtection
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. Calling csrfTokenName() is deprecated. The token is always named XSRF-TOKEN.')]
-    public function csrfTokenName(string $value): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.csrfTokenName', 'Calling csrfTokenName() is deprecated. The token is always named XSRF-TOKEN.'));
-
-        $this->csrfTokenName = $value;
 
         return $this;
     }
@@ -4435,31 +4105,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * Whether the system should run in [Dev Mode](https://craftcms.com/support/dev-mode).
-     *
-     * ```php
-     * ->devMode(true)
-     * ```
-     *
-     * @group System
-     *
-     * @see $devMode
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. Set `app.debug` or `APP_DEBUG` environment variable instead.')]
-    public function devMode(bool $value = true): self
-    {
-        app()->booting(function () use ($value) {
-            Deprecator::log('generalConfig.devMode', 'devMode is deprecated. Set `app.debug` or `APP_DEBUG` environment variable instead.');
-            Config::set('app.debug', $value);
-        });
-
-        $this->devMode = $value;
-
-        return $this;
-    }
-
-    /**
      * Whether two-step verification features should be disabled.
      *
      * ::: code
@@ -4575,29 +4220,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * Whether the `@transform` directive should be disabled for the GraphQL API.
-     *
-     * ```php
-     * ->disableGraphqlTransformDirective(true)
-     * ```
-     *
-     * ::: tip
-     * As of Craft 5.9.0, the `@transform` directive can be optionally included for each GraphQL schema,
-     * unless this setting is set to `true`.
-     * :::
-     *
-     * @group GraphQL
-     *
-     * @see $disableGraphqlTransformDirective
-     */
-    public function disableGraphqlTransformDirective(bool $value = true): self
-    {
-        $this->disableGraphqlTransformDirective = $value;
-
-        return $this;
-    }
-
-    /**
      * Whether CSRF values should be injected via JavaScript for greater cache-ability.
      *
      *  ```php
@@ -4609,56 +4231,6 @@ class GeneralConfig extends BaseConfig
     public function asyncCsrfInputs(bool $value = true): self
     {
         $this->asyncCsrfInputs = $value;
-
-        return $this;
-    }
-
-    /**
-     * Whether to use a cookie to persist the CSRF token if <config5:enableCsrfProtection> is enabled. If false, the CSRF token will be
-     * stored in session under the `csrfTokenName` config setting name. Note that while storing CSRF tokens in session increases security,
-     * it requires starting a session for every page that a CSRF token is needed, which may degrade site performance.
-     *
-     * ```php
-     * ->enableCsrfCookie(false)
-     * ```
-     *
-     * @group Security
-     *
-     * @see $enableCsrfCookie
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. A cookie will always be used to persist the CSRF token.')]
-    public function enableCsrfCookie(bool $value = true): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.enableCsrfCookie', 'A cookie will always be used to persist the CSRF token.'));
-
-        $this->enableCsrfCookie = $value;
-
-        return $this;
-    }
-
-    /**
-     * Whether to enable CSRF protection via hidden form inputs for all forms submitted via Craft.
-     *
-     * ```php
-     * ->enableCsrfProtection(false)
-     * ```
-     *
-     * @group Security
-     *
-     * @see $enableCsrfProtection
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. [Configure excluded routes instead](https://laravel.com/docs/12.x/csrf#csrf-excluding-uris)')]
-    public function enableCsrfProtection(bool $value = true): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.enableCsrfProtection', 'Configure excluded routes instead.'));
-
-        $this->enableCsrfProtection = $value;
-
-        if ($value === false) {
-            VerifyCsrfToken::except(['*']);
-        }
 
         return $this;
     }
@@ -4697,36 +4269,6 @@ class GeneralConfig extends BaseConfig
     public function enableGql(bool $value = true): self
     {
         $this->enableGql = $value;
-
-        return $this;
-    }
-
-    /**
-     * The amount of time a user’s elevated session will last, which is required for some sensitive actions (e.g. user group/permission assignment).
-     *
-     * Set to `0` to disable elevated session support.
-     *
-     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
-     *
-     * ```php
-     * ->elevatedSessionDuration(0)
-     * ```
-     *
-     * @group Security
-     *
-     * @defaultAlt 5 minutes
-     *
-     * @see $elevatedSessionDuration
-     */
-    #[Deprecated(message: 'use the `auth.password_timeout` config setting instead.', since: '6.0.0')]
-    public function elevatedSessionDuration(mixed $value): self
-    {
-        $this->elevatedSessionDuration = ConfigHelper::durationInSeconds($value);
-
-        app()->booting(function () {
-            Deprecator::log('generalConfig.elevatedSessionDuration', 'Use the `auth.password_timeout` config setting instead.');
-            Config::set('auth.password_timeout', $this->elevatedSessionDuration === 0 ? -1 : $this->elevatedSessionDuration);
-        });
 
         return $this;
     }
@@ -4788,25 +4330,6 @@ class GeneralConfig extends BaseConfig
     public function enableTemplateCaching(bool $value = true): self
     {
         $this->enableTemplateCaching = $value;
-
-        return $this;
-    }
-
-    /**
-     * Whether user-defined Twig templates should be sandboxed.
-     *
-     * ```php
-     * ->enableTwigSandbox()
-     * ```
-     *
-     * @group Security
-     *
-     * @see $enableTwigSandbox
-     */
-    #[Deprecated(message: 'in 6.0.0. Sandbox is always enabled.')]
-    public function enableTwigSandbox(bool $value = true): self
-    {
-        $this->enableTwigSandbox = $value;
 
         return $this;
     }
@@ -5600,38 +5123,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * Whether generated URLs should omit `index.php` (e.g. `http://my-project.tld/path` instead of `http://my-project.tld/index.php/path`)
-     *
-     * This can only be possible if your server is configured to redirect would-be 404s to `index.php`, for example, with the redirect found
-     * in the `.htaccess` file that came with Craft:
-     *
-     * ```
-     * RewriteEngine On
-     * RewriteCond %{REQUEST_FILENAME} !-f
-     * RewriteCond %{REQUEST_FILENAME} !-d
-     * RewriteRule (.+) /index.php?p=$1 [QSA,L]
-     * ```
-     *
-     * ```php
-     * ->omitScriptNameInUrls(true)
-     * ```
-     *
-     * @group Routing
-     *
-     * @see $omitScriptNameInUrls
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. Script name is now always omitted.')]
-    public function omitScriptNameInUrls(bool $value = true): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.omitScriptNameInUrls', 'Calling omitScriptNameInUrls() is deprecated. Script name is now always omitted.'));
-
-        $this->omitScriptNameInUrls = $value;
-
-        return $this;
-    }
-
-    /**
      * Whether Craft should optimize images for reduced file sizes without noticeably reducing image quality. (Only supported when
      * ImageMagick is used.)
      *
@@ -5718,55 +5209,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * The query string param that Craft will check when determining the request’s path.
-     *
-     * This can be set to `null` if your web server is capable of directing traffic to `index.php` without a query string param.
-     * If you’re using Apache, that means you’ll need to change the `RewriteRule` line in your `.htaccess` file to:
-     *
-     * ```
-     * RewriteRule (.+) index.php [QSA,L]
-     * ```
-     *
-     * ```php
-     * ->pathParam(null)
-     * ```
-     *
-     * @group Routing
-     *
-     * @see $pathParam
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. This method no longer does anything.')]
-    public function pathParam(?string $value): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.pathParam', 'Calling pathParam() is deprecated.'));
-
-        $this->pathParam = $value;
-
-        return $this;
-    }
-
-    /**
-     * The `Permissions-Policy` header that should be sent for web responses.
-     *
-     * ```php
-     * ->permissionsPolicyHeader('Permissions-Policy: geolocation=(self)')
-     * ```
-     *
-     * @group System
-     *
-     * @see $permissionsPolicyHeader
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 4.11.0. [[\craft\filters\Headers]] should be used instead.')]
-    public function permissionsPolicyHeader(?string $value): self
-    {
-        $this->permissionsPolicyHeader = $value;
-
-        return $this;
-    }
-
-    /**
      * The maximum amount of memory Craft will try to reserve during memory-intensive operations such as zipping,
      * unzipping and updating. Defaults to an empty string, which means it will use as much memory as it can.
      *
@@ -5783,32 +5225,6 @@ class GeneralConfig extends BaseConfig
     public function phpMaxMemoryLimit(?string $value): self
     {
         $this->phpMaxMemoryLimit = $value;
-
-        return $this;
-    }
-
-    /**
-     * The name of the PHP session cookie.
-     *
-     * ```php
-     * ->phpSessionName(null)
-     * ```
-     *
-     * @group Session
-     *
-     * @see $phpSessionName
-     * @see https://php.net/manual/en/function.session-name.php
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. Configure `session.cookie` or set `SESSION_COOKIE` environment variable.')]
-    public function phpSessionName(string $value): self
-    {
-        $this->phpSessionName = $value;
-
-        app()->booting(function () use ($value) {
-            Deprecator::log('generalConfig.phpSessionName', 'Calling phpSessionName() is deprecated. Configure `session.cookie` or set `SESSION_COOKIE` environment variable.');
-            Config::set('session.cookie', $value);
-        });
 
         return $this;
     }
@@ -6109,35 +5525,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * The amount of time to wait before Craft purges stale user sessions from the sessions table in the database.
-     *
-     * Set to `0` to disable this feature.
-     *
-     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
-     *
-     * ```php
-     * // 1 week
-     * ->purgeStaleUserSessionDuration(604800)
-     * ```
-     *
-     * @group Garbage Collection
-     *
-     * @defaultAlt 90 days
-     *
-     * @see $purgeStaleUserSessionDuration
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. This method no longer does anything, sessions are cleaned up on a lottery basis when needed.')]
-    public function purgeStaleUserSessionDuration(mixed $value): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.purgeStaleUserSessionDuration', 'Calling purgeStaleUserSessionDuration() is deprecated. Sessions are cleaned up on a lottery basis when needed.'));
-
-        $this->purgeStaleUserSessionDuration = ConfigHelper::durationInSeconds($value);
-
-        return $this;
-    }
-
-    /**
      * The amount of time to wait before Craft purges unpublished drafts that were never updated with content.
      *
      * Set to `0` to disable this feature.
@@ -6242,50 +5629,6 @@ class GeneralConfig extends BaseConfig
     public function rememberUsernameDuration(mixed $value): self
     {
         $this->rememberUsernameDuration = ConfigHelper::durationInSeconds($value);
-
-        return $this;
-    }
-
-    /**
-     * Whether Craft should require a matching user agent string when restoring a user session from a cookie.
-     *
-     * ```php
-     * ->requireMatchingUserAgentForSession(false)
-     * ```
-     *
-     * @group Session
-     *
-     * @see $requireMatchingUserAgentForSession
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. This method no longer configures anything.')]
-    public function requireMatchingUserAgentForSession(bool $value = true): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.requireMatchingUserAgentForSession', 'Calling requireMatchingUserAgentForSession() is deprecated.'));
-
-        $this->requireMatchingUserAgentForSession = $value;
-
-        return $this;
-    }
-
-    /**
-     * Whether Craft should require the existence of a user agent string and IP address when creating a new user session.
-     *
-     * ```php
-     * ->requireUserAgentAndIpForSession(false)
-     * ```
-     *
-     * @group Session
-     *
-     * @see $requireUserAgentAndIpForSession
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. This method no longer configures anything.')]
-    public function requireUserAgentAndIpForSession(bool $value = true): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.requireUserAgentAndIpForSession', 'Calling requireUserAgentAndIpForSession() is deprecated.'));
-
-        $this->requireUserAgentAndIpForSession = $value;
 
         return $this;
     }
@@ -6499,32 +5842,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * The [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) value that should be set on Craft cookies, if any.
-     *
-     * This can be set to `'None'`, `'Lax'`, `'Strict'`, or `null`.
-     *
-     * ```php
-     * ->sameSiteCookieValue('Strict')
-     * ```
-     *
-     * @group System
-     *
-     * @phpstan-param 'None'|'Lax'|'Strict'|null $value
-     *
-     * @see $sameSiteCookieValue
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. Configure `cookie.same_site` or set `SESSION_SAME_SITE` environment variable instead.')]
-    public function sameSiteCookieValue(?string $value): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.sameSiteCookieValue', 'Calling sameSiteCookieValue() is deprecated. Configure `cookie.same_site` or set `SESSION_SAME_SITE` environment variable instead.'));
-
-        $this->sameSiteCookieValue = $value;
-
-        return $this;
-    }
-
-    /**
      * Whether images uploaded via the control panel should be sanitized.
      *
      * ```php
@@ -6558,135 +5875,6 @@ class GeneralConfig extends BaseConfig
     public function sanitizeSvgUploads(bool $value = true): self
     {
         $this->sanitizeSvgUploads = $value;
-
-        return $this;
-    }
-
-    /**
-     * Lists of headers that are, by default, subject to the trusted host configuration.
-     *
-     * See [[\yii\web\Request::secureHeaders]] for more details.
-     *
-     * If not set, the default [[\yii\web\Request::secureHeaders]] value will be used.
-     *
-     * ```php
-     * ->secureHeaders([
-     *     'X-Forwarded-For',
-     *     'X-Forwarded-Host',
-     *     'X-Forwarded-Proto',
-     *     'X-Rewrite-Url',
-     *     'X-Original-Host',
-     *     'CF-Connecting-IP',
-     * ])
-     * ```
-     *
-     * @group Security
-     *
-     * @see $secureHeaders
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. [Configure trusted proxies instead](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies).')]
-    public function secureHeaders(?array $value): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.secureHeaders', 'Calling secureHeaders() is deprecated. [Configure trusted proxies instead](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies)'));
-
-        $this->secureHeaders = $value;
-
-        if (! $value) {
-            return $this;
-        }
-
-        $headerMap = [
-            'X-Forwarded-For' => Request::HEADER_X_FORWARDED_FOR,
-            'X-Forwarded-Host' => Request::HEADER_X_FORWARDED_HOST,
-            'X-Forwarded-Port' => Request::HEADER_X_FORWARDED_PORT,
-            'X-Forwarded-Proto' => Request::HEADER_X_FORWARDED_PROTO,
-            'X-Forwarded-Aws-ELB' => Request::HEADER_X_FORWARDED_AWS_ELB,
-            'X-Forwarded-Traefik' => Request::HEADER_X_FORWARDED_TRAEFIK,
-        ];
-
-        $bitmask = 0;
-        foreach ($value as $header) {
-            if (isset($headerMap[$header])) {
-                $bitmask |= $headerMap[$header];
-            }
-        }
-
-        TrustProxies::withHeaders($bitmask);
-
-        return $this;
-    }
-
-    /**
-     * List of headers to check for determining whether the connection is made via HTTPS.
-     *
-     * See [[\yii\web\Request::secureProtocolHeaders]] for more details.
-     *
-     * If not set, the default [[\yii\web\Request::secureProtocolHeaders]] value will be used.
-     *
-     * ```php
-     * ->secureProtocolHeaders([
-     *     'X-Forwarded-Proto' => [
-     *         'https',
-     *     ],
-     *     'Front-End-Https' => [
-     *         'on',
-     *     ],
-     *     'CF-Visitor' => [
-     *         '{\"scheme\":\"https\"}',
-     *     ],
-     * ])
-     * ```
-     *
-     * @group Security
-     *
-     * @see $secureProtocolHeaders
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. This method no longer configures anything.')]
-    public function secureProtocolHeaders(?array $value): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.secureProtocolHeaders', 'Calling secureProtocolHeaders() is deprecated.'));
-
-        $this->secureProtocolHeaders = $value;
-
-        return $this;
-    }
-
-    /**
-     * A private, random, cryptographically-secure key that is used for hashing and encrypting data in [[\craft\services\Security]].
-     *
-     * ::: warning
-     * **Do not** share this key publicly. If exposed, it could lead to a compromised system.
-     * :::
-     *
-     * In the event that the key is compromised, a new secure key can be generated with the command:
-     *
-     * ```sh
-     * php craft setup/security-key
-     * ```
-     *
-     * Note that if the key changes, any data that is encrypted with it (e.g. user session cookies) will be inaccessible.
-     *
-     * ```php
-     * ->securityKey('2cf24dba5...')
-     * ```
-     *
-     * @group Security
-     *
-     * @see $securityKey
-     * @see https://craftcms.com/knowledge-base/securing-craft
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. Configure `app.key` or set `APP_KEY` in your environment instead.')]
-    public function securityKey(string $value): self
-    {
-        $this->securityKey = $value;
-
-        app()->booting(function () use ($value) {
-            Deprecator::log('generalConfig.securityKey', 'Calling securityKey() is deprecated.');
-            Config::set('app.key', $value);
-        });
 
         return $this;
     }
@@ -6949,35 +6137,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * Configures Craft to send all system emails to either a single email address or an array of email addresses
-     * for testing purposes.
-     *
-     * The timezone of the site. If set, it will take precedence over the Timezone setting in Settings → General.
-     *
-     * This can be set to one of PHP’s [supported timezones](https://php.net/manual/en/timezones.php).
-     *
-     * ```php
-     * ->timezone('Europe/London')
-     * ```
-     *
-     * @group System
-     *
-     * @see $timezone
-     */
-    #[Deprecated(message: "in 6.0.0. Laravel's `app.timezone` config variable should be used instead.")]
-    public function timezone(?string $value): self
-    {
-        app()->booting(function () use ($value) {
-            Deprecator::log('generalConfig.timezone', 'Calling timezone() is deprecated. Laravel\'s `app.timezone` config variable should be used instead.');
-            Config::set('app.timezone', $value);
-        });
-
-        $this->timezone = $value;
-
-        return $this;
-    }
-
-    /**
      * Whether GIF files should be cleansed/transformed.
      *
      * ```php
@@ -7038,36 +6197,6 @@ class GeneralConfig extends BaseConfig
     public function translationDebugOutput(bool $value = true): self
     {
         $this->translationDebugOutput = $value;
-
-        return $this;
-    }
-
-    /**
-     * The configuration for trusted security-related headers.
-     *
-     * See [[\yii\web\Request::trustedHosts]] for more details.
-     *
-     * By default, all hosts are trusted.
-     *
-     * ```php
-     * ->trustedHosts(['trusted-one.foo', 'trusted-two.foo'])
-     * ```
-     *
-     * @group Security
-     *
-     * @see $trustedHosts
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. [Configure trusted proxies instead](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies).')]
-    public function trustedHosts(array $value): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.trustedHosts', 'Calling secureProtocolHeaders() is deprecated. [Configure trusted proxies instead](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies).'));
-
-        $this->trustedHosts = $value;
-
-        if (! empty($value)) {
-            TrustProxies::at($value);
-        }
 
         return $this;
     }
@@ -7195,58 +6324,6 @@ class GeneralConfig extends BaseConfig
     }
 
     /**
-     * Whether Craft should specify the path using `PATH_INFO` or as a query string parameter when generating URLs.
-     *
-     * This setting only takes effect if <config5:omitScriptNameInUrls> is set to `false`.
-     *
-     * ```php
-     * ->usePathInfo(true)
-     * ```
-     *
-     * @group Routing
-     *
-     * @see $usePathInfo
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. This setting no longer has any effect.')]
-    public function usePathInfo(bool $value = true): self
-    {
-        app()->booting(fn () => Deprecator::log('generalConfig.usePathInfo', 'Calling usePathInfo() is deprecated. This setting no longer has any effect.'));
-
-        $this->usePathInfo = $value;
-
-        return $this;
-    }
-
-    /**
-     * Whether Craft will set the “secure” flag when saving cookies when using `Craft::cookieConfig()` to create a cookie.
-     *
-     * Valid values are `true`, `false`, and `'auto'`. Defaults to `'auto'`, which will set the secure flag if the page you’re currently accessing
-     * is over `https://`. `true` will always set the flag, regardless of protocol and `false` will never automatically set the flag.
-     *
-     * ```php
-     * ->useSecureCookies(true)
-     * ```
-     *
-     * @group Security
-     *
-     * @see $useSecureCookies
-     * @since 4.2.0
-     */
-    #[Deprecated(message: 'in 6.0.0. Configure `session.secure` or set `SESSION_SECURE_COOKIE` in your environment instead.')]
-    public function useSecureCookies(string|bool $value): self
-    {
-        app()->booting(function () use ($value) {
-            Deprecator::log('generalConfig.useSecureCookies', 'Calling useSecureCookies() is deprecated. Configure `session.secure` or set `SESSION_SECURE_COOKIE` in your environment instead.');
-            Config::set('session.secure', $value === 'auto' ? null : $value);
-        });
-
-        $this->useSecureCookies = $value;
-
-        return $this;
-    }
-
-    /**
      * Determines what protocol/schema Craft will use when generating tokenized URLs. If set to `'auto'`, Craft will check the
      * current site’s base URL and the protocol of the current request and if either of them are HTTPS will use `https` in the tokenized URL. If not,
      * will use `http`.
@@ -7264,32 +6341,6 @@ class GeneralConfig extends BaseConfig
     public function useSslOnTokenizedUrls(string|bool $value): self
     {
         $this->useSslOnTokenizedUrls = $value;
-
-        return $this;
-    }
-
-    /**
-     * The amount of time before a user will get logged out due to inactivity.
-     *
-     * Set to `0` if you want users to stay logged in as long as their browser is open rather than a predetermined amount of time.
-     *
-     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
-     *
-     * ```php
-     * // 3 hours
-     * ->userSessionDuration(10800)
-     * ```
-     *
-     * @group Session
-     *
-     * @defaultAlt 1 hour
-     *
-     * @see $userSessionDuration
-     */
-    #[Deprecated(message: "configure sessions using Laravel's session config instead.", since: '6.0.0')]
-    public function userSessionDuration(mixed $value): self
-    {
-        $this->userSessionDuration = ConfigHelper::durationInSeconds($value);
 
         return $this;
     }

--- a/tests/Unit/Config/GeneralConfigTest.php
+++ b/tests/Unit/Config/GeneralConfigTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use craft\config\GeneralConfig as LegacyGeneralConfig;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Config\ConfigServiceProvider;
 use CraftCms\Cms\Config\GeneralConfig;
@@ -59,4 +60,24 @@ it('can set trackedQueueNames via fluent setter', function () {
     $config = GeneralConfig::create()->trackedQueueNames(['craft', 'default']);
 
     expect($config->trackedQueueNames)->toBe(['craft', 'default']);
+});
+
+it('does not expose moved deprecated members on the new class', function () {
+    $config = GeneralConfig::create();
+
+    expect(method_exists($config, 'devMode'))->toBeFalse()
+        ->and(method_exists($config, 'enableCsrfProtection'))->toBeFalse()
+        ->and(method_exists($config, 'securityKey'))->toBeFalse()
+        ->and(property_exists($config, 'allowedGraphqlOrigins'))->toBeFalse()
+        ->and(property_exists($config, 'userSessionDuration'))->toBeFalse();
+});
+
+it('keeps moved deprecated members on the legacy class', function () {
+    $config = LegacyGeneralConfig::create();
+
+    expect(method_exists($config, 'devMode'))->toBeTrue()
+        ->and(method_exists($config, 'enableCsrfProtection'))->toBeTrue()
+        ->and(method_exists($config, 'securityKey'))->toBeTrue()
+        ->and(property_exists($config, 'allowedGraphqlOrigins'))->toBeTrue()
+        ->and(property_exists($config, 'userSessionDuration'))->toBeTrue();
 });

--- a/yii2-adapter/legacy/config/GeneralConfig.php
+++ b/yii2-adapter/legacy/config/GeneralConfig.php
@@ -307,7 +307,10 @@ class GeneralConfig extends \CraftCms\Cms\Config\GeneralConfig
             ->cooldownDuration($this->cooldownDuration)
             ->defaultTokenDuration($this->defaultTokenDuration)
             ->invalidLoginWindowDuration($this->invalidLoginWindowDuration)
-            ->previewTokenDuration($this->previewTokenDuration ?? $this->defaultTokenDuration)
+            ->previewTokenDuration($this->previewTokenDuration ?? $this->defaultTokenDuration);
+
+        $this
+            // legacy-only durations
             ->purgeStaleUserSessionDuration($this->purgeStaleUserSessionDuration)
             ->purgePendingUsersDuration($this->purgePendingUsersDuration)
             ->purgeUnsavedDraftsDuration($this->purgeUnsavedDraftsDuration)

--- a/yii2-adapter/legacy/config/GeneralConfig.php
+++ b/yii2-adapter/legacy/config/GeneralConfig.php
@@ -8,8 +8,13 @@
 namespace craft\config;
 
 use craft\services\Config;
+use CraftCms\Cms\Support\Config as ConfigHelper;
 use CraftCms\Cms\Support\Facades\Deprecator;
 use Deprecated;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config as ConfigFacade;
 use yii\base\InvalidConfigException;
 
 use function CraftCms\Cms\t;
@@ -38,6 +43,251 @@ class GeneralConfig extends \CraftCms\Cms\Config\GeneralConfig
      * @inheritdoc
      */
     protected ?string $filename = Config::CATEGORY_GENERAL;
+
+    /**
+     * @var string[]|null|false The Ajax origins that should be allowed to access the GraphQL API, if enabled.
+     *
+     * If this is set to an array, then `graphql/api` requests will only include the current request’s [[\yii\web\Request::getOrigin()|origin]]
+     * in the `Access-Control-Allow-Origin` response header if it’s listed here.
+     *
+     * If this is set to `false`, then the `Access-Control-Allow-Origin` response header will never be sent.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->allowedGraphqlOrigins(false)
+     * ```
+     * ```shell Environment Override
+     * CRAFT_ALLOW_GRAPHQL_ORIGINS=false
+     * ```
+     * :::
+     *
+     * @group GraphQL
+     *
+     * @since 3.5.0
+     * @deprecated in 4.11.0. [[\craft\filters\Cors]] should be used instead.
+     * @see https://www.yiiframework.com/doc/api/2.0/yii-filters-cors
+     */
+    public array|null|false $allowedGraphqlOrigins = null;
+
+    /**
+     * @var bool Whether drafts should be saved automatically as they are edited.
+     *
+     * Note that drafts *will* be autosaved while Live Preview is open, regardless of this setting.
+     *
+     * ::: code
+     *  ```php Static Config
+     *  ->autosaveDrafts(false)
+     *  ```
+     * ```shell Environment Override
+     * CRAFT_AUTOSAVE_DRAFTS=false
+     * ```
+     * :::
+     *
+     * @group System
+     *
+     * @since 3.5.6
+     * @deprecated in 4.0.0
+     */
+    public bool $autosaveDrafts = true;
+
+    /**
+     * @var int The higher the cost value, the longer it takes to generate a password hash and to verify against it.
+     *
+     * Therefore, higher cost slows down a brute-force attack.
+     *
+     * For best protection against brute force attacks, set it to the highest value that is tolerable on production servers.
+     *
+     * The time taken to compute the hash doubles for every increment by one for this value.
+     *
+     * For example, if the hash takes 1 second to compute when the value is 14 then the compute time varies as
+     * 2^(value - 14) seconds.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->blowfishHashCost(15)
+     * ```
+     * ```shell Environment Override
+     * CRAFT_BLOWFISH_HASH_COST=15
+     * ```
+     * :::
+     *
+     * @group Security
+     *
+     * @deprecated 6.0.0. Set hashing.bcrypt.rounds or BCRYPT_ROUNDS environment variable instead.
+     */
+    public int $blowfishHashCost = 13;
+
+    /**
+     * @var bool Whether the `@transform` directive should be disabled for the GraphQL API.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->disableGraphqlTransformDirective(true)
+     * ```
+     * ```shell Environment Override
+     * CRAFT_DISABLE_GRAPHQL_TRANSFORM_DIRECTIVE=true
+     * ```
+     * :::
+     *
+     * ::: tip
+     * As of Craft 5.9.0, the `@transform` directive can be optionally included for each GraphQL schema,
+     * unless this setting is set to `true`.
+     * :::
+     *
+     * @group GraphQL
+     *
+     * @since 3.6.0
+     * @deprecated in 5.9.0
+     */
+    public bool $disableGraphqlTransformDirective = false;
+
+    /**
+     * @var string|null The `Permissions-Policy` header that should be sent for site responses.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->permissionsPolicyHeader('Permissions-Policy: geolocation=(self)')
+     * ```
+     * ```shell Environment Override
+     * CRAFT_PERMISSIONS_POLICY_HEADER=Permissions-Policy: geolocation=(self)
+     * ```
+     * :::
+     *
+     * @group System
+     *
+     * @since 3.6.14
+     * @deprecated in 4.11.0. [[\craft\filters\Headers]] should be used instead.
+     */
+    public ?string $permissionsPolicyHeader = null;
+
+    /**
+     * @var string The name of the PHP session cookie.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->phpSessionName(null)
+     * ```
+     * ```shell Environment Override
+     * CRAFT_PHP_SESSION_NAME=
+     * ```
+     * :::
+     *
+     * @see https://php.net/manual/en/function.session-name.php
+     *
+     * @group Session
+     *
+     * @deprecated 6.0.0 configure sessions using Laravel's session config instead.
+     */
+    public string $phpSessionName = 'CraftSessionId';
+
+    /**
+     * @var mixed The amount of time to wait before Craft purges stale user sessions from the sessions table in the database.
+     *
+     * Set to `0` to disable this feature.
+     *
+     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
+     *
+     * ::: code
+     * ```php Static Config
+     * // 1 week
+     * ->purgeStaleUserSessionDuration(604800)
+     * ```
+     * ```shell Environment Override
+     * # 1 week
+     * CRAFT_PURGE_STALE_USER_SESSION_DURATION=604800
+     * ```
+     * :::
+     *
+     * @group Garbage Collection
+     *
+     * @defaultAlt 90 days
+     *
+     * @since 3.3.0
+     * @deprecated 6.0.0 configure sessions using Laravel's session config instead.
+     */
+    public mixed $purgeStaleUserSessionDuration = 7776000;
+
+    /**
+     * @var bool Whether Craft should require a matching user agent string when restoring a user session from a cookie.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->requireMatchingUserAgentForSession(false)
+     * ```
+     * ```shell Environment Override
+     * CRAFT_REQUIRE_MATCHING_USER_AGENT_FOR_SESSION=false
+     * ```
+     * :::
+     *
+     * @group Session
+     *
+     * @deprecated 6.0.0
+     */
+    public bool $requireMatchingUserAgentForSession = true;
+
+    /**
+     * @var bool Whether Craft should require the existence of a user agent string and IP address when creating a new user session.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->requireUserAgentAndIpForSession(false)
+     * ```
+     * ```shell Environment Override
+     * CRAFT_REQUIRE_USER_AGENT_AND_IP_FOR_SESSION=false
+     * ```
+     * :::
+     *
+     * @group Session
+     *
+     * @deprecated 6.0.0
+     */
+    public bool $requireUserAgentAndIpForSession = true;
+
+    /**
+     * @var string|null The timezone of the site. If set, it will take precedence over the Timezone setting in Settings → General.
+     *
+     * This can be set to one of PHP’s [supported timezones](https://php.net/manual/en/timezones.php).
+     *
+     * ::: code
+     * ```php Static Config
+     * ->timezone('Europe/London')
+     * ```
+     * ```shell Environment Override
+     * CRAFT_TIMEZONE=Europe/London
+     * ```
+     * :::
+     *
+     * @group System
+     *
+     * @deprecated in 6.0.0. Laravel's `app.timezone` config variable should be used instead.
+     */
+    public ?string $timezone = null;
+
+    /**
+     * @var mixed The amount of time before a user will get logged out due to inactivity.
+     *
+     * Set to `0` if you want users to stay logged in as long as their browser is open rather than a predetermined amount of time.
+     *
+     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
+     *
+     * ::: code
+     * ```php Static Config
+     * // 3 hours
+     * ->userSessionDuration(10800)
+     * ```
+     * ```shell Environment Override
+     * # 3 hours
+     * CRAFT_USER_SESSION_DURATION=10800
+     * ```
+     * :::
+     *
+     * @group Session
+     *
+     * @defaultAlt 1 hour
+     *
+     * @deprecated 6.0.0
+     */
+    public mixed $userSessionDuration = 3600;
 
     /**
      * @inheritdoc
@@ -72,6 +322,684 @@ class GeneralConfig extends \CraftCms\Cms\Config\GeneralConfig
             ->maxUploadFileSize($this->maxUploadFileSize)
             ->disabledPlugins($this->disabledPlugins)
         ;
+    }
+
+    /**
+     * The Ajax origins that should be allowed to access the GraphQL API, if enabled.
+     *
+     * If this is set to an array, then `graphql/api` requests will only include the current request’s [[\yii\web\Request::getOrigin()|origin]]
+     * in the `Access-Control-Allow-Origin` response header if it’s listed here.
+     *
+     * If this is set to `false`, then the `Access-Control-Allow-Origin` response header will never be sent.
+     *
+     * ```php
+     * ->allowedGraphqlOrigins(false)
+     * ```
+     *
+     * @group GraphQL
+     *
+     * @see $allowedGraphqlOrigins
+     * @since 4.2.0
+     * @see https://www.yiiframework.com/doc/api/2.0/yii-filters-cors
+     */
+    #[Deprecated(message: 'in 4.11.0. [[\craft\filters\Cors]] should be used instead.')]
+    public function allowedGraphqlOrigins(array|null|false $value): self
+    {
+        $this->allowedGraphqlOrigins = $value;
+
+        return $this;
+    }
+    /**
+     * The higher the cost value, the longer it takes to generate a password hash and to verify against it.
+     *
+     * Therefore, higher cost slows down a brute-force attack.
+     *
+     * For best protection against brute force attacks, set it to the highest value that is tolerable on production servers.
+     *
+     * The time taken to compute the hash doubles for every increment by one for this value.
+     *
+     * For example, if the hash takes 1 second to compute when the value is 14 then the compute time varies as
+     * 2^(value - 14) seconds.
+     *
+     * ```php
+     * ->blowfishHashCost(15)
+     * ```
+     *
+     * @group Security
+     *
+     * @see $blowfishHashCost
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. Set hashing.bcrypt.rounds or BCRYPT_ROUNDS environment variable instead.')]
+    public function blowfishHashCost(int $value): self
+    {
+        app()->booting(function() use ($value) {
+            ConfigFacade::set('hashing.bcrypt.rounds', $value);
+            Deprecator::log('generalConfig.blowfishHashCost', 'blowfishHashCost is deprecated. Set hashing.bcrypt.rounds or BCRYPT_ROUNDS instead.');
+        });
+
+        $this->blowfishHashCost = $value;
+
+        return $this;
+    }
+    /**
+     * The name of CSRF token used for CSRF validation if <config5:enableCsrfProtection> is set to `true`.
+     *
+     * ```php
+     * ->csrfTokenName('MY_CSRF')
+     * ```
+     *
+     * @group Security
+     *
+     * @see $csrfTokenName
+     * @see enableCsrfProtection
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. Calling csrfTokenName() is deprecated. The token is always named XSRF-TOKEN.')]
+    public function csrfTokenName(string $value): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.csrfTokenName', 'Calling csrfTokenName() is deprecated. The token is always named XSRF-TOKEN.'));
+
+        $this->csrfTokenName = $value;
+
+        return $this;
+    }
+    /**
+     * Whether the system should run in [Dev Mode](https://craftcms.com/support/dev-mode).
+     *
+     * ```php
+     * ->devMode(true)
+     * ```
+     *
+     * @group System
+     *
+     * @see $devMode
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. Set `app.debug` or `APP_DEBUG` environment variable instead.')]
+    public function devMode(bool $value = true): self
+    {
+        app()->booting(function() use ($value) {
+            Deprecator::log('generalConfig.devMode', 'devMode is deprecated. Set `app.debug` or `APP_DEBUG` environment variable instead.');
+            ConfigFacade::set('app.debug', $value);
+        });
+
+        $this->devMode = $value;
+
+        return $this;
+    }
+    /**
+     * Whether the `@transform` directive should be disabled for the GraphQL API.
+     *
+     * ```php
+     * ->disableGraphqlTransformDirective(true)
+     * ```
+     *
+     * ::: tip
+     * As of Craft 5.9.0, the `@transform` directive can be optionally included for each GraphQL schema,
+     * unless this setting is set to `true`.
+     * :::
+     *
+     * @group GraphQL
+     *
+     * @see $disableGraphqlTransformDirective
+     */
+    public function disableGraphqlTransformDirective(bool $value = true): self
+    {
+        $this->disableGraphqlTransformDirective = $value;
+
+        return $this;
+    }
+    /**
+     * Whether to use a cookie to persist the CSRF token if <config5:enableCsrfProtection> is enabled. If false, the CSRF token will be
+     * stored in session under the `csrfTokenName` config setting name. Note that while storing CSRF tokens in session increases security,
+     * it requires starting a session for every page that a CSRF token is needed, which may degrade site performance.
+     *
+     * ```php
+     * ->enableCsrfCookie(false)
+     * ```
+     *
+     * @group Security
+     *
+     * @see $enableCsrfCookie
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. A cookie will always be used to persist the CSRF token.')]
+    public function enableCsrfCookie(bool $value = true): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.enableCsrfCookie', 'A cookie will always be used to persist the CSRF token.'));
+
+        $this->enableCsrfCookie = $value;
+
+        return $this;
+    }
+    /**
+     * Whether to enable CSRF protection via hidden form inputs for all forms submitted via Craft.
+     *
+     * ```php
+     * ->enableCsrfProtection(false)
+     * ```
+     *
+     * @group Security
+     *
+     * @see $enableCsrfProtection
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. [Configure excluded routes instead](https://laravel.com/docs/12.x/csrf#csrf-excluding-uris)')]
+    public function enableCsrfProtection(bool $value = true): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.enableCsrfProtection', 'Configure excluded routes instead.'));
+
+        $this->enableCsrfProtection = $value;
+
+        if ($value === false) {
+            VerifyCsrfToken::except(['*']);
+        }
+
+        return $this;
+    }
+    /**
+     * The amount of time a user’s elevated session will last, which is required for some sensitive actions (e.g. user group/permission assignment).
+     *
+     * Set to `0` to disable elevated session support.
+     *
+     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
+     *
+     * ```php
+     * ->elevatedSessionDuration(0)
+     * ```
+     *
+     * @group Security
+     *
+     * @defaultAlt 5 minutes
+     *
+     * @see $elevatedSessionDuration
+     */
+    #[Deprecated(message: 'use the `auth.password_timeout` config setting instead.', since: '6.0.0')]
+    public function elevatedSessionDuration(mixed $value): self
+    {
+        $this->elevatedSessionDuration = ConfigHelper::durationInSeconds($value);
+
+        app()->booting(function() {
+            Deprecator::log('generalConfig.elevatedSessionDuration', 'Use the `auth.password_timeout` config setting instead.');
+            ConfigFacade::set('auth.password_timeout', $this->elevatedSessionDuration === 0 ? -1 : $this->elevatedSessionDuration);
+        });
+
+        return $this;
+    }
+    /**
+     * Whether user-defined Twig templates should be sandboxed.
+     *
+     * ```php
+     * ->enableTwigSandbox()
+     * ```
+     *
+     * @group Security
+     *
+     * @see $enableTwigSandbox
+     */
+    #[Deprecated(message: 'in 6.0.0. Sandbox is always enabled.')]
+    public function enableTwigSandbox(bool $value = true): self
+    {
+        $this->enableTwigSandbox = $value;
+
+        return $this;
+    }
+    /**
+     * Whether generated URLs should omit `index.php` (e.g. `http://my-project.tld/path` instead of `http://my-project.tld/index.php/path`)
+     *
+     * This can only be possible if your server is configured to redirect would-be 404s to `index.php`, for example, with the redirect found
+     * in the `.htaccess` file that came with Craft:
+     *
+     * ```
+     * RewriteEngine On
+     * RewriteCond %{REQUEST_FILENAME} !-f
+     * RewriteCond %{REQUEST_FILENAME} !-d
+     * RewriteRule (.+) /index.php?p=$1 [QSA,L]
+     * ```
+     *
+     * ```php
+     * ->omitScriptNameInUrls(true)
+     * ```
+     *
+     * @group Routing
+     *
+     * @see $omitScriptNameInUrls
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. Script name is now always omitted.')]
+    public function omitScriptNameInUrls(bool $value = true): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.omitScriptNameInUrls', 'Calling omitScriptNameInUrls() is deprecated. Script name is now always omitted.'));
+
+        $this->omitScriptNameInUrls = $value;
+
+        return $this;
+    }
+    /**
+     * The query string param that Craft will check when determining the request’s path.
+     *
+     * This can be set to `null` if your web server is capable of directing traffic to `index.php` without a query string param.
+     * If you’re using Apache, that means you’ll need to change the `RewriteRule` line in your `.htaccess` file to:
+     *
+     * ```
+     * RewriteRule (.+) index.php [QSA,L]
+     * ```
+     *
+     * ```php
+     * ->pathParam(null)
+     * ```
+     *
+     * @group Routing
+     *
+     * @see $pathParam
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. This method no longer does anything.')]
+    public function pathParam(?string $value): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.pathParam', 'Calling pathParam() is deprecated.'));
+
+        $this->pathParam = $value;
+
+        return $this;
+    }
+    /**
+     * The `Permissions-Policy` header that should be sent for web responses.
+     *
+     * ```php
+     * ->permissionsPolicyHeader('Permissions-Policy: geolocation=(self)')
+     * ```
+     *
+     * @group System
+     *
+     * @see $permissionsPolicyHeader
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 4.11.0. [[\craft\filters\Headers]] should be used instead.')]
+    public function permissionsPolicyHeader(?string $value): self
+    {
+        $this->permissionsPolicyHeader = $value;
+
+        return $this;
+    }
+    /**
+     * The name of the PHP session cookie.
+     *
+     * ```php
+     * ->phpSessionName(null)
+     * ```
+     *
+     * @group Session
+     *
+     * @see $phpSessionName
+     * @see https://php.net/manual/en/function.session-name.php
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. Configure `session.cookie` or set `SESSION_COOKIE` environment variable.')]
+    public function phpSessionName(string $value): self
+    {
+        $this->phpSessionName = $value;
+
+        app()->booting(function() use ($value) {
+            Deprecator::log('generalConfig.phpSessionName', 'Calling phpSessionName() is deprecated. Configure `session.cookie` or set `SESSION_COOKIE` environment variable.');
+            ConfigFacade::set('session.cookie', $value);
+        });
+
+        return $this;
+    }
+    /**
+     * The amount of time to wait before Craft purges stale user sessions from the sessions table in the database.
+     *
+     * Set to `0` to disable this feature.
+     *
+     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
+     *
+     * ```php
+     * // 1 week
+     * ->purgeStaleUserSessionDuration(604800)
+     * ```
+     *
+     * @group Garbage Collection
+     *
+     * @defaultAlt 90 days
+     *
+     * @see $purgeStaleUserSessionDuration
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. This method no longer does anything, sessions are cleaned up on a lottery basis when needed.')]
+    public function purgeStaleUserSessionDuration(mixed $value): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.purgeStaleUserSessionDuration', 'Calling purgeStaleUserSessionDuration() is deprecated. Sessions are cleaned up on a lottery basis when needed.'));
+
+        $this->purgeStaleUserSessionDuration = ConfigHelper::durationInSeconds($value);
+
+        return $this;
+    }
+    /**
+     * Whether Craft should require a matching user agent string when restoring a user session from a cookie.
+     *
+     * ```php
+     * ->requireMatchingUserAgentForSession(false)
+     * ```
+     *
+     * @group Session
+     *
+     * @see $requireMatchingUserAgentForSession
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. This method no longer configures anything.')]
+    public function requireMatchingUserAgentForSession(bool $value = true): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.requireMatchingUserAgentForSession', 'Calling requireMatchingUserAgentForSession() is deprecated.'));
+
+        $this->requireMatchingUserAgentForSession = $value;
+
+        return $this;
+    }
+    /**
+     * Whether Craft should require the existence of a user agent string and IP address when creating a new user session.
+     *
+     * ```php
+     * ->requireUserAgentAndIpForSession(false)
+     * ```
+     *
+     * @group Session
+     *
+     * @see $requireUserAgentAndIpForSession
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. This method no longer configures anything.')]
+    public function requireUserAgentAndIpForSession(bool $value = true): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.requireUserAgentAndIpForSession', 'Calling requireUserAgentAndIpForSession() is deprecated.'));
+
+        $this->requireUserAgentAndIpForSession = $value;
+
+        return $this;
+    }
+    /**
+     * The [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) value that should be set on Craft cookies, if any.
+     *
+     * This can be set to `'None'`, `'Lax'`, `'Strict'`, or `null`.
+     *
+     * ```php
+     * ->sameSiteCookieValue('Strict')
+     * ```
+     *
+     * @group System
+     *
+     * @phpstan-param 'None'|'Lax'|'Strict'|null $value
+     *
+     * @see $sameSiteCookieValue
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. Configure `cookie.same_site` or set `SESSION_SAME_SITE` environment variable instead.')]
+    public function sameSiteCookieValue(?string $value): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.sameSiteCookieValue', 'Calling sameSiteCookieValue() is deprecated. Configure `cookie.same_site` or set `SESSION_SAME_SITE` environment variable instead.'));
+
+        $this->sameSiteCookieValue = $value;
+
+        return $this;
+    }
+    /**
+     * Lists of headers that are, by default, subject to the trusted host configuration.
+     *
+     * See [[\yii\web\Request::secureHeaders]] for more details.
+     *
+     * If not set, the default [[\yii\web\Request::secureHeaders]] value will be used.
+     *
+     * ```php
+     * ->secureHeaders([
+     *     'X-Forwarded-For',
+     *     'X-Forwarded-Host',
+     *     'X-Forwarded-Proto',
+     *     'X-Rewrite-Url',
+     *     'X-Original-Host',
+     *     'CF-Connecting-IP',
+     * ])
+     * ```
+     *
+     * @group Security
+     *
+     * @see $secureHeaders
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. [Configure trusted proxies instead](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies).')]
+    public function secureHeaders(?array $value): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.secureHeaders', 'Calling secureHeaders() is deprecated. [Configure trusted proxies instead](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies)'));
+
+        $this->secureHeaders = $value;
+
+        if (!$value) {
+            return $this;
+        }
+
+        $headerMap = [
+            'X-Forwarded-For' => Request::HEADER_X_FORWARDED_FOR,
+            'X-Forwarded-Host' => Request::HEADER_X_FORWARDED_HOST,
+            'X-Forwarded-Port' => Request::HEADER_X_FORWARDED_PORT,
+            'X-Forwarded-Proto' => Request::HEADER_X_FORWARDED_PROTO,
+            'X-Forwarded-Aws-ELB' => Request::HEADER_X_FORWARDED_AWS_ELB,
+            'X-Forwarded-Traefik' => Request::HEADER_X_FORWARDED_TRAEFIK,
+        ];
+
+        $bitmask = 0;
+        foreach ($value as $header) {
+            if (isset($headerMap[$header])) {
+                $bitmask |= $headerMap[$header];
+            }
+        }
+
+        TrustProxies::withHeaders($bitmask);
+
+        return $this;
+    }
+    /**
+     * List of headers to check for determining whether the connection is made via HTTPS.
+     *
+     * See [[\yii\web\Request::secureProtocolHeaders]] for more details.
+     *
+     * If not set, the default [[\yii\web\Request::secureProtocolHeaders]] value will be used.
+     *
+     * ```php
+     * ->secureProtocolHeaders([
+     *     'X-Forwarded-Proto' => [
+     *         'https',
+     *     ],
+     *     'Front-End-Https' => [
+     *         'on',
+     *     ],
+     *     'CF-Visitor' => [
+     *         '{\"scheme\":\"https\"}',
+     *     ],
+     * ])
+     * ```
+     *
+     * @group Security
+     *
+     * @see $secureProtocolHeaders
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. This method no longer configures anything.')]
+    public function secureProtocolHeaders(?array $value): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.secureProtocolHeaders', 'Calling secureProtocolHeaders() is deprecated.'));
+
+        $this->secureProtocolHeaders = $value;
+
+        return $this;
+    }
+    /**
+     * A private, random, cryptographically-secure key that is used for hashing and encrypting data in [[\craft\services\Security]].
+     *
+     * ::: warning
+     * **Do not** share this key publicly. If exposed, it could lead to a compromised system.
+     * :::
+     *
+     * In the event that the key is compromised, a new secure key can be generated with the command:
+     *
+     * ```sh
+     * php craft setup/security-key
+     * ```
+     *
+     * Note that if the key changes, any data that is encrypted with it (e.g. user session cookies) will be inaccessible.
+     *
+     * ```php
+     * ->securityKey('2cf24dba5...')
+     * ```
+     *
+     * @group Security
+     *
+     * @see $securityKey
+     * @see https://craftcms.com/knowledge-base/securing-craft
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. Configure `app.key` or set `APP_KEY` in your environment instead.')]
+    public function securityKey(string $value): self
+    {
+        $this->securityKey = $value;
+
+        app()->booting(function() use ($value) {
+            Deprecator::log('generalConfig.securityKey', 'Calling securityKey() is deprecated.');
+            ConfigFacade::set('app.key', $value);
+        });
+
+        return $this;
+    }
+    /**
+     * Configures Craft to send all system emails to either a single email address or an array of email addresses
+     * for testing purposes.
+     *
+     * The timezone of the site. If set, it will take precedence over the Timezone setting in Settings → General.
+     *
+     * This can be set to one of PHP’s [supported timezones](https://php.net/manual/en/timezones.php).
+     *
+     * ```php
+     * ->timezone('Europe/London')
+     * ```
+     *
+     * @group System
+     *
+     * @see $timezone
+     */
+    #[Deprecated(message: "in 6.0.0. Laravel's `app.timezone` config variable should be used instead.")]
+    public function timezone(?string $value): self
+    {
+        app()->booting(function() use ($value) {
+            Deprecator::log('generalConfig.timezone', 'Calling timezone() is deprecated. Laravel\'s `app.timezone` config variable should be used instead.');
+            ConfigFacade::set('app.timezone', $value);
+        });
+
+        $this->timezone = $value;
+
+        return $this;
+    }
+    /**
+     * The configuration for trusted security-related headers.
+     *
+     * See [[\yii\web\Request::trustedHosts]] for more details.
+     *
+     * By default, all hosts are trusted.
+     *
+     * ```php
+     * ->trustedHosts(['trusted-one.foo', 'trusted-two.foo'])
+     * ```
+     *
+     * @group Security
+     *
+     * @see $trustedHosts
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. [Configure trusted proxies instead](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies).')]
+    public function trustedHosts(array $value): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.trustedHosts', 'Calling secureProtocolHeaders() is deprecated. [Configure trusted proxies instead](https://laravel.com/docs/12.x/requests#configuring-trusted-proxies).'));
+
+        $this->trustedHosts = $value;
+
+        if (!empty($value)) {
+            TrustProxies::at($value);
+        }
+
+        return $this;
+    }
+    /**
+     * Whether Craft should specify the path using `PATH_INFO` or as a query string parameter when generating URLs.
+     *
+     * This setting only takes effect if <config5:omitScriptNameInUrls> is set to `false`.
+     *
+     * ```php
+     * ->usePathInfo(true)
+     * ```
+     *
+     * @group Routing
+     *
+     * @see $usePathInfo
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. This setting no longer has any effect.')]
+    public function usePathInfo(bool $value = true): self
+    {
+        app()->booting(fn() => Deprecator::log('generalConfig.usePathInfo', 'Calling usePathInfo() is deprecated. This setting no longer has any effect.'));
+
+        $this->usePathInfo = $value;
+
+        return $this;
+    }
+    /**
+     * Whether Craft will set the “secure” flag when saving cookies when using `Craft::cookieConfig()` to create a cookie.
+     *
+     * Valid values are `true`, `false`, and `'auto'`. Defaults to `'auto'`, which will set the secure flag if the page you’re currently accessing
+     * is over `https://`. `true` will always set the flag, regardless of protocol and `false` will never automatically set the flag.
+     *
+     * ```php
+     * ->useSecureCookies(true)
+     * ```
+     *
+     * @group Security
+     *
+     * @see $useSecureCookies
+     * @since 4.2.0
+     */
+    #[Deprecated(message: 'in 6.0.0. Configure `session.secure` or set `SESSION_SECURE_COOKIE` in your environment instead.')]
+    public function useSecureCookies(string|bool $value): self
+    {
+        app()->booting(function() use ($value) {
+            Deprecator::log('generalConfig.useSecureCookies', 'Calling useSecureCookies() is deprecated. Configure `session.secure` or set `SESSION_SECURE_COOKIE` in your environment instead.');
+            ConfigFacade::set('session.secure', $value === 'auto' ? null : $value);
+        });
+
+        $this->useSecureCookies = $value;
+
+        return $this;
+    }
+    /**
+     * The amount of time before a user will get logged out due to inactivity.
+     *
+     * Set to `0` if you want users to stay logged in as long as their browser is open rather than a predetermined amount of time.
+     *
+     * See {@see ConfigHelper::durationInSeconds()} for a list of supported value types.
+     *
+     * ```php
+     * // 3 hours
+     * ->userSessionDuration(10800)
+     * ```
+     *
+     * @group Session
+     *
+     * @defaultAlt 1 hour
+     *
+     * @see $userSessionDuration
+     */
+    #[Deprecated(message: "configure sessions using Laravel's session config instead.", since: '6.0.0')]
+    public function userSessionDuration(mixed $value): self
+    {
+        $this->userSessionDuration = ConfigHelper::durationInSeconds($value);
+
+        return $this;
     }
 
     /**

--- a/yii2-adapter/legacy/controllers/GraphqlController.php
+++ b/yii2-adapter/legacy/controllers/GraphqlController.php
@@ -95,7 +95,7 @@ class GraphqlController extends Controller
         $headers->setDefault('Access-Control-Allow-Credentials', 'true');
         $headers->setDefault('Access-Control-Allow-Headers', 'Authorization, Content-Type, X-Craft-Authorization, X-Craft-Token');
 
-        $generalConfig = Cms::config();
+        $generalConfig = Craft::$app->getConfig()->getGeneral();
         if (is_array($generalConfig->allowedGraphqlOrigins)) {
             if (($origins = $this->request->getOrigin()) !== null) {
                 $origins = Arr::whereNotEmpty(array_map('trim', explode(',', $origins)));

--- a/yii2-adapter/legacy/helpers/App.php
+++ b/yii2-adapter/legacy/helpers/App.php
@@ -832,7 +832,8 @@ class App
      */
     public static function userConfig(): array
     {
-        $generalConfig = Cms::config();
+        /** @var \craft\config\GeneralConfig $generalConfig */
+        $generalConfig = Craft::$app->getConfig()->getConfigSettings(\craft\services\Config::CATEGORY_GENERAL);
         $request = Craft::$app->getRequest();
 
         if ($request->getIsConsoleRequest() || $request->getIsSiteRequest()) {

--- a/yii2-adapter/legacy/services/Config.php
+++ b/yii2-adapter/legacy/services/Config.php
@@ -181,9 +181,12 @@ class Config extends Component
             Craft::configure($existingConfig, $config);
             $config = $existingConfig;
         } else {
-            $config = $category === self::CATEGORY_GENERAL
-                ? $configClass::__set_state($config)
-                : new $configClass($config);
+            if ($category === self::CATEGORY_GENERAL) {
+                $config = $configClass::__set_state($config);
+            } else {
+                /** @var class-string<DbConfig> $configClass */
+                $config = new $configClass($config);
+            }
         }
 
         $this->_loadingConfigFile = $loadingConfig;

--- a/yii2-adapter/legacy/services/Config.php
+++ b/yii2-adapter/legacy/services/Config.php
@@ -9,9 +9,9 @@ namespace craft\services;
 
 use Craft;
 use craft\config\DbConfig;
-use CraftCms\Cms\Cms;
+use craft\config\GeneralConfig as LegacyGeneralConfig;
 use CraftCms\Cms\Config\BaseConfig;
-use CraftCms\Cms\Config\GeneralConfig;
+use CraftCms\Cms\Config\GeneralConfig as NewGeneralConfig;
 use CraftCms\Cms\Support\Env;
 use CraftCms\Cms\Support\Facades\Deprecator;
 use CraftCms\Cms\Support\Typecast;
@@ -28,7 +28,7 @@ use yii\base\Component;
  * An instance of the service is available via [[\craft\base\ApplicationTrait::getConfig()|`Craft::$app->getConfig()`]].
  *
  * @property-read DbConfig $db the DB config settings
- * @property-read GeneralConfig $general the general config settings
+ * @property-read LegacyGeneralConfig $general the general config settings
  * @property-read object $custom the custom config settings
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
@@ -103,7 +103,7 @@ class Config extends Component
 
             if ($category !== self::CATEGORY_CUSTOM && isset($this->appType)) {
                 // See if an application type-specific config exists (general.web.php / general.console.php)
-                /** @var GeneralConfig|DbConfig $config */
+                /** @var LegacyGeneralConfig|DbConfig $config */
                 $config = $this->_createConfigObj($category, "$category.$this->appType", $config);
             }
 
@@ -115,29 +115,38 @@ class Config extends Component
 
     private function _createConfigObj(string $category, string $filename, BaseConfig|\craft\config\BaseConfig|null $existingConfig): object
     {
-        if ($category === self::CATEGORY_GENERAL) {
-            return Cms::config();
-        }
-
         $config = ConfigFacade::get("craft.$filename", []);
 
         if ($existingConfig && empty($config)) {
             return $existingConfig;
         }
 
-        switch ($category) {
-            case self::CATEGORY_CUSTOM:
-                return (object)$config;
-            case self::CATEGORY_DB:
-                $configClass = DbConfig::class;
-                $envPrefix = 'CRAFT_DB_';
-                break;
-            default:
-                throw new InvalidArgumentException("Invalid config category: $category");
+        if ($category === self::CATEGORY_GENERAL) {
+            $configClass = LegacyGeneralConfig::class;
+            $envPrefix = 'CRAFT_';
+
+            if ($config instanceof NewGeneralConfig) {
+                $config = LegacyGeneralConfig::__set_state($config->toArray());
+            }
+        } else {
+            switch ($category) {
+                case self::CATEGORY_CUSTOM:
+                    return (object)$config;
+                case self::CATEGORY_DB:
+                    $configClass = DbConfig::class;
+                    $envPrefix = 'CRAFT_DB_';
+                    break;
+                default:
+                    throw new InvalidArgumentException("Invalid config category: $category");
+            }
         }
 
         if (is_callable($config)) {
             $config = $config($existingConfig ?? $configClass::create());
+        }
+
+        if ($config instanceof NewGeneralConfig) {
+            $config = LegacyGeneralConfig::__set_state($config->toArray());
         }
 
         // Get any environment value overrides
@@ -172,7 +181,9 @@ class Config extends Component
             Craft::configure($existingConfig, $config);
             $config = $existingConfig;
         } else {
-            $config = new $configClass($config);
+            $config = $category === self::CATEGORY_GENERAL
+                ? $configClass::__set_state($config)
+                : new $configClass($config);
         }
 
         $this->_loadingConfigFile = $loadingConfig;
@@ -233,14 +244,15 @@ class Config extends Component
      * </a>
      * ```
      *
-     * @return GeneralConfig
+     * @return LegacyGeneralConfig
      * @deprecated in 6.0.0. Use `app(\CraftCms\Cms\Config\GeneralConfig::class)` (PHP) or `app.config.craft.general` (Twig) instead.
      */
-    public function getGeneral(): GeneralConfig
+    public function getGeneral(): LegacyGeneralConfig
     {
         Deprecator::log('Craft::$app->config->general', 'Craft::$app->config->general is deprecated. Use `CraftCms\Cms\Cms::config()` (PHP) or `app.config.craft.general` (Twig) instead.');
 
-        return Cms::config();
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getConfigSettings(self::CATEGORY_GENERAL);
     }
 
     /**

--- a/yii2-adapter/legacy/services/Gql.php
+++ b/yii2-adapter/legacy/services/Gql.php
@@ -1565,7 +1565,7 @@ class Gql extends Component
             }
 
             if (
-                !Cms::config()->disableGraphqlTransformDirective &&
+                !Craft::$app->getConfig()->getGeneral()->disableGraphqlTransformDirective &&
                 in_array('directive:transform', $schema->scope)
             ) {
                 $directiveClasses[] = Transform::class;

--- a/yii2-adapter/legacy/web/assets/cp/CpAsset.php
+++ b/yii2-adapter/legacy/web/assets/cp/CpAsset.php
@@ -247,7 +247,7 @@ JS;
             'apiParams' => app(Api::class)->apiParams,
             'appId' => Craft::$app->id,
             'autofocusPreferred' => $currentUser->getAutofocusPreferred(),
-            'autosaveDrafts' => $generalConfig->autosaveDrafts,
+            'autosaveDrafts' => Craft::$app->getConfig()->getGeneral()->autosaveDrafts,
             'canAccessQueueManager' => app(Utilities::class)->checkAuthorization(QueueManager::class),
             'dataAttributes' => Html::$dataAttributes,
             'defaultIndexCriteria' => [],


### PR DESCRIPTION
### Description

This keeps backwards compatibility for projects using the legacy config class in `general.php`, old methods and properties won't throw exceptions and set new config values where appropriate.