### PR TITLE
[6.x] Fix field layout session flashing

### DIFF
--- a/resources/templates/settings/entry-types/_edit.twig
+++ b/resources/templates/settings/entry-types/_edit.twig
@@ -217,7 +217,9 @@
 
 {{ forms.fieldLayoutDesignerField({
     id: 'field-layout',
-    fieldLayout: session('oldFieldLayout', entryType.getFieldLayout()),
+    fieldLayout: old('fieldLayout')
+        ? Fields.createLayout(old('fieldLayout'))
+        : entryType.getFieldLayout(),
     withGeneratedFields: true,
     withCardViewDesigner: true,
     disabled: readOnly,

--- a/src/Http/Controllers/Settings/EntryTypesController.php
+++ b/src/Http/Controllers/Settings/EntryTypesController.php
@@ -34,7 +34,6 @@ use CraftCms\Cms\View\HtmlStack;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Session;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -57,15 +56,9 @@ class EntryTypesController
     ) {
         $this->readOnly = ! $generalConfig->allowAdminChanges;
 
-        /**
-         * We assemble the field layout here before validation runs
-         * so we can flash the old layout to the session.
-         */
         if ($request->route()->getActionMethod() === 'store') {
             $this->fieldLayout = $fields->assembleLayoutFromPost();
             $this->fieldLayout->type = Entry::class;
-
-            Session::flash('oldFieldLayout', $this->fieldLayout);
         }
     }
 

--- a/tests/Feature/Http/Controllers/Settings/EntryTypesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/EntryTypesControllerTest.php
@@ -17,6 +17,7 @@ use function Pest\Laravel\get;
 use function Pest\Laravel\getJson;
 use function Pest\Laravel\post;
 use function Pest\Laravel\postJson;
+use function Pest\Laravel\withSession;
 
 beforeEach(function () {
     actingAs(User::find()->one());
@@ -66,6 +67,16 @@ test('create can be loaded', function () {
 
 test('it can edit an entry type', function () {
     $entryType = $this->entryTypes->getEntryTypeById(EntryType::first()->id);
+
+    get(action([EntryTypesController::class, 'edit'], [$entryType->id]))
+        ->assertOk()
+        ->assertSee($entryType->name);
+});
+
+test('it ignores stale flashed field layouts when editing an entry type', function () {
+    $entryType = $this->entryTypes->getEntryTypeById(EntryType::first()->id);
+
+    withSession(['oldFieldLayout' => []]);
 
     get(action([EntryTypesController::class, 'edit'], [$entryType->id]))
         ->assertOk()


### PR DESCRIPTION
### Description

Fixes #18846

We flash the old fieldlayout so it can be re-rendered with existing elements on a validation error, this was mistakenly being reflashed as an array instead of a FieldLayout object which caused the exception.
