### PR TITLE
Default to craftcms/cloud:^3

### DIFF
--- a/src/console/controllers/SetupController.php
+++ b/src/console/controllers/SetupController.php
@@ -622,7 +622,7 @@ EOD;
         $io = new ConsoleIO($input, $output, new HelperSet([new QuestionHelper()]));
 
         $composerService->install([
-            'craftcms/cloud' => '*',
+            'craftcms/cloud' => '^3',
         ], $io);
 
         $message = sprintf('Extension %s', $moduleInstalled ? 'updated' : 'installed');


### PR DESCRIPTION
### Description
`craftcms/cloud:3.0.0` is a non-breaking release that combines support for Craft 4 and 5.

It feels better to require an explicit major, and makes things easier on the Cloud API side.