### PR TITLE
[6.x] Ignore missing transaction during plugin uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 6
 
+## Unreleased
+
+- Fixed an error that occurred when uninstalling plugins. ([#18862](https://github.com/craftcms/cms/pull/18862))
+
 ## 6.0.0-alpha.2 - 2026-05-13
 
 - Added support for SQLite backups and restores. ([#18803](https://github.com/craftcms/cms/pull/18803))

--- a/src/Plugin/Plugins.php
+++ b/src/Plugin/Plugins.php
@@ -589,7 +589,14 @@ class Plugins
                 ->where('track', "plugin:$handle")
                 ->delete();
 
-            DB::commit();
+            try {
+                DB::commit();
+            } catch (PDOException $e) {
+                // The transaction could be implicitly committed by Mysql
+                if ($e->getMessage() !== 'There is no active transaction') {
+                    throw $e;
+                }
+            }
         } catch (Throwable $e) {
             DB::rollBack();
             throw $e;

--- a/tests/Feature/Plugin/PluginsTest.php
+++ b/tests/Feature/Plugin/PluginsTest.php
@@ -13,6 +13,7 @@ use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Tests\TestClasses\TestPlugin\src\TestPlugin;
 use CraftCms\Cms\View\TemplateMode;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 
 beforeEach(function () {
@@ -110,6 +111,34 @@ it('can uninstall and install a plugin', function () {
 
     expect($this->plugins->isPluginInstalled('test-plugin'))->toBeTrue();
     expect($this->plugins->isPluginEnabled('test-plugin'))->toBeTrue();
+});
+
+it('ignores missing transaction exceptions during uninstall commits', function () {
+    $this->plugins->enablePlugin('test-plugin');
+
+    $manager = DB::getFacadeRoot();
+    $connectionName = DB::getDefaultConnection();
+    $connection = DB::connection();
+    $connectionMock = Mockery::mock($connection)->makePartial();
+
+    $connections = new ReflectionProperty($manager, 'connections');
+    $resolvedConnections = $connections->getValue($manager);
+    $resolvedConnections[$connectionName] = $connectionMock;
+    $connections->setValue($manager, $resolvedConnections);
+
+    $connectionMock
+        ->shouldReceive('commit')
+        ->once()
+        ->andThrow(new PDOException('There is no active transaction'));
+
+    try {
+        $this->plugins->uninstallPlugin('test-plugin');
+    } finally {
+        $resolvedConnections[$connectionName] = $connection;
+        $connections->setValue($manager, $resolvedConnections);
+    }
+
+    expect($this->plugins->isPluginInstalled('test-plugin'))->toBeFalse();
 });
 
 it('cannot uninstall a plugin that is not enabled', function () {


### PR DESCRIPTION
### Description

Ignores MySQL missing-transaction exceptions when committing plugin uninstall transactions, matching the existing plugin install behavior. Adds a regression test for the uninstall commit path.

### Related issues

Fixes CMS-2080
