### PR TITLE
[6.x] Fix clearing empty submitted values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Removed a stray dump statement ([#18902](https://github.com/craftcms/cms/issues/18902))
+- Fixed a bug where clearing submitted values could retain the previous value. ([#18905](https://github.com/craftcms/cms/issues/18905))
 - Fixed a bug where legacy redirect responses were not being returned as a redirect ([#18893](https://github.com/craftcms/cms/pull/18893))
 
 ## 6.0.0-alpha.3 - 2026-05-15

--- a/src/Element/Concerns/HasCustomFields.php
+++ b/src/Element/Concerns/HasCustomFields.php
@@ -305,7 +305,7 @@ trait HasCustomFields
 
     private function hasFieldValueFromRequest(FieldInterface $field, array $values): bool
     {
-        if (isset($values[$field->handle])) {
+        if (array_key_exists((string) $field->handle, $values)) {
             return true;
         }
 

--- a/src/Field/Addresses.php
+++ b/src/Field/Addresses.php
@@ -445,7 +445,7 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
             }
 
             foreach ($nativeFields as $field) {
-                if (isset($addressData[$field])) {
+                if (array_key_exists($field, $addressData)) {
                     $address->$field = $addressData[$field];
                 }
             }

--- a/src/Field/BaseRelationField.php
+++ b/src/Field/BaseRelationField.php
@@ -809,6 +809,12 @@ JS, [
         return $query;
     }
 
+    #[Override]
+    public function normalizeValueFromRequest(mixed $value, ?ElementInterface $element): mixed
+    {
+        return $this->normalizeValue($value ?? [], $element);
+    }
+
     protected function fetchRelationsFromDbTable(?ElementInterface $element): bool
     {
         if ($this->layoutElement?->uid === null) {

--- a/src/Field/Matrix.php
+++ b/src/Field/Matrix.php
@@ -1679,16 +1679,16 @@ JS,
                 $entry->propagateAll = true;
             }
 
-            if (isset($entryData['title']) && $entry->getType()->hasTitleField) {
+            if (array_key_exists('title', $entryData) && $entry->getType()->hasTitleField) {
                 $entry->title = $entryData['title'];
             }
 
-            if (isset($entryData['slug']) && $entry->getType()->showSlugField) {
+            if (array_key_exists('slug', $entryData) && $entry->getType()->showSlugField) {
                 $entry->slug = $entryData['slug'];
             }
 
             // Allow setting the UID for the entry
-            if (isset($entryData['uid'])) {
+            if (array_key_exists('uid', $entryData)) {
                 $entry->uid = $entryData['uid'];
             }
 

--- a/src/Http/Controllers/Entries/StoreEntryController.php
+++ b/src/Http/Controllers/Entries/StoreEntryController.php
@@ -219,14 +219,17 @@ readonly class StoreEntryController
     private function populateEntry(Entry $entry): void
     {
         // Set the entry attributes, defaulting to the existing values for whatever is missing from the post data
-        $entry->setAttributesFromRequest(array_filter([
+        $attributes = [
             'authorIds' => $this->request->input('authors') ?? $this->request->input('author') ?? $entry->getAuthorId() ?? $this->request->user()->id,
-            'expiryDate' => $this->request->input('expiryDate'),
-            'postDate' => $this->request->input('postDate'),
-            'slug' => $this->request->input('slug'),
-            'title' => $this->request->input('title'),
-            'typeId' => $this->request->input('typeId'),
-        ], fn ($value) => $value !== null));
+        ];
+
+        foreach (['expiryDate', 'postDate', 'slug', 'title', 'typeId'] as $attribute) {
+            if ($this->request->has($attribute)) {
+                $attributes[$attribute] = $this->request->input($attribute);
+            }
+        }
+
+        $entry->setAttributesFromRequest($attributes);
 
         $enabledForSite = $this->enabledForSiteValue();
         if (is_array($enabledForSite)) {

--- a/src/Http/Controllers/Gql/SchemasController.php
+++ b/src/Http/Controllers/Gql/SchemasController.php
@@ -69,10 +69,8 @@ readonly class SchemasController extends GqlController
             $schema = new GqlSchema;
         }
 
-        $name = $request->input('name');
-
-        if ($name !== null) {
-            $schema->name = $name;
+        if ($request->has('name')) {
+            $schema->name = $request->input('name');
         }
 
         $permissions = $request->input('permissions', []);
@@ -99,8 +97,8 @@ readonly class SchemasController extends GqlController
 
         $token->enabled = (bool) $request->input('enabled');
 
-        if (($expiryDate = $request->input('expiryDate')) !== null) {
-            $token->expiryDate = DateTimeHelper::toDateTime($expiryDate) ?: null;
+        if ($request->has('expiryDate')) {
+            $token->expiryDate = DateTimeHelper::toDateTime($request->input('expiryDate')) ?: null;
         }
 
         if (! $this->gql->saveToken($token)) {

--- a/src/Http/Controllers/Gql/TokensController.php
+++ b/src/Http/Controllers/Gql/TokensController.php
@@ -60,14 +60,12 @@ readonly class TokensController extends GqlController
             $token = new GqlToken;
         }
 
-        $name = $request->input('name');
-        if ($name !== null) {
-            $token->name = $name;
+        if ($request->has('name')) {
+            $token->name = $request->input('name');
         }
 
-        $accessToken = $request->input('accessToken');
-        if ($accessToken !== null) {
-            $token->accessToken = $accessToken;
+        if ($request->has('accessToken')) {
+            $token->accessToken = $request->input('accessToken');
         }
 
         $token->enabled = (bool) $request->input('enabled');
@@ -75,8 +73,8 @@ readonly class TokensController extends GqlController
         $schemaId = $request->input('schema');
         $token->schemaId = is_numeric($schemaId) ? (int) $schemaId : null;
 
-        if (($expiryDate = $request->input('expiryDate')) !== null) {
-            $token->expiryDate = DateTimeHelper::toDateTime($expiryDate) ?: null;
+        if ($request->has('expiryDate')) {
+            $token->expiryDate = DateTimeHelper::toDateTime($request->input('expiryDate')) ?: null;
         }
 
         if (! $this->gql->saveToken($token)) {

--- a/src/Http/Controllers/Users/AddressesController.php
+++ b/src/Http/Controllers/Users/AddressesController.php
@@ -77,9 +77,8 @@ readonly class AddressesController
         // All safe attributes
         $safeAttributes = [];
         foreach ($address->safeAttributes() as $name) {
-            $value = $request->input($name);
-            if ($value !== null) {
-                $safeAttributes[$name] = $value;
+            if ($request->has($name)) {
+                $safeAttributes[$name] = $request->input($name);
             }
         }
 

--- a/src/Http/Controllers/Users/PopulatesNames.php
+++ b/src/Http/Controllers/Users/PopulatesNames.php
@@ -10,25 +10,22 @@ trait PopulatesNames
 {
     protected function populateNameAttributes(Request $request, object $model): void
     {
-        $fullName = $request->input('fullName');
-
-        if ($fullName !== null) {
-            $model->fullName = $fullName;
+        if ($request->has('fullName')) {
+            $model->fullName = $request->input('fullName');
 
             // Unset firstName and lastName so NameTrait::prepareNamesForSave() can set them
             $model->firstName = $model->lastName = null;
-        } else {
+        } elseif ($request->hasAny(['firstName', 'lastName'])) {
             // Still check for firstName/lastName in case a front-end form is still posting them
-            $firstName = $request->input('firstName');
-            $lastName = $request->input('lastName');
-
-            if ($firstName !== null || $lastName !== null) {
-                $model->firstName = $firstName ?? $model->firstName;
-                $model->lastName = $lastName ?? $model->lastName;
-
-                // Unset fullName so NameTrait::prepareNamesForSave() can set it
-                $model->fullName = null;
+            if ($request->has('firstName')) {
+                $model->firstName = $request->input('firstName');
             }
+            if ($request->has('lastName')) {
+                $model->lastName = $request->input('lastName');
+            }
+
+            // Unset fullName so NameTrait::prepareNamesForSave() can set it
+            $model->fullName = null;
         }
     }
 }

--- a/tests/Feature/Http/Controllers/Entries/StoreEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/StoreEntryControllerTest.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\Entry\Models\EntryType;
 use CraftCms\Cms\Field\Assets;
 use CraftCms\Cms\Field\ContentBlock;
 use CraftCms\Cms\Field\Contracts\FieldInterface;
+use CraftCms\Cms\Field\Entries as EntriesField;
 use CraftCms\Cms\Field\Matrix;
 use CraftCms\Cms\Field\Models\Field;
 use CraftCms\Cms\Field\PlainText;
@@ -131,6 +132,95 @@ it('can update an existing entry', function () {
 
     $entry = Entry::find()->id($entryModel->id)->status(null)->one();
     expect($entry->title)->toBe('Updated Title');
+});
+
+it('clears existing plain text field values', function () {
+    $field = Field::factory()->create([
+        'name' => 'Body Field',
+        'handle' => 'bodyField',
+        'type' => PlainText::class,
+    ]);
+
+    $fieldLayout = FieldLayout::create([
+        'type' => Entry::class,
+        'config' => createFieldLayoutConfig($field),
+    ]);
+
+    $this->entryType->update(['fieldLayoutId' => $fieldLayout->id]);
+
+    EntryTypes::refreshEntryTypes();
+    Fields::invalidateCaches();
+    Fields::refreshFields();
+
+    $entryModel = EntryModel::factory()->forSection($this->section)->forEntryType($this->entryType)->create();
+    $entry = Entry::find()->id($entryModel->id)->status(null)->one();
+    $entry->setFieldValue($field->handle, 'Existing value');
+    Elements::saveElement($entry);
+
+    post(action(StoreEntryController::class), [
+        'entryId' => $entryModel->id,
+        'fields' => [
+            'bodyField' => '',
+        ],
+    ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $entry = Entry::find()->id($entryModel->id)->status(null)->one();
+    expect($entry->getFieldValue('bodyField'))->toBeNull();
+});
+
+it('clears existing entries field values', function () {
+    $targetEntry = EntryModel::factory()->create();
+    $field = Field::factory()->create([
+        'name' => 'Related Entries',
+        'handle' => 'relatedEntries',
+        'type' => EntriesField::class,
+    ]);
+
+    $fieldLayout = FieldLayout::create([
+        'type' => Entry::class,
+        'config' => createFieldLayoutConfig($field),
+    ]);
+
+    $this->entryType->update(['fieldLayoutId' => $fieldLayout->id]);
+
+    EntryTypes::refreshEntryTypes();
+    Fields::invalidateCaches();
+    Fields::refreshFields();
+
+    $entryModel = EntryModel::factory()->forSection($this->section)->forEntryType($this->entryType)->create();
+    $entry = Entry::find()->id($entryModel->id)->status(null)->one();
+    $entry->setFieldValue($field->handle, [$targetEntry->id]);
+    Elements::saveElement($entry);
+
+    post(action(StoreEntryController::class), [
+        'entryId' => $entryModel->id,
+        'fields' => [
+            'relatedEntries' => '',
+        ],
+    ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $entry = Entry::find()->id($entryModel->id)->status(null)->one();
+    expect($entry->getFieldValue('relatedEntries')->ids())->toBe([]);
+});
+
+it('clears existing native entry attributes', function () {
+    $entryModel = EntryModel::factory()->forSection($this->section)->forEntryType($this->entryType)->create([
+        'expiryDate' => now()->addDay(),
+    ]);
+
+    post(action(StoreEntryController::class), [
+        'entryId' => $entryModel->id,
+        'expiryDate' => '',
+    ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $entry = Entry::find()->id($entryModel->id)->status(null)->one();
+    expect($entry->expiryDate)->toBeNull();
 });
 
 it('can duplicate an entry', function () {

--- a/tests/Feature/Http/Controllers/Gql/TokensControllerTest.php
+++ b/tests/Feature/Http/Controllers/Gql/TokensControllerTest.php
@@ -185,6 +185,19 @@ it('saves, updates, fetches, generates, and deletes tokens', function () {
         ->and($token?->schemaId)->toBe($updatedSchema->id)
         ->and($token?->expiryDate?->getTimestamp())->toBe(DateTimeHelper::toDateTime('2026-12-31 15:30')?->getTimestamp());
 
+    postJson(cp_url('actions/graphql/save-token'), [
+        'tokenId' => $token->id,
+        'name' => 'Updated API Token',
+        'accessToken' => 'api-token-2',
+        'enabled' => false,
+        'schema' => $updatedSchema->id,
+        'expiryDate' => '',
+    ])->assertOk();
+
+    $token = Gql::getTokenById($token->id);
+
+    expect($token?->expiryDate)->toBeNull();
+
     postJson(cp_url('actions/graphql/fetch-token'), [
         'tokenUid' => $token->uid,
     ])->assertOk()

--- a/tests/Feature/Http/Controllers/User/AddressesControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/AddressesControllerTest.php
@@ -54,6 +54,36 @@ test('store & destroy', function () {
     expect(new AddressQuery()->count())->toBe(0);
 });
 
+test('store clears existing address fields', function () {
+    postJson(action([AddressesController::class, 'store']), [
+        'userId' => auth()->id(),
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+        'title' => 'Home',
+        'addressLine1' => '123 Fake Street',
+        'addressLine2' => 'Suite 100',
+        'administrativeArea' => 'CA',
+        'locality' => 'San Francisco',
+        'postalCode' => '94107',
+    ])->assertOk();
+
+    $address = DB::table(Table::ADDRESSES)->first();
+
+    postJson(action([AddressesController::class, 'store']), [
+        'userId' => auth()->id(),
+        'addressId' => $address->id,
+        'firstName' => '',
+        'lastName' => '',
+        'addressLine2' => '',
+    ])->assertOk();
+
+    $address = DB::table(Table::ADDRESSES)->where('id', $address->id)->first();
+
+    expect($address->firstName)->toBeNull()
+        ->and($address->lastName)->toBeNull()
+        ->and($address->addressLine2)->toBeNull();
+});
+
 test('store ignores ownership attributes', function () {
     $user = auth()->user();
     $otherUser = UserModel::factory()->createElement();

--- a/tests/Feature/Http/Controllers/User/SaveUserController/UserEditTest.php
+++ b/tests/Feature/Http/Controllers/User/SaveUserController/UserEditTest.php
@@ -31,6 +31,27 @@ it('succeeds when admin edits another user', function () {
     expect($updatedUser->lastName)->toBe('User');
 });
 
+it('clears existing user name fields', function () {
+    $admin = UserFactory::new()->admin()->createElement();
+    $targetUser = UserFactory::new()->createElement([
+        'firstName' => 'Existing',
+        'lastName' => 'User',
+    ]);
+
+    actingAs($admin)->post(action(SaveUserController::class), [
+        'userId' => $targetUser->id,
+        'firstName' => '',
+        'lastName' => '',
+    ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $updatedUser = User::find()->id($targetUser->id)->one();
+    expect($updatedUser)->not->toBeNull();
+    expect($updatedUser->firstName)->toBeNull();
+    expect($updatedUser->lastName)->toBeNull();
+});
+
 it('fails when user without permission edits another user', function () {
     $regularUser = UserFactory::new()->createElement();
     $targetUser = UserFactory::new()->createElement();


### PR DESCRIPTION
### Description
Fixes a bug where clearing fields or other editable values could retain the old value after save. 

Laravel converts submitted empty strings to `null`, but several save paths were still using Yii-era assumptions and treated `null` as if the input had not been submitted. That meant cleared values were skipped, and relation fields could fall back to loading existing database relations.

### Related issues
Fixes #18905