### PR TITLE
[6.x] Adjust plugin config merge order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a bug where the `cpTrigger` would be appended twice to the URL after running migrations from the control panel. ([#18858](https://github.com/craftcms/cms/pull/18858))
 - Fixed an error that occurred when uninstalling plugins. ([#18862](https://github.com/craftcms/cms/pull/18862))
 - Fixed an error that could occur when Control Panel HTML values were passed as `Stringable` objects. ([#18883](https://github.com/craftcms/cms/pull/18883))
+- Fixed a bug where plugin package config files could affect plugin settings before being published. ([#18885](https://github.com/craftcms/cms/pull/18885))
 - Fixed a bug where the control panel would continuously poll for queue job info, even if there were no active jobs. ([#18853](https://github.com/craftcms/cms/issues/18853))
 - Fixed a bug where legacy redirect responses were not being handled. ([#18860](https://github.com/craftcms/cms/pull/18860))
 - Fixed a bug where email addresses couldn’t be saved when applying unpublished user drafts. ([#18882](https://github.com/craftcms/cms/pull/18882))

--- a/src/Plugin/Concerns/HasConfig.php
+++ b/src/Plugin/Concerns/HasConfig.php
@@ -27,7 +27,5 @@ trait HasConfig
         $this->publishes([
             $source => config_path("craft/$handle.php"),
         ], $handle);
-
-        $this->mergeConfigFrom($source, "craft.$handle");
     }
 }

--- a/tests/Unit/Plugin/Concerns/HasConfigTest.php
+++ b/tests/Unit/Plugin/Concerns/HasConfigTest.php
@@ -16,7 +16,7 @@ beforeEach(function () {
     ServiceProvider::$publishGroups = [];
 });
 
-it('merges plugin config and registers publish paths', function () {
+it('registers publish paths without merging plugin config', function () {
     Config::set('craft.test-plugin', [
         'shared' => 'app',
     ]);
@@ -31,7 +31,6 @@ it('merges plugin config and registers publish paths', function () {
     $plugin->bootHasConfig();
 
     expect(Config::get('craft.test-plugin'))->toBe([
-        'fromFile' => 'default',
         'shared' => 'app',
     ]);
 


### PR DESCRIPTION
### Description

Stops plugin package default config files from being merged into `craft.{plugin-handle}` at runtime. `HasConfig` still registers `config/{plugin-handle}.php` as publishable, so once a project publishes and edits it at `config/craft/{plugin-handle}.php`, Laravel loads it normally and Craft still applies those host project values over stored plugin settings.

We do not need to merge the plugin package config because that file is only meant to be a starter/default file for publishing. Merging it directly makes unpublished vendor defaults participate in config resolution after project config and can unexpectedly fill or override settings that should be controlled by project config or the host project config file. Published config remains supported through Laravel’s standard configuration loading, which is the user-space path we want to preserve.