### PR TITLE
[6.x] Fix invalid query filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed an error that occurred when Updates were cached and deserialized.
 - Fixed an error that prevented link fields from saving.
 - Fixed a bug where Money fields could throw an error during element validation when the field value was falsy.
+- Fixed a bug where invalid element query filters could return all results. ([#18937](https://github.com/craftcms/cms/pull/18937))
 
 ## 6.0.0-alpha.4 - 2026-05-19
 

--- a/src/Database/ElementRelationParamFilter.php
+++ b/src/Database/ElementRelationParamFilter.php
@@ -194,26 +194,45 @@ class ElementRelationParamFilter
      *
      * @param  int|string|int[]|null  $siteId
      */
-    public function apply(Builder $query, mixed $relatedToParam, array|int|string|null $siteId = null): Builder
+    public function apply(Builder $query, mixed $relatedToParam, array|int|string|null $siteId = null, bool $matchNoneWhenInvalid = true): bool
     {
         $relatedToParam = self::normalizeRelatedToParam($relatedToParam, $siteId);
         $glue = array_shift($relatedToParam);
 
         if (empty($relatedToParam)) {
-            return $query;
+            return false;
         }
 
-        return $query->where(function (Builder $query) use ($relatedToParam, $glue) {
+        $applied = false;
+        $failed = false;
+
+        $query->where(function (Builder $query) use ($relatedToParam, $glue, &$applied, &$failed) {
             foreach ($relatedToParam as $relCriteria) {
-                $query->where(fn (Builder $query) => $this->subparse($query, $relCriteria), boolean: $glue);
+                $query->where(function (Builder $query) use ($relCriteria, &$applied, &$failed) {
+                    if ($this->subparse($query, $relCriteria)) {
+                        $applied = true;
+                    } else {
+                        $failed = true;
+                    }
+                }, boolean: $glue);
             }
         });
+
+        if (! $applied || ($glue === 'and' && $failed)) {
+            if ($matchNoneWhenInvalid) {
+                $query->whereRaw('0 = 1');
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     /**
      * Parses a part of a relatedTo element query param and returns the condition or `false` if there's an issue.
      */
-    private function subparse(Builder $query, mixed $relCriteria): Builder
+    private function subparse(Builder $query, mixed $relCriteria): bool
     {
         // Get the element IDs, wherever they are
         $relElementIds = [];
@@ -258,7 +277,7 @@ class ElementRelationParamFilter
         }
 
         if (empty($relElementIds)) {
-            return $query;
+            return false;
         }
 
         // Going both ways?
@@ -299,6 +318,7 @@ class ElementRelationParamFilter
             return $this->apply($query, $newRelatedToParam);
         }
         $relationFieldIds = [];
+        $applied = false;
 
         if ($relCriteria['field']) {
             // Loop through all of the fields in this rel criteria, create the Matrix-specific
@@ -316,7 +336,7 @@ class ElementRelationParamFilter
                 if (($fieldModel = $this->getField($field, $fieldHandleParts, $useElementQueryFields)) === null) {
                     Log::warning('Attempting to load relations for an invalid field: '.$field);
 
-                    return $query;
+                    return false;
                 }
 
                 if ($fieldModel instanceof BaseRelationField) {
@@ -396,12 +416,13 @@ class ElementRelationParamFilter
                     }
 
                     $query->orWhereIn('elements.id', $subQuery);
+                    $applied = true;
 
                     unset($subQuery);
                 } else {
                     Log::warning('Attempting to load relations for a non-relational field: '.$fieldModel->handle);
 
-                    return $query;
+                    return false;
                 }
             }
         }
@@ -438,9 +459,10 @@ class ElementRelationParamFilter
             }
 
             $query->orWhereIn('elements.id', $subQuery);
+            $applied = true;
         }
 
-        return $query;
+        return $applied;
     }
 
     /**

--- a/src/Element/Queries/Concerns/Entry/QueriesAuthors.php
+++ b/src/Element/Queries/Concerns/Entry/QueriesAuthors.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\Database\QueryParam;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\Element\Queries\EntryQuery;
+use CraftCms\Cms\Element\Queries\Exceptions\QueryAbortedException;
 use CraftCms\Cms\Support\Facades\UserGroups;
 use CraftCms\Cms\Support\Query;
 use CraftCms\Cms\User\Data\UserGroup;
@@ -51,7 +52,7 @@ trait QueriesAuthors
     {
         $this->beforeQuery(function (EntryQuery $query) {
             if ($this->authorGroupId === []) {
-                return;
+                throw new QueryAbortedException;
             }
 
             if (Edition::get() === Edition::Solo) {

--- a/src/Element/Queries/Concerns/Entry/QueriesEntryTypes.php
+++ b/src/Element/Queries/Concerns/Entry/QueriesEntryTypes.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\Element\Queries\Concerns\Entry;
 
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Queries\EntryQuery;
+use CraftCms\Cms\Element\Queries\Exceptions\QueryAbortedException;
 use CraftCms\Cms\Entry\Data\EntryType;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\EntryTypes;
@@ -46,7 +47,7 @@ trait QueriesEntryTypes
             $this->normalizeTypeId($entryQuery);
 
             if ($entryQuery->typeId === []) {
-                return;
+                throw new QueryAbortedException;
             }
 
             if (! $entryQuery->typeId) {

--- a/src/Element/Queries/Concerns/Entry/QueriesSections.php
+++ b/src/Element/Queries/Concerns/Entry/QueriesSections.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\Element\Queries\Concerns\Entry;
 
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Queries\EntryQuery;
+use CraftCms\Cms\Element\Queries\Exceptions\QueryAbortedException;
 use CraftCms\Cms\Section\Data\Section;
 use CraftCms\Cms\Section\Enums\SectionType;
 use CraftCms\Cms\Support\Arr;
@@ -43,6 +44,11 @@ trait QueriesSections
     {
         $this->beforeQuery(function (EntryQuery $entryQuery) {
             $this->normalizeSectionId($entryQuery);
+
+            if ($entryQuery->sectionId === []) {
+                throw new QueryAbortedException;
+            }
+
             $this->applySectionIdParam($entryQuery);
         });
     }

--- a/src/Element/Queries/Concerns/QueriesRelatedElements.php
+++ b/src/Element/Queries/Concerns/QueriesRelatedElements.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\Element\Queries\Concerns;
 
 use CraftCms\Cms\Database\ElementRelationParamFilter;
 use CraftCms\Cms\Element\Queries\ElementQuery;
+use CraftCms\Cms\Element\Queries\Exceptions\QueryAbortedException;
 use CraftCms\Cms\Field\Contracts\FieldInterface;
 use CraftCms\Cms\Support\Arr;
 use Illuminate\Database\Query\Builder;
@@ -47,7 +48,7 @@ trait QueriesRelatedElements
                 return;
             }
 
-            new ElementRelationParamFilter(
+            $applied = new ElementRelationParamFilter(
                 fields: $elementQuery->customFields
                     ? Arr::keyBy(
                         $elementQuery->customFields,
@@ -59,6 +60,10 @@ trait QueriesRelatedElements
                 relatedToParam: $elementQuery->relatedTo,
                 siteId: $elementQuery->siteId !== '*' ? $elementQuery->siteId : null
             );
+
+            if (! $applied) {
+                throw new QueryAbortedException;
+            }
         });
     }
 
@@ -82,7 +87,8 @@ trait QueriesRelatedElements
                 )->apply(
                     query: $query,
                     relatedToParam: $notRelatedToParam,
-                    siteId: $elementQuery->siteId !== '*' ? $elementQuery->siteId : null
+                    siteId: $elementQuery->siteId !== '*' ? $elementQuery->siteId : null,
+                    matchNoneWhenInvalid: false,
                 );
             });
         });

--- a/src/Element/Queries/Concerns/User/QueriesUserGroups.php
+++ b/src/Element/Queries/Concerns/User/QueriesUserGroups.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Element\Queries\Concerns\User;
 use CraftCms\Cms\Database\QueryParam;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Edition;
+use CraftCms\Cms\Element\Queries\Exceptions\QueryAbortedException;
 use CraftCms\Cms\Element\Queries\UserQuery;
 use CraftCms\Cms\Support\Facades\UserGroups;
 use CraftCms\Cms\Support\Query;
@@ -63,6 +64,10 @@ trait QueriesUserGroups
     protected function initQueriesUserGroups(): void
     {
         $this->beforeQuery(function (UserQuery $userQuery) {
+            if ($userQuery->groupId === []) {
+                throw new QueryAbortedException;
+            }
+
             if (! $userQuery->groupId) {
                 return;
             }
@@ -170,9 +175,10 @@ trait QueriesUserGroups
             fn ($item) => $item instanceof UserGroup ? $item->id : null)) {
             $this->groupId = $value;
         } else {
-            $operator = QueryParam::extractOperator($value);
+            $values = QueryParam::toArray($value);
+            $operator = QueryParam::extractOperator($values);
             $this->groupId = DB::table(Table::USERGROUPS)
-                ->whereParam('handle', $value)
+                ->whereParam('handle', $values)
                 ->pluck('id')
                 ->all();
 

--- a/tests/Feature/Element/Queries/Concerns/Entry/QueriesAuthorsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/Entry/QueriesAuthorsTest.php
@@ -105,6 +105,7 @@ it('can query entries by author groups', function () {
     expect(entryQuery()->authorGroup(['not', $userGroup1->handle])->count())->toBe(1);
     expect(entryQuery()->authorGroup(['not', $userGroup1->handle, $userGroup2->handle])->count())->toBe(0);
     expect(entryQuery()->authorGroup(implode(', ', [$userGroup1->handle, $userGroup2->handle]))->count())->toBe(2);
+    expect(entryQuery()->authorGroup('notavalidhandle')->count())->toBe(0);
 });
 
 it('treats falsy author group IDs as explicit filters', function (mixed $groupId) {

--- a/tests/Feature/Element/Queries/Concerns/Entry/QueriesEntryTypesTest.php
+++ b/tests/Feature/Element/Queries/Concerns/Entry/QueriesEntryTypesTest.php
@@ -20,4 +20,5 @@ it('can query entries by entry types', function () {
 
     expect(entryQuery()->type('not '.$entry1->entryType->handle)->count())->toBe(1);
     expect(entryQuery()->type('not '.$entry2->entryType->handle)->count())->toBe(1);
+    expect(entryQuery()->type('notavalidhandle')->count())->toBe(0);
 });

--- a/tests/Feature/Element/Queries/Concerns/Entry/QueriesSectionsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/Entry/QueriesSectionsTest.php
@@ -20,4 +20,5 @@ it('can query entries by section', function () {
 
     expect(entryQuery()->section('not '.$entry1->section->handle)->count())->toBe(1);
     expect(entryQuery()->section('not '.$entry2->section->handle)->count())->toBe(1);
+    expect(entryQuery()->section('notavalidhandle')->count())->toBe(0);
 });

--- a/tests/Feature/Element/Queries/Concerns/QueriesRelatedElementsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/QueriesRelatedElementsTest.php
@@ -44,6 +44,8 @@ test('related elements', function () {
     expect(entryQuery()->count())->toBe(3);
     expect(entryQuery()->relatedTo($entries[1]->id)->count())->toBe(1);
     expect(entryQuery()->notRelatedTo($entries[1]->id)->count())->toBe(2);
+    expect(entryQuery()->relatedTo('notavalidelement')->count())->toBe(0);
+    expect(entryQuery()->notRelatedTo('notavalidelement')->count())->toBe(3);
 });
 
 test('relation fields modify element queries with relation filters', function () {

--- a/tests/Feature/Element/Queries/Concerns/User/QueriesUserGroupsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/User/QueriesUserGroupsTest.php
@@ -14,4 +14,5 @@ it('can query users in groups', function () {
     expect(userQuery()->group($userGroup->handle)->count())->toBe(1);
     expect(userQuery()->group([$userGroup->handle])->count())->toBe(1);
     expect(userQuery()->group(['not', $userGroup->handle])->count())->toBe(1);
+    expect(userQuery()->group('notavalidhandle')->count())->toBe(0);
 });


### PR DESCRIPTION
### Description
Fixes invalid entry/user/relation query filters so unresolved handles and relation criteria produce empty results where 5.x aborts the query, instead of leaving the query unconstrained.

### Related issues
Fixes #18928
