### PR TITLE
[6.x] Trigger legacy ErrorHandler exception through adapter

### DIFF
--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -3,7 +3,9 @@
 namespace CraftCms\Yii2Adapter;
 
 use Craft;
+use craft\events\ExceptionEvent;
 use craft\web\Application as WebApplication;
+use craft\web\ErrorHandler;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Table;
@@ -36,8 +38,12 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use PDOException;
 use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Throwable;
 use yii\base\Application as YiiApplication;
 use yii\base\ExitException;
+use yii\web\HttpException as YiiHttpException;
+use yii\web\NotFoundHttpException as YiiNotFoundHttpException;
 
 class Yii2ServiceProvider extends ServiceProvider
 {
@@ -127,6 +133,41 @@ class Yii2ServiceProvider extends ServiceProvider
 
         $handler->dontReport([ExitException::class]);
         $handler->renderable(fn(ExitException $exception) => LegacyMiddleware::createResponse());
+        $handler->renderable(function(Throwable $exception): null {
+            $this->triggerLegacyBeforeHandleException($exception);
+
+            return null;
+        });
+    }
+
+    private function triggerLegacyBeforeHandleException(Throwable $exception): void
+    {
+        if ($exception instanceof ExitException || !Craft::$app) {
+            return;
+        }
+
+        $errorHandler = Craft::$app->getErrorHandler();
+
+        if (!$errorHandler->hasEventHandlers(ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION)) {
+            return;
+        }
+
+        $errorHandler->trigger(ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION, new ExceptionEvent([
+            'exception' => $this->toLegacyException($exception),
+        ]));
+    }
+
+    private function toLegacyException(Throwable $exception): Throwable
+    {
+        if (!$exception instanceof HttpExceptionInterface) {
+            return $exception;
+        }
+
+        if ($exception->getStatusCode() === 404) {
+            return new YiiNotFoundHttpException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+
+        return new YiiHttpException($exception->getStatusCode(), $exception->getMessage(), $exception->getCode(), $exception);
     }
 
     public function boot(): void

--- a/yii2-adapter/tests-laravel/Http/LegacyErrorHandlerCompatibilityTest.php
+++ b/yii2-adapter/tests-laravel/Http/LegacyErrorHandlerCompatibilityTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use craft\events\ExceptionEvent;
+use craft\web\ErrorHandler;
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use yii\base\Event as YiiEvent;
+use yii\web\HttpException;
+
+it('triggers legacy before handle exception handlers for Laravel 404s', function() {
+    $receivedException = null;
+
+    $handler = function(ExceptionEvent $event) use (&$receivedException) {
+        $receivedException = $event->exception;
+    };
+
+    YiiEvent::on(ErrorHandler::class, ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION, $handler);
+
+    try {
+        $response = app(ExceptionHandlerContract::class)->render(
+            Request::create('/definitely-missing'),
+            new NotFoundHttpException('Page not found.')
+        );
+    } finally {
+        YiiEvent::off(ErrorHandler::class, ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION, $handler);
+    }
+
+    expect($response->getStatusCode())->toBe(404);
+    expect($receivedException)
+        ->toBeInstanceOf(HttpException::class)
+        ->and($receivedException->statusCode)->toBe(404);
+});


### PR DESCRIPTION
### Description

Fixes #18851

This might not work for every exception, but we'll tackle those if any others come up.