### PR TITLE
[6.x] Handle non-inertia responses as page visits

### DIFF
--- a/resources/js/bootstrap/cp.ts
+++ b/resources/js/bootstrap/cp.ts
@@ -100,24 +100,49 @@ const Cp = {
       },
     });
 
-    // Handle normal responses as page visits
-    let activeVisitUrl = '';
-
-    router.on('start', (event) => {
-      activeVisitUrl = event.detail.visit.url.href;
-    });
-
-    router.on('httpException', (event) => {
-      if (event.detail.response.status === 200) {
-        event.preventDefault();
-        window.location.href = activeVisitUrl;
-      }
-    });
+    handleNonInertiaRequests();
 
     console.log('Calling booted callbacks', bootedCallbacks);
     bootedCallbacks.forEach((callback) => callback(this));
     bootedCallbacks = [];
   },
 };
+
+function handleNonInertiaRequests() {
+  let fallbackUrl = '';
+
+  router.on('start', (event) => {
+    const visit = event.detail.visit;
+
+    if (visit.prefetch || visit.async || visit.method !== 'get') {
+      return;
+    }
+
+    fallbackUrl = visit.url.href;
+  });
+
+  router.on('finish', (event) => {
+    const visit = event.detail.visit;
+
+    if (fallbackUrl === visit.url.href) {
+      fallbackUrl = '';
+    }
+  });
+
+  router.on('httpException', (event) => {
+    const response = event.detail.response;
+
+    const shouldReload =
+      response.status === 200 &&
+      response.headers['content-type']?.includes('text/html');
+
+    if (!fallbackUrl || !shouldReload) {
+      return;
+    }
+
+    event.preventDefault();
+    window.location.assign(fallbackUrl);
+  });
+}
 
 export default Cp;

--- a/resources/js/bootstrap/cp.ts
+++ b/resources/js/bootstrap/cp.ts
@@ -1,6 +1,6 @@
 import {ConfigService} from '@craftcms/cp/services/Config.ts.mjs';
 import {QueueService} from '@craftcms/cp/services/Queue.ts.mjs';
-import {createInertiaApp} from '@inertiajs/vue3';
+import {createInertiaApp, router} from '@inertiajs/vue3';
 import QueueManager from '@/components/utilities/QueueManager/QueueManager.vue';
 import {Axios, Config, Queue} from '@/types/keys';
 import axios from 'axios';
@@ -98,6 +98,20 @@ const Cp = {
         app.component('AssetIndexes', AssetIndexes);
         app.component('SystemMessages', SystemMessages);
       },
+    });
+
+    // Handle normal responses as page visits
+    let activeVisitUrl = '';
+
+    router.on('start', (event) => {
+      activeVisitUrl = event.detail.visit.url.href;
+    });
+
+    router.on('httpException', (event) => {
+      if (event.detail.response.status === 200) {
+        event.preventDefault();
+        window.location.href = activeVisitUrl;
+      }
     });
 
     console.log('Calling booted callbacks', bootedCallbacks);

--- a/resources/js/pages/SettingsIndexPage.vue
+++ b/resources/js/pages/SettingsIndexPage.vue
@@ -2,8 +2,8 @@
   import {t} from '@craftcms/cp';
   import AppLayout from '@/layout/AppLayout.vue';
   import CalloutReadOnly from '@/components/CalloutReadOnly.vue';
-  import {Link} from '@inertiajs/vue3';
   import {default as settingsIndex} from '@actions/Settings/SettingsIndexController';
+  import CpLink from '@/components/CpLink.vue';
 
   interface SettingItem {
     icon?: string;
@@ -38,7 +38,7 @@
             <ul class="settings-grid">
               <template v-for="(item, handle) in items">
                 <li>
-                  <Link
+                  <CpLink
                     :href="item.url || `${settingsIndex().url}/${handle}`"
                     class="settings-item"
                   >
@@ -58,7 +58,7 @@
                       {{ item.label
                       }}<span class="sr-only"> - {{ t('Settings') }}</span>
                     </div>
-                  </Link>
+                  </CpLink>
                 </li>
               </template>
             </ul>

--- a/resources/js/pages/SettingsIndexPage.vue
+++ b/resources/js/pages/SettingsIndexPage.vue
@@ -2,6 +2,8 @@
   import {t} from '@craftcms/cp';
   import AppLayout from '@/layout/AppLayout.vue';
   import CalloutReadOnly from '@/components/CalloutReadOnly.vue';
+  import {Link} from '@inertiajs/vue3';
+  import {default as settingsIndex} from '@actions/Settings/SettingsIndexController';
 
   interface SettingItem {
     icon?: string;
@@ -36,8 +38,8 @@
             <ul class="settings-grid">
               <template v-for="(item, handle) in items">
                 <li>
-                  <a
-                    :href="item.url || `settings/${handle}`"
+                  <Link
+                    :href="item.url || `${settingsIndex().url}/${handle}`"
                     class="settings-item"
                   >
                     <div class="settings-content">
@@ -56,7 +58,7 @@
                       {{ item.label
                       }}<span class="sr-only"> - {{ t('Settings') }}</span>
                     </div>
-                  </a>
+                  </Link>
                 </li>
               </template>
             </ul>

--- a/src/Cp/Settings.php
+++ b/src/Cp/Settings.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\Cp\Events\RegisterCpSettings;
 use CraftCms\Cms\Cp\Events\RegisterReadonlyCpSettings;
 use CraftCms\Cms\Plugin\Plugins;
+use CraftCms\Cms\Support\Url;
 
 use function CraftCms\Cms\t;
 
@@ -97,7 +98,7 @@ readonly class Settings
         foreach ($this->pluginsService->getAllPlugins() as $plugin) {
             if ($plugin->hasCpSettings && (! $readOnly || $plugin->hasReadOnlyCpSettings)) {
                 $settings[$label][$plugin->handle] = [
-                    'url' => 'settings/plugins/'.$plugin->handle,
+                    'url' => Url::cpUrl('settings/plugins/'.$plugin->handle),
                     'icon' => $this->pluginsService->getPluginIconSvg($plugin->handle),
                     'label' => $plugin->name,
                 ];


### PR DESCRIPTION
### Description

This prevents Inertia from opening successful requests in a modal if it's visited through `<Link>` but doesn't return an Inertia request.

We can now always use `<Link>` and not worry about if it's a new controller/view we're accessing or a standard response

I've adjusted the settings index page as a test & example.

@brianjhanson I did not commit the built assets as to not pollute the diff
