### PR TITLE
[6.x] Upgrade Litemoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Updated `yiisoft/html` to 4.1.0. ([#18920](https://github.com/craftcms/cms/pull/18920))
+- Updated `elvanto/litemoji` to 5.2.0. ([#18917](https://github.com/craftcms/cms/pull/18917))
 - Removed a stray dump statement ([#18902](https://github.com/craftcms/cms/issues/18902))
 - Fixed an error that occurred when opening element selector modals with string `sources` values. ([#18915](https://github.com/craftcms/cms/pull/18915))
 - Added “Elements” and “Deprecations” panels to Laravel Debugbar. ([#18897](https://github.com/craftcms/cms/pull/18897)

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "craftcms/laravel-ruleset-validation": "^1.1",
     "craftcms/plugin-installer": "~1.6.0",
     "craftcms/server-check": "~6.0.0",
-    "elvanto/litemoji": "~4.3.0",
+    "elvanto/litemoji": "^5.2.0",
     "enshrined/svg-sanitize": "~0.22.0",
     "guzzlehttp/guzzle": "^7.2.0",
     "inertiajs/inertia-laravel": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "551a09ac18f361a619628575754ee429",
+    "content-hash": "3b6c5f504fd99874ec829e99f1682ee6",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1269,24 +1269,24 @@
         },
         {
             "name": "elvanto/litemoji",
-            "version": "4.3.0",
+            "version": "5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elvanto/litemoji.git",
-                "reference": "f13cf10686f7110a3b17d09de03050d0708840b8"
+                "reference": "859dbcaa31ac5eb99c0811a981ba9d9ca3dab1c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elvanto/litemoji/zipball/f13cf10686f7110a3b17d09de03050d0708840b8",
-                "reference": "f13cf10686f7110a3b17d09de03050d0708840b8",
+                "url": "https://api.github.com/repos/elvanto/litemoji/zipball/859dbcaa31ac5eb99c0811a981ba9d9ca3dab1c1",
+                "reference": "859dbcaa31ac5eb99c0811a981ba9d9ca3dab1c1",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=7.3"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "milesj/emojibase": "7.0.*",
+                "milesj/emojibase": "^16.0.3",
                 "phpunit/phpunit": "^9.0"
             },
             "type": "library",
@@ -1306,9 +1306,9 @@
             ],
             "support": {
                 "issues": "https://github.com/elvanto/litemoji/issues",
-                "source": "https://github.com/elvanto/litemoji/tree/4.3.0"
+                "source": "https://github.com/elvanto/litemoji/tree/5.2.0"
             },
-            "time": "2022-10-28T02:32:19+00:00"
+            "time": "2025-07-15T04:24:11+00:00"
         },
         {
             "name": "enshrined/svg-sanitize",

--- a/tests/Unit/Support/StrTest.php
+++ b/tests/Unit/Support/StrTest.php
@@ -77,8 +77,8 @@ test('encDec', function (string $string) {
 test('emojiToShortcodes', function (string $expected, string $str) {
     expect(Str::emojiToShortcodes($str))->toBe($expected);
 })->with([
-    ['Baby you light my :fire:! :smiley:', 'Baby you light my 🔥! 😃'],
-    ['Test — em – en - dashes :hand_with_index_and_middle_fingers_crossed:', 'Test — em – en - dashes 🤞'],
+    ['Baby you light my :fire:! :glad:', 'Baby you light my 🔥! 😃'],
+    ['Test — em – en - dashes :fingers_crossed:', 'Test — em – en - dashes 🤞'],
 ]);
 
 test('encodeMb4', function (string $expected, string $string) {


### PR DESCRIPTION
### Description

Upgrades `elvanto/litemoji` to 5.2.0 and updates the affected shortcode expectations for the newer Emojibase data.

Even though 🤞 now resolves to `:fingers_crossed:`, `:hand_with_index_and_middle_fingers_crossed:` still resolves back to the correct emoji so there should be no breaking changes for content. 