### PR TITLE
Bugfix/18711 editing entry authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where entries weren’t redirecting back to their section’s page’s URL by default.
 - Fixed a bug where the `resourceBasePath` and `resourceBaseUrl` config settings weren’t being respected for console requests. ([#18685](https://github.com/craftcms/cms/issues/18685))
 - Fixed a bug where eager-loadable GraphQL fields could be populated with the wrong field’s results, if they followed a fragment with a `*Interface` type condition. ([#18708](https://github.com/craftcms/cms/issues/18708))
+- Fixed a bug where users with permission to edit entries, but not view peer entries in a section, weren’t allowed to edit the authors for entries in the section. ([#18717](https://github.com/craftcms/cms/pull/18717))
 
 ## 5.9.20 - 2026-04-14
 

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -2485,7 +2485,7 @@ JS, [
                     ],
                     'single' => false,
                     'elements' => $authors ?: null,
-                    'disabled' => false,
+                    'disabled' => !$this->canChangeAuthor(),
                     'errors' => $this->getErrors('authorIds'),
                     'limit' => $section->maxAuthors,
                 ]);

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -2797,10 +2797,6 @@ JS;
 
         $section = $this->getSection();
 
-        if (!$user->can("viewPeerEntries:$section->uid")) {
-            return false;
-        }
-
         $authorIds = $this->getAuthorIds();
 
         return (


### PR DESCRIPTION
### Description
This PR removes the `viewPeerEntries` permission check from the `Entry::canChangeAuthor()` method.

It also ensures that the `canChangeAuthor()` checks are enforced when using the inline edit mechanism.


### Related issues
#18711
