### PR TITLE
[Security] Add allowed_classes => false to LogTarget unserialize() to prevent PHP Object Injection

### DIFF
--- a/src/debug/LogTarget.php
+++ b/src/debug/LogTarget.php
@@ -73,7 +73,7 @@ class LogTarget extends \yii\debug\LogTarget
         $content = $this->module->fs->read($indexFile);
 
         if ($content !== '') {
-            return array_reverse(unserialize($content), true);
+            return array_reverse(unserialize($content, ['allowed_classes' => false]), true);
         }
 
         return [];
@@ -89,12 +89,12 @@ class LogTarget extends \yii\debug\LogTarget
         }
 
         $dataFile = $this->module->dataPath . "/$tag.data";
-        $data = unserialize($this->module->fs->read($dataFile));
+        $data = unserialize($this->module->fs->read($dataFile), ['allowed_classes' => false]);
         $exceptions = $data['exceptions'];
         foreach ($this->module->panels as $id => $panel) {
             if (isset($data[$id])) {
                 $panel->tag = $tag;
-                $panel->load(unserialize($data[$id]));
+                $panel->load(unserialize($data[$id], ['allowed_classes' => false]));
             }
             if (isset($exceptions[$id])) {
                 $panel->setError($exceptions[$id]);
@@ -168,7 +168,7 @@ class LogTarget extends \yii\debug\LogTarget
     private function _updateIndexFile(string $indexFile, array $summary): void
     {
         try {
-            $manifest = unserialize($this->module->fs->read($indexFile));
+            $manifest = unserialize($this->module->fs->read($indexFile), ['allowed_classes' => false]);
         } catch (FsException $e) {
             $manifest = [];
         }


### PR DESCRIPTION
## Summary

The Craft CMS debug LogTarget serializes and deserializes panel data to/from the filesystem. All four unserialize() calls in LogTarget.php lack an allowed_classes restriction.

All panel save() methods return plain PHP arrays of scalars — no PHP objects are ever legitimately stored. Adding allowed_classes => false to all four call sites prevents PHP Object Injection if an attacker can write to the debug data path.

Note: ProjectConfig already uses allowed_classes => false correctly (line 1857). This PR applies the same pattern to LogTarget.