### PR TITLE
[6.x] Fix legacy cache not accepting new DependencyCache objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Removed a stray dump statement ([#18902](https://github.com/craftcms/cms/issues/18902))
+- Fixed an error that occurred when using the legacy cache service with a new dependency object ([##18904](https://github.com/craftcms/cms/pull/#18904))
 - Fixed a bug where legacy redirect responses were not being returned as a redirect ([#18893](https://github.com/craftcms/cms/pull/18893))
 
 ## 6.0.0-alpha.3 - 2026-05-15

--- a/yii2-adapter/src/Cache.php
+++ b/yii2-adapter/src/Cache.php
@@ -9,6 +9,8 @@
 
 namespace CraftCms\Yii2Adapter;
 
+use CraftCms\DependencyAwareCache\Dependency\Dependency;
+use CraftCms\DependencyAwareCache\Facades\DependencyCache;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Cache as CacheFacade;
 
@@ -29,6 +31,17 @@ class Cache extends \yii\caching\Cache
     protected function getValue($key)
     {
         return $this->laravelCache->get($key, false);
+    }
+
+    public function set($key, $value, $duration = null, $dependency = null)
+    {
+        if ($dependency instanceof Dependency) {
+            DependencyCache::put($key, $value, $this->convertDuration($duration), $dependency);
+
+            return true;
+        }
+
+        return parent::set($key, $value, $duration, $dependency);
     }
 
     /**


### PR DESCRIPTION
### Description

Using Yii's cache's `->set()` method with a dependency from the new DependencyCache package would result in an exception.