### PR TITLE
[6.x] Add configurable compiled templates path

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -2,6 +2,7 @@
 
 ### Administration
 - Added support for configuring the system time zone during installation. ([#18794](https://github.com/craftcms/cms/pull/18794))
+- Added the `compiledTemplatesPath` config setting. ([#18861](https://github.com/craftcms/cms/pull/18861))
 
 ### Development
 - Reference tags now support fallback values when no attribute is specified. ([#17688](https://github.com/craftcms/cms/pull/17688))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added the `compiledTemplatesPath` config setting. ([#18861](https://github.com/craftcms/cms/pull/18861))
 - Fixed a bug where the `cpTrigger` would be appended twice to the URL after running migrations from the control panel. ([#18858](https://github.com/craftcms/cms/pull/18858))
 - Fixed an error that occurred when uninstalling plugins. ([#18862](https://github.com/craftcms/cms/pull/18862))
 

--- a/src/Config/GeneralConfig.php
+++ b/src/Config/GeneralConfig.php
@@ -162,6 +162,8 @@ class GeneralConfig extends BaseConfig
      * :::
      *
      * @group Environment
+     *
+     * @since 6.0.0
      */
     public ?string $compiledTemplatesPath = null;
 
@@ -3308,6 +3310,7 @@ class GeneralConfig extends BaseConfig
      * @group Environment
      *
      * @see $compiledTemplatesPath
+     * @since 6.0.0
      */
     public function compiledTemplatesPath(?string $value): self
     {

--- a/src/Config/GeneralConfig.php
+++ b/src/Config/GeneralConfig.php
@@ -148,6 +148,24 @@ class GeneralConfig extends BaseConfig
     public array $aliases = [];
 
     /**
+     * @var string|null The server path to the directory where Craft should store compiled Twig templates.
+     *
+     * If this is set to `null`, Craft will store compiled templates in `storage/runtime/compiled_templates`.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->compiledTemplatesPath('@storage/runtime/templates')
+     * ```
+     * ```shell Environment Override
+     * CRAFT_COMPILED_TEMPLATES_PATH=@storage/runtime/templates
+     * ```
+     * :::
+     *
+     * @group Environment
+     */
+    public ?string $compiledTemplatesPath = null;
+
+    /**
      * @var bool Whether admins should be allowed to make administrative changes to the system.
      *
      * When this is disabled, the Settings section will be hidden, the Craft edition and Craft/plugin versions will be locked,
@@ -3274,6 +3292,26 @@ class GeneralConfig extends BaseConfig
         foreach ($value as $name => $path) {
             $this->addAlias($name, $path);
         }
+
+        return $this;
+    }
+
+    /**
+     * The server path to the directory where Craft should store compiled Twig templates.
+     *
+     * If this is set to `null`, Craft will store compiled templates in `storage/runtime/compiled_templates`.
+     *
+     * ```php
+     * ->compiledTemplatesPath('@storage/runtime/templates')
+     * ```
+     *
+     * @group Environment
+     *
+     * @see $compiledTemplatesPath
+     */
+    public function compiledTemplatesPath(?string $value): self
+    {
+        $this->compiledTemplatesPath = $value;
 
         return $this;
     }

--- a/src/Support/Path.php
+++ b/src/Support/Path.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Support;
 
 use CraftCms\Aliases\Aliases;
+use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\License\License;
 use CraftCms\Cms\ProjectConfig\ProjectConfig;
 use Illuminate\Container\Attributes\Singleton;
@@ -17,6 +18,7 @@ class Path
 {
     public function __construct(
         private readonly Application $app,
+        private readonly GeneralConfig $generalConfig,
         private readonly ProjectConfig $projectConfig,
         private readonly License $license,
     ) {}
@@ -172,6 +174,18 @@ class Path
 
     public function compiledTemplates(string $path = '', bool $create = true): string
     {
+        if ($this->generalConfig->compiledTemplatesPath !== null) {
+            $compiledTemplatesPath = Env::parse($this->generalConfig->compiledTemplatesPath);
+
+            if ($compiledTemplatesPath !== null && $compiledTemplatesPath !== '') {
+                return $this->directory(
+                    File::normalizePath($compiledTemplatesPath),
+                    $path,
+                    $create,
+                );
+            }
+        }
+
         return $this->subdirectory($this->runtime(create: $create), 'compiled_templates', $path, $create);
     }
 

--- a/tests/Feature/Support/PathTest.php
+++ b/tests/Feature/Support/PathTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CraftCms\Aliases\Aliases;
+use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\License\License;
 use CraftCms\Cms\ProjectConfig\ProjectConfig;
 use CraftCms\Cms\Support\Facades\Path;
@@ -33,6 +34,7 @@ beforeEach(function () {
 
     $this->originalProjectConfigFolderName = app(ProjectConfig::class)->folderName;
     app(ProjectConfig::class)->folderName = 'project';
+    $this->originalCompiledTemplatesPath = app(GeneralConfig::class)->compiledTemplatesPath;
 
     $this->laravelPath = function (): CraftCms\Cms\Support\Path {
         $laravelPathClass = CraftCms\Cms\Support\Path::class;
@@ -46,6 +48,7 @@ beforeEach(function () {
 
 afterEach(function () {
     app(ProjectConfig::class)->folderName = $this->originalProjectConfigFolderName;
+    app(GeneralConfig::class)->compiledTemplatesPath = $this->originalCompiledTemplatesPath;
 
     foreach ($this->originalAliases as $alias => $path) {
         Aliases::set($alias, $path);
@@ -121,6 +124,22 @@ test('directory getters return the expected path and creation side effects', fun
     'session path' => ['sessions', 'storage/runtime/sessions', false],
     'cache path' => ['cache', 'storage/runtime/cache', false],
 ]);
+
+test('compiled templates path can be configured', function () {
+    app(GeneralConfig::class)->compiledTemplatesPath = '@storage/custom-compiled-templates';
+
+    $path = ($this->laravelPath)();
+    $expectedPath = $this->aliases['@storage'].DIRECTORY_SEPARATOR.'custom-compiled-templates';
+
+    File::deleteDirectory($expectedPath);
+
+    expect($path->compiledTemplates(create: false))->toBe($expectedPath)
+        ->and(File::exists($expectedPath))->toBeFalse();
+
+    expect($path->compiledTemplates())->toBe($expectedPath)
+        ->and(File::isDirectory($expectedPath))->toBeTrue()
+        ->and($path->compiledTemplates('foo.php'))->toBe($expectedPath.DIRECTORY_SEPARATOR.'foo.php');
+});
 
 test('system paths return the expected ordered list', function () {
     $path = ($this->laravelPath)();

--- a/tests/Unit/Config/GeneralConfigTest.php
+++ b/tests/Unit/Config/GeneralConfigTest.php
@@ -61,6 +61,12 @@ it('can set trackedQueueNames via fluent setter', function () {
     expect($config->trackedQueueNames)->toBe(['craft', 'default']);
 });
 
+it('can set compiledTemplatesPath via fluent setter', function () {
+    $config = GeneralConfig::create()->compiledTemplatesPath('@storage/custom-compiled-templates');
+
+    expect($config->compiledTemplatesPath)->toBe('@storage/custom-compiled-templates');
+});
+
 it('does not expose moved deprecated members on the new class', function () {
     $config = GeneralConfig::create();
 


### PR DESCRIPTION
### Description

Adds a `compiledTemplatesPath` general config setting so Craft’s compiled Twig templates directory can be configured while preserving the default `storage/runtime/compiled_templates` path. The path supports aliases and environment-variable parsing via Craft’s existing path service.

### Related issues

- PT-3115
