### PR TITLE
[6.x] Fix legacy redirect responses from exception handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added the `compiledTemplatesPath` config setting. ([#18861](https://github.com/craftcms/cms/pull/18861))
 - Fixed a bug where the `cpTrigger` would be appended twice to the URL after running migrations from the control panel. ([#18858](https://github.com/craftcms/cms/pull/18858))
 - Fixed an error that occurred when uninstalling plugins. ([#18862](https://github.com/craftcms/cms/pull/18862))
+- Fixed a bug where legacy redirect responses were not being handled. ([#18860](https://github.com/craftcms/cms/pull/18860))
 
 ## 6.0.0-alpha.2 - 2026-05-13
 

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -133,8 +133,12 @@ class Yii2ServiceProvider extends ServiceProvider
 
         $handler->dontReport([ExitException::class]);
         $handler->renderable(fn(ExitException $exception) => LegacyMiddleware::createResponse());
-        $handler->renderable(function(Throwable $exception): null {
+        $handler->renderable(function(Throwable $exception) {
             $this->triggerLegacyBeforeHandleException($exception);
+
+            if (Craft::$app?->getResponse()->isSent) {
+                return LegacyMiddleware::createResponse();
+            }
 
             return null;
         });

--- a/yii2-adapter/tests-laravel/Http/LegacyErrorHandlerCompatibilityTest.php
+++ b/yii2-adapter/tests-laravel/Http/LegacyErrorHandlerCompatibilityTest.php
@@ -31,3 +31,25 @@ it('triggers legacy before handle exception handlers for Laravel 404s', function
         ->toBeInstanceOf(HttpException::class)
         ->and($receivedException->statusCode)->toBe(404);
 });
+
+it('can send a legacy redirect response from before handle exception handlers', function() {
+    $handler = function() {
+        Craft::$app->getResponse()
+            ->redirect('/redirect-target', 301, false)
+            ->send();
+    };
+
+    YiiEvent::on(ErrorHandler::class, ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION, $handler);
+
+    try {
+        $response = app(ExceptionHandlerContract::class)->render(
+            Request::create('/missing-page'),
+            new NotFoundHttpException('Page not found.')
+        );
+    } finally {
+        YiiEvent::off(ErrorHandler::class, ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION, $handler);
+    }
+
+    expect($response->getStatusCode())->toBe(301);
+    expect($response->headers->get('Location'))->toBe('http://localhost/redirect-target');
+});


### PR DESCRIPTION
### Description

- return the prepared legacy Yii response when a `beforeHandleException` handler sends one during Laravel exception rendering
- add coverage for redirects sent from `craft\web\ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION`

Laravel triggered the legacy exception event but continued rendering the original exception response when the handler called `Craft::$app->getResponse()->redirect(...)->send()`, so the redirect was replaced by the 404 response.

### Related issues
- #18855 