### PR TITLE
[6.x] Ensure legacy templates work even if there is a resources/views directory already

### DIFF
--- a/yii2-adapter/bootstrap/bootstrap.php
+++ b/yii2-adapter/bootstrap/bootstrap.php
@@ -98,7 +98,9 @@ Aliases::set('@dotenv', $app->environmentFilePath());
 Aliases::set('@config', $app->configPath());
 Aliases::set('@contentMigrations', Env::get('CRAFT_CONTENT_MIGRATIONS_PATH', $app->basePath('migrations')));
 Aliases::set('@storage', defined('CRAFT_STORAGE_PATH') ? CRAFT_STORAGE_PATH : $app->storagePath());
-Aliases::set('@templates', CRAFT_TEMPLATES_PATH); // Defined in Yii2ServiceProvider
+Aliases::set('@templates', defined('CRAFT_TEMPLATES_PATH')
+    ? CRAFT_TEMPLATES_PATH
+    : Aliases::get('@templates', is_dir($app->resourcePath('views')) ? $app->resourcePath('views') : $app->basePath('templates')));
 Aliases::set('@translations', Env::get('CRAFT_TRANSLATIONS_PATH', $app->langPath()));
 Aliases::set('@tests', Env::get('CRAFT_TESTS_PATH', $app->basePath('tests')));
 

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -13,6 +13,7 @@ use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Field\Events\FieldCachesInvalidated;
 use CraftCms\Cms\Support\Env;
 use CraftCms\Cms\Twig\Variables\CraftVariable;
+use CraftCms\Cms\View\Events\SiteTemplateRootsResolving;
 use CraftCms\Yii2Adapter\Config\MultiEnvironmentConfigCompatibility;
 use CraftCms\Yii2Adapter\Console\AddCategoriesSupportCommand;
 use CraftCms\Yii2Adapter\Console\AddGlobalSetsSupportCommand;
@@ -75,6 +76,7 @@ class Yii2ServiceProvider extends ServiceProvider
         });
 
         $this->setLaravelDefaults();
+        $this->registerLegacySiteTemplateRoot();
         $this->registerExceptionHandling();
     }
 
@@ -103,6 +105,20 @@ class Yii2ServiceProvider extends ServiceProvider
         } else {
             defined('CRAFT_TEMPLATES_PATH') || define('CRAFT_TEMPLATES_PATH', base_path('templates'));
         }
+    }
+
+    private function registerLegacySiteTemplateRoot(): void
+    {
+        Event::listen(SiteTemplateRootsResolving::class, function(SiteTemplateRootsResolving $event): void {
+            $templatesPath = base_path('templates');
+
+            if (CRAFT_TEMPLATES_PATH !== resource_path('views') || !is_dir($templatesPath)) {
+                return;
+            }
+
+            $event->roots[''] ??= [];
+            $event->roots[''] = array_merge((array)$event->roots[''], [$templatesPath]);
+        });
     }
 
     /**

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -99,25 +99,13 @@ class Yii2ServiceProvider extends ServiceProvider
         defined('CRAFT_STORAGE_PATH') || define('CRAFT_STORAGE_PATH', storage_path());
         defined('CRAFT_DOTENV_PATH') || define('CRAFT_DOTENV_PATH', app()->environmentPath());
         defined('CRAFT_VENDOR_PATH') || define('CRAFT_VENDOR_PATH', base_path('vendor'));
-
-        if (is_dir(resource_path('views'))) {
-            defined('CRAFT_TEMPLATES_PATH') || define('CRAFT_TEMPLATES_PATH', resource_path('views'));
-        } else {
-            defined('CRAFT_TEMPLATES_PATH') || define('CRAFT_TEMPLATES_PATH', base_path('templates'));
-        }
     }
 
     private function registerLegacySiteTemplateRoot(): void
     {
         Event::listen(SiteTemplateRootsResolving::class, function(SiteTemplateRootsResolving $event): void {
-            $templatesPath = base_path('templates');
-
-            if (CRAFT_TEMPLATES_PATH !== resource_path('views') || !is_dir($templatesPath)) {
-                return;
-            }
-
             $event->roots[''] ??= [];
-            $event->roots[''] = array_merge((array)$event->roots[''], [$templatesPath]);
+            $event->roots[''] = array_merge((array)$event->roots[''], [base_path('templates')]);
         });
     }
 

--- a/yii2-adapter/tests-laravel/Http/LegacySiteTemplateRoutingTest.php
+++ b/yii2-adapter/tests-laravel/Http/LegacySiteTemplateRoutingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Cms;
+use CraftCms\Cms\Twig\TemplateResolver;
+use CraftCms\Cms\View\TemplateMode;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Once;
+
+it('resolves legacy site templates from the base templates directory after resource views', function() {
+    $templatesPath = base_path('templates');
+    $createdTemplatesPath = !is_dir($templatesPath);
+    $resourcesPath = resource_path('views');
+
+    File::ensureDirectoryExists($templatesPath);
+    File::put("$templatesPath/legacy-fallback.twig", 'legacy-template-route');
+    File::put("$templatesPath/shared.twig", 'legacy-shared-route');
+    File::put("$resourcesPath/shared.twig", 'resource-shared-route');
+    Cms::setIsInstalled(false);
+    Once::flush();
+
+    try {
+        $resolver = app(TemplateResolver::class);
+
+        expect(TemplateMode::Site->templatesPath())->toBe($resourcesPath)
+            ->and($resolver->resolve('legacy-fallback', TemplateMode::Site, publicOnly: true))->toBe("$templatesPath/legacy-fallback.twig")
+            ->and($resolver->resolve('shared', TemplateMode::Site, publicOnly: true))->toBe("$resourcesPath/shared.twig");
+    } finally {
+        File::delete("$templatesPath/legacy-fallback.twig");
+        File::delete("$templatesPath/shared.twig");
+        File::delete("$resourcesPath/shared.twig");
+
+        if ($createdTemplatesPath) {
+            File::deleteDirectory($templatesPath);
+        }
+    }
+});


### PR DESCRIPTION
Fix registration so the adapter always registers the legacy template root