### PR TITLE
prevent ElementQuery in ElementQuery recursion when iterating over element's properties

### DIFF
--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -2918,7 +2918,10 @@ abstract class Element extends Component implements ElementInterface
             foreach ($fieldLayout->getCustomFieldElements() as $layoutElement) {
                 $field = $layoutElement->getField();
                 if (!isset($attributes[$field->handle])) {
-                    $attributes[$field->handle] = $this->getFieldValue($field->handle);
+                    $value = $this->getFieldValue($field->handle);
+                    if (!$value instanceof ElementQueryInterface) {
+                        $attributes[$field->handle] = $value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description
A potential fix that prevents infinite recursion when iterating over an element's properties.


### Related issues
#19004 
