### PR TITLE
[6.x] Fix plugin Twig variable registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where plugin-registered Twig variables weren’t available via the `craft` template variable. ([#18903](https://github.com/craftcms/cms/pull/18903))
 - Removed a stray dump statement ([#18902](https://github.com/craftcms/cms/issues/18902))
 
 ## 6.0.0-alpha.3 - 2026-05-15

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\events\ExceptionEvent;
 use craft\web\Application as WebApplication;
 use craft\web\ErrorHandler;
+use craft\web\twig\variables\CraftVariable as LegacyCraftVariable;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Table;
@@ -210,6 +211,7 @@ class Yii2ServiceProvider extends ServiceProvider
         new RebrandCompatibility()->boot();
 
         CraftVariable::mixin(new CraftVariableMixin());
+        $this->registerCraftVariableCompatibility();
 
         /**
          * Keep legacy CustomFieldBehavior statics in sync when field caches are invalidated.
@@ -243,6 +245,17 @@ class Yii2ServiceProvider extends ServiceProvider
         Craft::$app->state = YiiApplication::STATE_AFTER_REQUEST;
         Craft::$app->trigger(YiiApplication::EVENT_AFTER_REQUEST);
         Craft::$app->state = YiiApplication::STATE_END;
+    }
+
+    private function registerCraftVariableCompatibility(): void
+    {
+        $this->app->afterResolving(CraftVariable::class, function() {
+            $legacyVariable = new LegacyCraftVariable();
+
+            foreach (array_keys($legacyVariable->getComponents()) as $name) {
+                CraftVariable::macro($name, fn() => $legacyVariable->get($name));
+            }
+        });
     }
 
     /**

--- a/yii2-adapter/tests-laravel/View/CraftVariableCompatibilityTest.php
+++ b/yii2-adapter/tests-laravel/View/CraftVariableCompatibilityTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use craft\web\twig\variables\CraftVariable as LegacyCraftVariable;
+use CraftCms\Cms\Twig\TemplateRenderer;
+use CraftCms\Cms\Twig\Variables\CraftVariable as LaravelCraftVariable;
+use yii\base\Event;
+
+afterEach(function() {
+    Event::off(LegacyCraftVariable::class, LegacyCraftVariable::EVENT_INIT);
+
+    $macros = new ReflectionProperty(LaravelCraftVariable::class, 'macros');
+    $values = $macros->getValue();
+    unset($values['testVariable']);
+    $macros->setValue(null, $values);
+});
+
+it('registers custom Twig variables from the legacy init event', function() {
+    Event::on(LegacyCraftVariable::class, LegacyCraftVariable::EVENT_INIT, function(Event $event) {
+        $event->sender->set('testVariable', new class() {
+            public string $value = 'registered';
+        });
+    });
+
+    expect(app(TemplateRenderer::class)->renderString('{{ craft.testVariable.value }}'))->toBe('registered');
+});


### PR DESCRIPTION
### Description
Registers legacy `CraftVariable::EVENT_INIT` definitions as macros on the Laravel Twig variable from the Yii adapter, so plugin-provided Twig variables continue to resolve in templates.

### Related issues
Fixes #18901