### PR TITLE
[6.x] Migration and Plugin migration improvements

### DIFF
--- a/src/Console/Commands/Install/InstallCommand.php
+++ b/src/Console/Commands/Install/InstallCommand.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Console\Commands\Install;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\Console\CraftCommand;
+use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migrations\Install;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Site\Concerns\SiteDefaults;
@@ -49,6 +50,7 @@ class InstallCommand extends Command
         GeneralConfig $generalConfig,
         I18N $i18n,
         Migrator $migrator,
+        LaravelMigrations $laravelMigrations,
     ): int {
         if (Cms::isInstalled(true)) {
             $this->components->warn('Craft is already installed!');
@@ -176,6 +178,8 @@ class InstallCommand extends Command
         foreach ($migrator->getPendingMigrations() as $file) {
             $migrator->getRepository()->log($migrator->getMigrationName($file), 1);
         }
+
+        $laravelMigrations->install($migrator);
 
         $this->ensureProjectConfigFileExists();
 

--- a/src/Database/LaravelMigrations.php
+++ b/src/Database/LaravelMigrations.php
@@ -24,15 +24,21 @@ class LaravelMigrations
             return;
         }
 
-        $migrator->track('content');
+        $originalTrack = $migrator->getTrack();
 
-        $pendingMigrations = $migrator->getPendingMigrations($migrationPaths);
+        try {
+            $migrator->track('content');
 
-        if (empty($pendingMigrations)) {
-            return;
+            $pendingMigrations = $migrator->getPendingMigrations($migrationPaths);
+
+            if (empty($pendingMigrations)) {
+                return;
+            }
+
+            $migrator->run($pendingMigrations);
+        } finally {
+            $migrator->track($originalTrack ?? 'content');
         }
-
-        $migrator->run($pendingMigrations);
     }
 
     public function ensureSessionsTable(): void

--- a/src/Database/LaravelMigrations.php
+++ b/src/Database/LaravelMigrations.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Database;
+
+use Illuminate\Container\Attributes\Singleton;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+
+#[Singleton]
+class LaravelMigrations
+{
+    public function install(Migrator $migrator): void
+    {
+        $this->publishMigrationFiles();
+
+        $migrationPaths = $this->migrationPaths();
+
+        if (empty($migrationPaths)) {
+            return;
+        }
+
+        $migrator->track('content');
+
+        $pendingMigrations = $migrator->getPendingMigrations($migrationPaths);
+
+        if (empty($pendingMigrations)) {
+            return;
+        }
+
+        $migrator->run($pendingMigrations);
+    }
+
+    public function ensureSessionsTable(): void
+    {
+        if (Schema::hasTable(Table::SESSIONS)) {
+            return;
+        }
+
+        Schema::create(Table::SESSIONS, function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->longText('payload');
+            $table->integer('last_activity')->index();
+        });
+    }
+
+    private function publishMigrationFiles(): void
+    {
+        foreach ($this->migrationPatterns() as $command => $pattern) {
+            $existingMigrations = $this->migrationFiles($pattern);
+            $exitCode = Artisan::call($command);
+
+            if (! in_array($exitCode, [0, 1], true)) {
+                throw new RuntimeException("Could not create the [$command] migration.");
+            }
+
+            $migrationWasCreated = ! empty($existingMigrations) || ! empty($this->migrationFiles($pattern));
+
+            if (! $migrationWasCreated) {
+                throw new RuntimeException("Could not create the [$command] migration.");
+            }
+        }
+    }
+
+    private function migrationPaths(): array
+    {
+        $migrationPaths = [];
+
+        foreach ($this->migrationPatterns() as $pattern) {
+            $files = $this->migrationFiles($pattern);
+            $migrationPaths = [...$migrationPaths, ...$files];
+        }
+
+        $migrationPaths = array_values(array_unique($migrationPaths));
+        sort($migrationPaths);
+
+        return $migrationPaths;
+    }
+
+    private function migrationPatterns(): array
+    {
+        return [
+            'make:cache-table' => '*_create_cache_table.php',
+            'make:queue-table' => sprintf('*_create_%s_table.php', config('queue.connections.database.table', 'jobs')),
+            'make:queue-failed-table' => sprintf('*_create_%s_table.php', config('queue.failed.table', 'failed_jobs')),
+            'make:queue-batches-table' => sprintf('*_create_%s_table.php', config('queue.batching.table', 'job_batches')),
+            'make:session-table' => '*_create_sessions_table.php',
+            'make:notifications-table' => '*_create_notifications_table.php',
+        ];
+    }
+
+    private function migrationFiles(string $pattern): array
+    {
+        return File::glob(app()->databasePath("migrations/$pattern")) ?: [];
+    }
+}

