### PR TITLE
get nested elements for all localised owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where nested element cards weren’t showing validation errors. ([#18690](https://github.com/craftcms/cms/pull/18690))
 - Fixed a bug where read-only Matrix fields in Index mode weren’t respecting the Default Table Columns setting. ([#18684](https://github.com/craftcms/cms/issues/18684))
+- Fixed a bug where nested entries could be lost when reverting content from a revision. ([#18691](https://github.com/craftcms/cms/issues/18691))
 
 ## 5.9.19 - 2026-04-07
 

--- a/src/elements/NestedElementManager.php
+++ b/src/elements/NestedElementManager.php
@@ -1225,12 +1225,36 @@ JS, [
         );
 
         /** @var NestedElementInterface[] $elements */
-        $elements = $this->nestedElementQuery($canonical)
-            ->siteId($siteIds)
-            ->preferSites([$canonical->siteId])
-            ->unique()
-            ->status(null)
-            ->all();
+        $elements = [];
+        $processedElementIds = [];
+
+        foreach ($siteIds as $siteId) {
+            if ($siteId === $canonical->siteId) {
+                $owner = $canonical;
+            } else {
+                $owner = $canonical::find()
+                    ->id($canonical->id)
+                    ->siteId($siteId)
+                    ->status(null)
+                    ->one();
+
+                if ($owner === null) {
+                    continue;
+                }
+            }
+
+            $siteElements = $this->nestedElementQuery($owner)
+                ->status(null)
+                ->all();
+
+            /** @var NestedElementInterface $element */
+            foreach ($siteElements as $element) {
+                if (!isset($processedElementIds[$element->id])) {
+                    $processedElementIds[$element->id] = true;
+                    $elements[] = $element;
+                }
+            }
+        }
 
         $revisionsService = Craft::$app->getRevisions();
         $elementRevisionIds = [];


### PR DESCRIPTION
### Description
In v5.9.0, the before prepare element query for matrix field started calling `$query->owner($owner)` as opposed to `$query->ownerId = $owner->id` (https://github.com/craftcms/cms/commit/686acd93cc#diff-b69a116794c7e46c0ab7429df36ab933f3ff5071e8e1856aa27cf9de2c4b1b40L778). 

This change made significant performance improvements, but it looks like it has some adverse effects when combined with  certain propagation settings. The `NestedElementQueryTrait::owner()` method will set the query’s `siteId` to the owner’s `siteId` and ignore any other `siteId` param that was previously configured on the query. 
In the case described by OP, it means that when creating revisions, the nested elements are only found on the owner’s site, and any nested elements unique to other sites supported by the owner are ignored.

Fix:
When getting nested elements in the `NestedElementManager::createRevisions()` method, first get the owner element across all supported sites, then get the nested elements for each site individually.

### Related issues
#18691 
