### PR TITLE
Fix queue polling backoff and infinite retry when no displayable jobs

### DIFF
--- a/packages/craftcms-cp/src/services/Queue.ts
+++ b/packages/craftcms-cp/src/services/Queue.ts
@@ -255,8 +255,10 @@ export class QueueService extends EventTarget {
         return;
       }
 
-      // For other errors, retry with delay
-      this.startTracking(true, true);
+      // For other errors, retry with delay if there are jobs to track
+      if (this.jobInfo.length > 0) {
+        this.startTracking(true, true);
+      }
     } finally {
       this.isTracking = false;
       this.#abortController = null;
@@ -270,14 +272,16 @@ export class QueueService extends EventTarget {
     this.displayedJob = this.#selectDisplayedJob();
 
     // Track if displayed job changed for adaptive delay
-    if (
-      oldDisplayedJob &&
-      this.displayedJob &&
-      oldDisplayedJob.id === this.displayedJob.id &&
-      oldDisplayedJob.progress === this.displayedJob.progress &&
-      oldDisplayedJob.progressLabel === this.displayedJob.progressLabel &&
-      oldDisplayedJob.status === this.displayedJob.status
-    ) {
+    const jobsUnchanged =
+      (oldDisplayedJob &&
+        this.displayedJob &&
+        oldDisplayedJob.id === this.displayedJob.id &&
+        oldDisplayedJob.progress === this.displayedJob.progress &&
+        oldDisplayedJob.progressLabel === this.displayedJob.progressLabel &&
+        oldDisplayedJob.status === this.displayedJob.status) ||
+      (!oldDisplayedJob && !this.displayedJob && this.jobInfo.length > 0);
+
+    if (jobsUnchanged) {
       this.displayedJobUnchangedCount++;
     } else {
       this.displayedJobUnchangedCount = 1;


### PR DESCRIPTION
## Summary

- **Backoff not growing**: `displayedJobUnchangedCount` was always reset to `1` when `displayedJob` was `null` (e.g. all jobs are delayed), so `#getAdaptiveDelay()` never returned more than `500ms`. Now the counter also increments when `jobInfo` is non-empty but both `oldDisplayedJob` and `displayedJob` are `null` — covering the delayed-jobs scenario.
- **Infinite retries on error**: The `catch` block unconditionally called `startTracking(true, true)` on any non-auth error, even with an empty job list. Added a `jobInfo.length > 0` guard so it only retries when there's something to track.

## Test plan

- [ ] Verify queue badge backs off toward 60s when all jobs are delayed (no active displayable job)
- [ ] Verify polling stops after an error response when the queue is empty
- [ ] Verify normal job progress still resets the counter and polls quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)