### PR TITLE
turn on attr.id.html5 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where an empty `storage/runtime/` directory was getting created even if `runtimePath` was being overridden in `config/app.php`. ([#18936](https://github.com/craftcms/cms/issues/18936))
 - Fixed a bug where overridden entry type handles weren’t being respected when rendering partial templates. ([#18968](https://github.com/craftcms/cms/issues/18968))
 - Fixed an error that could occur when opening an element slideout. ([#18957](https://github.com/craftcms/cms/issues/18957))
+- Fixed a bug where HTML Purifier was stripping out IDs and ID references that included characters that weren’t allowed pre-HTML5. ([#18971](https://github.com/craftcms/cms/issues/18971))
 
 ## 5.10.3 - 2026-05-22
 

--- a/src/helpers/HtmlPurifier.php
+++ b/src/helpers/HtmlPurifier.php
@@ -87,5 +87,8 @@ class HtmlPurifier extends \yii\helpers\HtmlPurifier
 
             $def->addAttribute('a', 'rel', new RelAttrLinkTypeDef('rel'));
         }
+
+        // allow HTML5 ID attributes by default
+        $config->set('Attr.ID.HTML5', true);
     }
 }

--- a/src/helpers/HtmlPurifier.php
+++ b/src/helpers/HtmlPurifier.php
@@ -49,6 +49,9 @@ class HtmlPurifier extends \yii\helpers\HtmlPurifier
         $config->set('Attr.DefaultImageAlt', '');
         $config->set('Attr.DefaultInvalidImageAlt', '');
 
+        // allow HTML5 ID attributes by default
+        $config->set('Attr.ID.HTML5', true);
+
         // Add support for some HTML5 elements
         // see https://github.com/mewebstudio/Purifier/issues/32#issuecomment-182502361
         // see https://gist.github.com/lluchs/3303693
@@ -87,8 +90,5 @@ class HtmlPurifier extends \yii\helpers\HtmlPurifier
 
             $def->addAttribute('a', 'rel', new RelAttrLinkTypeDef('rel'));
         }
-
-        // allow HTML5 ID attributes by default
-        $config->set('Attr.ID.HTML5', true);
     }
 }


### PR DESCRIPTION
### Description
Turn on `Attr.ID.HTML5` by default for the HTML Purifier. 

More info: https://github.com/craftcms/cms/issues/18971


### Related issues
https://github.com/craftcms/cms/issues/18971
