### PR TITLE
Defer auto-setting post dates until entries are saved as enabled

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -10,6 +10,7 @@
 - Color field previews are now blank for fields without a value. ([#18614](https://github.com/craftcms/cms/issues/18614))
 - Text condition rules now have “does not equal” operators.
 - Editable table columns now set `min-width` styles based on their configured widths, if set. ([#18534](https://github.com/craftcms/cms/issues/18534))
+- Entry post dates are no longer automatically set until the entry is fully saved as enabled. ([#18642](https://github.com/craftcms/cms/pull/18642))
 - Address edit screens now have “Field settings” action menu items. ([#18544](https://github.com/craftcms/cms/discussions/18544))
 - Asset edit screens now have “Volume settings” and “Filesystem settings” action menu items. ([#18544](https://github.com/craftcms/cms/discussions/18544))
 - Entries’ “Entry type settings” and “Section settings” action menu items are now only shown for element edit screens’ primary action menus.
@@ -29,6 +30,7 @@
 - The `tag()` function now accepts a string for its second argument. ([#18524](https://github.com/craftcms/cms/pull/18524))
 - The `|time` and `|datetime` Twig filters now have `$withTimeZone` arguments. ([#18639](https://github.com/craftcms/cms/pull/18639))
 - `delete` GraphQL queries now have a `hardDelete` argument. ([#18511](https://github.com/craftcms/cms/pull/18511))
+- Entry `postDate` values are now `null` on creation, rather than set to the `dateCreated` value. ([#18642](https://github.com/craftcms/cms/pull/18642))
 - Assets’ `url` GraphQL fields’ `immediately` arguments are no longer deprecated. ([#18581](https://github.com/craftcms/cms/issues/18581))
 - `craft\fields\data\LinkData::getUrl()` now has an `$anyStatus` argument, which can be set to `false` to prevent a value from being returned if a disabled/pending/expired element is linked. ([#18527](https://github.com/craftcms/cms/issues/18527))
 

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -29,6 +29,7 @@
 - Added the `heading()`/`h()` and `h1()`…`h6()` Twig functions. ([#18524](https://github.com/craftcms/cms/pull/18524))
 - The `tag()` function now accepts a string for its second argument. ([#18524](https://github.com/craftcms/cms/pull/18524))
 - The `|time` and `|datetime` Twig filters now have `$withTimeZone` arguments. ([#18639](https://github.com/craftcms/cms/pull/18639))
+- The `|timestamp` filter now returns the current time, if applied to a `null`/empty string value. ([#18642](https://github.com/craftcms/cms/pull/18642))
 - `delete` GraphQL queries now have a `hardDelete` argument. ([#18511](https://github.com/craftcms/cms/pull/18511))
 - Entry `postDate` values are now `null` on creation, rather than set to the `dateCreated` value. ([#18642](https://github.com/craftcms/cms/pull/18642))
 - Assets’ `url` GraphQL fields’ `immediately` arguments are no longer deprecated. ([#18581](https://github.com/craftcms/cms/issues/18581))

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -175,8 +175,6 @@ class EntriesController extends BaseEntriesController
         // Post & expiry dates
         if (($postDate = $this->request->getParam('postDate')) !== null) {
             $entry->postDate = DateTimeHelper::toDateTime($postDate);
-        } else {
-            $entry->postDate = DateTimeHelper::now();
         }
 
         if (($expiryDate = $this->request->getParam('expiryDate')) !== null) {

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -169,9 +169,6 @@ class EntriesController extends BaseEntriesController
             $entry->slug = ElementHelper::tempSlug();
         }
 
-        // Pause time so postDate will definitely be equal to dateCreated, if not explicitly defined
-        DateTimeHelper::pause();
-
         // Post & expiry dates
         if (($postDate = $this->request->getParam('postDate')) !== null) {
             $entry->postDate = DateTimeHelper::toDateTime($postDate);
@@ -191,9 +188,6 @@ class EntriesController extends BaseEntriesController
         // Save it
         $entry->setScenario(Element::SCENARIO_ESSENTIALS);
         $success = Craft::$app->getDrafts()->saveElementAsDraft($entry, $user->id, markAsSaved: false);
-
-        // Resume time
-        DateTimeHelper::resume();
 
         if (!$success) {
             return $this->asModelFailure($entry, StringHelper::upperCaseFirst(Craft::t('app', 'Couldn’t create {type}.', [

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -2712,7 +2712,7 @@ JS, [
                 'label' => Craft::t('app', 'Post Date'),
                 'id' => 'postDate',
                 'name' => 'postDate',
-                'value' => $this->_userPostDate(),
+                'value' => $this->postDate,
                 'errors' => $this->getErrors('postDate'),
                 'disabled' => $static,
             ]);
@@ -2916,21 +2916,6 @@ JS;
         Craft::$app->set('formattingLocale', $formattingLocale);
     }
 
-    /**
-     * Returns the Post Date value that should be shown on the edit form.
-     *
-     * @return DateTime|null
-     */
-    private function _userPostDate(): ?DateTime
-    {
-        if (!$this->postDate || ($this->getIsUnpublishedDraft() && $this->postDate == $this->dateCreated)) {
-            // Pretend the post date hasn't been set yet, even if it has
-            return null;
-        }
-
-        return $this->postDate;
-    }
-
     // Events
     // -------------------------------------------------------------------------
 
@@ -3031,11 +3016,10 @@ JS;
         }
 
         if (
-            !$this->_userPostDate() &&
-            (
-                in_array($this->scenario, [self::SCENARIO_LIVE, self::SCENARIO_DEFAULT]) ||
-                (!$this->getIsDraft() && !$this->getIsRevision())
-            )
+            !$this->postDate &&
+            !$this->getIsRevision() &&
+            $this->enabled &&
+            in_array($this->scenario, [self::SCENARIO_LIVE, self::SCENARIO_DEFAULT])
         ) {
             // Default the post date to the current date/time
             $this->postDate = new DateTime();

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -657,7 +657,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
     public function timestampFilter(mixed $value, ?string $format = null, bool $withPreposition = false): string
     {
         if ($value === null || $value === '') {
-            return '';
+            $value = DateTimeHelper::now();
         }
 
         try {


### PR DESCRIPTION
Defers auto-setting entry post dates until they are fully saved as enabled.

Previously, `postDate` was set to the current date/time during creation, and the UI would awkwardly just pretend that the value was blank if `postDate` was set to the exact same time as `dateCreated`. Then, the first time the canonical entry was fully saved (regardless of status), if `postDate` was still set to `dateCreated`, the value would be updated to the current date/time.

With this PR, the `postDate` value will remain `null` on entry creation, up until the author explicitly sets it, or the entry is fully saved **as enabled**. Giving authors the ability to save disabled entries and continue working on them, and not have to worry about updating the Post Date value when they’re ready to actually publish.

It does away with the logic to ignore the `postDate` value if it’s set to `dateCreated`, meaning that any existing unpublished draft entries may start showing a Post Date value in Craft 5.10 where they wouldn’t on Craft 5.9. Those values can be cleared out if desired.

Development-wise, templates and API clients will need to be defensive about `null` `postDate` values when working with draft/disabled entries. However that _should_ already be the case, as it’s already possible for an entry to end up with a `null` `postDate` value, if the author explicitly clears the value out after it had already been explicitly/automatically set.

The `|date`, `|datetime`, and `|time` Twig filters each will default their values to the current date/time if `null` is passed, and this PR also updates `|timestamp` to follow suit, so in general, no changes will need to be made to Twig templates.