### PR TITLE
[6.x] Element query improvements

### DIFF
--- a/src/Element/Concerns/DisplayedInIndex.php
+++ b/src/Element/Concerns/DisplayedInIndex.php
@@ -260,7 +260,7 @@ trait DisplayedInIndex
      */
     private static function elementQueryWithAllDescendants(ElementQueryInterface $elementQuery): ElementQueryInterface|ElementQuery
     {
-        $wheres = $elementQuery->getSubQuery()->wheres;
+        $wheres = $elementQuery->getQuery()->wheres;
 
         if (! is_array($wheres)) {
             return $elementQuery;
@@ -275,7 +275,7 @@ trait DisplayedInIndex
 
             $elementQuery = clone $elementQuery;
             unset($wheres[$key]);
-            $elementQuery->getSubQuery()->wheres = $wheres;
+            $elementQuery->getQuery()->wheres = $wheres;
 
             return $elementQuery;
         }

--- a/src/Element/Policies/ElementPolicy.php
+++ b/src/Element/Policies/ElementPolicy.php
@@ -10,6 +10,7 @@ use craft\base\NestedElementInterface;
 use CraftCms\Cms\Auth\Events\AuthorizingElement;
 use CraftCms\Cms\Field\Contracts\ElementContainerFieldInterface;
 use CraftCms\Cms\Site\Models\Site;
+use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Gate;
 
@@ -87,7 +88,7 @@ class ElementPolicy
             return null;
         }
 
