### PR TITLE
remember the invalid nested element ids too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where nested element cards weren’t showing validation errors. ([#18690](https://github.com/craftcms/cms/pull/18690))
+
 ## 5.9.19 - 2026-04-07
 
 - Most classes can now be instantiated via the `create()` Twig function. ([#18376](https://github.com/craftcms/cms/discussions/18376))

--- a/src/controllers/ElementsController.php
+++ b/src/controllers/ElementsController.php
@@ -2190,10 +2190,12 @@ JS, [
             // save the draft anyway, so we don’t lose the latest changes
             // (see https://github.com/craftcms/cms/issues/18657)
             $errors = $element->getErrors();
+            $invalidNestedElementIds = $element->getInvalidNestedElementIds();
             $element->setScenario(Element::SCENARIO_ESSENTIALS);
             $elementsService->saveElement($element, saveContent: $saveContent);
             $element->clearErrors();
             $element->addErrors($errors);
+            $element->addInvalidNestedElementIds($invalidNestedElementIds);
 
             return $this->_asAppyDraftFailure($element);
         }


### PR DESCRIPTION
### Description
When the draft couldn’t be applied, we still save it, so that we don’t lose any content, and we “remember” the validation errors from before the draft was saved. 

This PR ensures that the invalid nested element IDs are also “remembered”. This ensures that, e.g. the relevant nested element can be visually marked as invalid.

Steps to reproduce:
1. clean 5.9.19 installation
2. create a matrix field with an entry type containing title and plain text fields; all default settings
3. create a section with an entry type that contains that matrix field
4. create an entry in that section, add a nested entry into the matrix field, but leave the plain text field empty; fully save it all
5. edit the entry type for the matrix field and make the plain text field required
6. edit the entry from step 4 but in a slideout (e.g. double-click or use the action from the element index page)
7. press save to try to fully save it - you should see a validation error about the nested entry

Before this PR: the relevant card didn’t have the indicators showing that it’s invalid (red title and an exclamation mark icon).

After this PR: the indicators are there


### Related issues
n/a
