### PR TITLE
[6.x] Add missing minAuthors migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added the `compiledTemplatesPath` config setting. ([#18861](https://github.com/craftcms/cms/pull/18861))
+- Added a missing migration that adds `minAuthors` to the section table ([#18875](https://github.com/craftcms/cms/pull/18875))
 - Fixed a bug where the `cpTrigger` would be appended twice to the URL after running migrations from the control panel. ([#18858](https://github.com/craftcms/cms/pull/18858))
 - Fixed an error that occurred when uninstalling plugins. ([#18862](https://github.com/craftcms/cms/pull/18862))
 

--- a/src/Database/Migrations/2026_04_01_155236_min_authors_setting.php
+++ b/src/Database/Migrations/2026_04_01_155236_min_authors_setting.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Database\Migration;
+use CraftCms\Cms\Database\Table;
+use CraftCms\Cms\Support\Facades\Sections;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn(Table::SECTIONS, 'minAuthors')) {
+            return;
+        }
+
+        Schema::table(Table::SECTIONS, function (Blueprint $table) {
+            $table->unsignedSmallInteger('minAuthors')->default(1)->after('enableVersioning');
+        });
+
+        foreach (Sections::getAllSections() as $section) {
+            $section->minAuthors = $section->maxAuthors === 0 ? 0 : 1;
+            Sections::saveSection($section);
+        }
+    }
+
+    public function down(): void
+    {
+        $this->output->error('2026_04_01_155236_min_authors_setting cannot be reverted.');
+    }
+};


### PR DESCRIPTION
### Description

I added the line breaks one but it seems I had missed the one for `minAuthors`

### Related issues

#18868