### PR TITLE
[6.x] Fix legacy exception redirects

### DIFF
--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -136,7 +136,9 @@ class Yii2ServiceProvider extends ServiceProvider
         $handler->renderable(function(Throwable $exception) {
             $this->triggerLegacyBeforeHandleException($exception);
 
-            if (Craft::$app?->getResponse()->isSent) {
+            $response = Craft::$app?->getResponse();
+
+            if ($response?->isSent || $response?->getIsRedirection()) {
                 return LegacyMiddleware::createResponse();
             }
 

--- a/yii2-adapter/tests-laravel/Http/LegacyErrorHandlerCompatibilityTest.php
+++ b/yii2-adapter/tests-laravel/Http/LegacyErrorHandlerCompatibilityTest.php
@@ -53,3 +53,24 @@ it('can send a legacy redirect response from before handle exception handlers', 
     expect($response->getStatusCode())->toBe(301);
     expect($response->headers->get('Location'))->toBe('http://localhost/redirect-target');
 });
+
+it('can create a legacy redirect response from before handle exception handlers', function() {
+    $handler = function() {
+        Craft::$app->getResponse()
+            ->redirect('/redirect-target', 301, false);
+    };
+
+    YiiEvent::on(ErrorHandler::class, ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION, $handler);
+
+    try {
+        $response = app(ExceptionHandlerContract::class)->render(
+            Request::create('/missing-page'),
+            new NotFoundHttpException('Page not found.')
+        );
+    } finally {
+        YiiEvent::off(ErrorHandler::class, ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION, $handler);
+    }
+
+    expect($response->getStatusCode())->toBe(301);
+    expect($response->headers->get('Location'))->toBe('http://localhost/redirect-target');
+});


### PR DESCRIPTION
### Description

Fix legacy exception handlers so prepared redirect responses are returned to Laravel even when the Yii response was not explicitly marked as sent.

### Related issues

- Fixes #18855