### PR TITLE
[6.x] Fix legacy model array access for null properties

### DIFF
--- a/yii2-adapter/legacy/base/Model.php
+++ b/yii2-adapter/legacy/base/Model.php
@@ -297,6 +297,13 @@ abstract class Model extends \yii\base\Model implements ModelInterface, Validata
         return parent::safeAttributes();
     }
 
+    public function offsetExists($offset): bool
+    {
+        return parent::offsetExists($offset) || (
+            is_string($offset) && $this->canGetProperty($offset)
+        );
+    }
+
     public function getAttributeLabel($attribute): string
     {
         return parent::getAttributeLabel($attribute);


### PR DESCRIPTION
### Description

Fixes #18837

5.x Twig had a special case for the legacy class which would check `canGetProperty`, this moves that check into the base legacy model class so the fallback to `ArrayAccess` from Twig still results in the same behavior without needing extra checks in the 6.x Twig code.

