### PR TITLE
[6.x] Validation improvements & fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed an error that occurred when Updates were cached and deserialized.
 - Fixed an error that prevented link fields from saving.
 - Fixed a bug where Money fields could throw an error during element validation when the field value was falsy.
+- Fixed a bug where `CraftCms\Cms\Validation\Contracts\Validatable::prepareForValidation()` wasn’t called consistently, and plain `Validatable` classes without a configured ruleset couldn’t be validated. ([#18944](https://github.com/craftcms/cms/pull/18944))
 
 ## 6.0.0-alpha.4 - 2026-05-19
 

--- a/src/Component/Component.php
+++ b/src/Component/Component.php
@@ -109,19 +109,6 @@ abstract class Component implements Arrayable, ArrayableInterface, ArrayAccess, 
         return $fields;
     }
 
-    public function setAttributes($values): void
-    {
-        Typecast::properties(static::class, $values);
-
-        foreach ($values as $name => $value) {
-            try {
-                $this->$name = $value;
-            } catch (UnknownPropertyException|InvalidCallException) {
-                // Property or setter doesn't exist
-            }
-        }
-    }
-
     public function __get(string $name)
     {
         $getter = $this->resolveMagicMethod('get', $name);

--- a/src/Component/Component.php
+++ b/src/Component/Component.php
@@ -13,9 +13,9 @@ use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Concerns\MacroableMagicMethods;
 use CraftCms\Cms\Support\DateTimeHelper;
 use CraftCms\Cms\Support\Typecast;
-use CraftCms\Cms\Validation\ComponentRules;
 use CraftCms\Cms\Validation\Concerns\Validates;
 use CraftCms\Cms\Validation\Contracts\Validatable;
+use CraftCms\Cms\Validation\ValidatableRules;
 use CraftCms\RulesetValidation\Attributes\Ruleset;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
@@ -23,7 +23,7 @@ use Illuminate\Support\Traits\Macroable;
 use Yiisoft\Arrays\ArrayableInterface;
 use Yiisoft\Arrays\ArrayableTrait;
 
-#[Ruleset(ComponentRules::class)]
+#[Ruleset(ValidatableRules::class)]
 abstract class Component implements Arrayable, ArrayableInterface, ArrayAccess, ComponentInterface, Validatable
 {
     use ArrayableTrait {

--- a/src/Element/Validation/ElementRules.php
+++ b/src/Element/Validation/ElementRules.php
@@ -43,6 +43,8 @@ class ElementRules extends Ruleset
     #[Override]
     public function prepareForValidation(): void
     {
+        parent::prepareForValidation();
+
         $shouldPrepare = fn (string $attribute) => is_null($this->validationAttributes) || in_array($attribute, $this->validationAttributes, true);
 
         if ($shouldPrepare('title')) {

--- a/src/Validation/ComponentRules.php
+++ b/src/Validation/ComponentRules.php
@@ -30,12 +30,6 @@ class ComponentRules extends Ruleset
     }
 
     #[Override]
-    protected function prepareForValidation(): void
-    {
-        $this->subject->prepareForValidation();
-    }
-
-    #[Override]
     protected function passedValidation(): void
     {
         $this->subject->passedValidation();

--- a/src/Validation/Concerns/Validates.php
+++ b/src/Validation/Concerns/Validates.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Validation\Concerns;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Support\Utils;
+use CraftCms\Cms\Validation\ComponentRules;
 use CraftCms\Cms\Validation\Contracts\Validatable;
 use CraftCms\RulesetValidation\Concerns\HasRuleset;
 use Illuminate\Support\MessageBag;
@@ -88,7 +89,7 @@ trait Validates
             $attributeNames = [$attributeNames];
         }
 
-        $ruleset = $this->ruleset;
+        $ruleset = $this->ruleset ?: app()->make(ComponentRules::class, ['subject' => $this]);
 
         if (! is_null($attributeNames)) {
             $ruleset->only($attributeNames);

--- a/src/Validation/Concerns/Validates.php
+++ b/src/Validation/Concerns/Validates.php
@@ -10,8 +10,8 @@ use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Support\Typecast;
 use CraftCms\Cms\Support\Utils;
-use CraftCms\Cms\Validation\ComponentRules;
 use CraftCms\Cms\Validation\Contracts\Validatable;
+use CraftCms\Cms\Validation\ValidatableRules;
 use CraftCms\RulesetValidation\Concerns\HasRuleset;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\Validator;
@@ -92,7 +92,7 @@ trait Validates
             $attributeNames = [$attributeNames];
         }
 
-        $ruleset = $this->ruleset ?: app()->make(ComponentRules::class, ['subject' => $this]);
+        $ruleset = $this->ruleset ?: app()->make(ValidatableRules::class, ['subject' => $this]);
 
         if (! is_null($attributeNames)) {
             $ruleset->only($attributeNames);

--- a/src/Validation/Concerns/Validates.php
+++ b/src/Validation/Concerns/Validates.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Validation\Concerns;
 
+use CraftCms\Cms\Component\Exceptions\InvalidCallException;
+use CraftCms\Cms\Component\Exceptions\UnknownPropertyException;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Str;
+use CraftCms\Cms\Support\Typecast;
 use CraftCms\Cms\Support\Utils;
 use CraftCms\Cms\Validation\ComponentRules;
 use CraftCms\Cms\Validation\Contracts\Validatable;
@@ -126,6 +129,19 @@ trait Validates
         $labels = $this->attributeLabels();
 
         return $labels[$attribute] ?? $this->generateAttributeLabel($attribute);
+    }
+
+    public function setAttributes($values): void
+    {
+        Typecast::properties(static::class, $values);
+
+        foreach ($values as $name => $value) {
+            try {
+                $this->$name = $value;
+            } catch (UnknownPropertyException|InvalidCallException) {
+                // Property or setter doesn't exist
+            }
+        }
     }
 
     /**

--- a/src/Validation/Contracts/Validatable.php
+++ b/src/Validation/Contracts/Validatable.php
@@ -81,6 +81,11 @@ interface Validatable extends ValidatesWithRuleset
     public function afterValidate(?Validator $validator = null): void;
 
     /**
+     * Handle a passed validation attempt.
+     */
+    public function passedValidation(): void;
+
+    /**
      * Returns the first error message for each attribute that has errors.
      *
      * @return array<string, string>

--- a/src/Validation/Ruleset.php
+++ b/src/Validation/Ruleset.php
@@ -17,6 +17,18 @@ use Override;
 abstract class Ruleset extends \CraftCms\RulesetValidation\Ruleset
 {
     #[Override]
+    protected function runValidation(bool $throw = true): bool
+    {
+        $subject = $this->resolveSubject();
+
+        if ($subject instanceof Validatable) {
+            $subject->prepareForValidation();
+        }
+
+        return parent::runValidation($throw);
+    }
+
+    #[Override]
     protected function validationRules(): array
     {
         $rules = parent::validationRules();

--- a/src/Validation/ValidatableRules.php
+++ b/src/Validation/ValidatableRules.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Validation;
 
-use CraftCms\Cms\Component\Component;
+use CraftCms\Cms\Validation\Contracts\Validatable;
 use Override;
 
 /**
- * @extends Ruleset<Component>
+ * A ruleset which takes its validation rules,
+ * attributes and messages from the subject.
+ *
+ * @extends Ruleset<Validatable>
  */
-class ComponentRules extends Ruleset
+class ValidatableRules extends Ruleset
 {
     public function rules(): array
     {

--- a/tests/Unit/Validation/Rules/EnvValueRuleTest.php
+++ b/tests/Unit/Validation/Rules/EnvValueRuleTest.php
@@ -3,14 +3,14 @@
 declare(strict_types=1);
 
 use CraftCms\Aliases\Aliases;
-use CraftCms\Cms\Validation\ComponentRules;
 use CraftCms\Cms\Validation\Concerns\Validates;
 use CraftCms\Cms\Validation\Contracts\Validatable;
 use CraftCms\Cms\Validation\Rules\EnvValueRule;
+use CraftCms\Cms\Validation\ValidatableRules;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
-class EnvValueRuleTestRuleset extends ComponentRules
+class EnvValueRuleTestRuleset extends ValidatableRules
 {
     #[Override]
     public function rules(): array

--- a/tests/Unit/Validation/ValidatesWithRulesetTest.php
+++ b/tests/Unit/Validation/ValidatesWithRulesetTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use CraftCms\Cms\Validation\ComponentRules;
 use CraftCms\Cms\Validation\Concerns\Validates;
 use CraftCms\Cms\Validation\Contracts\Validatable;
 use CraftCms\Cms\Validation\Ruleset;
+use CraftCms\Cms\Validation\ValidatableRules;
 use Illuminate\Validation\Validator;
 
 function createValidatableComponent(array $attributes, ?string $rulesetClass = null): Validatable
@@ -54,7 +54,7 @@ function createValidatableComponent(array $attributes, ?string $rulesetClass = n
     };
 }
 
-class TestRuleset extends ComponentRules
+class TestRuleset extends ValidatableRules
 {
     public bool $prepareForValidationCalled = false;
 

--- a/tests/Unit/Validation/ValidatesWithRulesetTest.php
+++ b/tests/Unit/Validation/ValidatesWithRulesetTest.php
@@ -18,6 +18,8 @@ function createValidatableComponent(array $attributes, ?string $rulesetClass = n
 
         public bool $afterValidateCalled = false;
 
+        public bool $prepareForValidationCalled = false;
+
         public function __construct(
             private array $testAttributes,
             ?string $rulesetClass = null,
@@ -38,6 +40,11 @@ function createValidatableComponent(array $attributes, ?string $rulesetClass = n
         public function ruleset(): string
         {
             return $this->rulesetClass;
+        }
+
+        public function prepareForValidation(): void
+        {
+            $this->prepareForValidationCalled = true;
         }
 
         public function afterValidate(?Validator $validator = null): void
@@ -87,6 +94,53 @@ class EmptyRuleset extends Ruleset
     }
 }
 
+class PlainValidatable implements Validatable
+{
+    use Validates;
+
+    public bool $prepareForValidationCalled = false;
+
+    public bool $passedValidationCalled = false;
+
+    public bool $afterValidateCalled = false;
+
+    public function __construct(
+        private array $testAttributes,
+    ) {}
+
+    public function setAttributes(array $values): void
+    {
+        $this->testAttributes = array_merge($this->testAttributes, $values);
+    }
+
+    public function validationData(): array
+    {
+        return $this->testAttributes;
+    }
+
+    public function getRules(): array
+    {
+        return [
+            'title' => ['required', 'string'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        $this->prepareForValidationCalled = true;
+    }
+
+    public function passedValidation(): void
+    {
+        $this->passedValidationCalled = true;
+    }
+
+    public function afterValidate(?Validator $validator = null): void
+    {
+        $this->afterValidateCalled = true;
+    }
+}
+
 describe('validate', function () {
     test('returns true when validation passes', function () {
         $component = createValidatableComponent([
@@ -115,6 +169,40 @@ describe('validate', function () {
         $component->validate();
 
         expect($component->ruleset->prepareForValidationCalled)->toBeTrue();
+        expect($component->prepareForValidationCalled)->toBeTrue();
+    });
+
+    test('calls subject prepareForValidation from base ruleset', function () {
+        $component = createValidatableComponent(['title' => 'Test'], EmptyRuleset::class);
+
+        $component->validate();
+
+        expect($component->prepareForValidationCalled)->toBeTrue();
+    });
+
+    test('validates with fallback ruleset when no ruleset is configured', function () {
+        $component = new PlainValidatable(['title' => 'Test']);
+
+        $result = $component->validate();
+
+        expect($component->ruleset)->toBeFalse();
+        expect($result)->toBeTrue();
+        expect($component->prepareForValidationCalled)->toBeTrue();
+        expect($component->passedValidationCalled)->toBeTrue();
+        expect($component->afterValidateCalled)->toBeTrue();
+    });
+
+    test('stores errors from fallback ruleset when no ruleset is configured', function () {
+        $component = new PlainValidatable(['title' => null]);
+
+        $result = $component->validate();
+
+        expect($component->ruleset)->toBeFalse();
+        expect($result)->toBeFalse();
+        expect($component->errors()->has('title'))->toBeTrue();
+        expect($component->prepareForValidationCalled)->toBeTrue();
+        expect($component->passedValidationCalled)->toBeFalse();
+        expect($component->afterValidateCalled)->toBeTrue();
     });
 
     test('passes attribute names to prepareForValidation', function () {

--- a/yii2-adapter/legacy/base/Model.php
+++ b/yii2-adapter/legacy/base/Model.php
@@ -289,7 +289,7 @@ abstract class Model extends \yii\base\Model implements ModelInterface, Validata
 
     public function attributes(): array
     {
-        return parent::attributes();
+        return array_values(array_diff(parent::attributes(), ['ruleset']));
     }
 
     public function safeAttributes(): array

--- a/yii2-adapter/legacy/base/Model.php
+++ b/yii2-adapter/legacy/base/Model.php
@@ -487,6 +487,11 @@ abstract class Model extends \yii\base\Model implements ModelInterface, Validata
         return [];
     }
 
+    public function passedValidation(): void
+    {
+        // Not implemented
+    }
+
     public function validationData($names = null, $except = []): array
     {
         return Arr::except($this->toArray($names ?? []), $except);

--- a/yii2-adapter/legacy/base/Model.php
+++ b/yii2-adapter/legacy/base/Model.php
@@ -17,8 +17,8 @@ use craft\helpers\DateTimeHelper;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Support\Typecast;
-use CraftCms\Cms\Validation\ComponentRules;
 use CraftCms\Cms\Validation\Contracts\Validatable;
+use CraftCms\Cms\Validation\ValidatableRules;
 use CraftCms\RulesetValidation\Attributes\Ruleset;
 use CraftCms\RulesetValidation\Concerns\HasRuleset;
 use Illuminate\Contracts\Support\Arrayable;
@@ -33,7 +33,7 @@ use Yiisoft\Arrays\ArrayableInterface;
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 3.0.0
  */
-#[Ruleset(ComponentRules::class)]
+#[Ruleset(ValidatableRules::class)]
 abstract class Model extends \yii\base\Model implements ModelInterface, Validatable, Arrayable, ArrayableInterface
 {
     use ClonefixTrait;

--- a/yii2-adapter/tests-laravel/Legacy/Base/ModelCompatibilityTest.php
+++ b/yii2-adapter/tests-laravel/Legacy/Base/ModelCompatibilityTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use craft\base\Model;
+
+test('legacy model arrays do not expose validation ruleset state', function() {
+    $model = new class(['foo' => 'bar']) extends Model {
+        public ?string $foo = null;
+    };
+
+    expect($model->attributes())->not->toContain('ruleset')
+        ->and($model->toArray())->toBe(['foo' => 'bar']);
+});
+
+test('legacy model unsafe attribute assignment ignores validation ruleset state', function() {
+    $model = new class(['foo' => 'bar']) extends Model {
+        public ?string $foo = null;
+    };
+
+    $model->setAttributes([
+        'foo' => 'baz',
+        'ruleset' => [],
+    ], false);
+
+    expect($model->foo)->toBe('baz');
+});


### PR DESCRIPTION
### Description

Fixes two validation lifecycle gaps:

- `Validatable::prepareForValidation()` is now called consistently from Craft ruleset validation, including element rulesets and custom rulesets that override their own preparation hook.
- Plain `Validatable` classes using `Validates` without a configured ruleset now fall back to `ComponentRules` instead of failing when `ruleset` resolves to `false`, so their `getRules()` contract works as expected.

- Also fixes an issue with the legacy yii model serializing rulesets.

Also improves the following
- `setAttributes()` is now moved from `Component` to the `Validates` trait, which makes plain class validation easier
- `ComponentRules` has been renamed to `ValidatableRules` to more clearly describe its intent.

### Related issues

- #18946