### PR TITLE
don't check if action request for site requests

### DIFF
--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -1275,7 +1275,8 @@ class Sites extends Component
     {
         if ($withDisabled === null) {
             $request = Craft::$app->getRequest();
-            $withDisabled = !$request->getIsSiteRequest() || $request->getIsActionRequest();
+
+            $withDisabled = !$request->getIsSiteRequest() && $request->getIsActionRequest();
         }
 
         return $withDisabled ? $this->_allSitesById : $this->_enabledSitesById;


### PR DESCRIPTION
### Description
When figuring out if getting all sites should return the disabled ones, we initially did this:
https://github.com/craftcms/cms/commit/e4165bd3276865e52a2d3f70ef294a5a6b5d7e5a
and then we changed it to this:
https://github.com/craftcms/cms/commit/a8faf8bb10d9b449ca8a2c365378f1f3c8828f82

That recent change triggers an infinite recursion for site requests if you’re trying to make one of the special paths site-dependent.

**Steps to reproduce:**
- clean 5.9.17 installation
- add this to the `config/general.php`:
```
	->setPasswordPath(function (string $handle) {
        $site = Craft::$app->sites->getSiteByHandle($handle);

        return 'my-set-password';
    })
```
- visit any site on the front end, e.g. the homepage

If you have Xdebug enabled, it will error quite quickly with “Xdebug has detected a possible infinite loop”.

The root cause is, as mentioned by the OP.

**Solution:** don’t include disabled sites for site requests, and don’t attempt to check for action requests in the process.


### Related issues
#18605 
