### PR TITLE
Fix users/remove-2fa CLI command

### DIFF
--- a/src/console/controllers/UsersController.php
+++ b/src/console/controllers/UsersController.php
@@ -17,6 +17,7 @@ use craft\errors\InvalidElementException;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Console;
 use craft\helpers\Db;
+use craft\helpers\StringHelper;
 use craft\helpers\UrlHelper;
 use DateTime;
 use Illuminate\Support\Collection;
@@ -98,6 +99,11 @@ class UsersController extends Controller
     public bool $hard = false;
 
     /**
+     * @var string The two-step verification method to remove, or 'all'.
+     */
+    public string $method = 'all';
+
+    /**
      * @inheritdoc
      */
     public function options($actionID): array
@@ -121,6 +127,9 @@ class UsersController extends Controller
                 break;
             case 'set-password':
                 $options[] = 'password';
+                break;
+            case 'remove-2fa':
+                $options[] = 'method';
                 break;
         }
 
@@ -539,35 +548,38 @@ class UsersController extends Controller
         }
 
         $authService = Craft::$app->getAuth();
-        $activeMethods = Collection::make($authService->getActiveMethods($user))
-            ->keyBy(fn(AuthMethodInterface $method) => $method::displayName())
-            ->all();
+        $activeMethodsByKey = Collection::make($authService->getActiveMethods($user))
+            ->keyBy(function (AuthMethodInterface $authMethod) {
+                return StringHelper::toKebabCase($authMethod->formName());
+            });
 
         // if user doesn't have any, say so, and we're done
