### PR TITLE
[6.x] Fix asset uploads with dynamic field locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed an error that prevented link fields from saving.
 - Fixed a bug where Money fields could throw an error during element validation when the field value was falsy.
 - Fixed a bug where invalid element query filters could return all results. ([#18937](https://github.com/craftcms/cms/pull/18937))
+- Fixed an error that occurred when uploading assets to fields with dynamic default upload locations. ([#18949](https://github.com/craftcms/cms/pull/18949))
 
 ## 6.0.0-alpha.4 - 2026-05-19
 

--- a/src/Http/Controllers/Assets/UploadController.php
+++ b/src/Http/Controllers/Assets/UploadController.php
@@ -63,8 +63,8 @@ readonly class UploadController
 
             abort_if(! $field instanceof AssetsField, 400, 'The field provided is not an Assets field');
 
-            if ($elementId = $request->input('elementId')) {
-                $siteId = $request->input('siteId') ?: null;
+            if ($elementId = $request->integer('elementId')) {
+                $siteId = $request->integer('siteId') ?: null;
                 $element = $this->elements->getElementById($elementId, null, $siteId);
             } else {
                 $element = null;

--- a/tests/Feature/Http/Controllers/Assets/UploadControllerTest.php
+++ b/tests/Feature/Http/Controllers/Assets/UploadControllerTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 use CraftCms\Cms\Asset\Models\Volume;
 use CraftCms\Cms\Asset\Models\VolumeFolder as VolumeFolderModel;
+use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Field\Assets as AssetsField;
 use CraftCms\Cms\Http\Controllers\Assets\UploadController;
 use CraftCms\Cms\User\Elements\User;
+use Illuminate\Http\UploadedFile;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
 use function Pest\Laravel\postJson;
 
 beforeEach(function () {
@@ -33,6 +37,36 @@ it('requires a file or field for upload', function () {
     postJson(action([UploadController::class, 'upload']), [
         'folderId' => $this->folder->id,
     ])->assertStatus(400);
+});
+
+it('uploads to a dynamic field location using posted element context', function () {
+    $result = EntryModel::factory()
+        ->withField('coverImage', AssetsField::class, [
+            'defaultUploadLocationSource' => "volume:{$this->volume->uid}",
+            'defaultUploadLocationSubpath' => '{uid}',
+        ])
+        ->createElementWithFields(['title' => 'Hub Resource']);
+
+    $entry = $result->element;
+    $field = $result->fields->get('coverImage');
+
+    post(action([UploadController::class, 'upload']), [
+        'fieldId' => (string) $field->id,
+        'elementId' => (string) $entry->id,
+        'siteId' => (string) $entry->siteId,
+        'assets-upload' => UploadedFile::fake()->image('cover.jpg'),
+    ], [
+        'Accept' => 'application/json',
+    ])
+        ->assertOk()
+        ->assertJson([
+            'filename' => 'cover.jpg',
+        ]);
+
+    expect($this->folder->newQuery()
+        ->where('volumeId', $this->volume->id)
+        ->where('path', "{$entry->uid}/")
+        ->exists())->toBeTrue();
 });
 
 it('requires authentication for replace file', function () {


### PR DESCRIPTION
### Description

Fixes asset uploads from fields with dynamic default upload subpaths by reading posted element and site context as integers before resolving the reference element.
### Related issues

- Fixes #18945
