### PR TITLE
empty username should be ordered as last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where users with permission to edit entries, but not view peer entries in a section, weren’t allowed to edit the authors for entries in the section. ([#18717](https://github.com/craftcms/cms/pull/18717))
 - Fixed a bug where reference tags weren’t working with generated fields. ([#18692](https://github.com/craftcms/cms/issues/18692))
 - Fixed errors that could occur when applying project config changes. ([#18720](https://github.com/craftcms/cms/issues/18720))
+- Fixed a bug where it wasn’t always possible to sign into a user account that had the same email address as an inactive user. ([#18723](https://github.com/craftcms/cms/issues/18723))
 
 ## 5.9.20 - 2026-04-14
 

--- a/src/elements/db/UserQuery.php
+++ b/src/elements/db/UserQuery.php
@@ -50,11 +50,7 @@ class UserQuery extends ElementQuery
     /**
      * @inheritdoc
      */
-    protected array $defaultOrderBy = [
-        'users.username' => SORT_ASC,
-        'users.active' => SORT_DESC,
-        'users.pending' => SORT_DESC,
-    ];
+    protected array $defaultOrderBy;
 
     // General parameters
     // -------------------------------------------------------------------------
@@ -243,6 +239,20 @@ class UserQuery extends ElementQuery
      * @since 3.6.0
      */
     public bool $withGroups = false;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct(string $elementType, array $config = [])
+    {
+        parent::__construct($elementType, $config);
+
+        $this->defaultOrderBy = [
+            new Expression('CASE WHEN [[users.username]] IS NULL THEN 1 ELSE 0 END ASC'),
+            'users.active' => SORT_DESC,
+            'users.pending' => SORT_DESC,
+        ];
+    }
 
     /**
      * @inheritdoc


### PR DESCRIPTION
### Description
Ensure that empty usernames are at the end of the sorted results. In other words, if you have usernames: `abc`, `NULL`, `def` and they’re all active, the default sort order should resolve to `abc`, `def`, `NULL`

Bit of history:
- we first adjusted the `Users::getUserByUsernameOrEmail()` method to prioritise the credentialed users (https://github.com/craftcms/cms/pull/18154); 
- then this code was removed in favour of a more general https://github.com/craftcms/cms/commit/856bc2d514d8ba9262d01949e56dcd318bbc8034 approach;


Steps to reproduce without involving Commerce:
- login to CP
- create a user with an empty username, and email of `test@test.com`
	- click “Create and set permissions”; don’t set permissions, don’t send activation email; exit to the user index page
- create another user with username and email both set to `test@test.com`
	- click “Create and set permissions”
	- set permissions (at least access CP)
	- click “Save and send activation email”
	- activate that account
- logout
- try to log in as `test@test.com`

Without this PR, you won’t be able to log in, as the first returned user will be the inactive one (one without a username).

With this PR, you should be able to log in as the first returned user will be the active one (one with the username).


### Related issues
#18723