-        if (empty($activeMethods)) {
+        if ($activeMethodsByKey->isEmpty()) {
             $this->stdout("User “{$user->username}” doesn’t have any active two-step verification methods." . PHP_EOL);
             return ExitCode::OK;
         }
 
+        $selectOptions = $activeMethodsByKey->map(fn(AuthMethodInterface $authMethod) => $authMethod->displayName())
+            ->prepend('All two-step verification methods', 'all')
+            ->all();
+
         $methodToRemove = $this->select(
             "Which two-step verification method would you like to remove for user “{$user->username}”",
-            [
-                'all' => 'all',
-                ...array_combine(array_keys($activeMethods), array_keys($activeMethods)),
-            ],
+            $selectOptions,
+            $this->method,
         );
 
         if ($methodToRemove === 'all') {
             $this->stdout('Removing all two-step verification methods for the user ...' . PHP_EOL);
 
-            foreach ($activeMethods as $method) {
+            $activeMethodsByKey->each(function (AuthMethodInterface $authMethod) use ($user) {
                 // Recovery Codes gets removed automatically after the last 2FA method is removed
-                if (!$method instanceof RecoveryCodes) {
-                    $this->_remove2faMethod($method, $user);
+                if (!$authMethod instanceof RecoveryCodes) {
+                    $this->_remove2faMethod($authMethod, $user);
                 }
-            }
+            });
         } else {
-            $this->_remove2faMethod($activeMethods[$methodToRemove], $user);
+            $this->_remove2faMethod($activeMethodsByKey[$methodToRemove], $user);
         }
 
         return ExitCode::OK;
@@ -617,7 +629,7 @@ class UsersController extends Controller
         if (empty($auth->getActiveMethods($user))) {
             $recoveryCodes = $auth->getMethod(RecoveryCodes::class, $user);
             if ($recoveryCodes->isActive()) {
-                $this->stdout("No further two-step verification methods left. Removing “{$recoveryCodes::displayName()}” for the user ...");
+                $this->stdout("   > No further two-step verification methods left. Removing “{$recoveryCodes::displayName()}” for the user ...");
                 $recoveryCodes->remove();
                 $this->stdout(" done" . PHP_EOL, Console::FG_GREEN);
             }

--- a/src/console/controllers/UsersController.php
+++ b/src/console/controllers/UsersController.php
@@ -23,6 +23,7 @@ use DateTime;
 use Illuminate\Support\Collection;
 use Throwable;
 use yii\base\InvalidArgumentException;
+use yii\base\Model;
 use yii\console\ExitCode;
 
 /**
@@ -550,7 +551,10 @@ class UsersController extends Controller
         $authService = Craft::$app->getAuth();
         $activeMethodsByKey = Collection::make($authService->getActiveMethods($user))
             ->keyBy(function(AuthMethodInterface $authMethod) {
-                return StringHelper::toKebabCase($authMethod->formName());
+                $formName = $authMethod instanceof Model
+                    ? $authMethod->formName()
+                    : $authMethod::class;
+                return StringHelper::toKebabCase($formName);
             });
 
         // if user doesn't have any, say so, and we're done

--- a/src/console/controllers/UsersController.php
+++ b/src/console/controllers/UsersController.php
@@ -549,7 +549,7 @@ class UsersController extends Controller
 
         $authService = Craft::$app->getAuth();
         $activeMethodsByKey = Collection::make($authService->getActiveMethods($user))
-            ->keyBy(function (AuthMethodInterface $authMethod) {
+            ->keyBy(function(AuthMethodInterface $authMethod) {
                 return StringHelper::toKebabCase($authMethod->formName());
             });
 
@@ -560,19 +560,22 @@ class UsersController extends Controller
         }
 
         $selectOptions = $activeMethodsByKey->map(fn(AuthMethodInterface $authMethod) => $authMethod->displayName())
-            ->prepend('All two-step verification methods', 'all')
-            ->all();
+            ->prepend('All two-step verification methods', 'all');
+
+        if (!$selectOptions->has($this->method)) {
+            $validSelections = $selectOptions->keys()->implode(', ');
+            $this->stderr("Invalid --method: $this->method. Must be one of: $validSelections." . PHP_EOL, Console::FG_RED);
+            return ExitCode::USAGE;
+        }
 
         $methodToRemove = $this->select(
             "Which two-step verification method would you like to remove for user “{$user->username}”",
-            $selectOptions,
+            $selectOptions->all(),
             $this->method,
         );
 
         if ($methodToRemove === 'all') {
-            $this->stdout('Removing all two-step verification methods for the user ...' . PHP_EOL);
-
-            $activeMethodsByKey->each(function (AuthMethodInterface $authMethod) use ($user) {
+            $activeMethodsByKey->each(function(AuthMethodInterface $authMethod) use ($user) {
                 // Recovery Codes gets removed automatically after the last 2FA method is removed
                 if (!$authMethod instanceof RecoveryCodes) {
                     $this->_remove2faMethod($authMethod, $user);
@@ -618,20 +621,22 @@ class UsersController extends Controller
      */
     private function _remove2faMethod(AuthMethodInterface $method, User $user): void
     {
-        $this->stdout("   > Removing “{$method::displayName()}” two-step verification method for the user ...");
-
         $auth = Craft::$app->getAuth();
-        $method->remove();
-
-        $this->stdout(" done" . PHP_EOL, Console::FG_GREEN);
+        $this->do(
+            "Removing “{$method::displayName()}” two-step verification method for the user",
+            fn() => $method->remove(),
+        );
 
         // if that was the last non-Recovery Codes method, remove Recovery Codes too
         if (empty($auth->getActiveMethods($user))) {
             $recoveryCodes = $auth->getMethod(RecoveryCodes::class, $user);
             if ($recoveryCodes->isActive()) {
-                $this->stdout("   > No further two-step verification methods left. Removing “{$recoveryCodes::displayName()}” for the user ...");
-                $recoveryCodes->remove();
-                $this->stdout(" done" . PHP_EOL, Console::FG_GREEN);
+                $this->stdout("No further two-step verification methods left. " , PHP_EOL);
+
+                $this->do(
+                    "Removing “{$recoveryCodes::displayName()}” for the user",
+                    fn() => $recoveryCodes->remove(),
+                );
             }
         }
     }


### PR DESCRIPTION
### Description
- allows non-interactive usage
- fixes issue where removing a specific method (besides `all`) threw an error.

### Related issues
Fixes https://github.com/craftcms/cloud/issues/150

