### PR TITLE
eagerly(), revisions and nested elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where nested element cards weren’t showing validation errors. ([#18690](https://github.com/craftcms/cms/pull/18690))
 - Fixed a bug where read-only Matrix fields in Index mode weren’t respecting the Default Table Columns setting. ([#18684](https://github.com/craftcms/cms/issues/18684))
 - Fixed a bug where nested entries could be lost when reverting content from a revision. ([#18691](https://github.com/craftcms/cms/issues/18691))
+- Fixed a bug where nested entries weren’t getting loaded when previewing a revision, if queried with `eagerly()`. ([#18693](https://github.com/craftcms/cms/issues/18693))
 
 ## 5.9.19 - 2026-04-07
 

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3493,8 +3493,8 @@ class Elements extends Component
                         $query->limit = null;
 
                         $criteria = array_merge(
+                            $plan->criteria,
                             $map['criteria'] ?? [],
-                            $plan->criteria
                         );
 
                         // Save the offset & limit params for later

--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -3492,6 +3492,8 @@ class Elements extends Component
                         $query->offset = null;
                         $query->limit = null;
 
+                        // The mapping criteria should take precedence here
+                        // (see https://github.com/craftcms/cms/pull/18704)
                         $criteria = array_merge(
                             $plan->criteria,
                             $map['criteria'] ?? [],


### PR DESCRIPTION
### Description
When getting an eager loading map for, e.g. a matrix field, we specify some criteria for the query (https://github.com/craftcms/cms/blob/5.9.19/src/fields/Matrix.php#L1560-L1568). 

Those criteria are then merged with the plan’s criteria, which are based on the query’s default criteria: https://github.com/craftcms/cms/blob/5.9.19/src/services/Elements.php#L3495-L3498. 

The order in which they’re merged meant that the map criteria were overwritten by the plan’s criteria.

Fix: changed the order of the merged criteria arrays so that the map’s criteria take priority.

### Related issues
#18693 
