### PR TITLE
[6.x] Allow stringable CP HTML values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added the `compiledTemplatesPath` config setting. ([#18861](https://github.com/craftcms/cms/pull/18861))
 - Fixed a bug where the `cpTrigger` would be appended twice to the URL after running migrations from the control panel. ([#18858](https://github.com/craftcms/cms/pull/18858))
 - Fixed an error that occurred when uninstalling plugins. ([#18862](https://github.com/craftcms/cms/pull/18862))
+- Fixed an error that could occur when Control Panel HTML values were passed as `Stringable` objects. ([#18883](https://github.com/craftcms/cms/pull/18883))
 - Fixed a bug where the control panel would continuously poll for queue job info, even if there were no active jobs. ([#18853](https://github.com/craftcms/cms/issues/18853))
 - Fixed a bug where legacy redirect responses were not being handled. ([#18860](https://github.com/craftcms/cms/pull/18860))
 

--- a/src/Cp/FormFields.php
+++ b/src/Cp/FormFields.php
@@ -22,13 +22,14 @@ use Illuminate\Support\ViewErrorBag;
 use Illuminate\Validation\ConditionalRules;
 use Illuminate\Validation\Rules\RequiredIf;
 use InvalidArgumentException;
+use Stringable;
 
 use function CraftCms\Cms\t;
 use function CraftCms\Cms\template;
 
 readonly class FormFields
 {
-    public static function fieldHtml(string|callable $input, array $config = []): string
+    public static function fieldHtml(string|Stringable|callable $input, array $config = []): string
     {
         $attribute = $config['attribute'] ?? $config['id'] ?? null;
         $id = $config['id'] ??= 'field'.mt_rand();
@@ -61,6 +62,10 @@ readonly class FormFields
         }
 
         $siteId = Sites::isMultiSite() && isset($config['siteId']) ? (int) $config['siteId'] : null;
+
+        if (! is_callable($input)) {
+            $input = (string) $input;
+        }
 
         if (is_callable($input) || str_starts_with($input, 'template:')) {
             // Set labelledBy and describedBy values in case the input template supports it
@@ -244,11 +249,13 @@ readonly class FormFields
             Html::endTag('div');
     }
 
-    private static function noticeHtml(string $id, string $class, string $label, ?string $message): string
+    private static function noticeHtml(string $id, string $class, string $label, string|Stringable|null $message): string
     {
         if (! $message) {
             return '';
         }
+
+        $message = (string) $message;
 
         return
             Html::beginTag('p', [

--- a/src/Http/Responses/CpModalResponse.php
+++ b/src/Http/Responses/CpModalResponse.php
@@ -15,6 +15,7 @@ use CraftCms\Cms\View\TemplateMode;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Traits\Conditionable;
+use Stringable;
 
 use function CraftCms\Cms\template;
 
@@ -53,7 +54,7 @@ class CpModalResponse implements Responsable
     public ?string $submitButtonLabel = null;
 
     /**
-     * @var string|callable|null The content HTML.
+     * @var string|Stringable|callable|null The content HTML.
      *
      * @see contentHtml()
      * @see contentTemplate()
@@ -61,7 +62,7 @@ class CpModalResponse implements Responsable
     public $contentHtml;
 
     /**
-     * @var string|callable|null The errors summary HTML (DEV-212).
+     * @var string|Stringable|callable|null The errors summary HTML (DEV-212).
      *
      * @see errorSummary()
      * @see errorSummaryTemplate()
@@ -113,7 +114,7 @@ class CpModalResponse implements Responsable
     /**
      * Sets the content HTML.
      */
-    public function contentHtml(callable|string|null $value): self
+    public function contentHtml(callable|string|Stringable|null $value): self
     {
         $this->contentHtml = $value;
 
@@ -133,7 +134,7 @@ class CpModalResponse implements Responsable
     /**
      * Sets the errors summary HTML.
      */
-    public function errorSummary(callable|string|null $value): self
+    public function errorSummary(callable|string|Stringable|null $value): self
     {
         $this->errorSummary = $value;
 

--- a/src/Http/Responses/CpScreenResponse.php
+++ b/src/Http/Responses/CpScreenResponse.php
@@ -191,7 +191,7 @@ class CpScreenResponse implements Responsable
     public $contextMenuItems;
 
     /**
-     * @var string|callable|null Toolbar HTML
+     * @var string|Stringable|callable|null Toolbar HTML
      *
      * @see toolbarHtml()
      * @see toolbarTemplate()
@@ -213,7 +213,7 @@ class CpScreenResponse implements Responsable
     public ?string $submitButtonLabel = null;
 
     /**
-     * @var string|callable|null Additional buttons’ HTML.
+     * @var string|Stringable|callable|null Additional buttons’ HTML.
      *
      * This will only be used by full-page screens.
      *
@@ -223,7 +223,7 @@ class CpScreenResponse implements Responsable
     public $additionalButtonsHtml;
 
     /**
-     * @var string|callable|null The content HTML.
+     * @var string|Stringable|callable|null The content HTML.
      *
      * @see contentHtml()
      * @see contentTemplate()
@@ -231,7 +231,7 @@ class CpScreenResponse implements Responsable
     public $contentHtml;
 
     /**
-     * @var string|callable|null The right-hand meta sidebar HTML.
+     * @var string|Stringable|callable|null The right-hand meta sidebar HTML.
      *
      * @see metaSidebarHtml()
      * @see metaSidebarTemplate()
@@ -239,7 +239,7 @@ class CpScreenResponse implements Responsable
     public $metaSidebarHtml;
 
     /**
-     * @var string|callable|null The left-hand page sidebar HTML (only used by full-page screens).
+     * @var string|Stringable|callable|null The left-hand page sidebar HTML (only used by full-page screens).
      *
      * @see pageSidebarHtml()
      * @see pageSidebarTemplate()
@@ -247,7 +247,7 @@ class CpScreenResponse implements Responsable
     public $pageSidebarHtml;
 
     /**
-     * @var string|callable|null The content notice HTML.
+     * @var string|Stringable|callable|null The content notice HTML.
      *
      * @see noticeHtml()
      * @see noticeTemplate()
@@ -255,7 +255,7 @@ class CpScreenResponse implements Responsable
     public $noticeHtml;
 
     /**
-     * @var string|callable|null The errors summary HTML (DEV-212).
+     * @var string|Stringable|callable|null The errors summary HTML (DEV-212).
      *
      * @see errorSummary()
      * @see errorSummaryTemplate()
@@ -540,7 +540,7 @@ class CpScreenResponse implements Responsable
     /**
      * Sets the toolbar HTML.
      */
-    public function toolbarHtml(callable|string|null $value): self
+    public function toolbarHtml(callable|string|Stringable|null $value): self
     {
         $this->toolbarHtml = $value;
 
@@ -606,7 +606,7 @@ class CpScreenResponse implements Responsable
     /**
      * Sets the content HTML.
      */
-    public function contentHtml(callable|string|null $value): self
+    public function contentHtml(callable|string|Stringable|null $value): self
     {
         $this->contentHtml = $value;
 
@@ -640,7 +640,7 @@ class CpScreenResponse implements Responsable
     /**
      * Sets the right-hand meta sidebar HTML.
      */
-    public function metaSidebarHtml(callable|string|null $value): self
+    public function metaSidebarHtml(callable|string|Stringable|null $value): self
     {
         $this->metaSidebarHtml = $value;
 
@@ -660,7 +660,7 @@ class CpScreenResponse implements Responsable
     /**
      * Sets the left-hand page sidebar HTML (only used by full-page screens).
      */
-    public function pageSidebarHtml(callable|string|null $value): self
+    public function pageSidebarHtml(callable|string|Stringable|null $value): self
     {
         $this->pageSidebarHtml = $value;
 
@@ -680,7 +680,7 @@ class CpScreenResponse implements Responsable
     /**
      * Sets the content notice HTML.
      */
-    public function noticeHtml(callable|string|null $value): self
+    public function noticeHtml(callable|string|Stringable|null $value): self
     {
         $this->noticeHtml = $value;
 
@@ -700,7 +700,7 @@ class CpScreenResponse implements Responsable
     /**
      * Sets the errors summary HTML.
      */
-    public function errorSummary(callable|string|null $value): self
+    public function errorSummary(callable|string|Stringable|null $value): self
     {
         $this->errorSummary = $value;
 

--- a/src/Support/Facades/InputNamespace.php
+++ b/src/Support/Facades/InputNamespace.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string|null get()
  * @method static \CraftCms\Cms\View\InputNamespace set(string|null $namespace)
  * @method static mixed with(string|null $namespace, callable $callback)
- * @method static string namespaceInputs(callable|string $html, string|null $namespace = null, bool $otherAttributes = true, bool $withClasses = false)
+ * @method static string namespaceInputs(callable|string|\Stringable $html, string|null $namespace = null, bool $otherAttributes = true, bool $withClasses = false)
  * @method static string namespaceInputName(string $inputName, string|null $namespace = null)
  * @method static string namespaceId(string $inputId, string|null $namespace = null)
  *

--- a/src/Twig/Variables/Cp.php
+++ b/src/Twig/Variables/Cp.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Uri;
 use InvalidArgumentException;
+use Stringable;
 
 use function CraftCms\Cms\t;
 
@@ -313,7 +314,7 @@ class Cp extends Component
      * @throws TemplateLoaderException if $input begins with `template:` and is followed by an invalid template path
      * @throws InvalidArgumentException if `$config['siteId']` is invalid
      */
-    public function field(string $input, array $config = []): string
+    public function field(string|Stringable $input, array $config = []): string
     {
         return FormFields::fieldHtml($input, $config);
     }

--- a/src/View/InputNamespace.php
+++ b/src/View/InputNamespace.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\View;
 
 use CraftCms\Cms\Support\Html;
 use Illuminate\Container\Attributes\Scoped;
+use Stringable;
 
 #[Scoped]
 class InputNamespace
@@ -106,14 +107,14 @@ class InputNamespace
      * }, 'widget-settings');
      * ```
      *
-     * @param  callable|string  $html  The HTML code, or a callable that returns the HTML code
+     * @param  callable|string|Stringable  $html  The HTML code, or a callable that returns the HTML code
      * @param  string|null  $namespace  The namespace. Defaults to the [[getNamespace()|active namespace]].
      * @param  bool  $otherAttributes  Whether `id`, `for`, and other attributes should be namespaced (in addition to `name`)
      * @param  bool  $withClasses  Whether class names should be namespaced as well (affects both `class` attributes and
      *                             class name CSS selectors within `<style>` tags). This will only have an effect if `$otherAttributes` is `true`.
      * @return string The HTML with namespaced attributes
      */
-    public function namespaceInputs(callable|string $html, ?string $namespace = null, bool $otherAttributes = true, bool $withClasses = false): string
+    public function namespaceInputs(callable|string|Stringable $html, ?string $namespace = null, bool $otherAttributes = true, bool $withClasses = false): string
     {
         if (is_callable($html)) {
             // If no namespace was passed in, just return the callable response directly.
@@ -132,6 +133,8 @@ class InputNamespace
 
             return $response;
         }
+
+        $html = (string) $html;
 
         if ($html === '') {
             return $html;

--- a/tests/Unit/Cp/FormFieldsTest.php
+++ b/tests/Unit/Cp/FormFieldsTest.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\FieldLayout\FieldLayout;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Twig\Exceptions\TemplateLoaderException;
 use CraftCms\RulesetValidation\Attributes\Ruleset;
+use Twig\Markup;
 
 #[Ruleset(AddressRules::class)]
 class TestAddressForFormFields extends Address
@@ -30,6 +31,12 @@ describe('fieldHtml', function () {
         expect($html)->toContain('<div class="input ltr"><input></div>')
             ->and($labelHtml)->toContain('<label id="id-label" for="id">Label</label>')
             ->and($blankLabelHtml)->not->toContain('<label');
+    });
+
+    it('renders markup input', function () {
+        $html = FormFields::fieldHtml(new Markup('<input name="title">', 'UTF-8'));
+
+        expect($html)->toContain('<div class="input ltr"><input name="title"></div>');
     });
 
     it('throws for an invalid site id in multi-site mode', function () {
@@ -73,6 +80,16 @@ describe('fieldHtml', function () {
             ->and($withWarning)->toContain('<p id="warning" class="warning has-icon">')
             ->and($withErrors)->toContain('has-errors')
             ->and((bool) preg_match('/<ul id="[\w\-]+" class="errors">/', $withErrors))->toBeTrue();
+    });
+
+    it('renders markup warnings', function () {
+        $html = FormFields::fieldHtml('<input>', [
+            'warningId' => 'warning',
+            'warning' => new Markup('Config warning', 'UTF-8'),
+        ]);
+
+        expect($html)->toContain('<p id="warning" class="warning has-icon">')
+            ->and($html)->toContain('Config warning');
     });
 
     it('throws for invalid template paths', function () {

--- a/tests/Unit/Http/Responses/CpModalResponseTest.php
+++ b/tests/Unit/Http/Responses/CpModalResponseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Http\Responses\CpModalResponse;
+use Twig\Markup;
+
+it('accepts markup for html sections', function (string $method, string $property) {
+    $markup = new Markup('<div>HTML</div>', 'UTF-8');
+    $response = new CpModalResponse;
+
+    expect($response->$method($markup))->toBe($response)
+        ->and($response->$property)->toBe($markup);
+})->with([
+    ['contentHtml', 'contentHtml'],
+    ['errorSummary', 'errorSummary'],
+]);

--- a/tests/Unit/Http/Responses/CpScreenResponseTest.php
+++ b/tests/Unit/Http/Responses/CpScreenResponseTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Http\Responses\CpScreenResponse;
+use Twig\Markup;
+
+it('accepts markup for html sections', function (string $method, string $property) {
+    $markup = new Markup('<div>HTML</div>', 'UTF-8');
+    $response = new CpScreenResponse;
+
+    expect($response->$method($markup))->toBe($response)
+        ->and($response->$property)->toBe($markup);
+})->with([
+    ['toolbarHtml', 'toolbarHtml'],
+    ['additionalButtonsHtml', 'additionalButtonsHtml'],
+    ['contentHtml', 'contentHtml'],
+    ['metaSidebarHtml', 'metaSidebarHtml'],
+    ['pageSidebarHtml', 'pageSidebarHtml'],
+    ['noticeHtml', 'noticeHtml'],
+    ['errorSummary', 'errorSummary'],
+]);

--- a/tests/Unit/View/InputNamespaceTest.php
+++ b/tests/Unit/View/InputNamespaceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\View\InputNamespace;
+use Twig\Markup;
 
 beforeEach(function () {
     $this->inputNamespace = app(InputNamespace::class);
@@ -151,6 +152,16 @@ describe('namespaceInputs with string html', function () {
         $html = '<input type="text" name="title" id="title">';
 
         expect($this->inputNamespace->namespaceInputs($html))->toBe($html);
+    });
+
+    it('accepts markup html', function () {
+        $html = new Markup('<input type="text" name="title" id="title">', 'UTF-8');
+
+        $result = $this->inputNamespace->namespaceInputs($html, 'foo');
+
+        expect($result)
+            ->toContain('name="foo[title]"')
+            ->toContain('id="foo-title"');
     });
 
     it('namespaces html with an explicit namespace', function () {

--- a/yii2-adapter/legacy/web/CpModalResponseBehavior.php
+++ b/yii2-adapter/legacy/web/CpModalResponseBehavior.php
@@ -9,6 +9,7 @@ namespace craft\web;
 
 use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\View\TemplateMode;
+use Stringable;
 use yii\base\Behavior;
 use function CraftCms\Cms\template;
 
@@ -118,11 +119,11 @@ class CpModalResponseBehavior extends Behavior
     /**
      * Sets the content HTML.
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
 
      */
-    public function contentHtml(callable|string|null $value): Response
+    public function contentHtml(callable|string|Stringable|null $value): Response
     {
         $this->contentHtml = $value;
         return $this->owner;
@@ -145,10 +146,10 @@ class CpModalResponseBehavior extends Behavior
     /**
      * Sets the errors summary HTML.
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
      */
-    public function errorSummary(callable|string|null $value): Response
+    public function errorSummary(callable|string|Stringable|null $value): Response
     {
         $this->errorSummary = $value;
         return $this->owner;

--- a/yii2-adapter/legacy/web/CpScreenResponseBehavior.php
+++ b/yii2-adapter/legacy/web/CpScreenResponseBehavior.php
@@ -11,6 +11,7 @@ use CraftCms\Cms\Site\Data\Site;
 use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\View\TemplateMode;
+use Stringable;
 use yii\base\Behavior;
 use function CraftCms\Cms\template;
 
@@ -550,11 +551,11 @@ class CpScreenResponseBehavior extends Behavior
     /**
      * Sets the toolbar HTML.
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
      * @since 5.7.0
      */
-    public function toolbarHtml(callable|string|null $value): Response
+    public function toolbarHtml(callable|string|Stringable|null $value): Response
     {
         $this->toolbarHtml = $value;
         return $this->owner;
@@ -607,11 +608,11 @@ class CpScreenResponseBehavior extends Behavior
      *
      * This will only be used by full-page screens.
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
      * @since 5.0.0
      */
-    public function additionalButtonsHtml(callable|string|null $value): Response
+    public function additionalButtonsHtml(callable|string|Stringable|null $value): Response
     {
         $this->additionalButtonsHtml = $value;
         return $this->owner;
@@ -636,11 +637,11 @@ class CpScreenResponseBehavior extends Behavior
     /**
      * Sets the content HTML.
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
      * @since 5.0.0
      */
-    public function contentHtml(callable|string|null $value): Response
+    public function contentHtml(callable|string|Stringable|null $value): Response
     {
         $this->contentHtml = $value;
         return $this->owner;
@@ -663,11 +664,11 @@ class CpScreenResponseBehavior extends Behavior
     /**
      * Sets the right-hand meta sidebar HTML.
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
      * @since 5.0.0
      */
-    public function metaSidebarHtml(callable|string|null $value): Response
+    public function metaSidebarHtml(callable|string|Stringable|null $value): Response
     {
         $this->metaSidebarHtml = $value;
         return $this->owner;
@@ -690,11 +691,11 @@ class CpScreenResponseBehavior extends Behavior
     /**
      * Sets the left-hand page sidebar HTML (only used by full-page screens).
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
      * @since 5.0.0
      */
-    public function pageSidebarHtml(callable|string|null $value): Response
+    public function pageSidebarHtml(callable|string|Stringable|null $value): Response
     {
         $this->pageSidebarHtml = $value;
         return $this->owner;
@@ -718,11 +719,11 @@ class CpScreenResponseBehavior extends Behavior
     /**
      * Sets the content notice HTML.
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
      * @since 5.0.0
      */
-    public function noticeHtml(callable|string|null $value): Response
+    public function noticeHtml(callable|string|Stringable|null $value): Response
     {
         $this->noticeHtml = $value;
         return $this->owner;
@@ -745,11 +746,11 @@ class CpScreenResponseBehavior extends Behavior
     /**
      * Sets the errors summary HTML.
      *
-     * @param callable|string|null $value
+     * @param callable|string|Stringable|null $value
      * @return Response
      * @since 4.5.0
      */
-    public function errorSummary(callable|string|null $value): Response
+    public function errorSummary(callable|string|Stringable|null $value): Response
     {
         $this->errorSummary = $value;
         return $this->owner;


### PR DESCRIPTION
### Description

Due to applying strict types everywhere, PHP no longer automatically coerces the Stringable types into strings.

Allow CP HTML rendering APIs to accept `Stringable` values such as `Twig\Markup`. This covers form field notices/input HTML, input namespacing, CP screen/modal HTML sections, and legacy Yii response behaviors, with unit coverage for Markup values.

### Related issues

#18877