### PR TITLE
[6.x] infinite queue polling in control panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added the `compiledTemplatesPath` config setting. ([#18861](https://github.com/craftcms/cms/pull/18861))
 - Fixed a bug where the `cpTrigger` would be appended twice to the URL after running migrations from the control panel. ([#18858](https://github.com/craftcms/cms/pull/18858))
 - Fixed an error that occurred when uninstalling plugins. ([#18862](https://github.com/craftcms/cms/pull/18862))
+- Fixed a bug where the control panel would continuously poll for queue job info, even if there were no active jobs. ([#18853](https://github.com/craftcms/cms/issues/18853))
 
 ## 6.0.0-alpha.2 - 2026-05-13
 

--- a/packages/craftcms-cp/src/services/Queue.ts
+++ b/packages/craftcms-cp/src/services/Queue.ts
@@ -255,8 +255,10 @@ export class QueueService extends EventTarget {
         return;
       }
 
-      // For other errors, retry with delay
-      this.startTracking(true, true);
+      // For other errors, retry with delay if there are jobs to track
+      if (this.jobInfo.length > 0) {
+        this.startTracking(true, true);
+      }
     } finally {
       this.isTracking = false;
       this.#abortController = null;
@@ -270,14 +272,16 @@ export class QueueService extends EventTarget {
     this.displayedJob = this.#selectDisplayedJob();
 
     // Track if displayed job changed for adaptive delay
-    if (
-      oldDisplayedJob &&
-      this.displayedJob &&
-      oldDisplayedJob.id === this.displayedJob.id &&
-      oldDisplayedJob.progress === this.displayedJob.progress &&
-      oldDisplayedJob.progressLabel === this.displayedJob.progressLabel &&
-      oldDisplayedJob.status === this.displayedJob.status
-    ) {
+    const jobsUnchanged =
+      (oldDisplayedJob &&
+        this.displayedJob &&
+        oldDisplayedJob.id === this.displayedJob.id &&
+        oldDisplayedJob.progress === this.displayedJob.progress &&
+        oldDisplayedJob.progressLabel === this.displayedJob.progressLabel &&
+        oldDisplayedJob.status === this.displayedJob.status) ||
+      (!oldDisplayedJob && !this.displayedJob && this.jobInfo.length > 0);
+
+    if (jobsUnchanged) {
       this.displayedJobUnchangedCount++;
     } else {
       this.displayedJobUnchangedCount = 1;

--- a/packages/craftcms-cp/src/services/Queue.ts
+++ b/packages/craftcms-cp/src/services/Queue.ts
@@ -193,7 +193,7 @@ export class QueueService extends EventTarget {
           this.setJobData(data.jobData.jobs);
         }
         // Schedule our next poll with extra delay to avoid conflicts
-        if (this.jobInfo.length > 0) {
+        if (this.displayedJob !== null) {
           const delay = this.#getAdaptiveDelay() + 1000;
           this.startTracking(delay);
         }
@@ -235,8 +235,8 @@ export class QueueService extends EventTarget {
       // Broadcast to other tabs
       this.#broadcast('trackJobProgress', {jobData: response.data});
 
-      // Continue polling if there are jobs
-      if (this.jobInfo.length > 0) {
+      // Continue polling while there's an active job to display
+      if (this.displayedJob !== null) {
         this.startTracking(true, true);
       }
     } catch (error) {
@@ -255,8 +255,8 @@ export class QueueService extends EventTarget {
         return;
       }
 
-      // For other errors, retry with delay if there are jobs to track
-      if (this.jobInfo.length > 0) {
+      // For other errors, retry with delay if there's still an active job
+      if (this.displayedJob !== null) {
         this.startTracking(true, true);
       }
     } finally {
@@ -265,23 +265,24 @@ export class QueueService extends EventTarget {
     }
   }
 
+  #displayedJobEqual(a: JobInfo | null, b: JobInfo | null): boolean {
+    if (a === null && b === null) return true;
+    if (a === null || b === null) return false;
+    return (
+      a.id === b.id &&
+      a.progress === b.progress &&
+      a.progressLabel === b.progressLabel &&
+      a.status === b.status
+    );
+  }
+
   #setJobInfo(jobs: JobInfo[]): void {
     const oldDisplayedJob = this.displayedJob;
 
     this.jobInfo = jobs;
     this.displayedJob = this.#selectDisplayedJob();
 
-    // Track if displayed job changed for adaptive delay
-    const jobsUnchanged =
-      (oldDisplayedJob &&
-        this.displayedJob &&
-        oldDisplayedJob.id === this.displayedJob.id &&
-        oldDisplayedJob.progress === this.displayedJob.progress &&
-        oldDisplayedJob.progressLabel === this.displayedJob.progressLabel &&
-        oldDisplayedJob.status === this.displayedJob.status) ||
-      (!oldDisplayedJob && !this.displayedJob && this.jobInfo.length > 0);
-
-    if (jobsUnchanged) {
+    if (this.#displayedJobEqual(oldDisplayedJob, this.displayedJob)) {
       this.displayedJobUnchangedCount++;
     } else {
       this.displayedJobUnchangedCount = 1;
@@ -296,7 +297,7 @@ export class QueueService extends EventTarget {
     }
 
     // Check for completion
-    if (this.jobInfo.length === 0 && oldDisplayedJob) {
+    if (this.displayedJob === null && oldDisplayedJob) {
       this.#emitJobComplete();
     }
   }


### PR DESCRIPTION
Fixes infinite polling for job info. In Craft 5 jobs were immediately removed (and therefore not returned in `get-job-info`) after they were processed, but that's not the case in 6. This updates our Queue code to handle that. 

It also fixes a bug in the backoff timer.

Fixes #18853