### PR TITLE
[6.x] Ensure there's still output when pcntl_fork isn't available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Improved performance of the dashboard by reducing the amount of queries for widgets
 - Fixed a bug where criteria added to clones of executed element queries could be ignored. ([#18826](https://github.com/craftcms/cms/pull/18826))
 - Fixed a bug where Yii2 behaviors registered from plugins weren’t getting attached at the right time. ([#18824](https://github.com/craftcms/cms/issues/18824))
+- Fixed an error that occurred when running `craft:install` in environments where Laravel Prompts can only render tasks statically. ([#18830](https://github.com/craftcms/cms/pull/18830))
 
 ## 6.0.0-alpha.1 - 2026-05-06
 

--- a/rector.php
+++ b/rector.php
@@ -44,7 +44,7 @@ return RectorConfig::configure()
         AppToResolveRector::class,
         StringClassNameToClassConstantRector::class => [
             __DIR__.'/src/Console/PromptTask.php',
-        ]
+        ],
     ])
     ->withSetProviders(LaravelSetProvider::class)
     ->withComposerBased(laravel: true)

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
 use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 use RectorLaravel\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector;
 use RectorLaravel\Rector\Class_\AnonymousMigrationsRector;
@@ -41,6 +42,9 @@ return RectorConfig::configure()
             __DIR__.'/src/Http/Mixins/SessionMixin.php',
         ],
         AppToResolveRector::class,
+        StringClassNameToClassConstantRector::class => [
+            __DIR__.'/src/Console/PromptTask.php',
+        ]
     ])
     ->withSetProviders(LaravelSetProvider::class)
     ->withComposerBased(laravel: true)

--- a/src/Console/Commands/Install/InstallCommand.php
+++ b/src/Console/Commands/Install/InstallCommand.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Console\Commands\Install;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\Console\CraftCommand;
+use CraftCms\Cms\Console\PromptTask;
 use CraftCms\Cms\Cp\SelectOptions;
 use CraftCms\Cms\Database\Migrations\Install;
 use CraftCms\Cms\Database\Migrator;
@@ -29,7 +30,6 @@ use function Laravel\Prompts\info;
 use function Laravel\Prompts\outro;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\suggest;
-use function Laravel\Prompts\task;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\warning;
 
@@ -196,10 +196,10 @@ class InstallCommand extends Command
 
         info('Installing Craft CMS...');
 
