### PR TITLE
`Html::_namespaceAttributes()` and empty string values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where an empty `storage/runtime/` directory was getting created even if `runtimePath` was being overridden in `config/app.php`. ([#18936](https://github.com/craftcms/cms/issues/18936))
 - Fixed a bug where overridden entry type handles weren’t being respected when rendering partial templates. ([#18968](https://github.com/craftcms/cms/issues/18968))
+- Fixed an error that could occur when opening an element slideout. ([#18957](https://github.com/craftcms/cms/issues/18957))
 
 ## 5.10.3 - 2026-05-22
 

--- a/src/helpers/Html.php
+++ b/src/helpers/Html.php
@@ -903,6 +903,7 @@ class Html extends \yii\helpers\Html
                 foreach ($matchIds as $i => $id) {
                     if (
                         $i % 2 === 0 && // not a delimiter
+                        $id !== '' && // check if it's not an empty string, or the next line will error
                         $id[0] !== '.' // not a class name
                     ) {
                         $isHash = $id[0] === '#';

--- a/tests/unit/helpers/HtmlHelperTest.php
+++ b/tests/unit/helpers/HtmlHelperTest.php
@@ -672,6 +672,8 @@ class HtmlHelperTest extends TestCase
             ['<div id="foo-bar"></div><div data-reverse-target="#foo-bar, #foo-bar .foo"></div>', '<div id="bar"></div><div data-reverse-target="#bar, #bar .foo"></div>', 'foo', false],
             ['<div id="foo-bar"></div><div data-target-prefix="#foo-"></div>', '<div id="bar"></div><div data-target-prefix="#"></div>', 'foo', false],
             ['<div id="foo-bar"></div><div data-target-prefix></div>', '<div id="bar"></div><div data-target-prefix></div>', 'foo', false],
+            // https://github.com/craftcms/cms/issues/18957
+            ['<div for=" "></div>', '<div for=" "></div>', 'foo', false],
         ];
     }
 


### PR DESCRIPTION
### Description
Only attempt to check the first character in a string if the string isn't empty.


### Related issues
#18957 