-        if (! $site = Site::find($siteId)) {
+        if (! $site = Sites::getSiteById($siteId)) {
             return false;
         }
 

--- a/src/Element/Queries/AddressQuery.php
+++ b/src/Element/Queries/AddressQuery.php
@@ -11,6 +11,7 @@ use CraftCms\Cms\Element\Queries\Concerns\QueriesNestedElements;
 use CraftCms\Cms\Element\Queries\Exceptions\QueryAbortedException;
 use CraftCms\Cms\Support\Arr;
 use Illuminate\Support\Collection;
+use Override;
 
 /**
  * @extends ElementQuery<Address>
@@ -351,7 +352,7 @@ class AddressQuery extends ElementQuery
                     throw new QueryAbortedException;
                 }
 
-                $addressQuery->subQuery->whereIn('addresses.primaryOwnerId', Arr::wrap($addressQuery->primaryOwnerId ?? $addressQuery->ownerId));
+                $addressQuery->whereIn('addresses.primaryOwnerId', Arr::wrap($addressQuery->primaryOwnerId ?? $addressQuery->ownerId));
             }
 
             foreach ([
@@ -374,7 +375,7 @@ class AddressQuery extends ElementQuery
                     continue;
                 }
 
-                $addressQuery->subQuery->whereParam("addresses.$property", $addressQuery->$property);
+                $addressQuery->whereParam("addresses.$property", $addressQuery->$property);
             }
         });
     }
@@ -885,7 +886,7 @@ class AddressQuery extends ElementQuery
         return $this;
     }
 
-    #[\Override]
+    #[Override]
     protected function fieldLayouts(): Collection
     {
         return new Collection([

--- a/src/Element/Queries/AddressQuery.php
+++ b/src/Element/Queries/AddressQuery.php
@@ -20,6 +20,15 @@ class AddressQuery extends ElementQuery
 {
     use QueriesNestedElements;
 
+    #[Override]
+    protected string $table = Table::ADDRESSES;
+
+    #[Override]
+    protected array $defaultOrderBy = [
+        'addresses.dateCreated' => SORT_DESC,
+        'addresses.id' => SORT_DESC,
+    ];
+
     /**
      * @var mixed The address countryCode(s) that the resulting address must be in.
      *            ---
@@ -318,8 +327,6 @@ class AddressQuery extends ElementQuery
     public function __construct(array $config = [])
     {
         parent::__construct(Address::class, $config);
-
-        $this->joinElementTable(Table::ADDRESSES);
 
         $this->query->addSelect([
             'addresses.id as id',

--- a/src/Element/Queries/AssetQuery.php
+++ b/src/Element/Queries/AssetQuery.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Override;
 use Tpetry\QueryExpressions\Language\Alias;
 
 /**
@@ -136,7 +137,7 @@ class AssetQuery extends ElementQuery
                 throw new QueryAbortedException;
             }
 
-            $this->subQuery->where(function (Builder $query) use ($user, $fullyAuthorizedVolumeIds, $partiallyAuthorizedVolumeIds) {
+            $this->where(function (Builder $query) use ($user, $fullyAuthorizedVolumeIds, $partiallyAuthorizedVolumeIds) {
                 if ($fullyAuthorizedVolumeIds) {
                     $query->orWhereIn('assets.volumeId', $fullyAuthorizedVolumeIds);
                 }
@@ -156,7 +157,7 @@ class AssetQuery extends ElementQuery
             throw new QueryAbortedException;
         }
 
-        $this->subQuery->where(function (Builder $query) use ($user, $unauthorizedVolumeIds, $partiallyAuthorizedVolumeIds) {
+        $this->where(function (Builder $query) use ($user, $unauthorizedVolumeIds, $partiallyAuthorizedVolumeIds) {
             if ($unauthorizedVolumeIds) {
                 $query->orWhereIn('assets.volumeId', $unauthorizedVolumeIds);
             }
@@ -173,7 +174,7 @@ class AssetQuery extends ElementQuery
         });
     }
 
-    #[\Override]
+    #[Override]
     public function createElement(array $row): ElementInterface
     {
         // Use the site-specific alt text, if set
@@ -186,7 +187,7 @@ class AssetQuery extends ElementQuery
         return parent::createElement($row);
     }
 
-    #[\Override]
+    #[Override]
     protected function cacheTags(): array
     {
         $tags = [];
@@ -200,7 +201,7 @@ class AssetQuery extends ElementQuery
         return $tags;
     }
 
-    #[\Override]
+    #[Override]
     protected function fieldLayouts(): Collection
     {
         if (! $this->volumeId) {

--- a/src/Element/Queries/AssetQuery.php
+++ b/src/Element/Queries/AssetQuery.php
@@ -33,6 +33,15 @@ class AssetQuery extends ElementQuery
     use QueriesAssetProperties;
     use QueriesSizes;
 
+    #[Override]
+    protected string $table = Table::ASSETS;
+
+    #[Override]
+    protected array $defaultOrderBy = [
+        'assets.dateCreated' => SORT_DESC,
+        'assets.id' => SORT_DESC,
+    ];
+
     /**
      * @var bool|null Whether to only return assets that the user has permission to view.
      *
@@ -50,8 +59,6 @@ class AssetQuery extends ElementQuery
     public function __construct(array $config = [])
     {
         parent::__construct(Asset::class, $config);
-
-        $this->joinElementTable(Table::ASSETS);
 
         $this->query->addSelect([
             'assets.volumeId as volumeId',

--- a/src/Element/Queries/Concerns/Asset/QueriesAlt.php
+++ b/src/Element/Queries/Concerns/Asset/QueriesAlt.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Element\Queries\Concerns\Asset;
 
-use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Queries\AssetQuery;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Query\JoinClause;
-use Tpetry\QueryExpressions\Language\Alias;
 
 /**
  * @internal
@@ -49,12 +46,7 @@ trait QueriesAlt
                     });
             };
 
-            $this->subQuery
-                ->leftJoin(new Alias(Table::ASSETS_SITES, 'assets_sites'), function (JoinClause $join) {
-                    $join->on('assets_sites.assetId', '=', 'assets.id')
-                        ->whereColumn('assets_sites.siteId', '=', 'elements_sites.siteId');
-                })
-                ->where($this->hasAlt ? $hasAltCondition : $withoutAltCondition);
+            $assetQuery->where($this->hasAlt ? $hasAltCondition : $withoutAltCondition);
         });
     }
 

--- a/src/Element/Queries/Concerns/Asset/QueriesAssetLocation.php
+++ b/src/Element/Queries/Concerns/Asset/QueriesAssetLocation.php
@@ -73,14 +73,13 @@ trait QueriesAssetLocation
                 throw new QueryAbortedException;
             }
 
-            $assetQuery->subQuery->join(new Alias(Table::VOLUMEFOLDERS, 'volumeFolders'), 'volumeFolders.id', '=', 'assets.folderId');
-            $assetQuery->query->join(new Alias(Table::VOLUMEFOLDERS, 'volumeFolders'), 'volumeFolders.id', '=', 'assets.folderId');
+            $assetQuery->join(new Alias(Table::VOLUMEFOLDERS, 'volumeFolders'), 'volumeFolders.id', '=', 'assets.folderId');
 
             if ($assetQuery->volumeId) {
                 if ($assetQuery->volumeId === ':empty:') {
-                    $assetQuery->subQuery->whereNull('assets.volumeId');
+                    $assetQuery->whereNull('assets.volumeId');
                 } else {
-                    $assetQuery->subQuery->whereIn('assets.volumeId', Arr::wrap($this->volumeId));
+                    $assetQuery->whereIn('assets.volumeId', Arr::wrap($this->volumeId));
                 }
             }
 
@@ -91,7 +90,7 @@ trait QueriesAssetLocation
                     $assetQuery->folderId = reset($assetQuery->folderId);
                 }
 
-                $assetQuery->subQuery->where(function (Builder $query) use ($assetQuery) {
+                $assetQuery->where(function (Builder $query) use ($assetQuery) {
                     $query->whereNumericParam('assets.folderId', $assetQuery->folderId)
                         ->when(
                             is_numeric($assetQuery->folderId) && $assetQuery->includeSubfolders,
@@ -117,7 +116,7 @@ trait QueriesAssetLocation
                     }
                 }
 
-                $assetQuery->subQuery->whereParam('volumeFolders.path', $folderPath);
+                $assetQuery->whereParam('volumeFolders.path', $folderPath);
             }
         });
     }

--- a/src/Element/Queries/Concerns/Asset/QueriesAssetProperties.php
+++ b/src/Element/Queries/Concerns/Asset/QueriesAssetProperties.php
@@ -85,15 +85,15 @@ trait QueriesAssetProperties
     {
         $this->beforeQuery(function (AssetQuery $assetQuery) {
             if ($assetQuery->uploaderId) {
-                $assetQuery->subQuery->whereIn('uploaderId', Arr::wrap($assetQuery->uploaderId));
+                $assetQuery->whereIn('uploaderId', Arr::wrap($assetQuery->uploaderId));
             }
 
             if ($assetQuery->filename) {
-                $assetQuery->subQuery->whereParam('assets.filename', $assetQuery->filename);
+                $assetQuery->whereParam('assets.filename', $assetQuery->filename);
             }
 
             if ($assetQuery->kind) {
-                $assetQuery->subQuery->where(function (Builder $query) use ($assetQuery) {
+                $assetQuery->where(function (Builder $query) use ($assetQuery) {
                     $query->whereParam('assets.kind', $assetQuery->kind);
 
                     $kinds = AssetsHelper::getFileKinds();
@@ -111,7 +111,7 @@ trait QueriesAssetProperties
             }
 
             if ($assetQuery->dateModified) {
-                $assetQuery->subQuery->whereDateParam('assets.dateModified', $assetQuery->dateModified);
+                $assetQuery->whereDateParam('assets.dateModified', $assetQuery->dateModified);
             }
         });
     }

--- a/src/Element/Queries/Concerns/Asset/QueriesSizes.php
+++ b/src/Element/Queries/Concerns/Asset/QueriesSizes.php
@@ -67,15 +67,15 @@ trait QueriesSizes
     {
         $this->beforeQuery(function (AssetQuery $assetQuery) {
             if ($assetQuery->width) {
-                $assetQuery->subQuery->whereNumericParam('assets.width', $assetQuery->width);
+                $assetQuery->whereNumericParam('assets.width', $assetQuery->width);
             }
 
             if ($assetQuery->height) {
-                $assetQuery->subQuery->whereNumericParam('assets.height', $assetQuery->height);
+                $assetQuery->whereNumericParam('assets.height', $assetQuery->height);
             }
 
             if ($assetQuery->size) {
-                $assetQuery->subQuery->whereNumericParam('assets.size', $assetQuery->size, '=', Query::TYPE_BIGINT);
+                $assetQuery->whereNumericParam('assets.size', $assetQuery->size, '=', Query::TYPE_BIGINT);
             }
         });
     }

--- a/src/Element/Queries/Concerns/Entry/QueriesAuthors.php
+++ b/src/Element/Queries/Concerns/Entry/QueriesAuthors.php
@@ -95,7 +95,7 @@ trait QueriesAuthors
                 $authorIdOperator = 'whereExists';
             }
 
-            $query->subQuery->$authorIdOperator(
+            $query->$authorIdOperator(
                 DB::table(Table::ENTRIES_AUTHORS, 'entries_authors')
                     ->whereColumn('entries.id', 'entries_authors.entryId')
                     ->whereNumericParam('authorId', $authorIdCheck),
@@ -135,7 +135,7 @@ trait QueriesAuthors
                 $groupIdOperator = 'whereExists';
             }
 
-            $query->subQuery->$groupIdOperator(
+            $query->$groupIdOperator(
                 DB::table(Table::ENTRIES_AUTHORS, "entries_authors$i")
                     ->join(new Alias(Table::USERGROUPS_USERS, "usergroups_users$i"), "usergroups_users$i.userId", '=', "entries_authors$i.authorId")
                     ->whereColumn('entries.id', "entries_authors$i.entryId")

--- a/src/Element/Queries/Concerns/Entry/QueriesEntryDates.php
+++ b/src/Element/Queries/Concerns/Entry/QueriesEntryDates.php
@@ -82,18 +82,18 @@ trait QueriesEntryDates
     {
         $this->beforeQuery(function (EntryQuery $query) {
             if ($query->postDate) {
-                $query->subQuery->whereDateParam('entries.postDate', $query->postDate);
+                $query->whereDateParam('entries.postDate', $query->postDate);
             } else {
                 if ($query->before) {
-                    $query->subQuery->whereDateParam('entries.postDate', $query->before, '<');
+                    $query->whereDateParam('entries.postDate', $query->before, '<');
                 }
                 if ($query->after) {
-                    $query->subQuery->whereDateParam('entries.postDate', $query->after, '>=');
+                    $query->whereDateParam('entries.postDate', $query->after, '>=');
                 }
             }
 
             if ($query->expiryDate) {
-                $query->subQuery->whereDateParam('entries.expiryDate', $query->expiryDate);
+                $query->whereDateParam('entries.expiryDate', $query->expiryDate);
             }
         });
     }

--- a/src/Element/Queries/Concerns/Entry/QueriesEntryTypes.php
+++ b/src/Element/Queries/Concerns/Entry/QueriesEntryTypes.php
@@ -53,7 +53,7 @@ trait QueriesEntryTypes
                 return;
             }
 
-            $entryQuery->subQuery->whereIn('entries.typeId', $entryQuery->typeId);
+            $entryQuery->whereIn('entries.typeId', $entryQuery->typeId);
         });
     }
 

--- a/src/Element/Queries/Concerns/Entry/QueriesRef.php
+++ b/src/Element/Queries/Concerns/Entry/QueriesRef.php
@@ -36,7 +36,7 @@ trait QueriesRef
             }
 
             $joinSections = false;
-            $query->subQuery->where(function (Builder $query) use (&$joinSections, $refs) {
+            $query->where(function (Builder $query) use (&$joinSections, $refs) {
                 foreach ($refs as $ref) {
                     $parts = array_filter(explode('/', (string) $ref), static fn (string $part) => $part !== '');
 
@@ -60,7 +60,7 @@ trait QueriesRef
             });
 
             if ($joinSections) {
-                $this->subQuery->join(new Alias(Table::SECTIONS, 'sections'), 'sections.id', '=', 'entries.sectionId');
+                $this->join(new Alias(Table::SECTIONS, 'sections'), 'sections.id', '=', 'entries.sectionId');
             }
         });
     }

--- a/src/Element/Queries/Concerns/Entry/QueriesSections.php
+++ b/src/Element/Queries/Concerns/Entry/QueriesSections.php
@@ -162,7 +162,7 @@ trait QueriesSections
             return;
         }
 
-        $entryQuery->subQuery->whereIn('entries.sectionId', $entryQuery->sectionId);
+        $entryQuery->whereIn('entries.sectionId', $entryQuery->sectionId);
 
         // Should we set the structureId param?
         if (

--- a/src/Element/Queries/Concerns/FormatsResults.php
+++ b/src/Element/Queries/Concerns/FormatsResults.php
@@ -211,7 +211,6 @@ trait FormatsResults
         }
 
         $this->parseOrderColumnMappings($elementQuery, $this->query);
-        $this->parseOrderColumnMappings($elementQuery, $this->subQuery);
     }
 
     private function applyDefaultOrder(ElementQuery $elementQuery): void
@@ -262,7 +261,6 @@ trait FormatsResults
             };
 
             $elementQuery->query->orderBy($column, $direction);
-            $elementQuery->subQuery->orderBy($column, $direction);
         }
     }
 
@@ -287,13 +285,8 @@ trait FormatsResults
 
     private function orderBySearchResults(ElementQuery $elementQuery): void
     {
-        $elementQuery->query->orders = array_filter(
-            $elementQuery->query->orders ?? [],
-            fn (array $order) => $order['column'] !== 'score',
-        );
-
-        $elementQuery->subQuery->orders = array_filter(
-            $elementQuery->subQuery->orders ?? [],
+        $elementQuery->getQuery()->orders = array_filter(
+            $elementQuery->getQuery()->orders ?? [],
             fn (array $order) => isset($order['column']) && $order['column'] !== 'score',
         );
 
@@ -324,6 +317,5 @@ trait FormatsResults
         }
 
         $elementQuery->query->orderBy(new CaseGroup($rules, new Value($i + 1)));
-        $elementQuery->subQuery->orderBy(new CaseGroup($rules, new Value($i + 1)));
     }
 }

--- a/src/Element/Queries/Concerns/QueriesCustomFields.php
+++ b/src/Element/Queries/Concerns/QueriesCustomFields.php
@@ -226,7 +226,7 @@ trait QueriesCustomFields
                 ? QueryParam::AND
                 : QueryParam::OR;
 
-            $this->subQuery->where(function (Builder $query) use ($fieldsByHandle, $glue, $handle, $elementQuery) {
+            $this->where(function (Builder $query) use ($fieldsByHandle, $glue, $handle, $elementQuery) {
                 foreach ($fieldsByHandle[$handle] as $instances) {
                     $query->where(function (Builder $query) use ($handle, $elementQuery, $instances) {
                         $instances[0]::modifyQuery($query, $instances, $elementQuery->customFieldValues[$handle]);
@@ -258,7 +258,7 @@ trait QueriesCustomFields
                 ? $columns[0]
                 : new Coalesce($columns);
 
-            $elementQuery->subQuery->whereParam($column, $elementQuery->customFieldValues[$handle]);
+            $elementQuery->whereParam($column, $elementQuery->customFieldValues[$handle]);
         }
     }
 

--- a/src/Element/Queries/Concerns/QueriesDraftsAndRevisions.php
+++ b/src/Element/Queries/Concerns/QueriesDraftsAndRevisions.php
@@ -103,13 +103,12 @@ trait QueriesDraftsAndRevisions
     private function applyDraftParams(ElementQuery $elementQuery): void
     {
         if ($elementQuery->drafts === false) {
-            $elementQuery->subQuery->where($this->placeholderCondition(fn (Builder $q) => $q->whereNull('elements.draftId')));
+            $elementQuery->where($this->placeholderCondition(fn (Builder $q) => $q->whereNull('elements.draftId')));
 
             return;
         }
 
         $joinType = $elementQuery->drafts === true ? 'inner' : 'left';
-        $elementQuery->subQuery->join(new Alias(Table::DRAFTS, 'drafts'), 'drafts.id', 'elements.draftId', type: $joinType);
         $elementQuery->query->join(new Alias(Table::DRAFTS, 'drafts'), 'drafts.id', 'elements.draftId', type: $joinType);
 
         $elementQuery->query->addSelect([
@@ -121,32 +120,32 @@ trait QueriesDraftsAndRevisions
         ]);
 
         if ($elementQuery->draftId) {
-            $elementQuery->subQuery->where('elements.draftId', $elementQuery->draftId);
+            $elementQuery->where('elements.draftId', $elementQuery->draftId);
         }
 
         if ($elementQuery->draftOf === '*') {
-            $elementQuery->subQuery->whereNotNull('elements.canonicalId');
+            $elementQuery->whereNotNull('elements.canonicalId');
         } elseif (isset($elementQuery->draftOf)) {
             if ($elementQuery->draftOf === false) {
-                $elementQuery->subQuery->whereNull('elements.canonicalId');
+                $elementQuery->whereNull('elements.canonicalId');
             } else {
-                $elementQuery->subQuery->whereIn('elements.canonicalId', Arr::wrap($elementQuery->draftOf));
+                $elementQuery->whereIn('elements.canonicalId', Arr::wrap($elementQuery->draftOf));
             }
         }
 
         if ($elementQuery->draftCreator) {
-            $elementQuery->subQuery->where('drafts.creatorId', $elementQuery->draftCreator);
+            $elementQuery->where('drafts.creatorId', $elementQuery->draftCreator);
         }
 
         if (isset($elementQuery->provisionalDrafts)) {
-            $elementQuery->subQuery->where(function (Builder $q) use ($elementQuery) {
+            $elementQuery->where(function (Builder $q) use ($elementQuery) {
                 $q->whereNull('elements.draftId')
                     ->orWhereBool('drafts.provisional', $elementQuery->provisionalDrafts);
             });
         }
 
         if ($elementQuery->canonicalsOnly) {
-            $elementQuery->subQuery->where(function (Builder $query) use ($elementQuery) {
+            $elementQuery->where(function (Builder $query) use ($elementQuery) {
                 $query->whereNull('elements.draftId')
                     ->orWhere(function (Builder $q) use ($elementQuery) {
                         $q
@@ -158,7 +157,7 @@ trait QueriesDraftsAndRevisions
                     });
             });
         } elseif ($elementQuery->savedDraftsOnly) {
-            $elementQuery->subQuery->where(function (Builder $query) {
+            $elementQuery->where(function (Builder $query) {
                 $query->whereNull('elements.draftId')
                     ->orWhereNotNull('elements.canonicalId')
                     ->orWhereBool('drafts.saved', true);
@@ -169,13 +168,12 @@ trait QueriesDraftsAndRevisions
     private function applyRevisionParams(ElementQuery $elementQuery): void
     {
         if ($elementQuery->revisions === false) {
-            $elementQuery->subQuery->where($this->placeholderCondition(fn (Builder $q) => $q->whereNull('elements.revisionId')));
+            $elementQuery->where($this->placeholderCondition(fn (Builder $q) => $q->whereNull('elements.revisionId')));
 
             return;
         }
 
         $joinType = $elementQuery->revisions === true ? 'inner' : 'left';
-        $elementQuery->subQuery->join(new Alias(Table::REVISIONS, 'revisions'), 'revisions.id', 'elements.revisionId', type: $joinType);
         $elementQuery->query->join(new Alias(Table::REVISIONS, 'revisions'), 'revisions.id', 'elements.revisionId', type: $joinType);
 
         $elementQuery->query->addSelect([
@@ -186,15 +184,15 @@ trait QueriesDraftsAndRevisions
         ]);
 
         if ($elementQuery->revisionId) {
-            $elementQuery->subQuery->where('elements.revisionId', $elementQuery->revisionId);
+            $elementQuery->where('elements.revisionId', $elementQuery->revisionId);
         }
 
         if ($elementQuery->revisionOf) {
-            $elementQuery->subQuery->where('elements.canonicalId', $elementQuery->revisionOf);
+            $elementQuery->where('elements.canonicalId', $elementQuery->revisionOf);
         }
 
         if ($elementQuery->revisionCreator) {
-            $elementQuery->subQuery->where('revisions.creatorId', $elementQuery->revisionCreator);
+            $elementQuery->where('revisions.creatorId', $elementQuery->revisionCreator);
         }
     }
 

--- a/src/Element/Queries/Concerns/QueriesFields.php
+++ b/src/Element/Queries/Concerns/QueriesFields.php
@@ -92,31 +92,31 @@ trait QueriesFields
             if (! is_null($elementQuery->id)) {
                 throw_if(empty($elementQuery->id), QueryAbortedException::class);
 
-                $elementQuery->subQuery->whereNumericParam('elements.id', $elementQuery->id);
+                $elementQuery->whereNumericParam('elements.id', $elementQuery->id);
             }
 
             if (! is_null($elementQuery->uid)) {
                 throw_if(empty($elementQuery->uid), QueryAbortedException::class);
 
-                $elementQuery->subQuery->whereParam('elements.uid', $elementQuery->uid);
+                $elementQuery->whereParam('elements.uid', $elementQuery->uid);
             }
 
             if ($elementQuery->siteSettingsId) {
-                $elementQuery->subQuery->whereNumericParam('elements_sites.id', $elementQuery->siteSettingsId);
+                $elementQuery->whereNumericParam('elements_sites.id', $elementQuery->siteSettingsId);
             }
 
             match ($elementQuery->trashed) {
-                true => $elementQuery->subQuery->whereNotNull('elements.dateDeleted'),
-                false => $elementQuery->subQuery->whereNull('elements.dateDeleted'),
+                true => $elementQuery->whereNotNull('elements.dateDeleted'),
+                false => $elementQuery->whereNull('elements.dateDeleted'),
                 default => null,
             };
 
             if ($elementQuery->dateCreated) {
-                $elementQuery->subQuery->whereDateParam('elements.dateCreated', $elementQuery->dateCreated);
+                $elementQuery->whereDateParam('elements.dateCreated', $elementQuery->dateCreated);
             }
 
             if ($elementQuery->dateUpdated) {
-                $elementQuery->subQuery->whereDateParam('elements.dateUpdated', $elementQuery->dateUpdated);
+                $elementQuery->whereDateParam('elements.dateUpdated', $elementQuery->dateUpdated);
             }
 
             if (isset($elementQuery->title) && $elementQuery->title !== '' && $elementQuery->elementType::hasTitles()) {
@@ -124,19 +124,19 @@ trait QueriesFields
                     $elementQuery->title = Query::escapeCommas($elementQuery->title);
                 }
 
-                $elementQuery->subQuery->whereParam('elements_sites.title', $elementQuery->title, caseInsensitive: true);
+                $elementQuery->whereParam('elements_sites.title', $elementQuery->title, caseInsensitive: true);
             }
 
             if ($elementQuery->slug) {
-                $elementQuery->subQuery->whereParam('elements_sites.slug', $elementQuery->slug);
+                $elementQuery->whereParam('elements_sites.slug', $elementQuery->slug);
             }
 
             if ($elementQuery->uri) {
-                $elementQuery->subQuery->whereParam('elements_sites.uri', $elementQuery->uri, caseInsensitive: true);
+                $elementQuery->whereParam('elements_sites.uri', $elementQuery->uri, caseInsensitive: true);
             }
 
             if ($elementQuery->inBulkOp) {
-                $elementQuery->subQuery
+                $elementQuery
                     ->join(new Alias(Table::ELEMENTS_BULKOPS, 'elements_bulkops'), 'elements_bulkops.elementId', 'elements.id')
                     ->where('elements_bulkops.key', $elementQuery->inBulkOp);
             }

--- a/src/Element/Queries/Concerns/QueriesNestedElements.php
+++ b/src/Element/Queries/Concerns/QueriesNestedElements.php
@@ -112,14 +112,13 @@ trait QueriesNestedElements
 
             // Join in the elements_owners table
             $elementQuery->query->join(new Alias(Table::ELEMENTS_OWNERS, 'elements_owners'), $joinClause);
-            $elementQuery->subQuery->join(new Alias(Table::ELEMENTS_OWNERS, 'elements_owners'), $joinClause);
 
             if ($elementQuery->fieldId) {
-                $elementQuery->subQuery->whereIn($this->getFieldIdColumn(), $elementQuery->fieldId);
+                $elementQuery->whereIn($this->getFieldIdColumn(), $elementQuery->fieldId);
             }
 
             if ($elementQuery->primaryOwnerId) {
-                $this->subQuery->whereIn($this->getPrimaryOwnerIdColumn(), $elementQuery->primaryOwnerId);
+                $elementQuery->whereIn($this->getPrimaryOwnerIdColumn(), $elementQuery->primaryOwnerId);
             }
 
             // Ignore revision/draft blocks by default
@@ -127,7 +126,7 @@ trait QueriesNestedElements
             $allowOwnerRevisions = $elementQuery->allowOwnerRevisions ?? ($elementQuery->id || $elementQuery->primaryOwnerId || $elementQuery->ownerId);
 
             if (! $allowOwnerDrafts || ! $allowOwnerRevisions) {
-                $elementQuery->subQuery->join(
+                $elementQuery->join(
                     new Alias(Table::ELEMENTS, 'owners'),
                     fn (JoinClause $join) => $join->when(
                         $elementQuery->ownerId,
@@ -137,11 +136,11 @@ trait QueriesNestedElements
                 );
 
                 if (! $allowOwnerDrafts) {
-                    $elementQuery->subQuery->whereNull('owners.draftId');
+                    $elementQuery->whereNull('owners.draftId');
                 }
 
                 if (! $allowOwnerRevisions) {
-                    $elementQuery->subQuery->whereNull('owners.revisionId');
+                    $elementQuery->whereNull('owners.revisionId');
                 }
             }
 

--- a/src/Element/Queries/Concerns/QueriesRelatedElements.php
+++ b/src/Element/Queries/Concerns/QueriesRelatedElements.php
@@ -55,7 +55,7 @@ trait QueriesRelatedElements
                     )
                     : []
             )->apply(
-                query: $elementQuery->subQuery,
+                query: $elementQuery->getQuery(),
                 relatedToParam: $elementQuery->relatedTo,
                 siteId: $elementQuery->siteId !== '*' ? $elementQuery->siteId : null
             );
@@ -71,7 +71,7 @@ trait QueriesRelatedElements
 
             $notRelatedToParam = $elementQuery->notRelatedTo;
 
-            $elementQuery->subQuery->whereNot(function (Builder $query) use ($notRelatedToParam, $elementQuery) {
+            $elementQuery->whereNot(function (Builder $query) use ($notRelatedToParam, $elementQuery) {
                 new ElementRelationParamFilter(
                     fields: $elementQuery->customFields
                         ? Arr::keyBy(

--- a/src/Element/Queries/Concerns/QueriesSites.php
+++ b/src/Element/Queries/Concerns/QueriesSites.php
@@ -51,7 +51,7 @@ trait QueriesSites
             }
 
             if (Sites::isMultiSite(false, true)) {
-                $elementQuery->subQuery->whereIn('elements_sites.siteId', Arr::wrap($elementQuery->siteId));
+                $elementQuery->whereIn('elements_sites.siteId', Arr::wrap($elementQuery->siteId));
             }
         });
     }

--- a/src/Element/Queries/Concerns/QueriesStatuses.php
+++ b/src/Element/Queries/Concerns/QueriesStatuses.php
@@ -37,7 +37,7 @@ trait QueriesStatuses
     {
         $this->beforeQuery(function (ElementQuery $elementQuery) {
             if ($elementQuery->archived) {
-                $elementQuery->subQuery->whereBool('elements.archived', true);
+                $elementQuery->whereBool('elements.archived', true);
 
                 return;
             }
@@ -47,7 +47,7 @@ trait QueriesStatuses
             // only set archived=false if 'archived' doesn't show up in the status param
             // (_applyStatusParam() will normalize $this->status to an array if applicable)
             if (! is_array($elementQuery->status) || ! in_array($elementQuery->elementType::STATUS_ARCHIVED, $elementQuery->status)) {
-                $elementQuery->subQuery->whereBool('elements.archived', false);
+                $elementQuery->whereBool('elements.archived', false);
             }
         });
     }
@@ -128,7 +128,7 @@ trait QueriesStatuses
             $glue = 'and';
         }
 
-        $elementQuery->subQuery->where(function (Builder $query) use ($statuses, $negate, $glue) {
+        $elementQuery->where(function (Builder $query) use ($statuses, $negate, $glue) {
             foreach ($statuses as $status) {
                 match (true) {
                     $glue === 'or' && $negate === false => $query->orWhere($this->placeholderCondition($this->statusCondition($status))),

--- a/src/Element/Queries/Concerns/QueriesStructures.php
+++ b/src/Element/Queries/Concerns/QueriesStructures.php
@@ -582,7 +582,7 @@ trait QueriesStructures
             return;
         }
 
-        $elementQuery->query->addSelect([
+        $elementQuery->addSelect([
             'structureelements.root as root',
             'structureelements.lft as lft',
             'structureelements.rgt as rgt',
@@ -590,20 +590,10 @@ trait QueriesStructures
         ]);
 
         if ($elementQuery->structureId) {
-            $elementQuery->query->leftJoin(new Alias(Table::STRUCTUREELEMENTS, 'structureelements'), fn (JoinClause $join) => $join
-                ->on('structureelements.elementId', '=', 'subquery.elementsId')
-                ->where('structureelements.structureId', $elementQuery->structureId));
-
-            $elementQuery->subQuery->leftJoin(new Alias(Table::STRUCTUREELEMENTS, 'structureelements'), fn (JoinClause $join) => $join
+            $elementQuery->leftJoin(new Alias(Table::STRUCTUREELEMENTS, 'structureelements'), fn (JoinClause $join) => $join
                 ->on('structureelements.elementId', '=', 'elements.id')
                 ->where('structureelements.structureId', $elementQuery->structureId));
         } else {
-            $elementQuery->query
-                ->addSelect('structureelements.structureId as structureId')
-                ->leftJoin(new Alias(Table::STRUCTUREELEMENTS, 'structureelements'), fn (JoinClause $join) => $join
-                    ->on('structureelements.elementId', '=', 'subquery.elementsId')
-                    ->where('structureelements.structureId', '=', 'subquery.structureId'));
-
             $existsQuery = DB::table(Table::STRUCTURES)
                 // Use index hints to specify index so Mysql does not select the less
                 // performant one (dateDeleted).
@@ -614,45 +604,44 @@ trait QueriesStructures
                 ->whereColumn('id', 'structureelements.structureId')
                 ->whereNull('dateDeleted');
 
-            $elementQuery->subQuery
+            $elementQuery
                 ->addSelect('structureelements.structureId as structureId')
                 ->leftJoin(new Alias(Table::STRUCTUREELEMENTS, 'structureelements'), fn (JoinClause $join) => $join
                     ->on('structureelements.elementId', '=', 'elements.id')
-                    ->whereExists($existsQuery)
-                );
+                    ->whereExists($existsQuery));
         }
 
         if (isset($elementQuery->hasDescendants)) {
-            $elementQuery->subQuery->when(
+            $elementQuery->when(
                 $elementQuery->hasDescendants,
-                fn (Builder $query) => $elementQuery->where('structureelements.rgt', '>', DB::raw('structureelements.lft + 1')),
-                fn (Builder $query) => $elementQuery->where('structureelements.rgt', '=', DB::raw('structureelements.lft + 1')),
+                fn (ElementQuery $query) => $elementQuery->where('structureelements.rgt', '>', DB::raw('structureelements.lft + 1')),
+                fn (ElementQuery $query) => $elementQuery->where('structureelements.rgt', '=', DB::raw('structureelements.lft + 1')),
             );
         }
 
         if ($elementQuery->ancestorOf) {
             $ancestorOf = $elementQuery->normalizeStructureParamValue('ancestorOf');
 
-            $elementQuery->subQuery
+            $elementQuery
                 ->where('structureelements.lft', '<', $ancestorOf->lft)
                 ->where('structureelements.rgt', '>', $ancestorOf->rgt)
                 ->where('structureelements.root', $ancestorOf->root)
                 ->when(
                     $elementQuery->ancestorDist,
-                    fn (Builder $q) => $q->where('structureelements.level', '>=', $ancestorOf->level - $elementQuery->ancestorDist)
+                    fn (ElementQuery $q) => $q->where('structureelements.level', '>=', $ancestorOf->level - $elementQuery->ancestorDist)
                 );
         }
 
         if ($elementQuery->descendantOf) {
             $descendantOf = $elementQuery->normalizeStructureParamValue('descendantOf');
 
-            $elementQuery->subQuery
+            $elementQuery
                 ->where('structureelements.lft', '>', $descendantOf->lft)
                 ->where('structureelements.rgt', '<', $descendantOf->rgt)
                 ->where('structureelements.root', $descendantOf->root)
                 ->when(
                     $elementQuery->descendantDist,
-                    fn (Builder $q) => $q->where('structureelements.level', '<=', $descendantOf->level + $elementQuery->descendantDist)
+                    fn (ElementQuery $q) => $q->where('structureelements.level', '<=', $descendantOf->level + $elementQuery->descendantDist)
                 );
         }
 
@@ -663,7 +652,7 @@ trait QueriesStructures
 
             $siblingOf = $elementQuery->normalizeStructureParamValue($param);
 
-            $elementQuery->subQuery
+            $elementQuery
                 ->where('structureelements.level', $siblingOf->level)
                 ->where('structureelements.root', $siblingOf->root)
                 ->whereNot('structureelements.elementId', $siblingOf->id);
@@ -675,7 +664,7 @@ trait QueriesStructures
                     throw new QueryAbortedException;
                 }
 
-                $elementQuery->subQuery
+                $elementQuery
                     ->where('structureelements.lft', '>', $parent->lft)
                     ->where('structureelements.rgt', '>', $parent->rgt);
             }
@@ -683,14 +672,14 @@ trait QueriesStructures
             switch ($param) {
                 case 'prevSiblingOf':
                     $elementQuery->orderByDesc('structureelements.lft');
-                    $elementQuery->subQuery
+                    $elementQuery
                         ->where('structureelements.lft', '<', $siblingOf->lft)
                         ->orderByDesc('structureelements.lft')
                         ->limit(1);
                     break;
                 case 'nextSiblingOf':
                     $elementQuery->orderBy('structureelements.lft');
-                    $elementQuery->subQuery
+                    $elementQuery
                         ->where('structureelements.lft', '>', $siblingOf->lft)
                         ->orderBy('structureelements.lft')
                         ->limit(1);
@@ -701,7 +690,7 @@ trait QueriesStructures
         if ($elementQuery->positionedBefore) {
             $positionedBefore = $elementQuery->normalizeStructureParamValue('positionedBefore');
 
-            $elementQuery->subQuery
+            $elementQuery
                 ->where('structureelements.lft', '<', $positionedBefore->lft)
                 ->where('structureelements.root', $positionedBefore->root);
         }
@@ -709,7 +698,7 @@ trait QueriesStructures
         if ($elementQuery->positionedAfter) {
             $positionedAfter = $elementQuery->normalizeStructureParamValue('positionedAfter');
 
-            $elementQuery->subQuery
+            $elementQuery
                 ->where('structureelements.lft', '>', $positionedAfter->rgt)
                 ->where('structureelements.root', $positionedAfter->root);
         }
@@ -717,18 +706,18 @@ trait QueriesStructures
         if (isset($elementQuery->level)) {
             $allowNull = is_array($elementQuery->level) && in_array(null, $elementQuery->level, true);
 
-            $elementQuery->subQuery->when(
+            $elementQuery->when(
                 value: $allowNull,
-                callback: fn (Builder $q) => $q->where(function (Builder $q) use ($elementQuery) {
+                callback: fn (ElementQuery $q) => $q->where(function (Builder $q) use ($elementQuery) {
                     $q->whereNumericParam('structureelements.level', array_filter($elementQuery->level, fn ($v) => $v !== null))
                         ->orWhereNull('structureelements.level');
                 }),
-                default: fn (Builder $q) => $q->whereNumericParam('structureelements.level', $elementQuery->level),
+                default: fn (ElementQuery $q) => $q->whereNumericParam('structureelements.level', $elementQuery->level),
             );
         }
 
         if ($elementQuery->leaves) {
-            $elementQuery->subQuery->where('structureelements.rgt', DB::raw('structureelements.lft + 1'));
+            $elementQuery->where('structureelements.rgt', DB::raw('structureelements.lft + 1'));
         }
     }
 

--- a/src/Element/Queries/Concerns/QueriesUniqueElements.php
+++ b/src/Element/Queries/Concerns/QueriesUniqueElements.php
@@ -66,23 +66,33 @@ trait QueriesUniqueElements
 
         $caseGroup = new CaseGroup($cases, new Value($preferSites->count()));
 
-        $subSelectSql = $elementQuery->getQuery()->clone()
+        $subQuery = $elementQuery->getQuery()->clone()
             ->select(['elements_sites.id'])
-            ->from(Table::ELEMENTS, 'subElements')
-            ->whereColumn('subElements.id', 'tmpElements.id')
             ->orderBy($caseGroup)
             ->orderBy('elements_sites.id')
             ->offset(0)
-            ->limit(1)
-            ->toRawSql();
+            ->limit(1);
+
+        if ($elementQuery->from === Table::ELEMENTS) {
+            $subQuery
+                ->from(Table::ELEMENTS, 'subElements')
+                ->whereColumn('subElements.id', 'tmpElements.id');
+        } else {
+            $subQuery->whereColumn('elements.id', 'tmpElements.id');
+        }
+
+        $subSelectSql = $subQuery->toRawSql();
 
         $qElements = DB::getQueryGrammar()->wrapTable('elements');
         $qSubElements = DB::getQueryGrammar()->wrapTable('subElements');
         $qTmpElements = DB::getQueryGrammar()->wrapTable('tmpElements');
         $q = $qElements[0];
 
-        $subSelectSql = str_replace("$qElements.", "$qSubElements.", $subSelectSql);
-        $subSelectSql = str_replace("{$q}{$qElements}", "{$q}{$qSubElements}", $subSelectSql);
+        if ($elementQuery->from === Table::ELEMENTS) {
+            $subSelectSql = str_replace("$qElements.", "$qSubElements.", $subSelectSql);
+            $subSelectSql = str_replace("{$q}{$qElements}", "{$q}{$qSubElements}", $subSelectSql);
+        }
+
         $subSelectSql = str_replace($qTmpElements, $qElements, $subSelectSql);
 
         $elementQuery->whereRaw('elements_sites.id = ('.$subSelectSql.')');

--- a/src/Element/Queries/Concerns/QueriesUniqueElements.php
+++ b/src/Element/Queries/Concerns/QueriesUniqueElements.php
@@ -66,7 +66,7 @@ trait QueriesUniqueElements
 
         $caseGroup = new CaseGroup($cases, new Value($preferSites->count()));
 
-        $subSelectSql = $elementQuery->subQuery->clone()
+        $subSelectSql = $elementQuery->getQuery()->clone()
             ->select(['elements_sites.id'])
             ->from(Table::ELEMENTS, 'subElements')
             ->whereColumn('subElements.id', 'tmpElements.id')
@@ -85,7 +85,7 @@ trait QueriesUniqueElements
         $subSelectSql = str_replace("{$q}{$qElements}", "{$q}{$qSubElements}", $subSelectSql);
         $subSelectSql = str_replace($qTmpElements, $qElements, $subSelectSql);
 
-        $elementQuery->subQuery->whereRaw('elements_sites.id = ('.$subSelectSql.')');
+        $elementQuery->whereRaw('elements_sites.id = ('.$subSelectSql.')');
     }
 
     /**

--- a/src/Element/Queries/Concerns/SearchesElements.php
+++ b/src/Element/Queries/Concerns/SearchesElements.php
@@ -6,8 +6,8 @@ namespace CraftCms\Cms\Element\Queries\Concerns;
 
 use CraftCms\Cms\Element\Queries\ElementQuery;
 use CraftCms\Cms\Element\Queries\Exceptions\QueryAbortedException;
-use CraftCms\Cms\Search\Search;
 use CraftCms\Cms\Support\Arr;
+use CraftCms\Cms\Support\Facades\Search;
 use Illuminate\Database\Query\Builder;
 
 /**
@@ -53,13 +53,11 @@ trait SearchesElements
             return;
         }
 
-        $searchService = app(Search::class);
+        $scoreOrder = Arr::first($elementQuery->query->orders ?? [], fn ($order) => ($order['column'] ?? '') === 'score');
 
-        $scoreOrder = Arr::first($elementQuery->query->orders ?? [], fn ($order) => $order['column'] === 'score');
-
-        if ($scoreOrder || $searchService->shouldCallSearchElements($elementQuery)) {
+        if ($scoreOrder || Search::shouldCallSearchElements($elementQuery)) {
             // Get the scored results up front
-            $searchResults = $searchService->searchElements($elementQuery);
+            $searchResults = Search::searchElements($elementQuery);
 
             if ($scoreOrder['direction'] === 'asc') {
                 $searchResults = array_reverse($searchResults, true);
@@ -105,7 +103,7 @@ trait SearchesElements
         }
 
         // Just filter the main query by the search query
-        $searchQuery = $searchService->createDbQuery($elementQuery->search, $elementQuery);
+        $searchQuery = Search::createDbQuery($elementQuery->search, $elementQuery);
 
         if ($searchQuery === false) {
             throw new QueryAbortedException;

--- a/src/Element/Queries/Concerns/SearchesElements.php
+++ b/src/Element/Queries/Concerns/SearchesElements.php
@@ -69,14 +69,14 @@ trait SearchesElements
                 // Only use the portion we're actually querying for
                 if (is_int($elementQuery->query->getOffset()) && $elementQuery->query->getOffset() !== 0) {
                     $searchResults = array_slice($searchResults, $elementQuery->query->getOffset(), null, true);
-                    $elementQuery->subQuery->offset = null;
-                    $elementQuery->subQuery->unionOffset = null;
+                    $elementQuery->query->offset = null;
+                    $elementQuery->query->unionOffset = null;
                 }
 
                 if (is_int($elementQuery->query->getLimit()) && $elementQuery->query->getLimit() !== 0) {
                     $searchResults = array_slice($searchResults, 0, $elementQuery->query->getLimit(), true);
-                    $elementQuery->subQuery->limit = null;
-                    $elementQuery->subQuery->unionLimit = null;
+                    $elementQuery->query->limit = null;
+                    $elementQuery->query->unionLimit = null;
                 }
             }
 
@@ -92,7 +92,7 @@ trait SearchesElements
                 $elementIdsBySiteId[$siteId][] = $elementId;
             }
 
-            $elementQuery->subQuery->where(function (Builder $query) use ($elementIdsBySiteId) {
+            $elementQuery->where(function (Builder $query) use ($elementIdsBySiteId) {
                 foreach ($elementIdsBySiteId as $siteId => $elementIds) {
                     $query->orWhere(function (Builder $query) use ($siteId, $elementIds) {
                         $query->where('elements_sites.siteId', $siteId)
@@ -111,7 +111,7 @@ trait SearchesElements
             throw new QueryAbortedException;
         }
 
-        $elementQuery->subQuery->whereIn('elements.id', $searchQuery->pluck('elementId'));
+        $elementQuery->whereIn('elements.id', $searchQuery->pluck('elementId'));
     }
 
     /**

--- a/src/Element/Queries/Concerns/User/QueriesAffiliatedSite.php
+++ b/src/Element/Queries/Concerns/User/QueriesAffiliatedSite.php
@@ -33,7 +33,7 @@ trait QueriesAffiliatedSite
                 return;
             }
 
-            $userQuery->subQuery->whereIn('users.affiliatedSiteId', Arr::wrap($this->affiliatedSiteId));
+            $userQuery->whereIn('users.affiliatedSiteId', Arr::wrap($this->affiliatedSiteId));
         });
     }
 

--- a/src/Element/Queries/Concerns/User/QueriesAssetUploaders.php
+++ b/src/Element/Queries/Concerns/User/QueriesAssetUploaders.php
@@ -6,7 +6,6 @@ namespace CraftCms\Cms\Element\Queries\Concerns\User;
 
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Queries\UserQuery;
-use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -44,10 +43,10 @@ trait QueriesAssetUploaders
             $exists = DB::table(Table::ASSETS)
                 ->whereColumn('uploaderId', 'elements.id');
 
-            $userQuery->subQuery->when(
+            $userQuery->when(
                 $userQuery->assetUploaders,
-                fn (Builder $query) => $query->whereExists($exists),
-                fn (Builder $query) => $query->whereNotExists($exists),
+                fn (UserQuery $query) => $query->whereExists($exists),
+                fn (UserQuery $query) => $query->whereNotExists($exists),
             );
         });
     }

--- a/src/Element/Queries/Concerns/User/QueriesAuthors.php
+++ b/src/Element/Queries/Concerns/User/QueriesAuthors.php
@@ -48,7 +48,7 @@ trait QueriesAuthors
             if (is_bool($userQuery->authors)) {
                 $method = $userQuery->authors ? 'whereExists' : 'whereNotExists';
 
-                $userQuery->subQuery->$method(DB::table(Table::ENTRIES_AUTHORS)->whereColumn('authorId', 'elements.id'));
+                $userQuery->$method(DB::table(Table::ENTRIES_AUTHORS)->whereColumn('authorId', 'elements.id'));
             }
 
             if ($userQuery->authorOf) {
@@ -56,7 +56,7 @@ trait QueriesAuthors
                     throw new QueryAbortedException;
                 }
 
-                $userQuery->subQuery->whereExists(
+                $userQuery->whereExists(
                     DB::table(Table::ENTRIES_AUTHORS, 'entries_authors')
                         ->where('entryId', $this->authorOf->id)
                         ->whereColumn('entries_authors.authorId', 'users.id'),

--- a/src/Element/Queries/Concerns/User/QueriesRolesAndPermissions.php
+++ b/src/Element/Queries/Concerns/User/QueriesRolesAndPermissions.php
@@ -70,7 +70,7 @@ trait QueriesRolesAndPermissions
     {
         $this->beforeQuery(function (UserQuery $userQuery) {
             if (is_bool($userQuery->admin)) {
-                $userQuery->subQuery->whereBool('users.admin', $userQuery->admin);
+                $userQuery->whereBool('users.admin', $userQuery->admin);
             }
 
             if ($this->admin !== true) {
@@ -177,8 +177,8 @@ trait QueriesRolesAndPermissions
 
         $userQuery->when(
             $permittedUserIds->isEmpty(),
-            fn (UserQuery $userQuery) => $userQuery->subQuery->whereBool('users.admin', true),
-            fn (UserQuery $userQuery) => $userQuery->subQuery->where(function (Builder $query) use ($permittedUserIds) {
+            fn (UserQuery $userQuery) => $userQuery->whereBool('users.admin', true),
+            fn (UserQuery $userQuery) => $userQuery->where(function (Builder $query) use ($permittedUserIds) {
                 $query->whereBool('users.admin', true)
                     ->orWhereIn('users.id', $permittedUserIds);
             }),

--- a/src/Element/Queries/Concerns/User/QueriesUserGroups.php
+++ b/src/Element/Queries/Concerns/User/QueriesUserGroups.php
@@ -93,7 +93,7 @@ trait QueriesUserGroups
                     $groupIdOperator = 'whereExists';
                 }
 
-                $userQuery->subQuery->$groupIdOperator(
+                $userQuery->$groupIdOperator(
                     DB::table(Table::USERGROUPS_USERS, "ugu$i")
                         ->whereColumn('elements.id', "ugu$i.userId")
                         ->whereNumericParam('groupId', $groupIdCheck),

--- a/src/Element/Queries/Concerns/User/QueriesUserProperties.php
+++ b/src/Element/Queries/Concerns/User/QueriesUserProperties.php
@@ -65,14 +65,14 @@ trait QueriesUserProperties
     {
         $this->beforeQuery(function (UserQuery $userQuery) {
             if ($userQuery->lastLoginDate) {
-                $userQuery->subQuery->whereDateParam('users.lastLoginDate', $this->lastLoginDate);
+                $userQuery->whereDateParam('users.lastLoginDate', $this->lastLoginDate);
             }
 
             if (is_bool($userQuery->hasPhoto)) {
                 $userQuery->when(
                     $userQuery->hasPhoto,
-                    fn (UserQuery $q) => $q->subQuery->whereNotNull('users.photoId'),
-                    fn (UserQuery $q) => $q->subQuery->whereNull('users.photoId'),
+                    fn (UserQuery $q) => $q->whereNotNull('users.photoId'),
+                    fn (UserQuery $q) => $q->whereNull('users.photoId'),
                 );
             }
 
@@ -85,7 +85,7 @@ trait QueriesUserProperties
                     $userQuery->$property = Query::escapeCommas($userQuery->$property);
                 }
 
-                $userQuery->subQuery->whereParam(
+                $userQuery->whereParam(
                     column: "users.$property",
                     param: $userQuery->$property,
                     caseInsensitive: true,

--- a/src/Element/Queries/ContentBlockQuery.php
+++ b/src/Element/Queries/ContentBlockQuery.php
@@ -15,11 +15,12 @@ class ContentBlockQuery extends ElementQuery
 {
     use QueriesNestedElements;
 
+    #[\Override]
+    protected string $table = Table::CONTENTBLOCKS;
+
     public function __construct(array $config = [])
     {
         parent::__construct(ContentBlock::class, $config);
-
-        $this->joinElementTable(Table::CONTENTBLOCKS);
 
         $this->query->addSelect([
             'contentblocks.fieldId as fieldId',

--- a/src/Element/Queries/ElementQuery.php
+++ b/src/Element/Queries/ElementQuery.php
@@ -28,7 +28,6 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use InvalidArgumentException;
@@ -91,6 +90,8 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     use Concerns\QueriesUniqueElements;
     use Concerns\SearchesElements;
     use ForwardsCalls;
+
+    protected string $table = Table::ELEMENTS;
 
     /**
      * The base query builder instance.
@@ -188,19 +189,17 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     /**
      * @var array<string,string> Column alias => name mapping
      *
-     * @see joinElementTable()
      * @see applyOrderByParams()
      * @see applySelectParam()
      */
     private array $columnMap;
 
     /**
-     * @var bool Whether an element table has been joined for the query
+     * @var bool Whether the query is sourcing rows from a concrete element table
      *
-     * @see prepare()
-     * @see joinElementTable()
+     * @see configureSourceTable()
      */
-    private bool $joinedElementTable = false;
+    private bool $hasElementSourceTable = false;
 
     /**
      * @var bool Whether the element query before query callback has been called
@@ -221,10 +220,19 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     ) {
         parent::__construct($config);
 
-        $this->query = DB::query()
-            ->from(Table::ELEMENTS, 'elements')
-            ->join(new Alias(Table::ELEMENTS_SITES, 'elements_sites'), 'elements_sites.elementId', 'elements.id')
-            ->select('**');
+        $this->query = DB::table($this->table)->select('**');
+
+        if ($this->table !== Table::ELEMENTS) {
+            $this->when(
+                DB::isMysql(),
+                fn (self $query) => $this->straightJoin(new Alias(Table::ELEMENTS, 'elements'), 'elements.id', '=', "{$this->table}.id"),
+                fn (self $query) => $this->join(new Alias(Table::ELEMENTS, 'elements'), 'elements.id', '=', "{$this->table}.id"),
+            );
+
+            $this->hasElementSourceTable = true;
+        }
+
+        $this->query->join(new Alias(Table::ELEMENTS_SITES, 'elements_sites'), 'elements_sites.elementId', '=', 'elements.id');
 
         // Prepare a new column mapping
         // (for use in SELECT and ORDER BY clauses)
@@ -1039,8 +1047,8 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
 
         $this->applySelectParams();
 
-        // If an element table was never joined in, explicitly filter based on the element type
-        if (! $this->joinedElementTable && $this->elementType !== Element::class) {
+        // If the query isn't sourced from a concrete element table, explicitly filter by element type.
+        if (! $this->hasElementSourceTable && $this->elementType !== Element::class) {
             try {
                 $ref = new ReflectionClass($this->elementType);
             } catch (ReflectionException) {
@@ -1062,29 +1070,6 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
         }
 
         $this->elementQueryBeforeQueryCalled = true;
-    }
-
-    /**
-     * Joins in a table with an `id` column that has a foreign key pointing to `elements.id`.
-     *
-     * The table will be joined with an alias based on the unprefixed table name. For example,
-     * if `{{%entries}}` is passed, the table will be aliased to `entries`.
-     *
-     * @param  string  $table  The table name, e.g. `entries` or `{{%entries}}`
-     */
-    public function joinElementTable(string $table, ?string $alias = null): void
-    {
-        $alias ??= $table;
-
-        $this->query->join(new Alias($table, $alias), "$alias.id", 'elements.id');
-        $this->joinedElementTable = true;
-
-        // Add element table cols to the column map
-        foreach (Schema::getColumnListing($table) as $column) {
-            if (! isset($this->columnMap[$column])) {
-                $this->columnMap[$column] = "$alias.$column";
-            }
-        }
     }
 
     /**

--- a/src/Element/Queries/ElementQuery.php
+++ b/src/Element/Queries/ElementQuery.php
@@ -98,11 +98,6 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     protected Builder $query;
 
     /**
-     * The subquery that the main query will select from.
-     */
-    protected Builder $subQuery;
-
-    /**
      * All of the globally registered builder macros.
      */
     #[Override]
@@ -227,16 +222,9 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
         parent::__construct($config);
 
         $this->query = DB::query()
-            ->join(new Alias(Table::ELEMENTS_SITES, 'elements_sites'), 'elements_sites.id', 'subquery.siteSettingsId')
-            ->join(new Alias(Table::ELEMENTS, 'elements'), 'elements.id', 'subquery.elementsId')
+            ->from(Table::ELEMENTS, 'elements')
+            ->join(new Alias(Table::ELEMENTS_SITES, 'elements_sites'), 'elements_sites.elementId', 'elements.id')
             ->select('**');
-
-        $this->subQuery = DB::table(Table::ELEMENTS, 'elements')
-            ->select([
-                'elements.id as elementsId',
-                'elements_sites.id as siteSettingsId',
-            ])
-            ->join(new Alias(Table::ELEMENTS_SITES, 'elements_sites'), 'elements_sites.elementId', 'elements.id');
 
         // Prepare a new column mapping
         // (for use in SELECT and ORDER BY clauses)
@@ -585,7 +573,7 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     public function getCountForPagination($columns = ['*']): int
     {
         $query = clone $this;
-        $query->subQuery = $query->subQuery->cloneWithout([
+        $query->query = $query->query->cloneWithout([
             'limit',
             'offset',
             'unionLimit',
@@ -704,19 +692,11 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     }
 
     /**
-     * Get the underlying subquery builder instance.
-     */
-    public function getSubQuery(): Builder
-    {
-        return $this->subQuery;
-    }
-
-    /**
      * @param  int|null  $value
      */
     public function limit($value): self
     {
-        $this->subQuery->limit = $value;
+        $this->getQuery()->limit = $value;
 
         return $this;
     }
@@ -726,7 +706,7 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
      */
     public function getLimit(): mixed
     {
-        return $this->subQuery->getLimit();
+        return $this->getQuery()->getLimit();
     }
 
     /**
@@ -734,7 +714,7 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
      */
     public function offset($value): self
     {
-        $this->subQuery->offset = $value;
+        $this->getQuery()->offset = $value;
 
         return $this;
     }
@@ -749,14 +729,12 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
 
             foreach ($column as $c => $dir) {
                 $this->query->orderBy($c, $dir === SORT_ASC ? 'asc' : 'desc');
-                $this->subQuery->orderBy($c, $dir === SORT_ASC ? 'asc' : 'desc');
             }
 
             return $this;
         }
 
         $this->forwardCallTo($this->query, 'orderBy', [$column, $direction]);
-        $this->forwardCallTo($this->subQuery, 'orderBy', [$column, $direction]);
 
         return $this;
     }
@@ -766,13 +744,12 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
      */
     public function getOffset(): mixed
     {
-        return $this->subQuery->getOffset();
+        return $this->getQuery()->getOffset();
     }
 
     public function getWhereForColumn(string $column): ?array
     {
-        return collect($this->subQuery->wheres)
-            ->firstWhere('column', $column);
+        return collect($this->query->wheres)->firstWhere('column', $column);
     }
 
     /**
@@ -941,23 +918,13 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
             return $this->getQuery()->{$method}(...$parameters);
         }
 
-        /**
-         * Joins and orders should be done on both queries
-         */
-        if (in_array(strtolower($method), ['join', 'orderby', 'orderbydesc'])) {
-            $this->forwardCallTo($this->query, $method, $parameters);
-            $this->forwardCallTo($this->subQuery, $method, $parameters);
-
-            return $this;
-        }
-
-        if (in_array(strtolower($method), ['select', 'reorder', 'addselect'])) {
+        if (in_array(strtolower($method), ['join', 'orderby', 'orderbydesc', 'select', 'reorder', 'addselect'])) {
             $this->forwardCallTo($this->query, $method, $parameters);
 
             return $this;
         }
 
-        $this->forwardCallTo($this->subQuery, $method, $parameters);
+        $this->forwardCallTo($this->query, $method, $parameters);
 
         return $this;
     }
@@ -1035,7 +1002,6 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     public function __clone(): void
     {
         $this->query = clone $this->query;
-        $this->subQuery = clone $this->subQuery;
 
         foreach ($this->onCloneCallbacks as $onCloneCallback) {
             $onCloneCallback($this);
@@ -1082,7 +1048,7 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
             }
 
             if ($ref && ! $ref->isAbstract()) {
-                $this->subQuery->where('elements.type', $this->elementType);
+                $this->query->where('elements.type', $this->elementType);
             }
         }
 
@@ -1092,10 +1058,8 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
 
         if ($this->getOffset() !== null && $this->getLimit() === null && (DB::isMysql() || DB::isSqlite())) {
             // Limit is not optional in MySQL or SQLite
-            $this->subQuery->limit(PHP_INT_MAX);
+            $this->query->limit(PHP_INT_MAX);
         }
-
-        $this->query->fromSub($this->subQuery, 'subquery');
 
         $this->elementQueryBeforeQueryCalled = true;
     }
@@ -1112,8 +1076,7 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     {
         $alias ??= $table;
 
-        $this->query->join(new Alias($table, $alias), "$alias.id", 'subquery.elementsId');
-        $this->subQuery->join(new Alias($table, $alias), "$alias.id", 'elements.id');
+        $this->query->join(new Alias($table, $alias), "$alias.id", 'elements.id');
         $this->joinedElementTable = true;
 
         // Add element table cols to the column map

--- a/src/Element/Queries/EntryQuery.php
+++ b/src/Element/Queries/EntryQuery.php
@@ -46,7 +46,7 @@ class EntryQuery extends ElementQuery
     #[Override]
     protected array $defaultOrderBy = [
         'entries.postDate' => SORT_DESC,
-        'elements.id' => SORT_DESC,
+        'entries.id' => SORT_DESC,
     ];
 
     public function getFieldIdColumn(): string
@@ -237,7 +237,7 @@ class EntryQuery extends ElementQuery
             return;
         }
 
-        $query->subQuery->where(function (Builder $query) use ($value, $peerDraftPermissionPrefix, $peerPermissionPrefix, $permissionPrefix, $user, $sections) {
+        $query->where(function (Builder $query) use ($value, $peerDraftPermissionPrefix, $peerPermissionPrefix, $permissionPrefix, $user, $sections) {
             $partialAccessSections = [];
 
             foreach ($sections as $section) {

--- a/src/Element/Queries/EntryQuery.php
+++ b/src/Element/Queries/EntryQuery.php
@@ -44,6 +44,9 @@ class EntryQuery extends ElementQuery
     use QueriesSections;
 
     #[Override]
+    protected string $table = Table::ENTRIES;
+
+    #[Override]
     protected array $defaultOrderBy = [
         'entries.postDate' => SORT_DESC,
         'entries.id' => SORT_DESC,
@@ -83,8 +86,6 @@ class EntryQuery extends ElementQuery
         }
 
         parent::__construct(Entry::class, $config);
-
-        $this->joinElementTable(Table::ENTRIES);
 
         $this->query->addSelect([
             'entries.sectionId as sectionId',

--- a/src/Element/Queries/UserQuery.php
+++ b/src/Element/Queries/UserQuery.php
@@ -30,6 +30,9 @@ class UserQuery extends ElementQuery
     use QueriesUserGroups;
     use QueriesUserProperties;
 
+    #[Override]
+    protected string $table = Table::USERS;
+
     public const string STATUS_CREDENTIALED = 'credentialed';
 
     #[Override]
@@ -42,8 +45,6 @@ class UserQuery extends ElementQuery
     public function __construct(array $config = [])
     {
         parent::__construct(User::class, $config);
-
-        $this->joinElementTable(Table::USERS);
 
         $this->query->addSelect([
             'users.photoId',

--- a/src/Element/Queries/UserQuery.php
+++ b/src/Element/Queries/UserQuery.php
@@ -95,7 +95,6 @@ class UserQuery extends ElementQuery
 
             // If there's a custom orderBy, make sure we're showing active, non-pending accounts first
             $userQuery->query->orders = $orders;
-            $userQuery->subQuery->orders = $orders;
         });
     }
 

--- a/src/Field/BaseRelationField.php
+++ b/src/Field/BaseRelationField.php
@@ -186,7 +186,7 @@ abstract class BaseRelationField extends Field implements CrossSiteCopyableField
             ];
 
             if ($query instanceof ElementQuery) {
-                $filter->apply($query->getSubQuery(), $relationCriteria);
+                $filter->apply($query->getQuery(), $relationCriteria);
 
                 return $query;
             }
@@ -773,29 +773,28 @@ JS, [
                 // the criteria. Otherwise, if the query ends up A) getting executed normally, then B) getting
                 // eager-loaded with eagerly(), the `orderBy` value referencing the join table will get applied
                 // to the eager-loading query and cause a SQL error.
-                /** @var Builder $q */
-                foreach ([$elementQuery->getQuery(), $elementQuery->getSubQuery()] as $q) {
-                    $q->join(
-                        new Alias(Table::RELATIONS, $relationsAlias),
-                        function (JoinClause $join) use ($element, $relationsAlias) {
-                            $join->whereColumn("$relationsAlias.targetId", 'elements.id')
-                                ->where("$relationsAlias.sourceId", $element->id)
-                                ->where("$relationsAlias.fieldId", $this->id)
-                                ->where(function (JoinClause $join) use ($element, $relationsAlias) {
-                                    $join->whereNull("$relationsAlias.sourceSiteId")
-                                        ->orWhere("$relationsAlias.sourceSiteId", $element->siteId);
-                                });
-                        },
-                    );
+                $query = $elementQuery->getQuery();
 
-                    if (
-                        $this->sortable &&
-                        ! $this->maintainHierarchy &&
-                        count($q->orderBy ?? []) === 1 &&
-                        ($q->orderBy[0]['column'] ?? null) instanceof OrderByPlaceholderExpression
-                    ) {
-                        $q->orderBy("$relationsAlias.sortOrder");
-                    }
+                $query->join(
+                    new Alias(Table::RELATIONS, $relationsAlias),
+                    function (JoinClause $join) use ($element, $relationsAlias) {
+                        $join->whereColumn("$relationsAlias.targetId", 'elements.id')
+                            ->where("$relationsAlias.sourceId", $element->id)
+                            ->where("$relationsAlias.fieldId", $this->id)
+                            ->where(function (JoinClause $join) use ($element, $relationsAlias) {
+                                $join->whereNull("$relationsAlias.sourceSiteId")
+                                    ->orWhere("$relationsAlias.sourceSiteId", $element->siteId);
+                            });
+                    },
+                );
+
+                if (
+                    $this->sortable &&
+                    ! $this->maintainHierarchy &&
+                    count($query->orderBy ?? []) === 1 &&
+                    ($query->orderBy[0]['column'] ?? null) instanceof OrderByPlaceholderExpression
+                ) {
+                    $query->orderBy("$relationsAlias.sortOrder");
                 }
             });
         } else {
@@ -1041,7 +1040,7 @@ JS, [
                 $rawValue = $rawValue->where['elements.id'] ?? null;
             }
             if ($rawValue instanceof ElementQuery) {
-                $where = Arr::first($rawValue->getSubQuery()->wheres, fn ($where) => ($where['column'] ?? '') === 'elements.id');
+                $where = Arr::first($rawValue->getQuery()->wheres, fn ($where) => ($where['column'] ?? '') === 'elements.id');
                 $rawValue = $where['value'] ?? null;
             }
             if (is_array($rawValue)) {

--- a/src/Search/Search.php
+++ b/src/Search/Search.php
@@ -324,8 +324,8 @@ class Search
         if ($elementQuery instanceof ElementQuery) {
             $elementQuery->reorder();
             $elementQuery->select('elements.id as id');
-            $elementQuery->getSubQuery()->offset = null;
-            $elementQuery->getSubQuery()->limit = null;
+            $elementQuery->getQuery()->offset = null;
+            $elementQuery->getQuery()->limit = null;
             $ids = $elementQuery->pluck('id')->all();
         } else {
             $ids = $elementQuery;

--- a/tests/Feature/Element/Concerns/DisplayedInIndexTest.php
+++ b/tests/Feature/Element/Concerns/DisplayedInIndexTest.php
@@ -567,7 +567,7 @@ describe('indexElements', function () {
         $result = $method->invoke(null, $query);
 
         expect($result)->not->toBe($query);
-        expect($result->getSubQuery()->wheres)->not()->toContain($excludeDescendantIdsExpression);
+        expect($result->getQuery()->wheres)->not()->toContain($excludeDescendantIdsExpression);
     });
 });
 

--- a/tests/Feature/Element/Queries/Concerns/FormatsResultsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/FormatsResultsTest.php
@@ -42,7 +42,7 @@ test('it applies a default order when no orderBy is specified', function () {
 
     expect(
         collect($query->getQuery()->orders)
-            ->where('column', 'elements.id')
+            ->where('column', 'entries.id')
             ->where('direction', 'desc')
             ->first()
     )->not()->toBeNull();

--- a/tests/Feature/Element/Queries/ElementQueryTest.php
+++ b/tests/Feature/Element/Queries/ElementQueryTest.php
@@ -1,9 +1,14 @@
 <?php
 
+use CraftCms\Cms\Element\Queries\AddressQuery;
+use CraftCms\Cms\Element\Queries\ContentBlockQuery;
 use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Entry\Models\Entry as EntryModel;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\JoinClause;
+use Tpetry\QueryExpressions\Language\Alias;
 
 it('can run basic queries', function () {
     expect(entryQuery()->all())->toBeEmpty();
@@ -53,3 +58,46 @@ it('ignores inner query pagination when getting a pagination count', function ()
     expect($query->getCountForPagination())->toBe(5);
     expect($query->get())->toHaveCount(2);
 });
+
+it('sources concrete element queries from their element tables first', function (callable $queryFactory, string $sourceTable) {
+    /** @var Builder $builder */
+    $builder = $queryFactory();
+
+    expect($builder->from)->toBe($sourceTable);
+
+    $joins = collect($builder->joins);
+
+    expect($joins)->toHaveCount(2);
+    expect(normalizeJoinAlias($joins[0]))->toBe('elements as elements');
+    expect($joins[0]->wheres[0])->toMatchArray([
+        'type' => 'Column',
+        'first' => 'elements.id',
+        'operator' => '=',
+        'second' => "$sourceTable.id",
+        'boolean' => 'and',
+    ]);
+
+    expect(normalizeJoinAlias($joins[1]))->toBe('elements_sites as elements_sites');
+    expect($joins[1]->wheres[0])->toMatchArray([
+        'type' => 'Column',
+        'first' => 'elements_sites.elementId',
+        'operator' => '=',
+        'second' => 'elements.id',
+        'boolean' => 'and',
+    ]);
+})->with([
+    'entries' => [fn () => entryQuery()->getQuery(), 'entries'],
+    'users' => [fn () => userQuery()->getQuery(), 'users'],
+    'assets' => [fn () => assetQuery()->getQuery(), 'assets'],
+    'addresses' => [fn () => new AddressQuery()->getQuery(), 'addresses'],
+    'contentblocks' => [fn () => new ContentBlockQuery()->getQuery(), 'contentblocks'],
+]);
+
+function normalizeJoinAlias(JoinClause $join): string
+{
+    $table = $join->table;
+
+    expect($table)->toBeInstanceOf(Alias::class);
+
+    return preg_replace('/[`"\[\]]/', '', $table->getValue($join->getGrammar()));
+}


### PR DESCRIPTION
### Description

Heavily simplifies the element queries by no longer selecting from a subquery but selecting from the element type table first and joining in elements after.

MySQL uses a straight_join, forcing the MySQL query optimizer to first filter the element type's table (for examlpe `entries`) and then later joining elements onto it. This improves performance significantly. 

Postgres is already smart enough to optimize the query and this simplification of the query also speeds up the element queries a bit.

---

Tested on 500k entries (same section, same entry type), entry index query:

Postgres with subquery: 25ms
Postgres without subquery: 3ms

MySQL with subquery: 250ms
MySQL without subquery: 570ms
MySQL with straight join: 5ms