-        task('Running initial migrations', function (Logger $logger) {
+        PromptTask::run('Running initial migrations', function (Logger $logger) {
             $this->callSilent('migrate');
             $logger->success('Initial migrations completed.');
-        }, keepSummary: true);
+        }, keepSummary: true, output: $this->output);
 
         $migrator->track('craft')->runMigration(new Install(
             username: $username,
@@ -211,11 +211,11 @@ class InstallCommand extends Command
 
         $migrator->getRepository()->log('Install', 1);
 
-        task('Finishing up', function (Logger $logger) use ($migrator) {
+        PromptTask::run('Finishing up', function (Logger $logger) use ($migrator) {
             $this->markPendingMigrationsAsApplied($migrator);
             $this->ensureProjectConfigFileExists();
             $logger->success('Done.');
-        }, keepSummary: true);
+        }, keepSummary: true, output: $this->output);
 
         outro('Craft CMS installed successfully!');
 

--- a/src/Console/Commands/Setup/DatabaseCredentialsCommand.php
+++ b/src/Console/Commands/Setup/DatabaseCredentialsCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Console\Commands\Setup;
 
 use CraftCms\Cms\Console\CraftCommand;
+use CraftCms\Cms\Console\PromptTask;
 use CraftCms\Cms\Support\Env;
 use CraftCms\Cms\Support\Str;
 use Illuminate\Console\Command;
@@ -20,7 +21,6 @@ use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\select;
-use function Laravel\Prompts\task;
 use function Laravel\Prompts\text;
 
 class DatabaseCredentialsCommand extends Command
@@ -154,7 +154,7 @@ class DatabaseCredentialsCommand extends Command
 
         startTest:
 
-        $result = task('Testing database credentials...', function (Logger $logger) use (&$config, &$badUserCredentials) {
+        $result = PromptTask::run('Testing database credentials...', function (Logger $logger) use (&$config, &$badUserCredentials) {
             test:
 
             $config = array_filter([
@@ -219,7 +219,7 @@ class DatabaseCredentialsCommand extends Command
             $logger->success('Success!');
 
             return true;
-        }, keepSummary: true);
+        }, keepSummary: true, output: $this->output);
 
         if ($result === false) {
             if ($badUserCredentials) {
@@ -233,7 +233,7 @@ class DatabaseCredentialsCommand extends Command
             goto top;
         }
 
-        task('Saving database credentials to your .env file...', function (Logger $logger) {
+        PromptTask::run('Saving database credentials to your .env file...', function (Logger $logger) {
             $path = app()->environmentFilePath();
 
             if (! is_null(Env::get('DB_URL'))) {
@@ -256,7 +256,7 @@ class DatabaseCredentialsCommand extends Command
             }
 
             $logger->success('Database credentials saved successfully.');
-        }, keepSummary: true);
+        }, keepSummary: true, output: $this->output);
 
         Config::set('database.default', $this->driver);
         Config::set("database.connections.{$this->driver}", $config);

--- a/src/Console/CraftCommand.php
+++ b/src/Console/CraftCommand.php
@@ -9,8 +9,6 @@ use CraftCms\Cms\Support\Str;
 use Illuminate\Console\Command;
 use Laravel\Prompts\Support\Logger;
 
-use function Laravel\Prompts\task;
-
 /**
  * @mixin Command
  */
@@ -38,9 +36,9 @@ trait CraftCommand
             return;
         }
 
-        task('Generating project config files from the loaded project config', function (Logger $logger) use ($projectConfig) {
+        PromptTask::run('Generating project config files from the loaded project config', function (Logger $logger) use ($projectConfig) {
             $projectConfig->regenerateExternalConfig();
             $logger->success('Done.');
-        });
+        }, output: $this->output);
     }
 }

--- a/src/Console/FallbackPromptLogger.php
+++ b/src/Console/FallbackPromptLogger.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Console;
+
+use Laravel\Prompts\Support\Logger;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FallbackPromptLogger extends Logger
+{
+    public function __construct(private readonly OutputInterface $output)
+    {
+        parent::__construct('');
+    }
+
+    #[\Override]
+    protected function write(string $message, ?string $type = null): void
+    {
+        match ($type) {
+            'success' => $this->output->writeln("  <info>DONE</info> $message"),
+            'warning' => $this->output->writeln("  <comment>WARN</comment> $message"),
+            'error' => $this->output->writeln("  <error>FAIL</error> $message"),
+            'label', 'sublabel' => $this->output->writeln("  $message"),
+            'partial' => $this->output->write($message),
+            'commitpartial' => $this->output->writeln(''),
+            default => $this->output->writeln("  $message"),
+        };
+    }
+}

--- a/src/Console/PromptTask.php
+++ b/src/Console/PromptTask.php
@@ -6,7 +6,6 @@ namespace CraftCms\Cms\Console;
 
 use Closure;
 use Laravel\Prompts\Output\ConsoleOutput;
-use Laravel\Prompts\task;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Laravel\Prompts\task;
@@ -21,7 +20,7 @@ class PromptTask
         ?string $subLabel = null,
         ?OutputInterface $output = null,
     ): mixed {
-        if (! function_exists(task::class) || ! function_exists('pcntl_fork')) {
+        if (! function_exists('Laravel\Prompts\task') || ! function_exists('pcntl_fork')) {
             $output ??= new ConsoleOutput;
 
             $output->writeln(str($label)->finish('...')->toString());

--- a/src/Console/PromptTask.php
+++ b/src/Console/PromptTask.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Console;
+
+use Closure;
+use Laravel\Prompts\Output\ConsoleOutput;
+use Laravel\Prompts\task;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function Laravel\Prompts\task;
+
+class PromptTask
+{
+    public static function run(
+        string $label,
+        Closure $callback,
+        ?int $limit = null,
+        bool $keepSummary = false,
+        ?string $subLabel = null,
+        ?OutputInterface $output = null,
+    ): mixed {
+        if (! function_exists(task::class) || ! function_exists('pcntl_fork')) {
+            $output ??= new ConsoleOutput;
+
+            $output->writeln(str($label)->finish('...')->toString());
+
+            return $callback(new FallbackPromptLogger($output));
+        }
+
+        return task($label, $callback, $limit, $keepSummary, $subLabel);
+    }
+}

--- a/src/Database/Commands/MigrateCommand.php
+++ b/src/Database/Commands/MigrateCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Database\Commands;
 
 use CraftCms\Cms\Console\CraftCommand;
+use CraftCms\Cms\Console\PromptTask;
 use CraftCms\Cms\Database\Commands\Concerns\BackupTrait;
 use CraftCms\Cms\Database\Events\MigratorsResolving;
 use CraftCms\Cms\Database\Migrator;
@@ -23,7 +24,6 @@ use Override;
 use Throwable;
 
 use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\task;
 
 class MigrateCommand extends Command implements Isolatable
 {
@@ -241,9 +241,9 @@ class MigrateCommand extends Command implements Isolatable
             return;
         }
 
-        task('Preparing database', function (Logger $logger) {
+        PromptTask::run('Preparing database', function (Logger $logger) {
             $logger->subLabel('Creating migration table');
             $this->callSilent('migrate:install');
-        }, keepSummary: true);
+        }, keepSummary: true, output: $this->output);
     }
 }

--- a/src/Database/Migrations/Install.php
+++ b/src/Database/Migrations/Install.php
@@ -9,6 +9,7 @@ namespace CraftCms\Cms\Database\Migrations;
 use Closure;
 use CraftCms\Cms\Asset\Enums\FileKind;
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Console\PromptTask;
 use CraftCms\Cms\Database\Migration;
 use CraftCms\Cms\Database\Migrations\Event\TablesCreated;
 use CraftCms\Cms\Database\Migrator;
@@ -43,7 +44,6 @@ use Throwable;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
-use function Laravel\Prompts\task;
 use function Laravel\Prompts\warning;
 
 class Install extends Migration
@@ -67,13 +67,14 @@ class Install extends Migration
             return;
         }
 
-        task(
+        PromptTask::run(
             label: str($label)->finish('...')->toString(),
             callback: function (Logger $logger) use ($callback, $label) {
                 $callback($logger);
                 $logger->label($label);
             },
             keepSummary: true,
+            output: $this->output,
         );
     }
 

--- a/tests/Unit/Console/PromptTaskTest.php
+++ b/tests/Unit/Console/PromptTaskTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Console\FallbackPromptLogger;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+it('writes logger messages to fallback output', function () {
+    $output = new BufferedOutput;
+    $logger = new FallbackPromptLogger($output);
+
+    $logger->line('line');
+    $logger->success('success');
+    $logger->warning('warning');
+    $logger->error('error');
+    $logger->label('label');
+    $logger->subLabel('sub-label');
+
+    expect($output->fetch())->toContain('line')
+        ->toContain('DONE success')
+        ->toContain('WARN warning')
+        ->toContain('FAIL error')
+        ->toContain('label')
+        ->toContain('sub-label');
+});


### PR DESCRIPTION
### Description

Fixes #18805

pcntl_fork isn't available on Windows, this makes sure the commands don't crash and still show output.
