### PR TITLE
Bugfix/options fields empty

### DIFF
--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -24,7 +24,6 @@ use craft\gql\arguments\OptionField as OptionFieldArguments;
 use craft\gql\resolvers\OptionField as OptionFieldResolver;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
-use craft\helpers\Db;
 use craft\helpers\Html;
 use craft\helpers\Json;
 use craft\helpers\StringHelper;
@@ -116,13 +115,16 @@ abstract class BaseOptionsField extends Field implements
             $condition = [$param->operator];
             $qb = Craft::$app->getDb()->getQueryBuilder();
             $valueSql = static::valueSql($instances);
+            $emptyCondition = ['or', [$valueSql => null], [$valueSql => ''], [$valueSql => '[]']];
 
             foreach ($param->values as $value) {
                 if (
                     is_string($value) &&
                     in_array(strtolower($value), [':empty:', ':notempty:', 'not :empty:'])
                 ) {
-                    $condition[] = Db::parseParam($valueSql, $value, columnType: Schema::TYPE_JSON);
+                    $condition[] = strtolower($value) === ':empty:'
+                        ? $emptyCondition
+                        : ['not', $emptyCondition];
                 } else {
                     $condition[] = $qb->jsonContains($valueSql, $value);
                 }

--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -126,8 +126,8 @@ abstract class BaseOptionsField extends Field implements
                     $condition[] = strtolower($value) === ':empty:'
                         ? $emptyCondition
                         : ['not', $emptyCondition];
-                } else {
                     $hasSpecialValue = true;
+                } else {
                     $condition[] = $qb->jsonContains($valueSql, $value);
                 }
             }

--- a/src/fields/BaseOptionsField.php
+++ b/src/fields/BaseOptionsField.php
@@ -116,6 +116,7 @@ abstract class BaseOptionsField extends Field implements
             $qb = Craft::$app->getDb()->getQueryBuilder();
             $valueSql = static::valueSql($instances);
             $emptyCondition = ['or', [$valueSql => null], [$valueSql => ''], [$valueSql => '[]']];
+            $hasSpecialValue = false;
 
             foreach ($param->values as $value) {
                 if (
@@ -126,12 +127,13 @@ abstract class BaseOptionsField extends Field implements
                         ? $emptyCondition
                         : ['not', $emptyCondition];
                 } else {
+                    $hasSpecialValue = true;
                     $condition[] = $qb->jsonContains($valueSql, $value);
                 }
             }
 
             // if we're negating, include elements with empty value (or no value) as they don't match any of the values that can be specified
-            return $negate ? ['or', [$valueSql => null], ['not', $condition]] : $condition;
+            return $negate ? ($hasSpecialValue ? ['not', $condition] : ['or', [$valueSql => null], ['not', $condition]]) : $condition;
         }
 
         return parent::queryCondition($instances, $value, $params);


### PR DESCRIPTION
### Description
- fixes an issue that could occur when querying multi-option fields that were empty but used an empty array notation
- fixes an issue that could occur when querying multi-option fields with `['not', ':empty:']` notation

### Related issues

