### PR TITLE
[6.x] Prompt for site using select() when testing mailer

### DIFF
--- a/src/Email/Commands/SendTestMailCommand.php
+++ b/src/Email/Commands/SendTestMailCommand.php
@@ -35,7 +35,10 @@ class SendTestMailCommand extends Command
     {
         $site = $this->resolveSite();
 
-        // If a site couldn’t be determined by options, prompt the user:
+        if (! $site && ! $this->input->isInteractive()) {
+            $site = Sites::getPrimarySite();
+        }
+
         if (! $site) {
             $siteOptions = Sites::getAllSites()->keyBy('handle');
             $siteHandle = select(
@@ -82,12 +85,16 @@ class SendTestMailCommand extends Command
     }
 
     /**
-     * Resolves the --site option to a site.
+     * Resolves the requested site, defaulting to the primary site on single-site installs.
      *
-     * @return Site|null Site if discoverable by handle
+     * @return Site|null Site if discoverable by handle, otherwise null on multi-site installs
      */
     private function resolveSite(): ?Site
     {
+        if (! Sites::isMultiSite()) {
+            return Sites::getPrimarySite();
+        }
+
         $siteHandle = $this->option('site');
 
         if (! is_string($siteHandle) || $siteHandle === '') {

--- a/src/Email/Commands/SendTestMailCommand.php
+++ b/src/Email/Commands/SendTestMailCommand.php
@@ -6,10 +6,12 @@ namespace CraftCms\Cms\Email\Commands;
 
 use CraftCms\Cms\Console\CraftCommand;
 use CraftCms\Cms\Email\Actions\SendTestMailAction;
+use CraftCms\Cms\Site\Data\Site;
 use CraftCms\Cms\Support\Facades\Sites;
 use Illuminate\Console\Command;
 use Override;
 
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\table;
 use function Laravel\Prompts\text;
 
@@ -31,10 +33,18 @@ class SendTestMailCommand extends Command
 
     public function handle(SendTestMailAction $sendTestMail): int
     {
-        $siteId = $this->resolveSiteId();
+        $site = $this->resolveSite();
 
-        if ($siteId === false) {
-            return self::FAILURE;
+        // If a site couldn’t be determined by options, prompt the user:
+        if (! $site) {
+            $siteOptions = Sites::getAllSites()->keyBy('handle');
+            $siteHandle = select(
+                label: 'Choose a site',
+                options: $siteOptions->map(fn ($s) => $s->name),
+                default: Sites::getPrimarySite()->handle,
+            );
+
+            $site = $siteOptions->get($siteHandle);
         }
 
         $to = $this->option('to');
@@ -53,17 +63,18 @@ class SendTestMailCommand extends Command
             );
         }
 
-        $this->components->info("Sending a test email to {$to} with the following settings:");
+        $this->components->info("Sending a test email to <options=underscore>{$to}</> with the following settings:");
 
         table(
             headers: ['Setting', 'Value'],
-            rows: collect($sendTestMail->settings($siteId))
+            rows: collect($sendTestMail->settings($site->id))
                 ->map(fn (string $value, string $setting) => [$setting, $value])
+                ->push(['Site', "{$site->name} (ID #{$site->id})"])
                 ->values()
                 ->all(),
         );
 
-        $sendTestMail->handle($to, $siteId);
+        $sendTestMail->handle($to, $site->id);
 
         $this->components->success('Email sent successfully! Check your inbox.');
 
@@ -71,11 +82,11 @@ class SendTestMailCommand extends Command
     }
 
     /**
-     * Resolves the --site option to a site ID.
+     * Resolves the --site option to a site.
      *
-     * @return int|null|false null if no site specified, false on error, int on success
+     * @return Site|null Site if discoverable by handle
      */
-    private function resolveSiteId(): int|null|false
+    private function resolveSite(): ?Site
     {
         $siteHandle = $this->option('site');
 
@@ -83,14 +94,6 @@ class SendTestMailCommand extends Command
             return null;
         }
 
-        $site = Sites::getSiteByHandle($siteHandle);
-
-        if ($site === null) {
-            $this->components->error("Invalid site handle: {$siteHandle}");
-
-            return false;
-        }
-
-        return $site->id;
+        return Sites::getSiteByHandle($siteHandle);
     }
 }

--- a/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
+++ b/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
@@ -11,8 +11,6 @@ test('sends a test email to the provided recipient', function () {
     Mail::fake();
 
     $this->artisan('craft:mailer:test --to=test@example.com')
-        ->expectsOutputToContain('Sending a test email to test@example.com with the following settings:')
-        ->expectsOutputToContain('Email sent successfully! Check your inbox.')
         ->assertSuccessful();
 
     Mail::assertSent(
@@ -28,7 +26,6 @@ test('prompts for recipient email when no recipient option is provided', functio
 
     $this->artisan('craft:mailer:test')
         ->expectsQuestion('Which email address should the test email be sent to?', 'prompted@example.com')
-        ->expectsOutputToContain('Email sent successfully! Check your inbox.')
         ->assertSuccessful();
 
     Mail::assertSent(
@@ -39,7 +36,6 @@ test('prompts for recipient email when no recipient option is provided', functio
 
 test('requires a recipient in non-interactive mode', function () {
     $this->artisan('craft:mailer:test --no-interaction')
-        ->expectsOutputToContain('Please provide a recipient with the --to option when running non-interactively.')
         ->assertExitCode(1);
 });
 
@@ -60,7 +56,6 @@ test('sends a test email with site-specific overrides', function () {
     ]);
 
     $this->artisan("craft:mailer:test --to=test@example.com --site={$site->handle}")
-        ->expectsOutputToContain('Email sent successfully! Check your inbox.')
         ->assertSuccessful();
 
     Mail::assertSent(

--- a/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
+++ b/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
@@ -2,21 +2,26 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Site\Models\Site;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\SystemMessage\Mailables\SystemMessageMailable;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Mail;
 
 test('sends a test email to the provided recipient', function () {
     Mail::fake();
 
-    $this->artisan('craft:mailer:test --to=test@example.com')
+    $site = Sites::getPrimarySite();
+
+    $this->artisan("craft:mailer:test --to=test@example.com --site={$site->handle}")
         ->assertSuccessful();
 
     Mail::assertSent(
         SystemMessageMailable::class,
         fn (SystemMessageMailable $mailable): bool => $mailable->key === 'test_email' &&
             $mailable->hasTo('test@example.com') &&
+            $mailable->siteId === $site->id &&
             isset($mailable->variables['settings']),
     );
 });
@@ -24,18 +29,23 @@ test('sends a test email to the provided recipient', function () {
 test('prompts for recipient email when no recipient option is provided', function () {
     Mail::fake();
 
-    $this->artisan('craft:mailer:test')
+    $site = Sites::getPrimarySite();
+
+    $this->artisan("craft:mailer:test --site={$site->handle}")
         ->expectsQuestion('Which email address should the test email be sent to?', 'prompted@example.com')
         ->assertSuccessful();
 
     Mail::assertSent(
         SystemMessageMailable::class,
-        fn (SystemMessageMailable $mailable): bool => $mailable->hasTo('prompted@example.com'),
+        fn (SystemMessageMailable $mailable): bool => $mailable->hasTo('prompted@example.com') &&
+            $mailable->siteId === $site->id,
     );
 });
 
 test('requires a recipient in non-interactive mode', function () {
-    $this->artisan('craft:mailer:test --no-interaction')
+    $site = Sites::getPrimarySite();
+
+    $this->artisan("craft:mailer:test --site={$site->handle} --no-interaction")
         ->assertExitCode(1);
 });
 
@@ -60,29 +70,77 @@ test('sends a test email with site-specific overrides', function () {
 
     Mail::assertSent(
         SystemMessageMailable::class,
-        fn (SystemMessageMailable $mailable): bool => $mailable->hasTo('test@example.com') &&
-            $mailable->hasFrom('site@example.com', 'Site Sender') &&
-            $mailable->siteId === $site->id,
+        function (SystemMessageMailable $mailable) use ($site): bool {
+            $mailable->render();
+
+            return $mailable->hasTo('test@example.com') &&
+                $mailable->hasFrom('site@example.com', 'Site Sender') &&
+                $mailable->siteId === $site->id;
+        },
     );
 });
 
-test('uses the primary site when one is not provided', function () {
+test('prompts for a site when one is not provided', function () {
+    Mail::fake();
+
+    $otherSite = Site::factory()->create([
+        'handle' => 'otherSite',
+        'name' => 'Other Site',
+    ]);
+    Sites::refreshSites();
+
     $primarySite = Sites::getPrimarySite();
 
     $this->artisan('craft:mailer:test --to=test@example.com')
-        ->assetSuccessful();
+        ->expectsChoice('Choose a site', $otherSite->handle, [
+            $primarySite->handle => $primarySite->name,
+            $otherSite->handle => $otherSite->name,
+        ])
+        ->assertSuccessful();
 
     Mail::assertSent(
         SystemMessageMailable::class,
-        fn (SystemMessageMailable $mailable): bool => $mailable->siteId === $primarySite->id,
+        fn (SystemMessageMailable $mailable): bool => $mailable->siteId === $otherSite->id,
     );
 });
 
-test('defaults to the primary site when an invalid one is provided', function () {
+test('prompts for a site when an invalid one is provided', function () {
+    Mail::fake();
+
+    $otherSite = Site::factory()->create([
+        'handle' => 'otherSite',
+        'name' => 'Other Site',
+    ]);
+    Sites::refreshSites();
+
     $primarySite = Sites::getPrimarySite();
 
     $this->artisan('craft:mailer:test --to=test@example.com --site=nonexistent')
-        ->assetSuccessful();
+        ->expectsChoice('Choose a site', $otherSite->handle, [
+            $primarySite->handle => $primarySite->name,
+            $otherSite->handle => $otherSite->name,
+        ])
+        ->assertSuccessful();
+
+    Mail::assertSent(
+        SystemMessageMailable::class,
+        fn (SystemMessageMailable $mailable): bool => $mailable->siteId === $otherSite->id,
+    );
+});
+
+test('uses the primary site in non-interactive mode when one is not provided', function () {
+    Mail::fake();
+
+    Site::factory()->create([
+        'handle' => 'otherSite',
+        'name' => 'Other Site',
+    ]);
+    Sites::refreshSites();
+
+    $primarySite = Sites::getPrimarySite();
+
+    expect(Artisan::call('craft:mailer:test', ['--to' => 'test@example.com', '--no-interaction' => true]))
+        ->toBe(0);
 
     Mail::assertSent(
         SystemMessageMailable::class,

--- a/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
+++ b/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
@@ -61,6 +61,7 @@ test('sends a test email with site-specific overrides', function () {
     Mail::assertSent(
         SystemMessageMailable::class,
         fn (SystemMessageMailable $mailable): bool => $mailable->hasTo('test@example.com') &&
+            $mailable->hasFrom('site@example.com', 'Site Sender') &&
             $mailable->siteId === $site->id,
     );
 });

--- a/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
+++ b/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
@@ -80,6 +80,20 @@ test('sends a test email with site-specific overrides', function () {
     );
 });
 
+test('uses the primary site when one is not provided on a single-site install', function () {
+    Mail::fake();
+
+    $primarySite = Sites::getPrimarySite();
+
+    $this->artisan('craft:mailer:test --to=test@example.com')
+        ->assertSuccessful();
+
+    Mail::assertSent(
+        SystemMessageMailable::class,
+        fn (SystemMessageMailable $mailable): bool => $mailable->siteId === $primarySite->id,
+    );
+});
+
 test('prompts for a site when one is not provided', function () {
     Mail::fake();
 

--- a/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
+++ b/tests/Feature/Console/Commands/Mailer/TestCommandTest.php
@@ -66,8 +66,26 @@ test('sends a test email with site-specific overrides', function () {
     );
 });
 
-test('fails with an invalid site handle', function () {
+test('uses the primary site when one is not provided', function () {
+    $primarySite = Sites::getPrimarySite();
+
+    $this->artisan('craft:mailer:test --to=test@example.com')
+        ->assetSuccessful();
+
+    Mail::assertSent(
+        SystemMessageMailable::class,
+        fn (SystemMessageMailable $mailable): bool => $mailable->siteId === $primarySite->id,
+    );
+});
+
+test('defaults to the primary site when an invalid one is provided', function () {
+    $primarySite = Sites::getPrimarySite();
+
     $this->artisan('craft:mailer:test --to=test@example.com --site=nonexistent')
-        ->expectsOutputToContain('Invalid site handle: nonexistent')
-        ->assertExitCode(1);
+        ->assetSuccessful();
+
+    Mail::assertSent(
+        SystemMessageMailable::class,
+        fn (SystemMessageMailable $mailable): bool => $mailable->siteId === $primarySite->id,
+    );
 });


### PR DESCRIPTION
This replaces a couple of failure paths with a `select()` prompt to choose which site the test email is sent from.

When run with `--no-interaction`, `select()` uses the default value (the primary site).

---

Edit: I should have known better than to mess with the tests. It may be failing _because_ of the `select()` call?

Feel free to close this if it's just a distraction!