### PR TITLE
Twig 3.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Updated Twig to 3.27. ([#18980](https://github.com/craftcms/cms/pull/18980))
 - Fixed a bug where an empty `storage/runtime/` directory was getting created even if `runtimePath` was being overridden in `config/app.php`. ([#18936](https://github.com/craftcms/cms/issues/18936))
 - Fixed a bug where overridden entry type handles weren’t being respected when rendering partial templates. ([#18968](https://github.com/craftcms/cms/issues/18968))
 - Fixed an error that could occur when opening an element slideout. ([#18957](https://github.com/craftcms/cms/issues/18957))

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "symfony/var-dumper": "^5.0|^6.0|^7.0",
     "symfony/yaml": "^5.2.3|^6.0|^7.0",
     "theiconic/name-parser": "^1.2",
-    "twig/twig": "~3.26.0",
+    "twig/twig": "~3.27.0",
     "voku/portable-ascii": "^2.0",
     "web-auth/webauthn-lib": "~5.2.4",
     "yiisoft/yii2": "~2.0.55.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b342a3470a611557fcb7cae2ee1dd60e",
+    "content-hash": "136d5061250bec1927117103e7c8aaeb",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6707,16 +6707,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -6771,7 +6771,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -6783,7 +6783,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         },
         {
             "name": "voku/portable-ascii",


### PR DESCRIPTION
Updates Twig to 3.27, which includes [several security fixes](https://github.com/twigphp/Twig/releases/tag/v3.27.0).