### PR TITLE
Allow overnight time ranges

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -15,6 +15,7 @@
 - Category indexes can now have “Group” columns. ([#18553](https://github.com/craftcms/cms/discussions/18553))
 
 ### Administration
+- Time fields’ “Max Time” settings can now be set to an earlier time than “Min Time”, for overnight time ranges. ([#18575](https://github.com/craftcms/cms/pull/18575))
 - Newlines in system message bodies are now replaced with `<br>` tags. ([#18058](https://github.com/craftcms/cms/discussions/18058))
 - Added the `--to-default` option to `resave` commands. ([#18522](https://github.com/craftcms/cms/pull/18522))
 
@@ -27,6 +28,7 @@
 ### Extensibility
 - Added `craft\base\DefaultableFieldInterface`. ([#18522](https://github.com/craftcms/cms/pull/18522))
 - Added `craft\elements\PopulateElementEvent::$content`.
+- Added `craft\validators\TimeValidator::$outOfRange`. ([#18575](https://github.com/craftcms/cms/pull/18575))
 - `craft\elements\PopulateElementEvent::$row` no longer includes `fieldValues` or `generatedFieldValues` keys.
 
 ### System

--- a/src/fields/Time.php
+++ b/src/fields/Time.php
@@ -115,7 +115,6 @@ class Time extends Field implements InlineEditableFieldInterface, SortableFieldI
     {
         $rules = parent::defineRules();
         $rules[] = [['minuteIncrement'], 'integer', 'min' => 1, 'max' => 60];
-        $rules[] = [['max'], TimeValidator::class, 'min' => $this->min];
 
         return $rules;
     }

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -2253,6 +2253,7 @@ return [
     '{attribute} must be a date.' => '{attribute} must be a date.',
     '{attribute} must be a time.' => '{attribute} must be a time.',
     '{attribute} must be an array.' => '{attribute} must be an array.',
+    '{attribute} must be between {min} and {max}.' => '{attribute} must be between {min} and {max}.',
     '{attribute} must be no earlier than {min}.' => '{attribute} must be no earlier than {min}.',
     '{attribute} must be no greater than {max}.' => '{attribute} must be no greater than {max}.',
     '{attribute} must be no later than {max}.' => '{attribute} must be no later than {max}.',

--- a/src/validators/TimeValidator.php
+++ b/src/validators/TimeValidator.php
@@ -48,6 +48,12 @@ class TimeValidator extends Validator
     public ?string $tooLate = null;
 
     /**
+     * @var string|null user-defined error message used when the value is out of range and [[min]] is greater than [[max]]
+     * @since 5.10.0
+     */
+    public ?string $outOfRange = null;
+
+    /**
      * @inheritdoc
      */
     public function init(): void
@@ -64,6 +70,10 @@ class TimeValidator extends Validator
 
         if (isset($this->max) && !isset($this->tooLate)) {
             $this->tooLate = Craft::t('app', '{attribute} must be no later than {max}.');
+        }
+
+        if (isset($this->min) && isset($this->max) && !isset($this->outOfRange)) {
+            $this->outOfRange = Craft::t('app', '{attribute} must be between {min} and {max}.');
         }
     }
 
@@ -83,15 +93,14 @@ class TimeValidator extends Validator
             return;
         }
 
+        // If min > max (e.g. 10pm - 2am),
+
+        $min = $max = null;
+
         if (isset($this->min)) {
             $min = DateTimeHelper::toDateTime(['time' => $this->min], true);
             if (!$min) {
                 throw new InvalidConfigException("Invalid minimum time: $this->min");
-            }
-            if ($value < $min) {
-                $this->addError($model, $attribute, $this->tooEarly, [
-                    'min' => Craft::$app->getFormatter()->asTime($min, Locale::LENGTH_SHORT),
-                ]);
             }
         }
 
@@ -100,11 +109,29 @@ class TimeValidator extends Validator
             if (!$max) {
                 throw new InvalidConfigException("Invalid maximum time: $this->max");
             }
-            if ($value > $max) {
-                $this->addError($model, $attribute, $this->tooLate, [
+        }
+
+        // Overnight time range? (e.g. 10pm-2am)
+        if ($min !== null && $max !== null && $min > $max) {
+            if ($value < $min && $value > $max) {
+                $this->addError($model, $attribute, $this->outOfRange, [
+                    'min' => Craft::$app->getFormatter()->asTime($min, Locale::LENGTH_SHORT),
                     'max' => Craft::$app->getFormatter()->asTime($max, Locale::LENGTH_SHORT),
                 ]);
             }
+            return;
+        }
+
+        if ($min !== null && $value < $min) {
+            $this->addError($model, $attribute, $this->tooEarly, [
+                'min' => Craft::$app->getFormatter()->asTime($min, Locale::LENGTH_SHORT),
+            ]);
+        }
+
+        if ($max !== null && $value > $max) {
+            $this->addError($model, $attribute, $this->tooLate, [
+                'max' => Craft::$app->getFormatter()->asTime($max, Locale::LENGTH_SHORT),
+            ]);
         }
     }
 }


### PR DESCRIPTION
### Description

Makes it possible to set Time fields’ “Max Time” to an earlier time than “Min Time”, enabling the field options to represent an overnight time range (e.g. 10pm – 2am).

### Related issues

- #18574