### PR TITLE
[6.x] Debugbar integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added “Elements” and “Deprecations” panels to Laravel Debugbar. ([#18897](https://github.com/craftcms/cms/pull/18897))
 - Removed a stray dump statement ([#18902](https://github.com/craftcms/cms/issues/18902))
 - Fixed a bug where legacy redirect responses were not being returned as a redirect ([#18893](https://github.com/craftcms/cms/pull/18893))
 - Fixed a bug where plugin routes were not being registered with the `web` middleware.

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
     "yiisoft/translator-message-php": "^1.1"
   },
   "require-dev": {
+    "barryvdh/laravel-debugbar": "^4.2",
     "dg/bypass-finals": "^1.9",
     "driftingly/rector-laravel": "^2.1",
     "fakerphp/faker": "^1.19.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2e81a80b98d308a5ea39a9f95906548",
+    "content-hash": "72f8caffeafef2dbe41d64a96cbcca08",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -9734,6 +9734,105 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v4.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruitcake/laravel-debugbar.git",
+                "reference": "799d70c1101d3f8840dd76ff68ff6a78f9352905"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruitcake/laravel-debugbar/zipball/799d70c1101d3f8840dd76ff68ff6a78f9352905",
+                "reference": "799d70c1101d3f8840dd76ff68ff6a78f9352905",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "^11|^12|^13.0",
+                "illuminate/session": "^11|^12|^13.0",
+                "illuminate/support": "^11|^12|^13.0",
+                "php": "^8.2",
+                "php-debugbar/php-debugbar": "^3.7.2",
+                "php-debugbar/symfony-bridge": "^1.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3",
+                "laravel/octane": "^2",
+                "laravel/pennant": "^1",
+                "laravel/pint": "^1",
+                "laravel/telescope": "^5.16",
+                "livewire/livewire": "^3.7|^4",
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench-dusk": "^9|^10|^11",
+                "php-debugbar/twig-bridge": "^2.0",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11",
+                "shipmonk/phpstan-rules": "^4.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Debugbar": "Fruitcake\\LaravelDebugbar\\Facades\\Debugbar"
+                    },
+                    "providers": [
+                        "Fruitcake\\LaravelDebugbar\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Fruitcake\\LaravelDebugbar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fruitcake",
+                    "homepage": "https://fruitcake.nl"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "barryvdh",
+                "debug",
+                "debugbar",
+                "dev",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "support": {
+                "issues": "https://github.com/fruitcake/laravel-debugbar/issues",
+                "source": "https://github.com/fruitcake/laravel-debugbar/tree/v4.2.8"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-20T13:31:29+00:00"
+        },
+        {
             "name": "brianium/paratest",
             "version": "v7.20.0",
             "source": {
@@ -12186,6 +12285,174 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-debugbar/php-debugbar",
+            "version": "v3.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-debugbar/php-debugbar.git",
+                "reference": "1690ee1728827f9deb4b60457fa387cf44672c56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/1690ee1728827f9deb4b60457fa387cf44672c56",
+                "reference": "1690ee1728827f9deb4b60457fa387cf44672c56",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^5.4|^6|^7|^8"
+            },
+            "replace": {
+                "maximebf/debugbar": "self.version"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1.4",
+                "friendsofphp/php-cs-fixer": "^3.92",
+                "monolog/monolog": "^3.9",
+                "php-debugbar/doctrine-bridge": "^3@dev",
+                "php-debugbar/monolog-bridge": "^1@dev",
+                "php-debugbar/symfony-bridge": "^1@dev",
+                "php-debugbar/twig-bridge": "^2@dev",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10",
+                "predis/predis": "^3.3",
+                "shipmonk/phpstan-rules": "^4.3",
+                "symfony/browser-kit": "^6.4|7.0",
+                "symfony/dom-crawler": "^6.4|^7",
+                "symfony/event-dispatcher": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/mailer": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/panther": "^1|^2.1",
+                "twig/twig": "^3.11.2"
+            },
+            "suggest": {
+                "php-debugbar/doctrine-bridge": "To integrate Doctrine with php-debugbar.",
+                "php-debugbar/monolog-bridge": "To integrate Monolog with php-debugbar.",
+                "php-debugbar/symfony-bridge": "To integrate Symfony with php-debugbar.",
+                "php-debugbar/twig-bridge": "To integrate Twig with php-debugbar."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/php-debugbar/php-debugbar",
+            "keywords": [
+                "debug",
+                "debug bar",
+                "debugbar",
+                "dev",
+                "profiler",
+                "toolbar"
+            ],
+            "support": {
+                "issues": "https://github.com/php-debugbar/php-debugbar/issues",
+                "source": "https://github.com/php-debugbar/php-debugbar/tree/v3.7.6"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-30T07:31:44+00:00"
+        },
+        {
+            "name": "php-debugbar/symfony-bridge",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-debugbar/symfony-bridge.git",
+                "reference": "e37d2debe5d316408b00d0ab2688d9c2cf59b5ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-debugbar/symfony-bridge/zipball/e37d2debe5d316408b00d0ab2688d9c2cf59b5ad",
+                "reference": "e37d2debe5d316408b00d0ab2688d9c2cf59b5ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "php-debugbar/php-debugbar": "^3.1",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8.0"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1.4",
+                "phpunit/phpunit": "^10",
+                "symfony/browser-kit": "^6|^7",
+                "symfony/dom-crawler": "^6|^7",
+                "symfony/mailer": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/panther": "^1|^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\Bridge\\Symfony\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Symfony bridge for PHP Debugbar",
+            "homepage": "https://github.com/php-debugbar/php-debugbar",
+            "keywords": [
+                "debugbar",
+                "dev",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/php-debugbar/symfony-bridge/issues",
+                "source": "https://github.com/php-debugbar/symfony-bridge/tree/v1.1.0"
+            },
+            "time": "2026-01-15T14:47:34+00:00"
         },
         {
             "name": "phpseclib/phpseclib",

--- a/src/Debug/DebugServiceProvider.php
+++ b/src/Debug/DebugServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Debug;
+
+use CraftCms\Cms\Debug\Element\ElementCollectorProvider;
+use Fruitcake\LaravelDebugbar\CollectorProviders\AbstractCollectorProvider;
+use Fruitcake\LaravelDebugbar\LaravelDebugbar;
+use Illuminate\Support\ServiceProvider;
+
+class DebugServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        if (
+            ! $this->app->bound('debugbar') ||
+            ! $this->app->bound(LaravelDebugbar::class) ||
+            ! class_exists(AbstractCollectorProvider::class)
+        ) {
+            return;
+        }
+
+        $this->app->afterResolving('debugbar', fn () => $this->registerElementCollectorProvider());
+
+        if ($this->app->resolved('debugbar')) {
+            $this->registerElementCollectorProvider();
+        }
+    }
+
+    private function registerElementCollectorProvider(): void
+    {
+        $this->app->call(ElementCollectorProvider::class);
+    }
+}

--- a/src/Debug/DebugServiceProvider.php
+++ b/src/Debug/DebugServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Debug;
 
+use CraftCms\Cms\Debug\Deprecation\DeprecationCollectorProvider;
 use CraftCms\Cms\Debug\Element\ElementCollectorProvider;
 use Fruitcake\LaravelDebugbar\CollectorProviders\AbstractCollectorProvider;
 use Fruitcake\LaravelDebugbar\LaravelDebugbar;
@@ -21,15 +22,16 @@ class DebugServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->app->afterResolving('debugbar', fn () => $this->registerElementCollectorProvider());
+        $this->app->afterResolving('debugbar', fn () => $this->registerCollectorProviders());
 
         if ($this->app->resolved('debugbar')) {
-            $this->registerElementCollectorProvider();
+            $this->registerCollectorProviders();
         }
     }
 
-    private function registerElementCollectorProvider(): void
+    private function registerCollectorProviders(): void
     {
+        $this->app->call(DeprecationCollectorProvider::class);
         $this->app->call(ElementCollectorProvider::class);
     }
 }

--- a/src/Debug/Deprecation/DeprecationCollector.php
+++ b/src/Debug/Deprecation/DeprecationCollector.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Debug\Deprecation;
+
+use CraftCms\Cms\Deprecator\Deprecator;
+use CraftCms\Cms\Deprecator\Models\DeprecationError;
+use DebugBar\DataCollector\AssetProvider;
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\Renderable;
+use Override;
+
+class DeprecationCollector extends DataCollector implements AssetProvider, Renderable
+{
+    public const string NAME = 'deprecations';
+
+    public function __construct(
+        private readonly Deprecator $deprecator,
+    ) {}
+
+    #[Override]
+    public function collect(): array
+    {
+        $deprecations = [];
+
+        foreach (array_values($this->deprecator->getRequestLogs()) as $index => $log) {
+            $deprecations[] = $this->formatDeprecation($log, $index + 1);
+        }
+
+        return [
+            'count' => count($deprecations),
+            'deprecations' => $deprecations,
+        ];
+    }
+
+    #[Override]
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    #[Override]
+    public function getWidgets(): array
+    {
+        return [
+            self::NAME => [
+                'icon' => 'logs',
+                'widget' => 'PhpDebugBar.Widgets.CraftDeprecationsWidget',
+                'map' => self::NAME,
+                'default' => '{}',
+                'title' => 'Deprecations',
+            ],
+            self::NAME.':badge' => [
+                'map' => self::NAME.'.count',
+                'default' => 0,
+            ],
+        ];
+    }
+
+    #[Override]
+    public function getAssets(): array
+    {
+        return [
+            'inline_js' => [
+                'craft-debugbar-deprecations-widget' => $this->widgetScript(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *     number: int,
+     *     key: string|null,
+     *     message: string|null,
+     *     file: string|null,
+     *     line: int|null,
+     *     origin: string,
+     *     xdebug_link: array{url: string, ajax: bool, filename: string, line: string}|null,
+     *     traces: array<int, array{
+     *         call: string,
+     *         file: string|null,
+     *         line: int|null,
+     *         origin: string,
+     *         args: string|null,
+     *         xdebug_link: array{url: string, ajax: bool, filename: string, line: string}|null
+     *     }>
+     * }
+     */
+    private function formatDeprecation(DeprecationError $log, int $number): array
+    {
+        $file = $log->file ?: null;
+        $line = $log->line;
+
+        return [
+            'number' => $number,
+            'key' => $log->key,
+            'message' => $log->message,
+            'file' => $file,
+            'line' => $line,
+            'origin' => $this->formatOrigin($file, $line),
+            'xdebug_link' => $file ? $this->getXdebugLink($file, $line) : null,
+            'traces' => array_map($this->formatTrace(...), $log->traces ?? []),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     call: string,
+     *     file: string|null,
+     *     line: int|null,
+     *     origin: string,
+     *     args: string|null,
+     *     xdebug_link: array{url: string, ajax: bool, filename: string, line: string}|null
+     * }
+     */
+    private function formatTrace(array $trace): array
+    {
+        $file = $trace['file'] ?? null;
+        $line = $trace['line'] ?? null;
+
+        return [
+            'call' => $this->formatTraceCall($trace),
+            'file' => $file,
+            'line' => $line,
+            'origin' => $this->formatOrigin($file, $line),
+            'args' => $trace['args'] ?? null,
+            'xdebug_link' => $file ? $this->getXdebugLink($file, $line) : null,
+        ];
+    }
+
+    private function formatTraceCall(array $trace): string
+    {
+        $class = $trace['class'] ?? $trace['objectClass'] ?? null;
+        $method = $trace['method'] ?? null;
+
+        if ($class && $method) {
+            return "$class::$method()";
+        }
+
+        if ($method) {
+            return "$method()";
+        }
+
+        return $trace['file'] ?? '';
+    }
+
+    private function formatOrigin(?string $file, ?int $line): string
+    {
+        if (! $file) {
+            return '';
+        }
+
+        return $line ? "$file:$line" : $file;
+    }
+
+    private function widgetScript(): string
+    {
+        return <<<'JS'
+(function () {
+    const csscls = PhpDebugBar.utils.makecsscls('phpdebugbar-widgets-');
+
+    class CraftDeprecationsWidget extends PhpDebugBar.Widget {
+        get className() {
+            return csscls('templates');
+        }
+
+        render() {
+            this.status = document.createElement('div');
+            this.status.classList.add(csscls('status'));
+            this.el.append(this.status);
+
+            this.list = new PhpDebugBar.Widgets.ListWidget({
+                itemRenderer(li, deprecation) {
+                    const message = document.createElement('span');
+                    message.classList.add(csscls('name'));
+                    message.textContent = deprecation.message || '(no message)';
+                    li.append(message);
+
+                    if (deprecation.origin) {
+                        const origin = document.createElement('span');
+                        origin.setAttribute('title', 'Origin');
+                        origin.classList.add(csscls('type'));
+                        origin.textContent = deprecation.origin;
+                        li.append(origin);
+                    }
+
+                    const table = document.createElement('table');
+                    table.classList.add(csscls('params'));
+                    table.hidden = true;
+                    table.append(createHeader('Details'));
+
+                    const tbody = document.createElement('tbody');
+                    appendRow(tbody, 'Key', deprecation.key);
+                    appendRow(tbody, 'Origin', deprecation.origin, deprecation.xdebug_link);
+                    appendRow(tbody, 'Message', deprecation.message);
+                    appendTraceRows(tbody, deprecation.traces || []);
+                    table.append(tbody);
+
+                    li.append(table);
+                    li.style.cursor = 'pointer';
+                    li.addEventListener('click', (event) => {
+                        if (window.getSelection().type === 'Range' || event.target.closest('.sf-dump')) {
+                            return;
+                        }
+
+                        table.hidden = !table.hidden;
+                    });
+                },
+            });
+            this.el.append(this.list.el);
+
+            this.bindAttr('data', function (data) {
+                const deprecations = data.deprecations || [];
+                const count = data.count || deprecations.length;
+                this.status.textContent = `${count} ${count === 1 ? 'deprecation was' : 'deprecations were'} logged`;
+                this.list.set('data', deprecations);
+            });
+        }
+    }
+
+    function createHeader(label) {
+        const thead = document.createElement('thead');
+        const row = document.createElement('tr');
+        const cell = document.createElement('th');
+        cell.colSpan = 2;
+        cell.textContent = label;
+        row.append(cell);
+        thead.append(row);
+
+        return thead;
+    }
+
+    function appendRow(tbody, name, value, xdebugLink) {
+        const row = document.createElement('tr');
+        const nameCell = document.createElement('td');
+        nameCell.className = csscls('name');
+        nameCell.textContent = name;
+        row.append(nameCell);
+
+        const valueCell = document.createElement('td');
+        valueCell.className = csscls('value');
+        valueCell.textContent = value || '';
+
+        if (xdebugLink) {
+            valueCell.append(PhpDebugBar.Widgets.editorLink(xdebugLink));
+        }
+
+        row.append(valueCell);
+        tbody.append(row);
+    }
+
+    function appendTraceRows(tbody, traces) {
+        if (!traces.length) {
+            return;
+        }
+
+        const row = document.createElement('tr');
+        const nameCell = document.createElement('td');
+        nameCell.className = csscls('name');
+        nameCell.textContent = 'Trace';
+        row.append(nameCell);
+
+        const valueCell = document.createElement('td');
+        valueCell.className = csscls('value');
+        const traceTable = document.createElement('table');
+        traceTable.classList.add(csscls('params'));
+        traceTable.append(createHeader('Stack trace'));
+
+        const traceBody = document.createElement('tbody');
+        traces.forEach((trace, index) => {
+            const traceRow = document.createElement('tr');
+            const callCell = document.createElement('td');
+            callCell.className = csscls('name');
+            callCell.textContent = `${index + 1}. ${trace.call || '(unknown)'}`;
+            traceRow.append(callCell);
+
+            const originCell = document.createElement('td');
+            originCell.className = csscls('value');
+            originCell.textContent = trace.origin || '';
+
+            if (trace.args) {
+                const args = document.createElement('div');
+                args.textContent = trace.args;
+                originCell.append(args);
+            }
+
+            if (trace.xdebug_link) {
+                originCell.append(PhpDebugBar.Widgets.editorLink(trace.xdebug_link));
+            }
+
+            traceRow.append(originCell);
+            traceBody.append(traceRow);
+        });
+
+        traceTable.append(traceBody);
+        valueCell.append(traceTable);
+        row.append(valueCell);
+        tbody.append(row);
+    }
+
+    PhpDebugBar.Widgets.CraftDeprecationsWidget = CraftDeprecationsWidget;
+})();
+JS;
+    }
+}

--- a/src/Debug/Deprecation/DeprecationCollectorProvider.php
+++ b/src/Debug/Deprecation/DeprecationCollectorProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Debug\Deprecation;
+
+use CraftCms\Cms\Deprecator\Deprecator;
+use Fruitcake\LaravelDebugbar\CollectorProviders\AbstractCollectorProvider;
+
+class DeprecationCollectorProvider extends AbstractCollectorProvider
+{
+    public function __invoke(Deprecator $deprecator): void
+    {
+        if ($this->hasCollector(DeprecationCollector::NAME)) {
+            return;
+        }
+
+        $this->addCollector(new DeprecationCollector($deprecator));
+    }
+}

--- a/src/Debug/Element/ElementCollector.php
+++ b/src/Debug/Element/ElementCollector.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Debug\Element;
+
+use CraftCms\Cms\Element\Contracts\ElementInterface;
+use DebugBar\DataCollector\ObjectCountCollector;
+use Override;
+
+class ElementCollector extends ObjectCountCollector
+{
+    public const string NAME = 'elements';
+
+    public function __construct()
+    {
+        parent::__construct(self::NAME);
+
+        $this->setKeyMap([
+            'retrieved' => 'Retrieved',
+            'created' => 'Created',
+            'updated' => 'Updated',
+            'deleted' => 'Deleted',
+            'restored' => 'Restored',
+        ]);
+        $this->collectCountSummary(true);
+    }
+
+    /**
+     * @param  array<ElementInterface>  $elements
+     */
+    public function countElements(array $elements, string $key): void
+    {
+        foreach ($elements as $element) {
+            $this->countElement($element, $key);
+        }
+    }
+
+    public function countElement(ElementInterface $element, string $key): void
+    {
+        $this->countClass($element::class, 1, $key);
+    }
+
+    #[Override]
+    public function getWidgets(): array
+    {
+        $widgets = parent::getWidgets();
+        $widgets[$this->getName()]['icon'] = 'leaf';
+
+        return $widgets;
+    }
+}

--- a/src/Debug/Element/ElementCollectorProvider.php
+++ b/src/Debug/Element/ElementCollectorProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Debug\Element;
+
+use CraftCms\Cms\Element\Events\ElementDeleted;
+use CraftCms\Cms\Element\Events\ElementRestored;
+use CraftCms\Cms\Element\Events\ElementSaved;
+use CraftCms\Cms\Element\Queries\Events\ElementsHydrated;
+use Fruitcake\LaravelDebugbar\CollectorProviders\AbstractCollectorProvider;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class ElementCollectorProvider extends AbstractCollectorProvider
+{
+    public function __invoke(Dispatcher $events): void
+    {
+        if ($this->hasCollector(ElementCollector::NAME)) {
+            return;
+        }
+
+        $elementCollector = new ElementCollector;
+
+        $this->addCollector($elementCollector);
+
+        $events->listen(ElementsHydrated::class, fn (ElementsHydrated $event) => $elementCollector->countElements($event->elements, 'retrieved'));
+        $events->listen(ElementSaved::class, fn (ElementSaved $event) => $elementCollector->countElement($event->element, $event->isNew ? 'created' : 'updated'));
+        $events->listen(ElementDeleted::class, fn (ElementDeleted $event) => $elementCollector->countElement($event->element, 'deleted'));
+        $events->listen(ElementRestored::class, fn (ElementRestored $event) => $elementCollector->countElement($event->element, 'restored'));
+    }
+}

--- a/src/Providers/CraftServiceProvider.php
+++ b/src/Providers/CraftServiceProvider.php
@@ -9,6 +9,7 @@ use CraftCms\Cms\Auth\AuthServiceProvider;
 use CraftCms\Cms\Config\ConfigServiceProvider;
 use CraftCms\Cms\Console\ConsoleServiceProvider;
 use CraftCms\Cms\Database\DatabaseServiceProvider;
+use CraftCms\Cms\Debug\DebugServiceProvider;
 use CraftCms\Cms\Deprecator\DeprecatorServiceProvider;
 use CraftCms\Cms\Element\ElementServiceProvider;
 use CraftCms\Cms\Email\EmailServiceProvider;
@@ -44,6 +45,7 @@ class CraftServiceProvider extends AggregateServiceProvider
         TwigServiceProvider::class,
         ProjectConfigServiceProvider::class,
         DeprecatorServiceProvider::class,
+        DebugServiceProvider::class,
         LicenseServiceProvider::class,
         RouteServiceProvider::class,
         AppServiceProvider::class,

--- a/tests/Unit/Debug/Deprecation/DeprecationCollectorTest.php
+++ b/tests/Unit/Debug/Deprecation/DeprecationCollectorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Debug\DebugServiceProvider;
+use CraftCms\Cms\Debug\Deprecation\DeprecationCollector;
+use CraftCms\Cms\Debug\Deprecation\DeprecationCollectorProvider;
+use CraftCms\Cms\Deprecator\Deprecator;
+use Fruitcake\LaravelDebugbar\LaravelDebugbar;
+
+beforeEach(function () {
+    Deprecator::$logTarget = 'db';
+    Deprecator::$throwExceptions = false;
+});
+
+it('does not register duplicate collectors', function () {
+    $debugbar = new LaravelDebugbar(app(), request());
+    $debugbar->addCollector(new DeprecationCollector(app(Deprecator::class)));
+
+    app()->instance(LaravelDebugbar::class, $debugbar);
+
+    app()->call(DeprecationCollectorProvider::class);
+
+    expect($debugbar->getCollectors())->toHaveCount(1);
+});
+
+it('registers the collector when debugbar resolves later', function () {
+    $debugbar = new LaravelDebugbar(app(), request());
+
+    app()->forgetInstance('debugbar');
+    app()->forgetInstance(LaravelDebugbar::class);
+    app()->singleton('debugbar', fn () => $debugbar);
+    app()->instance(LaravelDebugbar::class, $debugbar);
+
+    new DebugServiceProvider(app())->boot();
+
+    expect($debugbar->hasCollector(DeprecationCollector::NAME))->toBeFalse();
+
+    app('debugbar');
+
+    expect($debugbar->hasCollector(DeprecationCollector::NAME))->toBeTrue();
+});
+
+it('collects current request deprecations with trace details', function () {
+    $deprecator = app(Deprecator::class);
+
+    $deprecator->log('legacy-api', 'Calling `legacyApi()` is deprecated.', __FILE__, 123);
+
+    $data = new DeprecationCollector($deprecator)->collect();
+
+    expect($data['count'])->toBe(1)
+        ->and($data['deprecations'][0])->toMatchArray([
+            'number' => 1,
+            'key' => 'legacy-api',
+            'message' => 'Calling `legacyApi()` is deprecated.',
+            'file' => __FILE__,
+            'line' => 123,
+            'origin' => __FILE__.':123',
+        ])
+        ->and($data['deprecations'][0]['traces'])->toBeArray()
+        ->and(count($data['deprecations'][0]['traces']))->toBeGreaterThan(0);
+});
+
+it('provides an expandable debugbar widget', function () {
+    $collector = new DeprecationCollector(app(Deprecator::class));
+
+    $widgets = $collector->getWidgets();
+
+    expect($widgets[DeprecationCollector::NAME])->toMatchArray([
+        'widget' => 'PhpDebugBar.Widgets.CraftDeprecationsWidget',
+        'map' => DeprecationCollector::NAME,
+        'title' => 'Deprecations',
+    ])
+        ->and($widgets[DeprecationCollector::NAME.':badge'])->toMatchArray([
+            'map' => DeprecationCollector::NAME.'.count',
+            'default' => 0,
+        ])
+        ->and($collector->getAssets()['inline_js'])->toHaveKey('craft-debugbar-deprecations-widget');
+});

--- a/tests/Unit/Debug/Element/ElementCollectorTest.php
+++ b/tests/Unit/Debug/Element/ElementCollectorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Debug\DebugServiceProvider;
+use CraftCms\Cms\Debug\Element\ElementCollector;
+use CraftCms\Cms\Debug\Element\ElementCollectorProvider;
+use CraftCms\Cms\Element\Element;
+use CraftCms\Cms\Element\Events\ElementDeleted;
+use CraftCms\Cms\Element\Events\ElementRestored;
+use CraftCms\Cms\Element\Events\ElementSaved;
+use CraftCms\Cms\Element\Queries\Events\ElementsHydrated;
+use Fruitcake\LaravelDebugbar\LaravelDebugbar;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+
+it('does not register when debugbar is unavailable', function () {
+    $app = new Application;
+
+    new DebugServiceProvider($app)->boot();
+
+    expect($app->bound('debugbar'))->toBeFalse();
+});
+
+it('does not register duplicate collectors', function () {
+    $debugbar = new LaravelDebugbar(app(), request());
+    $debugbar->addCollector(new ElementCollector);
+
+    app()->instance(LaravelDebugbar::class, $debugbar);
+
+    app()->call(ElementCollectorProvider::class);
+
+    expect($debugbar->getCollectors())->toHaveCount(1);
+});
+
+it('registers the collector when debugbar resolves later', function () {
+    $debugbar = new LaravelDebugbar(app(), request());
+
+    app()->forgetInstance('debugbar');
+    app()->forgetInstance(LaravelDebugbar::class);
+    app()->singleton('debugbar', fn () => $debugbar);
+    app()->instance(LaravelDebugbar::class, $debugbar);
+
+    new DebugServiceProvider(app())->boot();
+
+    expect($debugbar->hasCollector(ElementCollector::NAME))->toBeFalse();
+
+    app('debugbar');
+
+    expect($debugbar->hasCollector(ElementCollector::NAME))->toBeTrue();
+});
+
+it('counts element lifecycle events by class', function () {
+    $debugbar = new LaravelDebugbar(app(), Request::create('/'));
+
+    app()->instance(LaravelDebugbar::class, $debugbar);
+
+    app()->call(ElementCollectorProvider::class);
+
+    $first = new TestDebugbarElement;
+    $second = new TestDebugbarElement;
+
+    event(new ElementsHydrated([$first, $second], []));
+    event(new ElementSaved($first, true));
+    event(new ElementSaved($first, false));
+    event(new ElementDeleted($first));
+    event(new ElementRestored($first));
+
+    expect($debugbar->getCollector(ElementCollector::NAME)->collect())->toMatchArray([
+        'data' => [
+            TestDebugbarElement::class => [
+                'retrieved' => 2,
+                'created' => 1,
+                'updated' => 1,
+                'deleted' => 1,
+                'restored' => 1,
+            ],
+        ],
+        'count' => 6,
+        'key_map' => [
+            'retrieved' => 'Retrieved',
+            'created' => 'Created',
+            'updated' => 'Updated',
+            'deleted' => 'Deleted',
+            'restored' => 'Restored',
+        ],
+        'badges' => [
+            'retrieved' => 2,
+            'created' => 1,
+            'updated' => 1,
+            'deleted' => 1,
+            'restored' => 1,
+        ],
+    ]);
+});
+
+class TestDebugbarElement extends Element {}


### PR DESCRIPTION
### Description

This adds 2 extra panels to [Laravel Debugbar](https://github.com/fruitcake/laravel-debugbar) when it is installed:

#### Elements

Shows retrieved, created, updated, deleted & restored element counts from the request.

<img width="1379" height="125" alt="image" src="https://github.com/user-attachments/assets/24b8eeb5-7881-41d0-8ed1-05e785c3cb30" />

#### Deprecations

Shows any deprecations, with expandable details that happened in the request

Collapsed:
<img width="1380" height="438" alt="image" src="https://github.com/user-attachments/assets/2113c581-2542-49a6-b63d-4fa1e1e8fdd1" />

Expanded:
<img width="1382" height="471" alt="image" src="https://github.com/user-attachments/assets/d9a69f41-7bb6-426e-8cdd-96cdd5c55665" />
