### PR TITLE
[6.x] Fixes entries sidebar template error

### DIFF
--- a/resources/templates/_elements/sources.twig
+++ b/resources/templates/_elements/sources.twig
@@ -83,9 +83,9 @@
             {% endif %}
             <li class="heading">
                 <div class="source-item source-item--heading">
-                    <span class="type-heading-small">{{ source.heading|t('site') }}</span>
+                    <span class="type-heading-small">{{ source.heading is defined and source.heading|length ? source.heading|t('site') : '' }}</span>
                     {# Don't toggle blank headings #}
-                    {% if source.heading | length %}
+                    {% if source.heading is defined and source.heading | length %}
                         {% embed '_includes/disclosure-toggle' with {
                             persist: true,
                             storageKey: 'sources-list:' ~ key,


### PR DESCRIPTION
### Description
Checks if the heading is defined as well as populated before outputting it, preventing a template error.

I read the code of conduct and guidelines. This is my first time creating a pull request on a public repo. If there's any changes I need to make, please let me know.

### Related issues
https://github.com/craftcms/cms/issues/18889
