### PR TITLE
[6.x] Add translator event dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added Laravel event dispatching to Craft’s `Yiisoft\Translator\Translator` instance, enabling `Yiisoft\Translator\Event\MissingTranslationEvent` listeners. ([#18952](https://github.com/craftcms/cms/pull/18952))
 - The default value for `GeneralConfig::$loginPath` is now `false`.
 - Fixed some errors that could occur when running Craft through Laravel Octane ([#18921](https://github.com/craftcms/cms/pull/18921))
 - Fixed an error that occurred when Updates were cached and deserialized.

--- a/src/Translation/LaravelEventDispatcher.php
+++ b/src/Translation/LaravelEventDispatcher.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Translation;
+
+use Illuminate\Contracts\Events\Dispatcher as LaravelDispatcher;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+readonly class LaravelEventDispatcher implements EventDispatcherInterface
+{
+    public function __construct(
+        private LaravelDispatcher $events,
+    ) {}
+
+    #[\Override]
+    public function dispatch(object $event)
+    {
+        $this->events->dispatch($event);
+
+        return $event;
+    }
+}

--- a/src/Translation/TranslationServiceProvider.php
+++ b/src/Translation/TranslationServiceProvider.php
@@ -20,6 +20,7 @@ class TranslationServiceProvider extends ServiceProvider
             locale: app()->getLocale(),
             fallbackLocale: $this->app->make(ConfigRepository::class)->get('app.fallback_locale'),
             defaultCategory: 'app',
+            eventDispatcher: $this->app->make(LaravelEventDispatcher::class),
         ));
     }
 

--- a/tests/Unit/Translation/TranslationServiceProviderTest.php
+++ b/tests/Unit/Translation/TranslationServiceProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Yiisoft\Translator\CategorySource;
+use Yiisoft\Translator\Event\MissingTranslationEvent;
+use Yiisoft\Translator\MessageReaderInterface;
+use Yiisoft\Translator\Translator;
+
+test('translator dispatches missing translation events through Laravel', function () {
+    Event::fake([MissingTranslationEvent::class]);
+    app()->forgetInstance(Translator::class);
+
+    $translator = app(Translator::class);
+    $translator->addCategorySources(new CategorySource('custom', new class implements MessageReaderInterface
+    {
+        public function getMessage(string $id, string $category, string $locale, array $parameters = []): ?string
+        {
+            return null;
+        }
+
+        public function getMessages(string $category, string $locale): array
+        {
+            return [];
+        }
+    }));
+
+    $translator->translate('Unavailable message', category: 'custom', locale: 'nl');
+
+    Event::assertDispatched(fn (MissingTranslationEvent $event): bool => $event->getCategory() === 'custom'
+        && $event->getLanguage() === 'nl'
+        && $event->getMessage() === 'Unavailable message');
+});


### PR DESCRIPTION
### Description

Adds a small PSR event dispatcher adapter for Craft’s Yii translator service so Yiisoft translator events, including missing translation events, are dispatched through Laravel’s event dispatcher.

### Related issues

- https://github.com/craftcms/cms/discussions/18942
