### PR TITLE
[6.x] Fix element query clones not being able to apply new criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Fixed a user photo validation issue with file extensions.
 - Fixed a bug where legacy controllers could return `null` but were not considered handled.
 - Improved performance of the dashboard by reducing the amount of queries for widgets
+- Fixed a bug where criteria added to clones of executed element queries could be ignored. ([#18826](https://github.com/craftcms/cms/pull/18826))
 
 ## 6.0.0-alpha.1 - 2026-05-06
 

--- a/src/Element/Queries/ElementQuery.php
+++ b/src/Element/Queries/ElementQuery.php
@@ -210,6 +210,12 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
      */
     private bool $elementQueryBeforeQueryCalled = false;
 
+    private ?Builder $queryBeforePrepare = null;
+
+    private ?array $columnMapBeforePrepare = null;
+
+    private ?array $beforeQueryCallbacksBeforePrepare = null;
+
     /**
      * Create a new Element query instance.
      *
@@ -1076,7 +1082,22 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
      */
     public function __clone(): void
     {
-        $this->query = clone $this->query;
+        if ($this->queryBeforePrepare !== null) {
+            $beforeQueryCallbacks = $this->beforeQueryCallbacks;
+
+            $this->query = clone $this->queryBeforePrepare;
+            $this->columnMap = $this->columnMapBeforePrepare ?? $this->columnMap;
+            $this->beforeQueryCallbacks = [
+                ...($this->beforeQueryCallbacksBeforePrepare ?? []),
+                ...$beforeQueryCallbacks,
+            ];
+            $this->elementQueryBeforeQueryCalled = false;
+            $this->queryBeforePrepare = null;
+            $this->columnMapBeforePrepare = null;
+            $this->beforeQueryCallbacksBeforePrepare = null;
+        } else {
+            $this->query = clone $this->query;
+        }
 
         foreach ($this->onCloneCallbacks as $onCloneCallback) {
             $onCloneCallback($this);
@@ -1095,6 +1116,12 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
 
     public function applyBeforeQueryCallbacks(): void
     {
+        if (! $this->elementQueryBeforeQueryCalled && $this->queryBeforePrepare === null) {
+            $this->queryBeforePrepare = clone $this->query;
+            $this->columnMapBeforePrepare = $this->columnMap;
+            $this->beforeQueryCallbacksBeforePrepare = $this->beforeQueryCallbacks;
+        }
+
         foreach ($this->beforeQueryCallbacks as $i => $callback) {
             $callback($this);
 

--- a/tests/Feature/Element/Queries/Concerns/QueriesStructuresTest.php
+++ b/tests/Feature/Element/Queries/Concerns/QueriesStructuresTest.php
@@ -84,3 +84,29 @@ test('structure methods', function () {
     expect($query->clone()->ancestorOf($lastStructureElement->elementId)->count())->toBe(1);
     expect($query->clone()->ancestorOf($entries[1]->id)->count())->toBe(1);
 });
+
+test('cloned executed structure queries can be further narrowed', function () {
+    $structure = Structure::factory()->create();
+    // Clean structure from factory created elements
+    $structure->structureElements()->delete();
+
+    $entries = Entry::factory(2)->create();
+
+    $root = new StructureElement([
+        'structureId' => $structure->id,
+    ]);
+    $root->makeRoot();
+
+    foreach ($entries as $entry) {
+        new StructureElement([
+            'structureId' => $structure->id,
+            'elementId' => $entry->id,
+        ])->appendTo($root);
+    }
+
+    $query = entryQuery()->structureId($structure->id);
+    $elements = $query->all();
+
+    expect($elements)->toHaveCount(2)
+        ->and($query->clone()->descendantOf($elements[0])->count())->toBe(0);
+});


### PR DESCRIPTION
### Description

Fixes #18825

Fixed a query cloning bug where ElementQuery clones created after execution could retain their prepared internal state. That meant criteria added to the clone, such as `descendantOf()`, could be ignored.

This caused Structure element indexes to count all rows as descendants when rendering child toggles, so max-level-1 Structure entries could incorrectly show carets. Cloned executed queries now restore their unprepared query state before being further narrowed.