### PR TITLE
[6.x] Remove double cpTrigger prefix from returnUrl

### DIFF
--- a/src/Http/Controllers/Updates/UpdaterController.php
+++ b/src/Http/Controllers/Updates/UpdaterController.php
@@ -306,7 +306,7 @@ class UpdaterController extends BaseUpdaterController
     #[Override]
     protected function returnUrl(): string
     {
-        return Url::cpUrl($this->data['returnUrl'] ?? $this->generalConfig->getPostCpLoginRedirect());
+        return $this->data['returnUrl'] ?? $this->generalConfig->getPostCpLoginRedirect();
     }
 
     #[Override]

--- a/src/Http/Controllers/Updates/UpdaterController.php
+++ b/src/Http/Controllers/Updates/UpdaterController.php
@@ -306,7 +306,7 @@ class UpdaterController extends BaseUpdaterController
     #[Override]
     protected function returnUrl(): string
     {
-        return $this->data['returnUrl'] ?? $this->generalConfig->getPostCpLoginRedirect();
+        return $this->data['returnUrl'] ?? Url::cpUrl($this->generalConfig->getPostCpLoginRedirect());
     }
 
     #[Override]


### PR DESCRIPTION
Not the right fix

