### PR TITLE
Fix project config ordering for partial loaded elementSources entries

### DIFF
--- a/src/services/ProjectConfig.php
+++ b/src/services/ProjectConfig.php
@@ -1486,8 +1486,16 @@ class ProjectConfig extends Component
 
         unset($removedItem);
 
-        // Sort by number of dots to ensure deepest paths listed first
+        // Sort by top-level key first, then deepest paths first within each group.
         $sorter = function($a, $b) {
+            $aTop = explode('.', $a, 2)[0];
+            $bTop = explode('.', $b, 2)[0];
+            $topCmp = strcmp($aTop, $bTop);
+
+            if ($topCmp !== 0) {
+                return $topCmp;
+            }
+
             $aDepth = ProjectConfigHelper::pathDepth($a);
             $bDepth = ProjectConfigHelper::pathDepth($b);
             return $bDepth <=> $aDepth;

--- a/tests/unit/services/ProjectConfigTest.php
+++ b/tests/unit/services/ProjectConfigTest.php
@@ -9,7 +9,9 @@ namespace crafttests\unit\services;
 
 use Codeception\Stub\Expected;
 use Craft;
+use craft\elements\Category;
 use craft\helpers\StringHelper;
+use craft\models\ProjectConfigData;
 use craft\models\ReadOnlyProjectConfigData;
 use craft\mutex\Mutex;
 use craft\mutex\NullMutex;
@@ -214,6 +216,69 @@ class ProjectConfigTest extends TestCase
 
         $pc->remove('some.path');
         $pc->saveModifiedConfigData();
+    }
+
+    public function testApplyingConfigChangesDoesNotExposePartialElementSourcesToSectionHandlers(): void
+    {
+        $projectConfig = new ProjectConfig();
+        $internalConfig = new ReadOnlyProjectConfigData([], $projectConfig);
+        $currentWorkingConfig = new ProjectConfigData([], $projectConfig);
+
+        $internalConfigProperty = new \ReflectionProperty(ProjectConfig::class, '_internalConfig');
+        $internalConfigProperty->setValue($projectConfig, $internalConfig);
+
+        $currentWorkingConfigProperty = new \ReflectionProperty(ProjectConfig::class, '_currentWorkingConfig');
+        $currentWorkingConfigProperty->setValue($projectConfig, $currentWorkingConfig);
+
+        $incomingConfig = [
+            'elementSources' => [
+                'craft\\elements\\Category' => [[
+                    'defaultSort' => ['structure', 'asc'],
+                    'tableAttributes' => ['link'],
+                    'type' => 'native',
+                    'key' => 'group:bedad454-861f-4d7f-b0f6-40ce023cffc5',
+                    'disabled' => false,
+                ]],
+            ],
+            'sections' => [
+                'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' => [
+                    'siteSettings' => [
+                        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' => [
+                            'hasUrls' => true,
+                            'uriFormat' => 'test/{slug}',
+                            'template' => 'test/_entry',
+                            'enabledByDefault' => true,
+                        ],
+                    ],
+                    'entryTypes' => ['cccccccc-cccc-cccc-cccc-cccccccccccc'],
+                ],
+            ],
+        ];
+
+        $externalConfig = new ReadOnlyProjectConfigData($incomingConfig, $projectConfig);
+        $externalConfigProperty = new \ReflectionProperty(ProjectConfig::class, '_externalConfig');
+        $externalConfigProperty->setValue($projectConfig, $externalConfig);
+
+        $originalProjectConfig = Craft::$app->getProjectConfig();
+        $originalElementSources = Craft::$app->getElementSources();
+        $handlerWasCalled = false;
+
+        Craft::$app->set('projectConfig', $projectConfig);
+        Craft::$app->set('elementSources', new \craft\services\ElementSources());
+
+        $projectConfig->onAdd(ProjectConfig::PATH_SECTIONS . '.{uid}', function() use (&$handlerWasCalled) {
+            $handlerWasCalled = true;
+            Craft::$app->getElementSources()->getSources(Category::class);
+        });
+
+        try {
+            $projectConfig->applyConfigChanges($incomingConfig);
+        } finally {
+            Craft::$app->set('projectConfig', $originalProjectConfig);
+            Craft::$app->set('elementSources', $originalElementSources);
+        }
+
+        self::assertTrue($handlerWasCalled);
     }
 
     public function getConfigProvider(): array


### PR DESCRIPTION
### Description
When project config is applied to a clean install, pending changes are currently
sorted only by path depth. That can cause `sections` changes to be processed
before related `elementSources` entries are fully constructed.

In our case, `handleChangedSection()` ends up reading element sources while an
`elementSources` entry only contains nested values like `defaultSort` and
`tableAttributes`, but is still missing scalar keys such as `type`. That leads
to:

    Undefined array key "type"

in `ElementSources::defineSources()`.

| Before | After |
| --- | --- |
| `elementSources...defaultSort` | `elementSources...defaultSort` |
| `elementSources...tableAttributes` | `elementSources...tableAttributes` |
| `sections...siteSettings` | `elementSources...0` |
| `elementSources...0` | `sections...siteSettings` |
| `sections...entryTypes` | `sections...entryTypes` |

Before this change, `sections...siteSettings` could run before the parent
`elementSources...0` entry had been fully applied. After this change, all
`elementSources` paths are processed first, so section change handlers never
observe partially-built element source configs.

This change sorts pending changes by top-level config key first, and then by
depth within each group.

A minimal regression test has been added to reproduce that failure mode.

### Related issues
#18720 