### PR TITLE
[6.x] Fixes user settings for solo edition

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -260,7 +260,7 @@ Route::middleware(['auth:craft', 'can:accessCp'])->group(function () {
                     ->name('settings.site-groups.destroy');
             });
 
-        // User settings
+        // User settings index
         if (Edition::isAtLeast(Edition::Team)) {
             Route::get('settings/users', [UserGroupsController::class, 'index']);
         } else {
@@ -278,6 +278,7 @@ Route::middleware(['auth:craft', 'can:accessCp'])->group(function () {
             Route::get('settings/users/groups/{userGroup}', [UserGroupsController::class, 'edit']);
         });
 
+        // User settings
         Route::get('settings/users/settings', [UserSettingsController::class, 'index']);
     });
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -52,6 +52,8 @@ use CraftCms\Cms\Http\Middleware\RequireEdition;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
 
+use function CraftCms\Cms\cp_url;
+
 /**
  * Admin requests that do not require a login
  */
@@ -258,9 +260,15 @@ Route::middleware(['auth:craft', 'can:accessCp'])->group(function () {
                     ->name('settings.site-groups.destroy');
             });
 
+        // User settings
+        if (Edition::isAtLeast(Edition::Team)) {
+            Route::get('settings/users', [UserGroupsController::class, 'index']);
+        } else {
+            Route::get('settings/users', fn () => redirect(cp_url('settings/users/fields')));
+        }
+
         // User groups
         Route::middleware([RequireEdition::class.':'.Edition::Team->value])->group(function () {
-            Route::get('settings/users', [UserGroupsController::class, 'index']);
             Route::middleware([
                 RequireEdition::class.':'.Edition::Pro->value,
                 RequireAdminChanges::class,
@@ -270,7 +278,6 @@ Route::middleware(['auth:craft', 'can:accessCp'])->group(function () {
             Route::get('settings/users/groups/{userGroup}', [UserGroupsController::class, 'edit']);
         });
 
-        // User settings
         Route::get('settings/users/settings', [UserSettingsController::class, 'index']);
     });
 


### PR DESCRIPTION
While clicking around I noticed that clicking the `users` item when using the solo edition would result in a "Not found" error. 

It turns out the `settings/users` route was only defined for team versions and up, but Solo still uses it in v5.

I played with a handful of approaches but this one seemed to work best despite not being my favorite. 

Feel free to let me know if there's a better way to do this. 