--- a/src/Database/Migrations/Install.php
+++ b/src/Database/Migrations/Install.php
@@ -611,17 +611,6 @@ class Install extends Migration
             $table->char('uid', 36)->default('0');
         });
 
-        if (! Schema::hasTable('sessions')) {
-            Schema::create('sessions', function (Blueprint $table) {
-                $table->string('id')->primary();
-                $table->foreignId('user_id')->nullable()->index();
-                $table->string('ip_address', 45)->nullable();
-                $table->text('user_agent')->nullable();
-                $table->longText('payload');
-                $table->integer('last_activity')->index();
-            });
-        }
-
         Schema::create('shunnedmessages', function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('userId');

--- a/src/Http/Controllers/InstallController.php
+++ b/src/Http/Controllers/InstallController.php
@@ -8,6 +8,7 @@ use craft\helpers\App;
 use CraftCms\Aliases\Aliases;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Config\GeneralConfig;
+use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migrations\Install;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Site\Concerns\SiteDefaults;
@@ -97,7 +98,6 @@ readonly class InstallController
     {
         $data = $this->validateDbData($request->input());
 
-        // Test the connection
         $errors = [];
 
         try {
@@ -115,14 +115,14 @@ readonly class InstallController
             $errors['database'][] = 'PDO exception: '.$e->getMessage();
         }
 
-        $validates = empty($errors);
+        if (empty($errors)) {
+            return new JsonResponse;
+        }
 
-        return $validates ?
-            new JsonResponse :
-            new JsonResponse([
-                'message' => 'Could not connect to the database.',
-                'errors' => $errors,
-            ], 422);
+        return new JsonResponse([
+            'message' => 'Could not connect to the database.',
+            'errors' => $errors,
+        ], 422);
     }
 
     public function validateAccount(Request $request, GeneralConfig $generalConfig): Response
@@ -151,7 +151,7 @@ readonly class InstallController
         return new JsonResponse;
     }
 
-    public function install(Request $request, Migrator $migrator): Response
+    public function install(Request $request, Migrator $migrator, LaravelMigrations $laravelMigrations): Response
     {
         $path = app()->environmentFilePath();
 
@@ -195,9 +195,7 @@ readonly class InstallController
             $siteUrl = Aliases::get($siteUrl);
         }
 
