### PR TITLE
[6.x] Fix filesystem save null settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Removed a stray dump statement ([#18902](https://github.com/craftcms/cms/issues/18902))
 - Fixed a bug where legacy redirect responses were not being returned as a redirect ([#18893](https://github.com/craftcms/cms/pull/18893))
+- Fixed an error that could occur when saving filesystems with null transient settings. ([#18909](https://github.com/craftcms/cms/pull/18909))
 
 ## 6.0.0-alpha.3 - 2026-05-15
 

--- a/src/Http/Controllers/Settings/FilesystemsController.php
+++ b/src/Http/Controllers/Settings/FilesystemsController.php
@@ -120,13 +120,14 @@ class FilesystemsController
     public function save(Request $request): Response
     {
         $type = $request->input('type');
+        $settings = Arr::whereNotNull($request->array('types.'.Html::id($type)));
 
         $fs = $this->filesystems->createFilesystem([
             'type' => $type,
             'name' => $request->input('name'),
             'handle' => $request->input('handle'),
             'oldHandle' => $request->input('oldHandle'),
-            'settings' => $request->input('types')[Html::id($type)] ?? [],
+            'settings' => $settings,
         ]);
 
         if (! $this->filesystems->saveFilesystem($fs)) {

--- a/tests/Feature/Http/Controllers/Settings/FilesystemsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/FilesystemsControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Filesystem\Filesystems\Filesystem;
 use CraftCms\Cms\Http\Controllers\Settings\FilesystemsController;
 use CraftCms\Cms\Support\Facades\Filesystems;
 use CraftCms\Cms\User\Elements\User;
@@ -152,6 +153,24 @@ test('save creates filesystem with valid data', function () {
     expect($fs->name)->toBe('New Test Filesystem');
 });
 
+test('save ignores null transient filesystem settings', function () {
+    $response = postJson(action([FilesystemsController::class, 'save']), [
+        'type' => TransientSettingsFilesystem::class,
+        'name' => 'Transient Settings Filesystem',
+        'handle' => 'transientSettingsFilesystem',
+        'types' => [
+            TransientSettingsFilesystem::class => [
+                'transientSetting' => null,
+            ],
+        ],
+    ]);
+
+    $response->assertOk();
+
+    $fs = Filesystems::getFilesystemByHandle('transientSettingsFilesystem');
+    expect($fs)->not()->toBeNull();
+});
+
 test('save updates existing filesystem with oldHandle', function () {
     // Create a filesystem first
     $fs = Filesystems::createFilesystem([
@@ -261,3 +280,24 @@ test('respects read-only mode for delete operation', function () {
     ])
         ->assertForbidden();
 });
+
+class TransientSettingsFilesystem extends Filesystem
+{
+    public function __construct(array $config = [])
+    {
+        if (isset($config['transientSetting'])) {
+            unset($config['transientSetting']);
+        }
+
+        parent::__construct($config);
+    }
+
+    #[Override]
+    public function getDiskConfig(): array
+    {
+        return [
+            'driver' => 'local',
+            'root' => sys_get_temp_dir(),
+        ];
+    }
+}


### PR DESCRIPTION
### Description

Fixes filesystem saves so null transient CP settings are removed before component creation. This prevents plugin helper fields, such as AWS S3 manual bucket inputs, from being passed through as unknown component properties after Laravel converts empty strings to null.
