### PR TITLE
fieldLayouts and defaultTableColumns are needed in static mode too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where nested element cards weren’t showing validation errors. ([#18690](https://github.com/craftcms/cms/pull/18690))
+- Fixed a bug where read-only Matrix fields in Index mode weren’t respecting the Default Table Columns setting. ([#18684](https://github.com/craftcms/cms/issues/18684))
 
 ## 5.9.19 - 2026-04-07
 

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1387,14 +1387,11 @@ JS,
             'pageSize' => $this->pageSize ?? 50,
             'storageKey' => sprintf('field:%s', $this->uid),
             'defaultViewMode' => $this->defaultIndexViewMode,
+            'defaultTableColumns' => array_map(fn(string $attribute) => [$attribute], $this->defaultTableColumns),
+            // field layouts are needed in the read-only (static) mode
+            // so that you can adjust the table columns when using index view mode with table view
+            'fieldLayouts' => array_map(fn(EntryType $entryType) => $entryType->getFieldLayout(), $entryTypes),
         ];
-
-        if (!$static) {
-            $config += [
-                'fieldLayouts' => array_map(fn(EntryType $entryType) => $entryType->getFieldLayout(), $entryTypes),
-                'defaultTableColumns' => array_map(fn(string $attribute) => [$attribute], $this->defaultTableColumns),
-            ];
-        }
 
         return $this->entryManager()->getIndexHtml($owner, $config);
     }

--- a/src/fields/Matrix.php
+++ b/src/fields/Matrix.php
@@ -1389,7 +1389,7 @@ JS,
             'defaultViewMode' => $this->defaultIndexViewMode,
             'defaultTableColumns' => array_map(fn(string $attribute) => [$attribute], $this->defaultTableColumns),
             // field layouts are needed in the read-only (static) mode
-            // so that you can adjust the table columns when using index view mode with table view
+            // so that you can choose to show columns representing the custom fields when using index view mode with table view
             'fieldLayouts' => array_map(fn(EntryType $entryType) => $entryType->getFieldLayout(), $entryTypes),
         ];
 


### PR DESCRIPTION
### Description
`fieldLayouts` and `defaultTableColumns` are needed in read-only mode too.

The `defaultTableColumns` are needed so that the default table columns selected for the field are shown as expected.
The `fieldLayouts` are needed so you can choose to show columns representing the custom fields when using index view mode with table view.


### Related issues
#18684
