### PR TITLE
[6.x] don't use php.ini file for the backup test command

### DIFF
--- a/tests/Feature/Database/BackupsTest.php
+++ b/tests/Feature/Database/BackupsTest.php
@@ -30,7 +30,7 @@ afterEach(function () {
 
 function backupsTestPhpCommand(string $script, array $args = []): string
 {
-    $command = escapeshellarg(PHP_BINARY).' -r '.escapeshellarg($script);
+    $command = escapeshellarg(PHP_BINARY).' -n -r '.escapeshellarg($script);
 
     foreach ($args as $arg) {
         $command .= ' '.$arg;


### PR DESCRIPTION
### Description
I’m using `ddev` locally. When I run the whole suite of tests via `ddev exec --dir /var/www/html/vendor/craftcms/cms ./vendor/bin/pest`, it’ll hang after completing the `tests/Feature/Dashboard/Widgets/WidgetTest.php` test.

The next test file in line is `tests/Feature/Database/BackupsTest.php`, and running `ddev exec --dir /var/www/html/vendor/craftcms/cms ./vendor/bin/pest tests/Feature/Database/BackupsTest.php` just hangs.

Long story short, the solution seems to be to add the `-n` param to the backup command, which will cause no `php.ini` file to be used in the command.

Is anyone else having this issue? 
Does anyone have an opinion on whether the proposed change is safe in our case?


### Related issues
n/a
