### PR TITLE
[6.x] Fix icon disply for plugins on settings page

### DIFF
--- a/resources/js/pages/SettingsIndexPage.vue
+++ b/resources/js/pages/SettingsIndexPage.vue
@@ -5,6 +5,7 @@
 
   interface SettingItem {
     icon?: string;
+    iconName?: string;
     label: string;
     url?: string;
     handle: string;
@@ -42,9 +43,15 @@
                     <div class="settings-content">
                       <div class="settings-icon">
                         <craft-icon
-                          :name="item.icon"
+                          v-if="item.iconName"
+                          :name="item.iconName"
                           style="font-size: calc(40rem / 16)"
                         ></craft-icon>
+                        <div
+                          v-else-if="item.icon"
+                          v-html="item.icon"
+                          class="w-[40px] h-[40px] inline-block align-self-center"
+                        ></div>
                       </div>
                       {{ item.label
                       }}<span class="sr-only"> - {{ t('Settings') }}</span>
@@ -65,6 +72,11 @@
     display: grid;
     justify-content: center;
     align-items: center;
+  }
+
+  .settings-icon :deep(svg) {
+    width: 100%;
+    height: 100%;
   }
 
   .settings-grid {

--- a/src/Cp/Settings.php
+++ b/src/Cp/Settings.php
@@ -28,69 +28,68 @@ readonly class Settings
 
         $settings[$label]['general'] = [
             'url' => route('craft.cp.settings.general.index'),
-            'icon' => 'light/sliders',
+            'iconName' => 'light/sliders',
             'label' => t('General'),
         ];
 
         $settings[$label]['sites'] = [
-            'icon' => sprintf('light/%s', Icons::earth()),
+            'iconName' => sprintf('light/%s', Icons::earth()),
             'label' => t('Sites'),
         ];
 
         if (! $this->generalConfig->headlessMode) {
             $settings[$label]['routes'] = [
-                'icon' => 'light/signs-post',
+                'iconName' => 'light/signs-post',
                 'label' => t('Routes'),
             ];
         }
 
         $settings[$label]['users'] = [
-            'icon' => 'light/user-group',
-            // 'iconMask' => '@craftcms/resources/icons/light/user-group.svg',
+            'iconName' => 'light/user-group',
             'label' => t('Users'),
         ];
 
         if ($this->generalConfig->allowAdminChanges) {
             $settings[$label]['addresses'] = [
-                'icon' => 'light/map-location',
+                'iconName' => 'light/map-location',
                 'label' => t('Addresses'),
             ];
 
             $settings[$label]['email'] = [
                 'url' => route('craft.cp.settings.email.index'),
-                'icon' => 'light/envelope',
+                'iconName' => 'light/envelope',
                 'label' => t('Email'),
             ];
         }
 
         $settings[$label]['plugins'] = [
-            'icon' => 'light/plug',
+            'iconName' => 'light/plug',
             'label' => t('Plugins'),
         ];
 
         $label = t('Content');
 
         $settings[$label]['sections'] = [
-            'icon' => 'light/newspaper',
+            'iconName' => 'light/newspaper',
             'label' => t('Sections'),
         ];
         $settings[$label]['entry-types'] = [
-            'icon' => 'light/files',
+            'iconName' => 'light/files',
             'label' => t('Entry Types'),
         ];
         $settings[$label]['fields'] = [
-            'icon' => 'light/pen-to-square',
+            'iconName' => 'light/pen-to-square',
             'label' => t('Fields'),
         ];
 
         $label = t('Media');
 
         $settings[$label]['assets'] = [
-            'icon' => 'light/image',
+            'iconName' => 'light/image',
             'label' => t('Assets'),
         ];
         $settings[$label]['filesystems'] = [
-            'icon' => 'light/folder-open',
+            'iconName' => 'light/folder-open',
             'label' => t('Filesystems'),
         ];
 


### PR DESCRIPTION
Fixes icons for plugins. Continuation of the fix for https://linear.app/craftcms/issue/CMS-2018/plugins-icon-disappears-after-installing