-        // Try to save the site URL to a APP_URL environment variable
-        // if it’s not already set to an alias or environment variable
-        if ($siteUrl[0] !== '@' && $siteUrl[0] !== '$' && ! App::isEphemeral()) {
+        if (! in_array($siteUrl[0], ['@', '$']) && ! App::isEphemeral()) {
             try {
                 Env::writeVariable('APP_URL', $siteUrl, $path);
                 $siteUrl = '$APP_URL';
@@ -237,6 +235,8 @@ readonly class InstallController
         foreach ($migrator->getPendingMigrations() as $file) {
             $migrator->getRepository()->log($migrator->getMigrationName($file), 1);
         }
+
+        $laravelMigrations->install($migrator);
 
         $redirect = Cms::config()->postCpLoginRedirect;
 

--- a/src/Plugin/Concerns/Installable.php
+++ b/src/Plugin/Concerns/Installable.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Plugin\Concerns;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Plugin\Plugin;
 use CraftCms\Cms\Support\File;
+use ReflectionClass;
 
 /**
  * @mixin Plugin
@@ -45,10 +46,12 @@ trait Installable
     {
         $this->beforeUninstall();
 
-        if (File::exists($this->getBasePath().'/migrations/Install.php')) {
+        $installPath = $this->getMigrationsPath().'/Install.php';
+
+        if (File::exists($installPath)) {
             $this->getMigrator()->resetMigrations(
-                [$this->getBasePath().'/migrations/Install.php'],
-                [$this->getBasePath().'/migrations'],
+                [$installPath],
+                [dirname($installPath)],
             );
         }
 
@@ -57,23 +60,47 @@ trait Installable
 
     public function createInstallMigration(): ?object
     {
-        if (! File::exists($this->getBasePath().'/migrations/Install.php')) {
+        $path = $this->getMigrationsPath().'/Install.php';
+
+        if (! File::exists($path)) {
             return null;
         }
 
-        $namespace = substr(static::class, 0, strrpos(static::class, '\\'));
-        $class = $namespace.'\migrations\Install';
+        $realPath = realpath($path);
 
-        return app()->make($class);
+        $migration = $this->findMigrationClassByFile($realPath);
+
+        if ($migration !== null) {
+            return $migration;
+        }
+
+        $migration = require $path;
+
+        if (is_object($migration)) {
+            return $migration;
+        }
+
+        return $this->findMigrationClassByFile($realPath);
+    }
+
+    private function findMigrationClassByFile(string $realPath): ?object
+    {
+        foreach (array_reverse(get_declared_classes()) as $class) {
+            if ($realPath !== new ReflectionClass($class)->getFileName()) {
+                continue;
+            }
+
+            return app()->make($class);
+        }
+
+        return null;
     }
 
     public function getMigrator(): Migrator
     {
         return $this->migrator ?? $this->migrator = app(Migrator::class)
             ->track("plugin:$this->handle")
-            ->setPaths([
-                $this->getBasePath().'/migrations',
-            ]);
+            ->setPaths([$this->getMigrationsPath()]);
     }
 
     /**

--- a/src/Plugin/Contracts/PluginInterface.php
+++ b/src/Plugin/Contracts/PluginInterface.php
@@ -270,6 +270,14 @@ interface PluginInterface
     public function getBasePath(): string;
 
     /**
+     * Returns the plugin migrations directory.
+     *
+     * Prefers the package root's `database/migrations` directory, and falls
+     * back to the plugin class directory's `migrations`.
+     */
+    public function getMigrationsPath(): string;
+
+    /**
      * Creates and returns a new plugin instance based on a passed config
      */
     public static function create(array $config): self;

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Plugin;
 
 use CraftCms\Cms\Plugin\Contracts\PluginInterface;
+use CraftCms\Cms\Support\File;
 use Illuminate\Support\ServiceProvider;
 use Override;
 use ReflectionClass;
@@ -158,6 +159,23 @@ abstract class Plugin extends ServiceProvider implements PluginInterface
 
             return dirname($class->getFileName());
         });
+    }
+
+    public function getMigrationsPath(): string
+    {
+        $conventionalPath = dirname($this->getBasePath()).'/database/migrations';
+
+        if (File::isDirectory($conventionalPath)) {
+            return $conventionalPath;
+        }
+
+        $fallbackPath = $this->getBasePath().'/migrations';
+
+        if (File::isDirectory($fallbackPath)) {
+            return $fallbackPath;
+        }
+
+        return $conventionalPath;
     }
 
     #[Override]

--- a/src/Plugin/Testing/PluginTestCase.php
+++ b/src/Plugin/Testing/PluginTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Plugin\Testing;
 
+use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migrations\Install;
 use CraftCms\Cms\Providers\CraftServiceProvider;
 use CraftCms\Cms\Site\Data\Site;
@@ -42,6 +43,7 @@ abstract class PluginTestCase extends BaseTestCase
         );
 
         $migration->up();
+        app(LaravelMigrations::class)->ensureSessionsTable();
     }
 
     #[Override]

--- a/tests/Feature/Http/Controllers/InstallControllerTest.php
+++ b/tests/Feature/Http/Controllers/InstallControllerTest.php
@@ -3,8 +3,14 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Database\LaravelMigrations;
+use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Http\Controllers\InstallController;
+use CraftCms\Cms\Tests\TestClasses\TestPlugin\Tests\FakeMigrator;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Testing\TestResponse;
 use Inertia\Testing\AssertableInertia;
 
@@ -153,3 +159,87 @@ it('can validate site', function (array $data, array $errors) {
         'errors' => ['language'],
     ],
 ]);
