### PR TITLE
[5.10] Fixed JS issue with element deletion blockers after filtering

### DIFF
--- a/src/controllers/DeleteElementsController.php
+++ b/src/controllers/DeleteElementsController.php
@@ -161,6 +161,7 @@ class DeleteElementsController extends Controller
                 'details' => $blocker->getDetails(),
                 'actions' => $blocker->getActions(),
             ])
+            ->values()
             ->all();
 
         $elementPreview = Cp::elementPreviewHtml(


### PR DESCRIPTION
### Description
Noticed when registering deletion blockers and some getting filtered out that the array keys could become non-sequential e.g. 0, 2, 3

This meant the [following JS](https://github.com/craftcms/cms/blob/5.10/src/web/assets/cp/src/js/ElementDeletionManager.js#L41-L44) would not work as expected and showed the confirm delete dialog instead of the blockers modal.

```js
      if (!data.blockers.length) {
        await this.confirmAndDelete(data.totalElements);
        return;
      }
```

