### PR TITLE
[6.x] Contact form compatibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Removed a stray dump statement ([#18902](https://github.com/craftcms/cms/issues/18902))
 - Fixed a bug where legacy redirect responses were not being returned as a redirect ([#18893](https://github.com/craftcms/cms/pull/18893))
+- Fixed a bug where a legacy Yii action controller would result in a 404 when returning `null` as the response ([#18907](https://github.com/craftcms/cms/pull/18907))
+- Fixed an error that could occur because `ol` and `ul` were not normalizing the attributes ([#18907](https://github.com/craftcms/cms/pull/18907))
 
 ## 6.0.0-alpha.3 - 2026-05-15
 

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -28,6 +28,8 @@ use Yiisoft\Html\Html as YiiHtml;
 use Yiisoft\Html\NoEncode;
 use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Input;
+use Yiisoft\Html\Tag\Ol;
+use Yiisoft\Html\Tag\Ul;
 
 use function CraftCms\Cms\template;
 
@@ -314,18 +316,16 @@ class Html
         return self::tag('a', $text, $options);
     }
 
-    public static function ul(array $items = [], array $attributes = [], bool $encode = true): string
+    public static function ul(array $items = [], array $attributes = [], bool $encode = true): Ul
     {
         return YiiHtml::ul(self::normalizeTagAttributes($attributes))
-            ->strings(array_map(strval(...), $items), encode: $encode)
-            ->render();
+            ->strings(array_map(strval(...), $items), encode: $encode);
     }
 
-    public static function ol(array $items = [], array $attributes = [], bool $encode = true): string
+    public static function ol(array $items = [], array $attributes = [], bool $encode = true): Ol
     {
         return YiiHtml::ol(self::normalizeTagAttributes($attributes))
-            ->strings(array_map(strval(...), $items), encode: $encode)
-            ->render();
+            ->strings(array_map(strval(...), $items), encode: $encode);
     }
 
     /**

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -314,6 +314,20 @@ class Html
         return self::tag('a', $text, $options);
     }
 
+    public static function ul(array $items = [], array $attributes = [], bool $encode = true): string
+    {
+        return YiiHtml::ul(self::normalizeTagAttributes($attributes))
+            ->strings(array_map(strval(...), $items), encode: $encode)
+            ->render();
+    }
+
+    public static function ol(array $items = [], array $attributes = [], bool $encode = true): string
+    {
+        return YiiHtml::ol(self::normalizeTagAttributes($attributes))
+            ->strings(array_map(strval(...), $items), encode: $encode)
+            ->render();
+    }
+
     /**
      * Appends HTML to the end of the given tag.
      *

--- a/tests/.pest/snapshots/Unit/Support/HtmlTest/Ol.snap
+++ b/tests/.pest/snapshots/Unit/Support/HtmlTest/Ol.snap
@@ -1,0 +1,4 @@
+<ol class="steps">
+<li>One</li>
+<li>Two</li>
+</ol>

--- a/tests/.pest/snapshots/Unit/Support/HtmlTest/Ul.snap
+++ b/tests/.pest/snapshots/Unit/Support/HtmlTest/Ul.snap
@@ -1,0 +1,4 @@
+<ul class="errors">
+<li>One</li>
+<li>Two</li>
+</ul>

--- a/tests/Feature/Asset/Policies/AssetPolicyTest.php
+++ b/tests/Feature/Asset/Policies/AssetPolicyTest.php
@@ -210,6 +210,8 @@ it('allows delete on temp fs even for peer assets', function () {
 // Helper functions
 function createAssetTestUser(array $permissions): User
 {
+    static $nextUserId = 10000;
+
     $user = new class extends User
     {
         public array $grantedPermissions = [];
@@ -224,7 +226,7 @@ function createAssetTestUser(array $permissions): User
         }
     };
 
-    $user->id = random_int(1, 10000);
+    $user->id = ++$nextUserId;
     $user->grantedPermissions = $permissions;
 
     return $user;

--- a/tests/Unit/Support/HtmlTest.php
+++ b/tests/Unit/Support/HtmlTest.php
@@ -36,6 +36,24 @@ test('EncodeSpaces', function (string $expected, string $str) {
     ['foo%20%20bar', 'foo  bar'],
 ]);
 
+test('Ul', function () {
+    expect(Html::ul(['One', 'Two'], ['class' => 'errors']))->toBe(<<<'HTML'
+<ul class="errors">
+<li>One</li>
+<li>Two</li>
+</ul>
+HTML);
+});
+
+test('Ol', function () {
+    expect(Html::ol(['One', 'Two'], ['class' => 'steps']))->toBe(<<<'HTML'
+<ol class="steps">
+<li>One</li>
+<li>Two</li>
+</ol>
+HTML);
+});
+
 test('DisableInputs', function (?string $expected, callable|string|null $html) {
     $this->assertSame($expected, Html::disableInputs($html));
 })->with([

--- a/tests/Unit/Support/HtmlTest.php
+++ b/tests/Unit/Support/HtmlTest.php
@@ -37,21 +37,11 @@ test('EncodeSpaces', function (string $expected, string $str) {
 ]);
 
 test('Ul', function () {
-    expect((string) Html::ul(['One', 'Two'], ['class' => 'errors']))->toBe(<<<'HTML'
-<ul class="errors">
-<li>One</li>
-<li>Two</li>
-</ul>
-HTML);
+    expect((string) Html::ul(['One', 'Two'], ['class' => 'errors']))->toMatchSnapshot();
 });
 
 test('Ol', function () {
-    expect((string) Html::ol(['One', 'Two'], ['class' => 'steps']))->toBe(<<<'HTML'
-<ol class="steps">
-<li>One</li>
-<li>Two</li>
-</ol>
-HTML);
+    expect((string) Html::ol(['One', 'Two'], ['class' => 'steps']))->toMatchSnapshot();
 });
 
 test('DisableInputs', function (?string $expected, callable|string|null $html) {

--- a/tests/Unit/Support/HtmlTest.php
+++ b/tests/Unit/Support/HtmlTest.php
@@ -37,7 +37,7 @@ test('EncodeSpaces', function (string $expected, string $str) {
 ]);
 
 test('Ul', function () {
-    expect(Html::ul(['One', 'Two'], ['class' => 'errors']))->toBe(<<<'HTML'
+    expect((string) Html::ul(['One', 'Two'], ['class' => 'errors']))->toBe(<<<'HTML'
 <ul class="errors">
 <li>One</li>
 <li>Two</li>
@@ -46,7 +46,7 @@ HTML);
 });
 
 test('Ol', function () {
-    expect(Html::ol(['One', 'Two'], ['class' => 'steps']))->toBe(<<<'HTML'
+    expect((string) Html::ol(['One', 'Two'], ['class' => 'steps']))->toBe(<<<'HTML'
 <ol class="steps">
 <li>One</li>
 <li>Two</li>

--- a/yii2-adapter/legacy/web/Application.php
+++ b/yii2-adapter/legacy/web/Application.php
@@ -15,7 +15,10 @@ use craft\queue\QueueLogBehavior;
 use CraftCms\Aliases\Aliases;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Plugin\Plugins;
+use CraftCms\Cms\Route\DynamicRoute;
+use CraftCms\Cms\Site\Sites;
 use CraftCms\Cms\Support\Url;
+use CraftCms\Yii2Adapter\Http\CaptureOriginalActionRequestUri;
 use CraftCms\Yii2Adapter\Web\Response as IlluminateBridgeResponse;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request as IlluminateRequest;
@@ -206,6 +209,10 @@ class Application extends \yii\web\Application
             return $response;
         }
 
+        if ($request->getIsActionRequest() && request()->attributes->has(CaptureOriginalActionRequestUri::ORIGINAL_ACTION_REQUEST_URI)) {
+            return $this->handleOriginalLaravelActionRequest();
+        }
+
         // If we’re still here, finally let Yii do its thing.
         return parent::handleRequest($request);
     }
@@ -293,6 +300,36 @@ class Application extends \yii\web\Application
 
         /** @var SymfonyResponse $laravelResponse */
         $laravelResponse = app(Kernel::class)->handle($internalRequest);
+
+        $response = $this->getResponse();
+
+        if ($response instanceof IlluminateBridgeResponse) {
+            return $response->setIlluminateResponse($laravelResponse);
+        }
+
+        return $response;
+    }
+
+    private function handleOriginalLaravelActionRequest(): BaseResponse
+    {
+        /** @var IlluminateRequest $request */
+        $request = request();
+        $originalUri = (string) $request->attributes->get(CaptureOriginalActionRequestUri::ORIGINAL_ACTION_REQUEST_URI);
+
+        $originalRequest = $request->duplicateWithUri($originalUri);
+        $originalRequest->query->remove('action');
+        $originalRequest->request->remove('action');
+
+        app()->instance('request', $originalRequest);
+
+        $template = $originalRequest->isSiteRequest()
+            ? app(Sites::class)->getRequestPath($originalRequest)
+            : $originalRequest->craftPath();
+
+        $laravelResponse = new DynamicRoute('templates/render', [
+            'template' => $template,
+            'variables' => $this->getUrlManager()->getRouteParams() ?? [],
+        ])->handle($originalRequest);
 
         $response = $this->getResponse();
 

--- a/yii2-adapter/src/Http/CaptureOriginalActionRequestUri.php
+++ b/yii2-adapter/src/Http/CaptureOriginalActionRequestUri.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CraftCms\Yii2Adapter\Http;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class CaptureOriginalActionRequestUri
+{
+    public const ORIGINAL_ACTION_REQUEST_URI = '_craft_yii_original_action_request_uri';
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if ($request->isActionRequest() && trim($request->path(), '/') !== trim($request->actionSegmentsToRoute(), '/')) {
+            $request->attributes->set(self::ORIGINAL_ACTION_REQUEST_URI, $request->getRequestUri());
+        }
+
+        return $next($request);
+    }
+}

--- a/yii2-adapter/src/Web/Request.php
+++ b/yii2-adapter/src/Web/Request.php
@@ -10,6 +10,7 @@
 namespace CraftCms\Yii2Adapter\Web;
 
 use CraftCms\Cms\Config\GeneralConfig;
+use CraftCms\Yii2Adapter\Http\CaptureOriginalActionRequestUri;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Http\Request as IlluminateRequest;
 use Yii;
@@ -148,6 +149,12 @@ class Request extends \yii\web\Request
      */
     protected function resolveRequestUri(): bool|string
     {
+        $originalUri = $this->getIlluminateRequest()->attributes->get(CaptureOriginalActionRequestUri::ORIGINAL_ACTION_REQUEST_URI);
+
+        if (is_string($originalUri)) {
+            return $originalUri;
+        }
+
         return $this->getIlluminateRequest()->getRequestUri();
     }
 

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -25,11 +25,13 @@ use CraftCms\Yii2Adapter\Console\MigrateSessionsTableCommand;
 use CraftCms\Yii2Adapter\Console\RepairCategoryGroupStructureCommand;
 use CraftCms\Yii2Adapter\Filesystem\FilesystemCompatibility;
 use CraftCms\Yii2Adapter\HtmlPurifier\LegacyHtmlPurifierConfigRegistrar;
+use CraftCms\Yii2Adapter\Http\CaptureOriginalActionRequestUri;
 use CraftCms\Yii2Adapter\Http\LegacyMiddleware;
 use CraftCms\Yii2Adapter\I18N\I18NCompatibility;
 use CraftCms\Yii2Adapter\Mail\TestToEmailAddressCompatibility;
 use CraftCms\Yii2Adapter\Mixins\CraftVariableMixin;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
@@ -178,6 +180,8 @@ class Yii2ServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->app->make(HttpKernel::class)->prependMiddleware(CaptureOriginalActionRequestUri::class);
+
         $this->commands([
             AddCategoriesSupportCommand::class,
             AddGlobalSetsSupportCommand::class,

--- a/yii2-adapter/tests-laravel/Http/LegacyActionRoutingTest.php
+++ b/yii2-adapter/tests-laravel/Http/LegacyActionRoutingTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use CraftCms\Cms\Http\Middleware\HandleActionRequest;
+use CraftCms\Yii2Adapter\Http\CaptureOriginalActionRequestUri;
+use Illuminate\Http\Request as IlluminateRequest;
 use yii\base\Module;
 use yii\web\Controller;
 
@@ -27,6 +30,41 @@ it('accepts null responses from plugin default controller action shorthand', fun
     $response = Craft::$app->runAction('test-plugin/null');
 
     expect($response)->toBeNull();
+});
+
+it('preserves the original URI for legacy action param requests', function() {
+    $request = IlluminateRequest::create('/contact?site=en', 'POST', [
+        'action' => 'test-plugin/fail',
+        'foo' => 'bar',
+    ]);
+
+    app()->instance('request', $request);
+
+    app(CaptureOriginalActionRequestUri::class)->handle($request, function(IlluminateRequest $request) {
+        app(HandleActionRequest::class)->handle($request, function(IlluminateRequest $request) {
+            expect($request->getRequestUri())->toBe('/actions/test-plugin/fail')
+                ->and($request->attributes->get(CaptureOriginalActionRequestUri::ORIGINAL_ACTION_REQUEST_URI))->toBe('/contact?site=en');
+
+            app()->instance('request', $request);
+
+            $yiiRequest = Craft::createObject(\craft\helpers\App::webRequestConfig());
+
+            expect($yiiRequest->getFullPath())->toBe('contact')
+                ->and($yiiRequest->getIsActionRequest())->toBeTrue()
+                ->and($yiiRequest->getActionSegments())->toBe(['test-plugin', 'fail']);
+        });
+    });
+});
+
+it('does not override the URI for direct legacy action route requests', function() {
+    $request = IlluminateRequest::create('/actions/test-plugin/fail', 'POST', [
+        'foo' => 'bar',
+    ]);
+
+    app(CaptureOriginalActionRequestUri::class)->handle($request, function(IlluminateRequest $request) {
+        expect($request->getRequestUri())->toBe('/actions/test-plugin/fail')
+            ->and($request->attributes->has(CaptureOriginalActionRequestUri::ORIGINAL_ACTION_REQUEST_URI))->toBeFalse();
+    });
 });
 
 class TestPluginDefaultController extends Controller


### PR DESCRIPTION
### Description

Fixes two issues:

- `ol` and `ul` on the new HTML class weren't normalizing attributes which caused an exception in the errorList example of contact form
- A legacy controller returning `null` would not fall back and render the original url but tried to render the action url that was posted, which resulted in a 404. The adapter now remembers the original URL and falls back accordingly
