### PR TITLE
Bugfix/18780 project config sites and install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fixed a bug where nested elements would get soft-deleted after running the `entrify/global-set` command on subsequent environments. ([#18767](https://github.com/craftcms/cms/issues/18767))
 - Fixed a bug where row headings within Table fields weren’t getting statically translated in the control panel. ([#13703](https://github.com/craftcms/cms/discussions/13703))
 - Fixed a bug where entry type chips within Matrix settings could be missing their action items.
+- Fixed a bug where site name and language values set to environment variables were getting replaced with their resolved values when installing Craft. ([#18780](https://github.com/craftcms/cms/issues/18780))
+- Fixed a bug where site name values set to environment variables were getting replaced with their resolved values on save. ([#18789](https://github.com/craftcms/cms/pull/18789))
 
 ## 5.9.22 - 2026-04-29
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1184,7 +1184,7 @@ class Install extends Migration
             $site = $sitesService->getPrimarySite();
             $site->setBaseUrl($this->site->getBaseUrl(false));
             $site->hasUrls = $this->site->hasUrls;
-            $site->language = $this->site->language;
+            $site->language = $this->site->getLanguage(false);
             $site->setName($this->site->getName(false));
             $sitesService->saveSite($site);
         }
@@ -1322,7 +1322,7 @@ class Install extends Migration
                     'baseUrl' => $this->site->getBaseUrl(false),
                     'handle' => $this->site->handle,
                     'hasUrls' => $this->site->hasUrls,
-                    'language' => $this->site->language,
+                    'language' => $this->site->getLanguage(false),
                     'name' => $this->site->getName(false),
                     'primary' => true,
                     'siteGroup' => $siteGroupUid,

--- a/src/models/Site.php
+++ b/src/models/Site.php
@@ -260,10 +260,26 @@ class Site extends Model implements Chippable
     /**
      * @inheritdoc
      */
+    public function beforeValidate(): bool
+    {
+        if (!parent::beforeValidate()) {
+            return false;
+        }
+
+        // Can't use the `trim` rule because it replaces env vars
+        // see https://github.com/craftcms/cms/pull/18789
+        $this->setName(trim($this->getName(false)));
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function defineRules(): array
     {
         $rules = parent::defineRules();
-        $rules[] = [['name', 'handle'], 'trim'];
+        $rules[] = [['handle'], 'trim'];
         $rules[] = [['groupId', 'name', 'handle', 'language'], 'required'];
         $rules[] = [['id', 'groupId'], 'number', 'integerOnly' => true];
         $rules[] = [['name', 'handle', 'baseUrl'], 'string', 'max' => 255];

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -730,10 +730,14 @@ class Sites extends Component
             ]));
         }
 
+        // the trim chars taken from vendor/yiisoft/yii2/validators/TrimValidator.php trimValue() method
+        $originalSiteName = trim($site->getName(false), " \n\r\t\v\x00");
         if ($runValidation && !$site->validate()) {
             Craft::info('Site not saved due to validation error.', __METHOD__);
             return false;
         }
+        // if we passed validation, set the site name to what it was before validation parsed it
+        $site->setName($originalSiteName);
 
         if ($isNewSite) {
             $site->uid = StringHelper::UUID();

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -730,13 +730,10 @@ class Sites extends Component
             ]));
         }
 
-        $originalSiteName = trim($site->getName(false));
         if ($runValidation && !$site->validate()) {
             Craft::info('Site not saved due to validation error.', __METHOD__);
             return false;
         }
-        // if we passed validation, set the site name to what it was before validation parsed it
-        $site->setName($originalSiteName);
 
         if ($isNewSite) {
             $site->uid = StringHelper::UUID();

--- a/src/services/Sites.php
+++ b/src/services/Sites.php
@@ -730,8 +730,7 @@ class Sites extends Component
             ]));
         }
 
-        // the trim chars taken from vendor/yiisoft/yii2/validators/TrimValidator.php trimValue() method
-        $originalSiteName = trim($site->getName(false), " \n\r\t\v\x00");
+        $originalSiteName = trim($site->getName(false));
         if ($runValidation && !$site->validate()) {
             Craft::info('Site not saved due to validation error.', __METHOD__);
             return false;


### PR DESCRIPTION
### Description
When running the Install migration, ensure we get the site’s language without parsing the environment variable.

Also, ensure that the site’s name (when running the install migration and when saving via the control panel) is not parsed on save. This was happening because the trim validator gets the value via the getter method, and the default value for the `$parse` parameter in the site’s `getName()` is `true`.


### Related issues
#18780 
