### PR TITLE
Fix fatal error when session errors is a plain array

### DIFF
--- a/src/Validation/Concerns/Validates.php
+++ b/src/Validation/Concerns/Validates.php
@@ -37,7 +37,12 @@ trait Validates
         }
 
         $this->_errors = new MessageBag;
-        $this->_errors->merge(session('errors', new MessageBag)->getMessages());
+        $sessionErrors = session('errors', new MessageBag);
+        $this->_errors->merge(
+            $sessionErrors instanceof MessageBag
+                ? $sessionErrors->getMessages()
+                : (is_array($sessionErrors) ? $sessionErrors : [])
+        );
 
         return $this->_errors;
     }


### PR DESCRIPTION
## What's the problem?

When submitting the **Entry Types save** form (and likely other forms using the `Validates` trait), a fatal error is thrown:

```
Call to a member function getMessages() on array
```

This occurs in `Validation/Concerns/Validates.php` at the `errors()` method:

```php
$this->_errors->merge(session('errors', new MessageBag)->getMessages());
```

`session('errors')` can return a plain PHP array instead of a `MessageBag` — for example, when the Yii2 flash layer has previously stored errors in the session as a serialized array. Calling `->getMessages()` on a plain array causes the fatal error.

## Fix

Guard against both types before calling `->getMessages()`:

```php
$sessionErrors = session('errors', new MessageBag);
$this->_errors->merge(
    $sessionErrors instanceof MessageBag
        ? $sessionErrors->getMessages()
        : (is_array($sessionErrors) ? $sessionErrors : [])
);
```

## Steps to reproduce

1. Install Craft CMS 6.0.0-alpha.1
2. Go to **Settings → Entry Types → New Entry Type**
3. Fill in the form and click **Save**
4. Fatal error: `Call to a member function getMessages() on array`

## Environment

- Craft CMS 6.0.0-alpha.1
- PHP 8.5.4
- Laravel 13.8.0