### PR TITLE
Broken plugin store when loading remote Cloud assets locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where the Plugin Store would not load if you setup Craft to use remote Craft Cloud assets locally.
+
 ## 4.17.9 - 2026-03-09
 
 - Added `craft\filters\IpRateLimitIdentity`. ([#18510](https://github.com/craftcms/cms/pull/18510))

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
         - src
         - tests
     excludePaths:
-        - src/config/composer-classes.php
+        - src/config/composer-classes.php (?)
         - src/config/mimeTypes.php
         - src/image/*
         - src/services/Images.php

--- a/src/helpers/Api.php
+++ b/src/helpers/Api.php
@@ -92,7 +92,7 @@ abstract class Api
 
         // Craft Cloud
         $craftCloudProjectId = App::env('CRAFT_CLOUD_PROJECT_ID');
-        if ($craftCloudProjectId) {
+        if ($craftCloudProjectId && (App::env('CRAFT_CLOUD') ?? App::env('AWS_LAMBDA_RUNTIME_API'))) {
             $headers['X-Craft-Cloud-Project-Id'] = $craftCloudProjectId;
         }
 
@@ -114,9 +114,11 @@ abstract class Api
             $overrides = [];
         }
 
+        /** @phpstan-ignore-next-line */
         $repo = new PlatformRepository([], $overrides);
 
         $versions = [];
+        /** @phpstan-ignore-next-line */
         foreach ($repo->getPackages() as $package) {
             $versions[$package->getName()] = $package->getPrettyVersion();
         }


### PR DESCRIPTION
Fixed a bug where the Plugin Store would not load if you set up Craft to use remote Craft Cloud assets locally

Can be merged into 5.x