+
+test('install invokes the Laravel optional migration installer', function () {
+    $migrator = new FakeMigrator;
+
+    $migrator->pendingMigrations = [
+        '/tmp/2026_01_01_000000_first_migration.php',
+        '/tmp/2026_01_01_000001_second_migration.php',
+    ];
+
+    $this->mock(LaravelMigrations::class)
+        ->shouldReceive('install')
+        ->once()
+        ->with($migrator);
+
+    $response = (new InstallController)->install(
+        Request::create('/install', 'POST', [
+            'account' => [
+                'email' => 'support@pixelandtonic.com',
+                'username' => 'admin',
+                'password' => 'asupersecretpassword',
+            ],
+            'site' => [
+                'name' => 'Craft',
+                'baseUrl' => '$APP_URL',
+                'language' => 'en-US',
+            ],
+        ]),
+        $migrator,
+        app(LaravelMigrations::class),
+    );
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($migrator->tracked)->toBe('craft')
+        ->and($migrator->loggedMigrations)->toBe([
+            ['Install', 1],
+            ['2026_01_01_000000_first_migration', 1],
+            ['2026_01_01_000001_second_migration', 1],
+        ]);
+});
+
+test('install command invokes the Laravel optional migration installer', function () {
+    $migrator = new FakeMigrator;
+
+    $migrator->pendingMigrations = [
+        '/tmp/2026_01_01_000000_first_migration.php',
+        '/tmp/2026_01_01_000001_second_migration.php',
+    ];
+
+    DB::table('info')->delete();
+
+    app()->instance(Migrator::class, $migrator);
+
+    $this->mock(LaravelMigrations::class)
+        ->shouldReceive('install')
+        ->once()
+        ->with($migrator);
+
+    $this->artisan('craft:install', [
+        '--email' => 'support@pixelandtonic.com',
+        '--username' => 'admin',
+        '--password' => 'asupersecretpassword',
+        '--siteName' => 'Craft',
+        '--siteUrl' => '$APP_URL',
+        '--language' => 'en-US',
+    ])->assertSuccessful();
+
+    expect($migrator->loggedMigrations)->toBe([
+        ['Install', 1],
+        ['2026_01_01_000000_first_migration', 1],
+        ['2026_01_01_000001_second_migration', 1],
+    ]);
+});
+
+test('Laravel migration installer can recreate the sessions table', function () {
+    expect(Schema::hasTable('sessions'))->toBeTrue();
+
+    Schema::drop('sessions');
+
+    expect(Schema::hasTable('sessions'))->toBeFalse();
+
+    app(LaravelMigrations::class)->ensureSessionsTable();
+
+    expect(Schema::hasTable('sessions'))->toBeTrue();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Tests;
 use Craft;
 use craft\test\TestSetup;
 use CraftCms\Cms\Dashboard\Widgets\Widget;
+use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migrations\Install;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Edition;
@@ -194,6 +195,7 @@ class TestCase extends Orchestra
             Cache::lock(ProjectConfig::MUTEX_NAME)->forceRelease();
 
             $migration->up();
+            app(LaravelMigrations::class)->ensureSessionsTable();
 
             // Mark all existing migrations as applied
             $migrator = app(Migrator::class)->track('craft');

--- a/tests/TestClasses/TestPlugin/Tests/FakeMigrator.php
+++ b/tests/TestClasses/TestPlugin/Tests/FakeMigrator.php
@@ -14,6 +14,8 @@ class FakeMigrator extends Migrator
 
     public array $resetArguments = [];
 
+    public array $runArguments = [];
+
     public ?string $tracked = null;
 
     public array $configuredPaths = [];
@@ -55,6 +57,15 @@ class FakeMigrator extends Migrator
         {
             public function __construct(private FakeMigrator $migrator) {}
 
+            public function getNextBatchNumber(): int
+            {
+                if (empty($this->migrator->loggedMigrations)) {
+                    return 1;
+                }
+
+                return max(array_column($this->migrator->loggedMigrations, 1)) + 1;
+            }
+
             public function log(string $migration, int $batch): void
             {
                 $this->migrator->loggedMigrations[] = [$migration, $batch];
@@ -63,9 +74,38 @@ class FakeMigrator extends Migrator
     }
 
     #[\Override]
+    public function run($paths = [], array $options = []): array
+    {
+        $this->runArguments = [$paths, $options];
+
+        $paths = empty($paths) ? $this->pendingMigrations : $paths;
+        $batch = $this->getRepository()->getNextBatchNumber();
+        $loggedMigrations = [];
+
+        foreach ($paths as $path) {
+            $migrationName = $this->getMigrationName($path);
+
+            if (in_array($migrationName, $loggedMigrations, true)) {
+                continue;
+            }
+
+            $this->getRepository()->log($migrationName, $batch);
+            $loggedMigrations[] = $migrationName;
+        }
+
+        return $paths;
+    }
+
+    #[\Override]
     public function getPendingMigrations($paths = []): array
     {
-        return $this->pendingMigrations;
+        if (empty($paths)) {
+            return $this->pendingMigrations;
+        }
+
+        $loggedMigrations = array_map(fn (array $migration) => $migration[0], $this->loggedMigrations);
+
+        return array_values(array_filter($paths, fn (string $path) => ! in_array($this->getMigrationName($path), $loggedMigrations, true)));
     }
 
     #[\Override]

--- a/tests/TestClasses/TestPlugin/Tests/FakeMigrator.php
+++ b/tests/TestClasses/TestPlugin/Tests/FakeMigrator.php
@@ -35,6 +35,12 @@ class FakeMigrator extends Migrator
     }
 
     #[\Override]
+    public function getTrack(): ?string
+    {
+        return $this->tracked;
+    }
+
+    #[\Override]
     public function setPaths(array $paths): self
     {
         $this->configuredPaths = $paths;

--- a/tests/TestClasses/TestPlugin/database/migrations/Install.php
+++ b/tests/TestClasses/TestPlugin/database/migrations/Install.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace CraftCms\Cms\Tests\TestClasses\TestPlugin\src\migrations;
+namespace CraftCms\Cms\Tests\TestClasses\TestPlugin\database\migrations;
 
 use CraftCms\Cms\Database\Migration;
 

--- a/tests/TestClasses/TestPlugin/src/TestPlugin.php
+++ b/tests/TestClasses/TestPlugin/src/TestPlugin.php
@@ -154,13 +154,13 @@ class TestPlugin extends Plugin
     #[Override]
     public function createInstallMigration(): ?object
     {
-        $installMigrationPath = $this->getBasePath().'/migrations/Install.php';
+        $path = $this->getMigrationsPath().'/Install.php';
 
-        if (! is_file($installMigrationPath)) {
+        if (! is_file($path)) {
             return null;
         }
 
-        $migration = require $installMigrationPath;
+        $migration = require $path;
 
         if ($migration instanceof Migration) {
             return $migration;

--- a/tests/Unit/Database/LaravelMigrationsTest.php
+++ b/tests/Unit/Database/LaravelMigrationsTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Database\LaravelMigrations;
+use CraftCms\Cms\Tests\TestClasses\TestPlugin\Tests\FakeMigrator;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+afterEach(function () {
+    if (! isset($this->databasePath)) {
+        return;
+    }
+
+    Artisan::clearResolvedInstance('artisan');
+    app()->useDatabasePath(base_path('database'));
+    File::deleteDirectory($this->databasePath);
+});
+
+it('publishes and applies Laravel optional migrations during install', function () {
+    $this->databasePath = sys_get_temp_dir().'/craft-optional-migrations-'.uniqid();
+    app()->useDatabasePath($this->databasePath);
+    File::ensureDirectoryExists($this->databasePath.'/migrations');
+
+    $migrationMap = [
+        'make:cache-table' => '2026_01_01_000000_create_cache_table.php',
+        'make:queue-table' => '2026_01_01_000001_create_jobs_table.php',
+        'make:queue-failed-table' => '2026_01_01_000002_create_failed_jobs_table.php',
+        'make:queue-batches-table' => '2026_01_01_000003_create_job_batches_table.php',
+        'make:session-table' => '2026_01_01_000004_create_sessions_table.php',
+        'make:notifications-table' => '2026_01_01_000005_create_notifications_table.php',
+    ];
+
+    Artisan::swap(new class($this->databasePath, $migrationMap)
+    {
+        public array $calls = [];
+
+        public function __construct(
+            private readonly string $databasePath,
+            private readonly array $migrationMap,
+        ) {}
+
+        public function call(string $command, array $parameters = []): int
+        {
+            $this->calls[] = [$command, $parameters];
+
+            $filename = $this->migrationMap[$command] ?? null;
+
+            if (! $filename) {
+                return 1;
+            }
+
+            File::put($this->databasePath.'/migrations/'.$filename, '<?php');
+
+            return 0;
+        }
+    });
+
+    $migrator = new FakeMigrator;
+
+    app(LaravelMigrations::class)->install($migrator);
+
+    $artisan = Artisan::getFacadeRoot();
+
+    expect($artisan->calls)->toHaveCount(6)
+        ->and(array_column($artisan->calls, 0))->toBe(array_keys($migrationMap))
+        ->and($migrator->tracked)->toBe('content')
+        ->and($migrator->runArguments[0])->toBe([
+            $this->databasePath.'/migrations/2026_01_01_000000_create_cache_table.php',
+            $this->databasePath.'/migrations/2026_01_01_000001_create_jobs_table.php',
+            $this->databasePath.'/migrations/2026_01_01_000002_create_failed_jobs_table.php',
+            $this->databasePath.'/migrations/2026_01_01_000003_create_job_batches_table.php',
+            $this->databasePath.'/migrations/2026_01_01_000004_create_sessions_table.php',
+            $this->databasePath.'/migrations/2026_01_01_000005_create_notifications_table.php',
+        ])
+        ->and($migrator->loggedMigrations)->toBe([
+            ['2026_01_01_000000_create_cache_table', 1],
+            ['2026_01_01_000001_create_jobs_table', 1],
+            ['2026_01_01_000002_create_failed_jobs_table', 1],
+            ['2026_01_01_000003_create_job_batches_table', 1],
+            ['2026_01_01_000004_create_sessions_table', 1],
+            ['2026_01_01_000005_create_notifications_table', 1],
+        ]);
+});
+
+it('is idempotent when the Laravel optional migrations already exist', function () {
+    $this->databasePath = sys_get_temp_dir().'/craft-optional-migrations-'.uniqid();
+    app()->useDatabasePath($this->databasePath);
+    File::ensureDirectoryExists($this->databasePath.'/migrations');
+
+    foreach ([
+        '2026_01_01_000000_create_cache_table.php',
+        '2026_01_01_000001_create_jobs_table.php',
+        '2026_01_01_000002_create_failed_jobs_table.php',
+        '2026_01_01_000003_create_job_batches_table.php',
+        '2026_01_01_000004_create_sessions_table.php',
+        '2026_01_01_000005_create_notifications_table.php',
+    ] as $filename) {
+        File::put($this->databasePath.'/migrations/'.$filename, '<?php');
+    }
+
+    Artisan::swap(new class
+    {
+        public array $calls = [];
+
+        public function call(string $command, array $parameters = []): int
+        {
+            $this->calls[] = [$command, $parameters];
+
+            return 1;
+        }
+    });
+
+    $migrator = new FakeMigrator;
+    $migrator->loggedMigrations = [
+        ['2026_01_01_000000_create_cache_table', 1],
+        ['2026_01_01_000001_create_jobs_table', 1],
+        ['2026_01_01_000002_create_failed_jobs_table', 1],
+        ['2026_01_01_000003_create_job_batches_table', 1],
+        ['2026_01_01_000004_create_sessions_table', 1],
+        ['2026_01_01_000005_create_notifications_table', 1],
+    ];
+
+    app(LaravelMigrations::class)->install($migrator);
+
+    $artisan = Artisan::getFacadeRoot();
+
+    expect($artisan->calls)->toHaveCount(6)
+        ->and($migrator->runArguments)->toBe([])
+        ->and($migrator->loggedMigrations)->toHaveCount(6);
+});

--- a/tests/Unit/Database/LaravelMigrationsTest.php
+++ b/tests/Unit/Database/LaravelMigrationsTest.php
@@ -57,6 +57,7 @@ it('publishes and applies Laravel optional migrations during install', function 
     });
 
     $migrator = new FakeMigrator;
+    $migrator->tracked = 'craft';
 
     app(LaravelMigrations::class)->install($migrator);
 
@@ -64,7 +65,7 @@ it('publishes and applies Laravel optional migrations during install', function 
 
     expect($artisan->calls)->toHaveCount(6)
         ->and(array_column($artisan->calls, 0))->toBe(array_keys($migrationMap))
-        ->and($migrator->tracked)->toBe('content')
+        ->and($migrator->tracked)->toBe('craft')
         ->and($migrator->runArguments[0])->toBe([
             $this->databasePath.'/migrations/2026_01_01_000000_create_cache_table.php',
             $this->databasePath.'/migrations/2026_01_01_000001_create_jobs_table.php',
@@ -112,6 +113,7 @@ it('is idempotent when the Laravel optional migrations already exist', function 
     });
 
     $migrator = new FakeMigrator;
+    $migrator->tracked = 'craft';
     $migrator->loggedMigrations = [
         ['2026_01_01_000000_create_cache_table', 1],
         ['2026_01_01_000001_create_jobs_table', 1],
@@ -126,6 +128,7 @@ it('is idempotent when the Laravel optional migrations already exist', function 
     $artisan = Artisan::getFacadeRoot();
 
     expect($artisan->calls)->toHaveCount(6)
+        ->and($migrator->tracked)->toBe('craft')
         ->and($migrator->runArguments)->toBe([])
         ->and($migrator->loggedMigrations)->toHaveCount(6);
 });

--- a/tests/Unit/Plugin/Concerns/InstallableTest.php
+++ b/tests/Unit/Plugin/Concerns/InstallableTest.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 use CraftCms\Cms\Database\Migration;
 use CraftCms\Cms\Tests\TestClasses\TestPlugin\src\TestPlugin;
 use CraftCms\Cms\Tests\TestClasses\TestPlugin\Tests\FakeMigrator;
+use Illuminate\Support\Facades\File;
+
+afterEach(function () {
+    File::deleteDirectory(storage_path('framework/testing/plugins'));
+});
 
 it('runs the install migration and logs pending migrations', function () {
     $migrator = new FakeMigrator;
@@ -49,8 +54,58 @@ it('resets migrations on uninstall when an install migration exists', function (
     expect($plugin->didCallBeforeUninstall)->toBeTrue()
         ->and($plugin->didCallAfterUninstall)->toBeTrue()
         ->and($migrator->resetArguments)->toBe([
-            [dirname(__DIR__, 3).'/TestClasses/TestPlugin/src/migrations/Install.php'],
-            [dirname(__DIR__, 3).'/TestClasses/TestPlugin/src/migrations'],
+            [dirname(__DIR__, 3).'/TestClasses/TestPlugin/database/migrations/Install.php'],
+            [dirname(__DIR__, 3).'/TestClasses/TestPlugin/database/migrations'],
             false,
         ]);
+});
+
+it('prefers the Laravel migrations path when both paths exist', function () {
+    $migrator = new FakeMigrator;
+    $pluginRoot = storage_path('framework/testing/plugins/prioritized-plugin');
+    $legacyPath = $pluginRoot.'/src/migrations';
+    $laravelPath = $pluginRoot.'/database/migrations';
+
+    File::ensureDirectoryExists($legacyPath);
+    File::ensureDirectoryExists($laravelPath);
+    File::put($legacyPath.'/Install.php', <<<'PHP'
+<?php
+
+return new class extends \CraftCms\Cms\Database\Migration
+{
+    public function up(): void
+    {
+    }
+};
+PHP);
+    File::put($laravelPath.'/Install.php', <<<'PHP'
+<?php
+
+return new class extends \CraftCms\Cms\Database\Migration
+{
+    public function up(): void
+    {
+    }
+};
+PHP);
+
+    $plugin = TestPlugin::create([
+        'handle' => 'test-plugin',
+        'name' => 'Test Plugin',
+    ]);
+
+    $plugin->useBasePath($pluginRoot.'/src');
+    $plugin->useMigrator($migrator);
+
+    expect($plugin->getMigrationsPath())->toBe($laravelPath);
+
+    $plugin->uninstall();
+
+    expect($migrator->resetArguments)->toBe([
+        [$laravelPath.'/Install.php'],
+        [$laravelPath],
+        false,
+    ]);
+
+    File::deleteDirectory($pluginRoot);
 });

--- a/workbench/database/seeders/DatabaseSeeder.php
+++ b/workbench/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Workbench\Database\Seeders;
 
+use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migrations\Install;
 use CraftCms\Cms\Entry\Data\EntryType;
 use CraftCms\Cms\Entry\Elements\Entry;
@@ -70,6 +71,8 @@ class DatabaseSeeder extends Seeder
             email: 'support@craftcms.com',
             site: $site,
         )->up();
+
+        app(LaravelMigrations::class)->ensureSessionsTable();
 
         $site = Sites::getCurrentSite();
 

--- a/yii2-adapter/legacy/base/Plugin.php
+++ b/yii2-adapter/legacy/base/Plugin.php
@@ -296,6 +296,23 @@ class Plugin extends Module implements PluginInterface
         return parent::getBasePath();
     }
 
+    public function getMigrationsPath(): string
+    {
+        $laravelPath = dirname($this->getBasePath()) . '/database/migrations';
+
+        if (File::isDirectory($laravelPath)) {
+            return $laravelPath;
+        }
+
+        $legacyPath = $this->getBasePath() . '/migrations';
+
+        if (File::isDirectory($legacyPath)) {
+            return $legacyPath;
+        }
+
+        return $laravelPath;
+    }
+
     /** {@inheritdoc} */
     public static function create(array $config): PluginInterface
     {
@@ -312,13 +329,43 @@ class Plugin extends Module implements PluginInterface
 
     public function createInstallMigration(): ?object
     {
-        if (!File::exists($this->getBasePath() . '/migrations/Install.php')) {
+        $path = $this->getMigrationsPath() . '/Install.php';
+
+        if (!File::exists($path)) {
             return null;
         }
 
-        $namespace = substr(static::class, 0, strrpos(static::class, '\\'));
-        $class = $namespace . '\migrations\Install';
+        $realPath = realpath($path);
+        $migration = $this->findMigrationClassByFile($realPath);
 
+        if ($migration !== null) {
+            return $this->wrapIfNeeded($migration);
+        }
+
+        $migration = require $path;
+
+        if (is_object($migration)) {
+            return $migration;
+        }
+
+        $migration = $this->findMigrationClassByFile($realPath);
+
+        return $migration !== null ? $this->wrapIfNeeded($migration) : null;
+    }
+
+    private function findMigrationClassByFile(string $realPath): ?string
+    {
+        foreach (array_reverse(get_declared_classes()) as $class) {
+            if ($realPath === (new \ReflectionClass($class))->getFileName()) {
+                return $class;
+            }
+        }
+
+        return null;
+    }
+
+    private function wrapIfNeeded(string $class): object
+    {
         if (!is_a($class, Migration::class, true)) {
             return new MigrationWrapper($class);
         }

--- a/yii2-adapter/legacy/test/TestSetup.php
+++ b/yii2-adapter/legacy/test/TestSetup.php
@@ -59,6 +59,7 @@ use craft\web\UploadedFile;
 use craft\web\User;
 use CraftCms\Aliases\Aliases;
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migrations\Event\PostCreateTables;
 use CraftCms\Cms\Database\Migrations\Install;
 use CraftCms\Cms\ProjectConfig\ProjectConfig;
@@ -464,6 +465,7 @@ class TestSetup
         );
 
         $migration->up();
+        app(LaravelMigrations::class)->ensureSessionsTable();
     }
 
     /**

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -4,6 +4,7 @@ namespace CraftCms\Yii2Adapter;
 
 use Craft;
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Field\Events\FieldCachesInvalidated;
 use CraftCms\Cms\Support\Env;
@@ -180,6 +181,12 @@ class Yii2ServiceProvider extends ServiceProvider
     {
         try {
             if (app()->environment('workbench') || app()->environment('testing')) {
+                return;
+            }
+
+            if (!Schema::hasTable(Table::SESSIONS)) {
+                app(LaravelMigrations::class)->ensureSessionsTable();
+
                 return;
             }
 


### PR DESCRIPTION
### Description

- Adds a way to configure the migrations path a plugin loads migrations from using `getMigrationsPath`, defaults to Laravel convention + Craft's previous location for those files.

- Refactors the installation so all Laravel's optional migrations are also published and ran during a Craft install. This ensures we can use sessions, cache, batched jobs, etc without needing users to publish the migrations themselves. Using the framework commands to publish them ensures we don't need to maintain parity.
