### PR TITLE
Bugfix/18569 failed to impersonate with token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an error that could occur after running the `utils/fix-field-layout-uids` command. ([#18516](https://github.com/craftcms/cms/issues/18516))
 - Fixed a JavaScript error that could occur if any field layout elements were configured with unsupported widths. ([#18552](https://github.com/craftcms/cms/issues/18552))
+- Fixed an error that could occur when user impersonation failed. ([#18569](https://github.com/craftcms/cms/issues/18569))
 
 ## 4.17.10 - 2026-03-11
 

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -379,7 +379,7 @@ class UsersController extends Controller
             $this->setFailFlash(Craft::t('app', 'There was a problem impersonating this user.'));
             Craft::error(sprintf('%s tried to impersonate userId: %s but something went wrong.',
                 $userSession->getIdentity()?->username ?? 'Unknown user', $userId), __METHOD__);
-            return null;
+            return $this->redirectToPostedUrl();
         }
 
         return $this->_handleSuccessfulLogin($user);

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -379,7 +379,9 @@ class UsersController extends Controller
             $this->setFailFlash(Craft::t('app', 'There was a problem impersonating this user.'));
             Craft::error(sprintf('%s tried to impersonate userId: %s but something went wrong.',
                 $userSession->getIdentity()?->username ?? 'Unknown user', $userId), __METHOD__);
-            return $this->redirectToPostedUrl();
+            return $this->redirect($this->request->getIsCpRequest()
+                ? Request::CP_PATH_LOGIN
+                : Craft::$app->getConfig()->getGeneral()->getLoginPath() ?? '');
         }
 
         return $this->_handleSuccessfulLogin($user);

--- a/src/controllers/UsersController.php
+++ b/src/controllers/UsersController.php
@@ -378,7 +378,7 @@ class UsersController extends Controller
         if (!$success) {
             $this->setFailFlash(Craft::t('app', 'There was a problem impersonating this user.'));
             Craft::error(sprintf('%s tried to impersonate userId: %s but something went wrong.',
-                $userSession->getIdentity()->username, $userId), __METHOD__);
+                $userSession->getIdentity()?->username ?? 'Unknown user', $userId), __METHOD__);
             return null;
         }
 


### PR DESCRIPTION
### Description
Prevents an exception from being thrown when an anonymous user tries to impersonate another user via a token. An error logged in such a case will read “Unknown user tried to impersonate userId: XYZ but something went wrong.”

Leaving `return null` in such a case in v4 would still result in a redirect to the homepage or the CP login page, but in v5, an empty page would be shown, so I opted to ensure the redirection happens in both v4 and v5.

A flash message won’t be shown unless you log into the control panel with your credentials straight after failed impersonation.


### Related issues
#18569