### PR TITLE
[6.x] Namespace plugin-defined action routes by plugin handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where legacy plugin-defined `actions.php` routes could collide between plugins. ([#18994](https://github.com/craftcms/cms/pull/18994))
 - Fixed a bug where JavaScript and CSS registered by utility pages weren’t executed when navigating between utility
   pages, and weren’t cleaned up when navigating away. ([#18978](https://github.com/craftcms/cms/issues/18978))
 - Fixed a bug where custom element authorization methods weren’t respected by Laravel element policies. ([#18983](https://github.com/craftcms/cms/pull/18983))

--- a/src/Plugin/Concerns/HasRoutes.php
+++ b/src/Plugin/Concerns/HasRoutes.php
@@ -49,17 +49,23 @@ trait HasRoutes
 
     protected function registerActionRoutes(string|Closure $routes): void
     {
+        $handle = self::getInstance()->handle;
+
         $this->app['router']
             ->middleware(['web', 'craft', 'craft.cp'])
             ->prefix(implode('/', [
                 Cms::config()->cpTrigger,
                 Cms::config()->actionTrigger,
+                $handle,
             ]))
             ->group($routes);
 
         $this->app['router']
             ->middleware(['craft', 'craft.web'])
-            ->prefix(Cms::config()->actionTrigger)
+            ->prefix(implode('/', [
+                Cms::config()->actionTrigger,
+                $handle,
+            ]))
             ->group($routes);
     }
 }

--- a/tests/Unit/Plugin/Concerns/HasRoutesTest.php
+++ b/tests/Unit/Plugin/Concerns/HasRoutesTest.php
@@ -37,12 +37,14 @@ it('registers web, cp, and action routes from plugin route files', function () {
 
     expect($uris)->toContain('plugin-web')
         ->and($uris)->toContain('admin/plugin-cp')
-        ->and($uris)->toContain('admin/actions/plugin-action')
-        ->and($uris)->toContain('actions/plugin-action');
+        ->and($uris)->toContain('admin/actions/test-plugin/plugin-action')
+        ->and($uris)->toContain('actions/test-plugin/plugin-action')
+        ->and($uris)->not()->toContain('admin/actions/plugin-action')
+        ->and($uris)->not()->toContain('actions/plugin-action');
 
     $routesByUri = collect(Route::getRoutes()->getRoutes())
         ->keyBy(fn ($route) => $route->uri());
 
     expect($routesByUri->get('admin/plugin-cp')->middleware())->toContain('web', 'craft', 'craft.cp')
-        ->and($routesByUri->get('admin/actions/plugin-action')->middleware())->toContain('web', 'craft', 'craft.cp');
+        ->and($routesByUri->get('admin/actions/test-plugin/plugin-action')->middleware())->toContain('web', 'craft', 'craft.cp');
 });


### PR DESCRIPTION
### Description
Namespace legacy plugin-defined `actions.php` routes by plugin handle so plugins can define route tails without colliding under the shared action trigger.