### PR TITLE
Resolve runtime path aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where the runtime path wasn’t getting set correctly. ([#18986](https://github.com/craftcms/cms/pull/18986))
+
 ## 5.10.4 - 2026-05-27
 
 - Updated Twig to 3.27. ([#18980](https://github.com/craftcms/cms/pull/18980))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug where the runtime path wasn’t getting set correctly. ([#18986](https://github.com/craftcms/cms/pull/18986))
+- Fixed a bug where an empty `@storage/runtime` directory could be created within the webroot. ([#18986](https://github.com/craftcms/cms/pull/18986))
 
 ## 5.10.4 - 2026-05-27
 

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -297,8 +297,8 @@ if (function_exists('craft_modify_app_config')) {
     craft_modify_app_config($config, $appType);
 }
 
-// Create the storage/runtime/ folder if it doesn't already exist
-$runtimePath = Craft::getAlias($config['runtimePath'] ?? $storagePath . DIRECTORY_SEPARATOR . 'runtime');
+// Create the runtime folder if it doesn't already exist
+$runtimePath = Craft::getAlias($config['runtimePath']);
 $createFolder($runtimePath);
 $ensureFolderIsReadable($runtimePath, true);
 

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -298,7 +298,7 @@ if (function_exists('craft_modify_app_config')) {
 }
 
 // Create the storage/runtime/ folder if it doesn't already exist
-$runtimePath = $config['runtimePath'] ?? $storagePath . DIRECTORY_SEPARATOR . 'runtime';
+$runtimePath = Craft::getAlias($config['runtimePath'] ?? $storagePath . DIRECTORY_SEPARATOR . 'runtime');
 $createFolder($runtimePath);
 $ensureFolderIsReadable($runtimePath, true);
 


### PR DESCRIPTION
Prevents bootstrap from treating configured runtime paths like `@storage/runtime` as literal filesystem paths, which broke Craft Cloud’s writable `/tmp` storage setup.

Fixes https://github.com/craftcms/cms/issues/18984