### PR TITLE
Removed validation that enforced the maxTime to be later than the minTime for the time field

### DIFF
--- a/src/validators/TimeValidator.php
+++ b/src/validators/TimeValidator.php
@@ -9,7 +9,6 @@ namespace craft\validators;
 
 use Craft;
 use craft\helpers\DateTimeHelper;
-use craft\i18n\Locale;
 use DateTime;
 use yii\base\InvalidConfigException;
 use yii\validators\Validator;

--- a/src/validators/TimeValidator.php
+++ b/src/validators/TimeValidator.php
@@ -88,22 +88,12 @@ class TimeValidator extends Validator
             if (!$min) {
                 throw new InvalidConfigException("Invalid minimum time: $this->min");
             }
-            if ($value < $min) {
-                $this->addError($model, $attribute, $this->tooEarly, [
-                    'min' => Craft::$app->getFormatter()->asTime($min, Locale::LENGTH_SHORT),
-                ]);
-            }
         }
 
         if (isset($this->max)) {
             $max = DateTimeHelper::toDateTime(['time' => $this->max], true);
             if (!$max) {
                 throw new InvalidConfigException("Invalid maximum time: $this->max");
-            }
-            if ($value > $max) {
-                $this->addError($model, $attribute, $this->tooLate, [
-                    'max' => Craft::$app->getFormatter()->asTime($max, Locale::LENGTH_SHORT),
-                ]);
             }
         }
     }


### PR DESCRIPTION
### Description
The current validation conflicts with how the timepicker component behaves. The timepicker natively supports wrapping past midnight and allows selecting times up to 24 hours after the defined minTime.

For example: Setting only minTime to 09:00AM already produces a selectable range that continues past midnight and wraps until 08:55AM.

The proposed change enables valid use cases where the time range spans across midnight. For example:
- Start: 10:00AM
- End: 02:00AM

Previously, this configuration was blocked by validation despite being fully supported by the timepicker.