### PR TITLE
[6.x] Default legacy setAttributes to not use safeOnly

### DIFF
--- a/yii2-adapter/legacy/base/Model.php
+++ b/yii2-adapter/legacy/base/Model.php
@@ -257,7 +257,7 @@ abstract class Model extends \yii\base\Model implements ModelInterface, Validata
      * @inheritdoc
      * @since 4.0.0
      */
-    public function setAttributes($values, $safeOnly = true): void
+    public function setAttributes($values, $safeOnly = false): void
     {
         // Typecast them
         Typecast::properties(static::class, $values);


### PR DESCRIPTION
### Description

Fixes #18848

By default, the legacy model's `setAttributes` only allows safe attributes that are being validated. In 5.x the plugin settings would call `->setAttributes($values, false)` explicitly however the safeOnly behavior is not ported to 6.x as it was not necessary.

All legacy callsites of `->setAttributes()` call it with `false` currently, so making this the default for the adapter is a logical compatibility fix.
