### PR TITLE
Fix SVG handling for width and height attributes

### DIFF
--- a/src/image/Svg.php
+++ b/src/image/Svg.php
@@ -89,6 +89,8 @@ class Svg extends Image
 
         // If the size is defined by viewbox only, add in width and height attributes
         if (!preg_match(self::SVG_WIDTH_RE, $svg) && !preg_match(self::SVG_HEIGHT_RE, $svg)) {
+            $svg = preg_replace(self::SVG_CLEANUP_WIDTH_RE, '${1}', $svg);
+            $svg = preg_replace(self::SVG_CLEANUP_HEIGHT_RE, '${1}', $svg);
             $svg = preg_replace(self::SVG_TAG_RE,
                 "<svg width=\"{$width}px\" height=\"{$height}px\" ", $svg);
         }


### PR DESCRIPTION
### Description
 
Transforming an SVG with percentage root dimensions (`width="100%" height="100%"` + `viewBox`) produces duplicate `width`/`height` attributes → invalid XML ("Attribute width redefined"), so the image won't render.
 
Regression from **5.9.15** (commit `0a643d71`), which changed the `loadImage()` condition in `src/image/Svg.php` to `!width && !height`.
 
### Cause
 
In `src/image/Svg.php`, `SVG_WIDTH_RE`/`SVG_HEIGHT_RE` only match px, so `width="100%"` counts as *missing*. `loadImage()` then prepends `width="…px"` while the original `100%` stays → two attributes. `resize()`'s percentage-cleanup sits in the branch that's no longer reached.
 
### Fix
 
In `src/image/Svg.php`, strip percentage dimensions in `loadImage()` before prepending, reusing the existing constants.