### PR TITLE
[6.x] Entry type handle validation

### DIFF
--- a/src/Http/Controllers/Settings/EntryTypesController.php
+++ b/src/Http/Controllers/Settings/EntryTypesController.php
@@ -268,7 +268,7 @@ class EntryTypesController
         $entryType->showStatusField = $request->boolean('showStatusField', $entryType->showStatusField);
 
         // If we're duplicating the entry type and the handle hasn't changed, find a unique one
-        if ($entryType->handle === ($originalEntryType->handle ?? null)) {
+        if ($saveAsNew && $entryType->handle === ($originalEntryType->handle ?? null)) {
             if (preg_match('/^(.*?)(\d+)$/', (string) $entryType->handle, $match)) {
                 $baseHandle = $match[1];
                 $i = (int) $match[2];

--- a/src/Validation/Rules/HandleRule.php
+++ b/src/Validation/Rules/HandleRule.php
@@ -44,7 +44,7 @@ class HandleRule implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! preg_match(sprintf('/^%s$/', self::$handlePattern), (string) $value)) {
-            $fail(t('“{handle}” isn’t a valid handle.'));
+            $fail(t('“{handle}” isn’t a valid handle.', ['handle' => $value]));
 
             return;
         }

--- a/yii2-adapter/legacy/validators/HandleValidator.php
+++ b/yii2-adapter/legacy/validators/HandleValidator.php
@@ -62,12 +62,12 @@ class HandleValidator extends Validator
         $message = null;
 
         if (!preg_match(sprintf('/^%s$/', static::$handlePattern), $value)) {
-            $message = $this->message ?? t('“{handle}” isn’t a valid handle.');
+            $message = $this->message ?? t('“{handle}” isn’t a valid handle.', ['handle' => $value]);
         } else {
             $reservedWords = array_merge($this->reservedWords, static::$baseReservedWords);
             $reservedWords = array_map('strtolower', $reservedWords);
             if (in_array(strtolower($value), $reservedWords, true)) {
-                $message = t('“{handle}” is a reserved word.');
+                $message = t('“{handle}” is a reserved word.', ['handle' => $value]);
             }
         }
 


### PR DESCRIPTION
Placeholders were showing up in the `handle` validator on entry types; once that was fixed, the error was cryptic (like "“2” is not a valid handle.”), which led me to the second patch.

Checking `$saveAsNew` seemed appropriate before trying to increment the handle; if someone chooses an existing handle, we probably shouldn't quietly swallow the collision.