### PR TITLE
[6.x] Fix blank element source headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added the `compiledTemplatesPath` config setting. ([#18861](https://github.com/craftcms/cms/pull/18861))
 - Added a missing migration that adds `minAuthors` to the section table ([#18875](https://github.com/craftcms/cms/pull/18875))
 - Fixed a bug where the `cpTrigger` would be appended twice to the URL after running migrations from the control panel. ([#18858](https://github.com/craftcms/cms/pull/18858))
+- Fixed an error that occurred when rendering element indexes with blank source headings. ([#18891](https://github.com/craftcms/cms/pull/18891))
 - Fixed an error that occurred when uninstalling plugins. ([#18862](https://github.com/craftcms/cms/pull/18862))
 
 ## 6.0.0-alpha.2 - 2026-05-13

--- a/src/Element/ElementSources.php
+++ b/src/Element/ElementSources.php
@@ -176,6 +176,10 @@ class ElementSources
                     $source = $elementType::modifyCustomSource($source);
                 }
 
+                if ($source['type'] === self::TYPE_HEADING) {
+                    $source['heading'] ??= '';
+                }
+
                 $sources[] = $source;
             }
 
@@ -452,7 +456,7 @@ class ElementSources
                         'userGroups' => $s['userGroups'] ?? null,
                     ],
                     self::TYPE_HEADING => [
-                        'heading' => $s['heading'] ?? null,
+                        'heading' => $s['heading'] ?? '',
                     ],
                     default => [
                         'disabled' => $s['disabled'] ?? null,

--- a/tests/Feature/Http/Controllers/Elements/ElementSourcesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/ElementSourcesControllerTest.php
@@ -262,6 +262,81 @@ it('stores normalized source settings for multi-page sources', function () {
         ]));
 });
 
+it('preserves blank heading values when storing and returning source settings', function () {
+    $projectConfig = app(ProjectConfig::class);
+
+    $response = postJson(action([ElementSourcesController::class, 'store']), [
+        'elementType' => TestElementSourcesElement::class,
+        'sourceOrder' => [
+            'heading:blank',
+            'native-enabled',
+        ],
+        'sourcePages' => [
+            'heading:blank' => 'Content',
+            'native-enabled' => 'Content',
+        ],
+        'pageSettings' => [
+            'Content' => [
+                'label' => 'Content',
+            ],
+        ],
+        'sources' => [
+            'heading:blank' => [
+                'heading' => '',
+            ],
+            'native-enabled' => [
+                'tableAttributes' => ['slug'],
+                'enabled' => true,
+            ],
+        ],
+    ]);
+
+    $response->assertOk();
+
+    expect(normalizeConfig($projectConfig->get(sprintf('%s.%s', ProjectConfig::PATH_ELEMENT_SOURCES, TestElementSourcesElement::class))))->toBe(normalizeConfig([
+        [
+            'type' => ElementSources::TYPE_HEADING,
+            'key' => 'heading:blank',
+            'page' => 'Content',
+            'heading' => '',
+        ],
+        [
+            'type' => ElementSources::TYPE_NATIVE,
+            'key' => 'native-enabled',
+            'page' => 'Content',
+            'tableAttributes' => ['slug'],
+            'disabled' => false,
+        ],
+    ]));
+
+    postJson(action([ElementSourcesController::class, 'show']), [
+        'elementType' => TestElementSourcesElement::class,
+    ])
+        ->assertOk()
+        ->assertJsonPath('sources.0.type', ElementSources::TYPE_HEADING)
+        ->assertJsonPath('sources.0.heading', '');
+
+    $projectConfig->set(sprintf('%s.%s', ProjectConfig::PATH_ELEMENT_SOURCES, TestElementSourcesElement::class), [
+        [
+            'type' => ElementSources::TYPE_HEADING,
+            'key' => 'heading:malformed',
+            'page' => 'Content',
+        ],
+        [
+            'type' => ElementSources::TYPE_NATIVE,
+            'key' => 'native-enabled',
+            'page' => 'Content',
+        ],
+    ]);
+
+    postJson(action([ElementSourcesController::class, 'show']), [
+        'elementType' => TestElementSourcesElement::class,
+    ])
+        ->assertOk()
+        ->assertJsonPath('sources.0.type', ElementSources::TYPE_HEADING)
+        ->assertJsonPath('sources.0.heading', '');
+});
+
 it('stores single-page source settings without page reordering', function () {
     $projectConfig = app(ProjectConfig::class);
 


### PR DESCRIPTION
- Preserve blank element source heading values when source settings are saved.
- Normalize existing heading source configs that are missing the `heading` key so the element sources backend returns valid data.
- Add regression coverage for saving and returning blank headings.

### Root cause

In 6.x, Laravel request handling converts empty string form values to `null`. Blank source headings were therefore saved without a `heading` key, and the unchanged `_elements/sources.twig` template later failed when rendering that malformed backend data.

### Related issues

Fixes #18889
