### PR TITLE
[6.x] Fix custom element authorization policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where JavaScript and CSS registered by utility pages weren’t executed when navigating between utility
   pages, and weren’t cleaned up when navigating away. ([#18978](https://github.com/craftcms/cms/issues/18978))
+- Fixed a bug where custom element authorization methods weren’t respected by Laravel element policies. ([#18983](https://github.com/craftcms/cms/pull/18983))
 
 ## 6.0.0-alpha.5 - 2026-05-27
 

--- a/src/Element/Policies/ElementPolicy.php
+++ b/src/Element/Policies/ElementPolicy.php
@@ -8,11 +8,13 @@ use BadMethodCallException;
 use CraftCms\Cms\Auth\Events\ElementAuthorizing;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\Contracts\NestedElementInterface;
+use CraftCms\Cms\Element\Element;
 use CraftCms\Cms\Field\Contracts\ElementContainerFieldInterface;
 use CraftCms\Cms\Site\Models\Site;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Gate;
+use ReflectionMethod;
 
 class ElementPolicy
 {
@@ -26,6 +28,17 @@ class ElementPolicy
         'createDrafts',
         'deleteForSite',
         'duplicateAsDraft',
+    ];
+
+    private const array ELEMENT_AUTHORIZATION_METHODS = [
+        'view' => 'canView',
+        'save' => 'canSave',
+        'delete' => 'canDelete',
+        'duplicate' => 'canDuplicate',
+        'copy' => 'canCopy',
+        'createDrafts' => 'canCreateDrafts',
+        'deleteForSite' => 'canDeleteForSite',
+        'duplicateAsDraft' => 'canDuplicateAsDraft',
     ];
 
     /**
@@ -76,10 +89,33 @@ class ElementPolicy
     public function __call(string $method, array $arguments): bool
     {
         if (in_array($method, self::ABILITIES, true)) {
+            [$user, $element] = $arguments + [null, null];
+
+            if (
+                $user instanceof User &&
+                $element instanceof ElementInterface &&
+                $this->hasCustomElementAuthorizationMethod($element, $method)
+            ) {
+                return $element->{self::ELEMENT_AUTHORIZATION_METHODS[$method]}($user);
+            }
+
             return false;
         }
 
         throw new BadMethodCallException("Method {$method} does not exist.");
+    }
+
+    private function hasCustomElementAuthorizationMethod(ElementInterface $element, string $ability): bool
+    {
+        $method = self::ELEMENT_AUTHORIZATION_METHODS[$ability] ?? null;
+
+        if (! $method || ! method_exists($element, $method)) {
+            return false;
+        }
+
+        return new ReflectionMethod($element, $method)
+            ->getDeclaringClass()
+            ->getName() !== Element::class;
     }
 
     private function checkSiteAuthorization(User $user, ElementInterface $element): ?bool

--- a/tests/Feature/Cp/ElementHtmlTest.php
+++ b/tests/Feature/Cp/ElementHtmlTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use CraftCms\Cms\Cp\Events\ElementCardHtmlResolving;
 use CraftCms\Cms\Cp\Events\ElementChipHtmlResolving;
 use CraftCms\Cms\Cp\Html\ElementHtml;
+use CraftCms\Cms\Element\Element;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Event;
 
@@ -72,6 +73,19 @@ describe('elementChipHtml', function () {
 
         expect($html)->toBe('<div>overridden-chip</div>');
     });
+
+    it('links custom element labels when the element authorizes viewing', function () {
+        $element = new ElementHtmlTestElement;
+        $element->id = 123;
+        $element->title = 'Payment #123';
+
+        $html = $this->elementHtml->elementChipHtml($element, [
+            'hyperlink' => true,
+        ]);
+
+        expect($html)->toContain('<a class="label-link" href="')
+            ->and($html)->toContain('/custom-elements/123');
+    });
 });
 
 describe('elementCardHtml', function () {
@@ -101,3 +115,17 @@ describe('elementCardHtml', function () {
         expect($html)->toBe('<div>overridden-card</div>');
     });
 });
+
+class ElementHtmlTestElement extends Element
+{
+    #[Override]
+    public function canView(User $user): bool
+    {
+        return true;
+    }
+
+    protected function cpEditUrl(): ?string
+    {
+        return "custom-elements/$this->id";
+    }
+}


### PR DESCRIPTION
### Description

Fixes custom element authorization checks in the fallback element policy so custom `canView()` implementations are respected when generating CP element links.

### Related issues

Fixes #18981