### PR TITLE
`tag()` improvement & heading functions

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -8,6 +8,8 @@
 - Added the `--to-default` option to `resave` commands. ([#18522](https://github.com/craftcms/cms/pull/18522))
 
 ### Development
+- Added the `heading()`/`h()` and `h1()`…`h6()` Twig functions. ([#18524](https://github.com/craftcms/cms/pull/18524))
+- The `tag()` function now accepts a string for its second argument. ([#18524](https://github.com/craftcms/cms/pull/18524)) 
 - `delete` GraphQL queries now have a `hardDelete` argument. ([#18511](https://github.com/craftcms/cms/pull/18511))
 
 ### Extensibility

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1713,15 +1713,17 @@ class Extension extends AbstractExtension implements GlobalsInterface
      * @return string
      * @since 3.3.0
      */
-    public function tagFunction(string $type, array $attributes = []): string
+    public function tagFunction(string $type, string|array $attributes = ''): string
     {
-        $html = ArrayHelper::remove($attributes, 'html', '');
-        $text = ArrayHelper::remove($attributes, 'text');
-
-        if ($text !== null) {
-            $html = Html::encode($text);
+        if (is_array($attributes)) {
+            $html = ArrayHelper::remove($attributes, 'html');
+            $text = ArrayHelper::remove($attributes, 'text');
+        } else {
+            $text = $attributes;
+            $attributes = [];
         }
 
+        $html ??= Html::encode($text ?? '');
         return Html::tag($type, $html, $attributes);
     }
 

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -1417,6 +1417,14 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFunction('attr', [Html::class, 'renderTagAttributes'], ['is_safe' => ['html']]),
             new TwigFunction('csrfInput', [Html::class, 'csrfInput'], ['is_safe' => ['html']]),
             new TwigFunction('failMessageInput', [Html::class, 'failMessageInput'], ['is_safe' => ['html']]),
+            new TwigFunction('h', [$this, 'headingFunction'], ['is_safe' => ['html'], 'needs_context' => true]),
+            new TwigFunction('h1', fn($c, $a) => $this->headingFunction($c, 1, $a), ['is_safe' => ['html'], 'needs_context' => true]),
+            new TwigFunction('h2', fn($c, $a) => $this->headingFunction($c, 2, $a), ['is_safe' => ['html'], 'needs_context' => true]),
+            new TwigFunction('h3', fn($c, $a) => $this->headingFunction($c, 3, $a), ['is_safe' => ['html'], 'needs_context' => true]),
+            new TwigFunction('h4', fn($c, $a) => $this->headingFunction($c, 4, $a), ['is_safe' => ['html'], 'needs_context' => true]),
+            new TwigFunction('h5', fn($c, $a) => $this->headingFunction($c, 5, $a), ['is_safe' => ['html'], 'needs_context' => true]),
+            new TwigFunction('h6', fn($c, $a) => $this->headingFunction($c, 6, $a), ['is_safe' => ['html'], 'needs_context' => true]),
+            new TwigFunction('heading', [$this, 'headingFunction'], ['is_safe' => ['html'], 'needs_context' => true]),
             new TwigFunction('hiddenInput', [Html::class, 'hiddenInput'], ['is_safe' => ['html']]),
             new TwigFunction('input', [Html::class, 'input'], ['is_safe' => ['html']]),
             new TwigFunction('ol', [Html::class, 'ol'], ['is_safe' => ['html']]),
@@ -1669,6 +1677,20 @@ class Extension extends AbstractExtension implements GlobalsInterface
         shuffle($arr);
 
         return $arr;
+    }
+
+    public function headingFunction(array $context, int $level, array|string $attributes = ''): string
+    {
+        if ($level < 1 || $level > 6) {
+            throw new InvalidArgumentException("Invalid heading level: $level");
+        }
+
+        // Increment from the base heading level?
+        if (isset($context['baseHeadingLevel']) && is_int($context['baseHeadingLevel'])) {
+            $level = min($level + ($context['baseHeadingLevel'] - 1), 6);
+        }
+
+        return $this->tagFunction("h$level", $attributes);
     }
 
     /**

--- a/tests/unit/web/twig/ExtensionTest.php
+++ b/tests/unit/web/twig/ExtensionTest.php
@@ -1120,6 +1120,16 @@ class ExtensionTest extends TestCase
     public function testTagFunction(): void
     {
         $this->testRenderResult(
+            '<p>Hello</p>',
+            '{{ tag("p", "Hello") }}'
+        );
+
+        $this->testRenderResult(
+            '<p>&lt;script&gt;alert(&#039;Hello&#039;);&lt;/script&gt;</p>',
+            '{{ tag("p", "<script>alert(\'Hello\');</script>") }}'
+        );
+
+        $this->testRenderResult(
             '<p class="foo">Hello</p>',
             '{{ tag("p", {text: "Hello", class: "foo"}) }}'
         );

--- a/tests/unit/web/twig/ExtensionTest.php
+++ b/tests/unit/web/twig/ExtensionTest.php
@@ -1146,6 +1146,62 @@ class ExtensionTest extends TestCase
     }
 
     /**
+     *
+     */
+    public function testHeadingFunctions(): void
+    {
+        for ($i = 1; $i <= 6; $i++) {
+            $this->testRenderResult(
+                "<h$i>Hello</h$i>",
+                "{{ heading($i, 'Hello') }}"
+            );
+            $this->testRenderResult(
+                "<h$i>Hello</h$i>",
+                "{{ h($i, 'Hello') }}"
+            );
+            $this->testRenderResult(
+                "<h$i>Hello</h$i>",
+                "{{ h$i('Hello') }}"
+            );
+        }
+
+        $this->testRenderResult(
+            '<h1>&lt;script&gt;alert(&#039;Hello&#039;);&lt;/script&gt;</h1>',
+            '{{ h1("<script>alert(\'Hello\');</script>") }}'
+        );
+
+        $this->testRenderResult(
+            '<h1 class="foo">Hello</h1>',
+            '{{ h1({text: "Hello", class: "foo"}) }}'
+        );
+
+        $this->testRenderResult(
+            '<h1>&lt;script&gt;alert(&#039;Hello&#039;);&lt;/script&gt;</h1>',
+            '{{ h1({text: "<script>alert(\'Hello\');</script>"}) }}'
+        );
+
+        $this->testRenderResult(
+            '<h1><script>alert(\'Hello\');</script></h1>',
+            '{{ h1({html: "<script>alert(\'Hello\');</script>"}) }}'
+        );
+
+        $this->testRenderResult(
+            '<h3>Hello</h3>',
+            '{{ h1("Hello") }}',
+            ['baseHeadingLevel' => 3],
+        );
+
+        $this->testRenderResult(
+            '<h4>Hello</h4>',
+            '{{ h2("Hello") }}',
+            ['baseHeadingLevel' => 3],
+        );
+
+        self::expectException(RuntimeError::class);
+        $this->view->renderString("{{ heading(7, 'Hello') }}");
+    }
+
+    /**
      * @throws LoaderError
      * @throws SyntaxError
      */


### PR DESCRIPTION
### Description

Improves the `tag()` function, making it possible to pass a string into its second argument, as a shortcut for the `text` attribute:

```twig
{{ tag('p', 'Hello') }}
```

And adds new heading functions:

```twig
{{ heading(2, 'Hello') }}
{{ h(2, 'Hello') }}

{{ h1('Hello') }}
{{ h2('Hello') }}
{{ h3('Hello') }}
{{ h4('Hello') }}
{{ h5('Hello') }}
{{ h6('Hello') }}
```

Like `tag()` now, either a string or attribute hash can be passed to the heading functions.

```twig
{{ heading(2, {
  text: 'Hello',
  class: 'component-title',
}) }}
```

### Related issues

- #18518