### PR TITLE
Add Sec-Fetch-Site action filter

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,1 +1,4 @@
 # Release Notes for Craft CMS 4.18 (WIP)
+
+### Development
+- Added `craft\filters\SecFetchSiteFilter` for request origin verification. ([#18641](https://github.com/craftcms/cms/pull/18641))

--- a/src/filters/SecFetchSiteFilter.php
+++ b/src/filters/SecFetchSiteFilter.php
@@ -21,9 +21,9 @@ class SecFetchSiteFilter extends ActionFilter
     use ConditionalFilterTrait;
 
     /**
-     * Whether to require a valid `Sec-Fetch-Site` header (no CSRF token fallback).
+     * Whether to use origin verification only (no CSRF token fallback).
      */
-    public bool $strict = true;
+    public bool $originOnly = true;
 
     /**
      * Whether to accept `same-site` in addition to `same-origin` (e.g. subdomains).
@@ -59,7 +59,7 @@ class SecFetchSiteFilter extends ActionFilter
             return true;
         }
 
-        if ($this->strict) {
+        if ($this->originOnly) {
             throw new BadRequestHttpException($this->errorMessage);
         }
 

--- a/src/filters/SecFetchSiteFilter.php
+++ b/src/filters/SecFetchSiteFilter.php
@@ -20,8 +20,14 @@ class SecFetchSiteFilter extends ActionFilter
 {
     use ConditionalFilterTrait;
 
-    public bool $originOnly = true;
+    /**
+     * Whether to require a valid `Sec-Fetch-Site` header (no CSRF token fallback).
+     */
+    public bool $strict = true;
 
+    /**
+     * Whether to accept `same-site` in addition to `same-origin` (e.g. subdomains).
+     */
     public bool $allowSameSite = false;
 
     public string $headerName = 'Sec-Fetch-Site';
@@ -53,7 +59,7 @@ class SecFetchSiteFilter extends ActionFilter
             return true;
         }
 
-        if ($this->originOnly) {
+        if ($this->strict) {
             throw new BadRequestHttpException($this->errorMessage);
         }
 

--- a/src/filters/SecFetchSiteFilter.php
+++ b/src/filters/SecFetchSiteFilter.php
@@ -14,61 +14,32 @@ use yii\web\BadRequestHttpException;
 /**
  * Action filter for validating the `Sec-Fetch-Site` header.
  *
- * When enabled, requests with `Sec-Fetch-Site: same-origin` (or `same-site` when allowed)
- * will pass immediately without requiring a CSRF token. If the header is missing or invalid,
- * validation falls back to the CSRF token unless `originOnly` is enabled.
- *
- * This filter enforces the header regardless of the global CSRF setting; disable the filter
- * or add `except` rules to allow non-browser clients.
- *
  * @since 4.18.0
  */
 class SecFetchSiteFilter extends ActionFilter
 {
     use ConditionalFilterTrait;
 
-    /**
-     * @var bool Whether the filter is enabled.
-     */
-    public bool $enabled = true;
-
-    /**
-     * @var bool Whether to require a valid `Sec-Fetch-Site` header with no CSRF token fallback.
-     */
     public bool $originOnly = true;
 
-    /**
-     * @var bool Whether to accept `same-site` in addition to `same-origin`.
-     */
     public bool $allowSameSite = false;
 
-    /**
-     * @var string The header name to check.
-     */
     public string $headerName = 'Sec-Fetch-Site';
 
-    /**
-     * @var string The error message for rejected requests.
-     */
-    public string $errorMessage = 'Unable to verify your data submission.';
+    public ?string $errorMessage = null;
 
-    /**
-     * @var string[] The HTTP methods that should be checked.
-     */
-    public array $unsafeMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
+    public ?array $safeMethods = null;
 
     /**
      * @inheritdoc
      */
     public function beforeAction($action): bool
     {
-        if (!$this->enabled) {
-            return true;
-        }
+        $this->setDefaults();
 
         $request = Craft::$app->getRequest();
 
-        if (!in_array($request->getMethod(), $this->unsafeMethods, true)) {
+        if (in_array($request->getMethod(), $this->safeMethods, true)) {
             return true;
         }
 
@@ -87,5 +58,11 @@ class SecFetchSiteFilter extends ActionFilter
         }
 
         return true;
+    }
+
+    private function setDefaults(): void
+    {
+        $this->safeMethods = $this->safeMethods ?? Craft::$app->getRequest()->csrfTokenSafeMethods;
+        $this->errorMessage = $this->errorMessage ?? Craft::t('yii', 'Unable to verify your data submission.');
     }
 }

--- a/src/filters/SecFetchSiteFilter.php
+++ b/src/filters/SecFetchSiteFilter.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\filters;
+
+use Craft;
+use yii\base\ActionFilter;
+use yii\web\BadRequestHttpException;
+
+/**
+ * Action filter for validating the `Sec-Fetch-Site` header.
+ *
+ * When enabled, requests with `Sec-Fetch-Site: same-origin` (or `same-site` when allowed)
+ * will pass immediately without requiring a CSRF token. If the header is missing or invalid,
+ * validation falls back to the CSRF token unless `originOnly` is enabled.
+ *
+ * This filter enforces the header regardless of the global CSRF setting; disable the filter
+ * or add `except` rules to allow non-browser clients.
+ *
+ * @since 4.18.0
+ */
+class SecFetchSiteFilter extends ActionFilter
+{
+    use ConditionalFilterTrait;
+
+    /**
+     * @var bool Whether the filter is enabled.
+     */
+    public bool $enabled = true;
+
+    /**
+     * @var bool Whether to require a valid `Sec-Fetch-Site` header with no CSRF token fallback.
+     */
+    public bool $originOnly = true;
+
+    /**
+     * @var bool Whether to accept `same-site` in addition to `same-origin`.
+     */
+    public bool $allowSameSite = false;
+
+    /**
+     * @var string The header name to check.
+     */
+    public string $headerName = 'Sec-Fetch-Site';
+
+    /**
+     * @var string The error message for rejected requests.
+     */
+    public string $errorMessage = 'Unable to verify your data submission.';
+
+    /**
+     * @var string[] The HTTP methods that should be checked.
+     */
+    public array $unsafeMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+    /**
+     * @inheritdoc
+     */
+    public function beforeAction($action): bool
+    {
+        if (!$this->enabled) {
+            return true;
+        }
+
+        $request = Craft::$app->getRequest();
+
+        if (!in_array($request->getMethod(), $this->unsafeMethods, true)) {
+            return true;
+        }
+
+        $secFetchSite = $request->getHeaders()->get($this->headerName);
+
+        if ($secFetchSite === 'same-origin') {
+            return true;
+        }
+
+        if ($secFetchSite === 'same-site' && $this->allowSameSite) {
+            return true;
+        }
+
+        if ($this->originOnly) {
+            throw new BadRequestHttpException($this->errorMessage);
+        }
+
+        return true;
+    }
+}

--- a/tests/unit/filters/SecFetchSiteFilterTest.php
+++ b/tests/unit/filters/SecFetchSiteFilterTest.php
@@ -54,21 +54,21 @@ class SecFetchSiteFilterTest extends TestCase
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 
-    public function testAllowsFallbackWhenHeaderMissingAndOriginOnlyDisabled(): void
+    public function testAllowsFallbackWhenHeaderMissingAndNotStrict(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->remove('Sec-Fetch-Site');
 
-        $this->filter->originOnly = false;
+        $this->filter->strict = false;
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 
-    public function testRejectsWhenOriginOnlyAndHeaderInvalid(): void
+    public function testRejectsWhenStrictAndHeaderInvalid(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
 
-        $this->filter->originOnly = true;
+        $this->filter->strict = true;
 
         $this->expectException(BadRequestHttpException::class);
         $this->filter->beforeAction($this->action);
@@ -83,7 +83,7 @@ class SecFetchSiteFilterTest extends TestCase
         $this->request->enableCsrfValidation = false;
 
         try {
-            $this->filter->originOnly = true;
+            $this->filter->strict = true;
             $this->expectException(BadRequestHttpException::class);
             $this->filter->beforeAction($this->action);
         } finally {
@@ -96,18 +96,16 @@ class SecFetchSiteFilterTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
 
-        $this->filter->originOnly = true;
+        $this->filter->strict = true;
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 
-    public function testDisabledFilterSkipsValidation(): void
+    public function testInvalidHeaderFallsThroughWhenNotStrict(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
 
-        $this->filter->enabled = false;
-        $this->filter->originOnly = true;
-
+        $this->filter->strict = false;
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 }

--- a/tests/unit/filters/SecFetchSiteFilterTest.php
+++ b/tests/unit/filters/SecFetchSiteFilterTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace crafttests\unit\filters;
+
+use Craft;
+use craft\filters\SecFetchSiteFilter;
+use craft\test\TestCase;
+use craft\web\Request;
+use yii\base\Action;
+use yii\web\BadRequestHttpException;
+use yii\web\Controller;
+
+/**
+ * Unit tests for SecFetchSiteFilter
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.18.0
+ */
+class SecFetchSiteFilterTest extends TestCase
+{
+    private SecFetchSiteFilter $filter;
+    private Action $action;
+    private Request $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $controller = $this->createMock(Controller::class);
+        $this->action = new Action('test-action', $controller);
+        $this->filter = new SecFetchSiteFilter();
+        $this->request = Craft::$app->getRequest();
+    }
+
+    public function testAllowsSameOriginForUnsafeMethods(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $this->request->getHeaders()->set('Sec-Fetch-Site', 'same-origin');
+
+        self::assertTrue($this->filter->beforeAction($this->action));
+    }
+
+    public function testAllowsSameSiteWhenConfigured(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $this->request->getHeaders()->set('Sec-Fetch-Site', 'same-site');
+
+        $this->filter->allowSameSite = true;
+        self::assertTrue($this->filter->beforeAction($this->action));
+    }
+
+    public function testAllowsFallbackWhenHeaderMissingAndOriginOnlyDisabled(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $this->request->getHeaders()->remove('Sec-Fetch-Site');
+
+        $this->filter->originOnly = false;
+        self::assertTrue($this->filter->beforeAction($this->action));
+    }
+
+    public function testRejectsWhenOriginOnlyAndHeaderInvalid(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
+
+        $this->filter->originOnly = true;
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->filter->beforeAction($this->action);
+    }
+
+    public function testEnforcesWhenCsrfDisabled(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
+
+        $original = $this->request->enableCsrfValidation;
+        $this->request->enableCsrfValidation = false;
+
+        try {
+            $this->filter->originOnly = true;
+            $this->expectException(BadRequestHttpException::class);
+            $this->filter->beforeAction($this->action);
+        } finally {
+            $this->request->enableCsrfValidation = $original;
+        }
+    }
+
+    public function testSkipsSafeMethods(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
+
+        $this->filter->originOnly = true;
+        self::assertTrue($this->filter->beforeAction($this->action));
+    }
+
+    public function testDisabledFilterSkipsValidation(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
+
+        $this->filter->enabled = false;
+        $this->filter->originOnly = true;
+
+        self::assertTrue($this->filter->beforeAction($this->action));
+    }
+}

--- a/tests/unit/filters/SecFetchSiteFilterTest.php
+++ b/tests/unit/filters/SecFetchSiteFilterTest.php
@@ -59,7 +59,7 @@ class SecFetchSiteFilterTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->remove('Sec-Fetch-Site');
 
-        $this->filter->strict = false;
+        $this->filter->originOnly = false;
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 
@@ -68,7 +68,7 @@ class SecFetchSiteFilterTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
 
-        $this->filter->strict = true;
+        $this->filter->originOnly = true;
 
         $this->expectException(BadRequestHttpException::class);
         $this->filter->beforeAction($this->action);
@@ -83,7 +83,7 @@ class SecFetchSiteFilterTest extends TestCase
         $this->request->enableCsrfValidation = false;
 
         try {
-            $this->filter->strict = true;
+            $this->filter->originOnly = true;
             $this->expectException(BadRequestHttpException::class);
             $this->filter->beforeAction($this->action);
         } finally {
@@ -96,7 +96,7 @@ class SecFetchSiteFilterTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
 
-        $this->filter->strict = true;
+        $this->filter->originOnly = true;
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 
@@ -105,7 +105,7 @@ class SecFetchSiteFilterTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
 
-        $this->filter->strict = false;
+        $this->filter->originOnly = false;
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 }

--- a/tests/unit/filters/SecFetchSiteFilterTest.php
+++ b/tests/unit/filters/SecFetchSiteFilterTest.php
@@ -54,7 +54,7 @@ class SecFetchSiteFilterTest extends TestCase
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 
-    public function testAllowsFallbackWhenHeaderMissingAndNotStrict(): void
+    public function testAllowsFallbackWhenHeaderMissingAndNotOriginOnly(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->remove('Sec-Fetch-Site');
@@ -63,7 +63,7 @@ class SecFetchSiteFilterTest extends TestCase
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 
-    public function testRejectsWhenStrictAndHeaderInvalid(): void
+    public function testRejectsWhenOriginOnlyAndHeaderInvalid(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');
@@ -100,7 +100,7 @@ class SecFetchSiteFilterTest extends TestCase
         self::assertTrue($this->filter->beforeAction($this->action));
     }
 
-    public function testInvalidHeaderFallsThroughWhenNotStrict(): void
+    public function testInvalidHeaderFallsThroughWhenNotOriginOnly(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $this->request->getHeaders()->set('Sec-Fetch-Site', 'cross-site');


### PR DESCRIPTION
## Summary
Adds a `Sec-Fetch-Site` action filter for opt-in origin verification on requests.
Options match the Laravel 13.x implemention (`originOnly`, `allowSameSite`)

## Usage

### `config/app.web.php`

```php
'as secFetchSite' => [
    'class' => craft\filters\SecFetchSiteFilter::class,

    // require a valid Sec-Fetch-Site header
    'originOnly' => true,

    // only allow same-origin requests (no subdomains)
    'allowSameSite' => false,

    'except' => [
        'graphql/*',
        'webhooks/*',
    ],
],
```

```php
'as secFetchSite' => [
    'class' => craft\filters\SecFetchSiteFilter::class,

    // only enforce the header when it is present and invalid
    'originOnly' => false,

    // allow same-site (subdomain) requests in addition to same-origin
    'allowSameSite' => true,
],
```

## Links
- Fixes https://linear.app/craftcms/issue/CMS-1931
- Laravel PR: https://github.com/laravel/framework/pull/58400
- Tempest PR: https://github.com/tempestphp/tempest-framework/pull/1829