### PR TITLE
[6.x] Fix element selector modal source validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Removed a stray dump statement ([#18902](https://github.com/craftcms/cms/issues/18902))
+- Fixed an error that occurred when opening element selector modals with string `sources` values. ([#18915](https://github.com/craftcms/cms/pull/18915))
 - Fixed a bug where legacy redirect responses were not being returned as a redirect ([#18893](https://github.com/craftcms/cms/pull/18893))
 
 ## 6.0.0-alpha.3 - 2026-05-15

--- a/src/Http/Controllers/Elements/ElementSelectorModalController.php
+++ b/src/Http/Controllers/Elements/ElementSelectorModalController.php
@@ -10,13 +10,19 @@ use CraftCms\Cms\Element\CurrentElementIndex;
 use CraftCms\Cms\Http\Requests\ElementIndexRequest;
 use Illuminate\Http\JsonResponse;
 
+use function CraftCms\Cms\t;
+
 readonly class ElementSelectorModalController
 {
     public function __invoke(ElementIndexRequest $request, ElementIndexHtml $elementIndexHtml, CurrentElementIndex $currentElementIndex): JsonResponse
     {
         $request->validate([
             'showSiteMenu' => ['nullable', 'in:0,1'],
-            'sources' => ['nullable', 'array'],
+            'sources' => ['nullable', function (string $attribute, mixed $value, $fail): void {
+                if (! is_array($value) && ! is_string($value)) {
+                    $fail(t('The {attribute} field must be a string or array.', ['attribute' => $attribute]));
+                }
+            }],
             'sources.*' => ['string'],
         ]);
 

--- a/tests/Feature/Http/Controllers/Elements/ElementSelectorModalControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/ElementSelectorModalControllerTest.php
@@ -68,7 +68,7 @@ it('validates invalid request payloads', function (array $payload, array $errors
     ], ['showSiteMenu']],
     'invalid sources type' => [[
         'elementType' => Entry::class,
-        'sources' => 'not-an-array',
+        'sources' => 123,
     ], ['sources']],
     'invalid source item type' => [[
         'elementType' => Entry::class,
@@ -113,6 +113,15 @@ it('renders modal HTML with the expected config', function () {
             'sources' => ['*', 'singles'],
         ])
         ->and(array_keys($this->elementIndexHtmlState->config['statuses']))->toBe(array_keys(Entry::statuses()));
+});
+
+it('accepts string sources', function () {
+    postJson(action(ElementSelectorModalController::class), [
+        'elementType' => Entry::class,
+        'sources' => '[]',
+    ])->assertOk();
+
+    expect($this->elementIndexHtmlState->config['sources'])->toBe('[]');
 });
 
 it('passes the provided context through to the element index html', function () {


### PR DESCRIPTION
### Description
Fixes element selector modal body requests so the `sources` parameter may be posted as either an array or a string, matching the 5.x behavior where non-array source values were passed through and treated as unrestricted sources. Adds regression coverage for string `sources` values while preserving validation for invalid non-string/non-array payloads.

### Related issues
Fixes #18913
