### PR TITLE
Drafts - Avoid internal server error - SQLSTATE Integrity constraint violation…

### DIFF
--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -1340,7 +1340,13 @@ JS, [
             }
 
             if (!empty($newOwnershipData)) {
-                Db::batchInsert(Table::ELEMENTS_OWNERS, ['elementId', 'ownerId', 'sortOrder'], $newOwnershipData);
+                foreach ($newOwnershipData as $row) {
+                    Db::upsert(Table::ELEMENTS_OWNERS, [
+                        'elementId' => $row[0],
+                        'ownerId' => $row[1],
+                        'sortOrder' => $row[2],
+                    ], false);
+                }
             }
 
             // Keep track of the sites we've already covered


### PR DESCRIPTION
… on elements_owners table when attempting to view/edit a draft in the CMS.

### Description

On Craft 5.9.14, multilingual site with propagation method set to "Save entries to all sites enabled for this section", when viewing several drafts, we were seeing exceptions like this:

SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '4491049-4490682' for key 'craft_elements_owners.PRIMARY' The SQL being executed was: INSERT INTO craft_elements_owners (`elementId`, ownerId, sortOrder) VALUES (4491049, 4490682, 1)

When you open a draft entry in the Craft control panel, ElementsController calls mergeCanonicalChanges() to sync any changes from the live / canonical entry into the draft. Part of that process is NestedElementManager::mergeCanonicalChanges(), which looks at the canonical entry's nested/Matrix elements and finds any that were added after the draft was created. 

For those new nested elements, it inserts ownership records into craft_elements_owners.

It does this every single time the draft is opened, with a batchInsert. The first draft open works fine. But the ownership row already exists from that first open, so every subsequent open tries to insert a duplicate and hits the primary key constraint that was throwing an internal server error and preventing the draft from loading.

This commit swaps Db::batchInsert with Db::upsert to avoid the exception and let the user view/edit the draft.


