### PR TITLE
[6.x] Resolve Craft assets through Vite first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 6
 
+## Unreleased
+
+- The `craftAsset()` Twig function now resolves to Vite versioned assets. ([#18801](https://github.com/craftcms/cms/pull/18801))
+
 ## 6.0.0-alpha.1 - 2026-05-06
 
 ### Development

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,14 +6,17 @@ namespace CraftCms\Cms;
 
 use BackedEnum;
 use Closure;
+use CraftCms\Aliases\Aliases;
 use CraftCms\Cms\Support\Facades\I18N;
 use CraftCms\Cms\Support\PHP;
 use CraftCms\Cms\Support\Typecast;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\Twig\TemplateRenderer;
 use CraftCms\Cms\View\TemplateMode;
+use Illuminate\Foundation\ViteException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Vite;
 use Stringable;
 use UnitEnum;
 
@@ -31,7 +34,13 @@ function enum_value(mixed $value, mixed $default = null): mixed
 
 function craftAsset(string $path, ?bool $secure = null): string
 {
-    return asset("vendor/craft/$path", $secure);
+    try {
+        return Vite::useHotFile(Aliases::get('@resources/hot'))
+            ->useBuildDirectory('vendor/craft/build')
+            ->asset($path);
+    } catch (ViteException) {
+        return asset("vendor/craft/$path", $secure);
+    }
 }
 
 function t(string|Stringable|null $id, array $parameters = [], ?string $category = 'app', ?string $locale = null): string


### PR DESCRIPTION
### Description

Allows the usage of `{{ craftAsset('resources/images/install/installer-bg.png') }}` for example, which will point to the correct Vite versioned asset.
