### PR TITLE
[6.x] Status badge component

### DIFF
--- a/packages/craftcms-cp/scripts/generate-colors.js
+++ b/packages/craftcms-cp/scripts/generate-colors.js
@@ -31,6 +31,7 @@ const availableColors = [
   'white',
   'gray',
   'black',
+  'slate',
 ];
 
 const semanticColors = {
@@ -169,7 +170,7 @@ ${buildColorableTokens()}
 ${buildSemanticTokens()}
 }
 
-${[...availableColors, ...Object.values(semanticColors)].map((c) => buildStyleBlock(c)).join('\n')}
+${[...availableColors, ...Object.keys(semanticColors)].map((c) => buildStyleBlock(c)).join('\n')}
 `;
 }
 

--- a/packages/craftcms-cp/src/components/action-item/action-item.ts
+++ b/packages/craftcms-cp/src/components/action-item/action-item.ts
@@ -6,7 +6,12 @@ import variantsStyles from '@src/styles/variants.styles';
 import {classMap} from 'lit/directives/class-map.js';
 
 import '../shortcut/shortcut.js';
-import {type ActionFeedback, type BaseAction, type FeedbackData, runAction,} from '@src/actions';
+import {
+  type ActionFeedback,
+  type BaseAction,
+  type FeedbackData,
+  runAction,
+} from '@src/actions';
 import {Variant, type VariantKey} from '@src/constants/variants';
 
 /**

--- a/packages/craftcms-cp/src/components/badge/Badge.mdx
+++ b/packages/craftcms-cp/src/components/badge/Badge.mdx
@@ -1,0 +1,194 @@
+import {Canvas, Meta} from '@storybook/addon-docs/blocks';
+import BadgeMeta, {
+  Default,
+  AllColors,
+  SemanticColors,
+  CustomPrefix,
+} from './badge.stories';
+
+<Meta of={BadgeMeta} name="Docs" />
+
+# Badge
+
+`<craft-badge>` is a small status pill — a color `<craft-indicator>` dot followed
+by a label. Use it to surface an object's state in lists, tables, and headers
+(for example an entry's status or an order's payment state).
+
+<Canvas of={Default} />
+
+## Usage
+
+```html
+<craft-badge fill="success">Live</craft-badge>
+```
+
+The label is the default slot. By default the badge prepends a
+`<craft-indicator>` tinted to match `fill`; the badge's own surface, border, and
+text render in the quieter tone of the same color.
+
+## Properties
+
+<table>
+  <thead>
+    <tr>
+      <th>Property</th>
+      <th>Attribute</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>fill</code>
+      </td>
+      <td>
+        <code>fill</code>
+      </td>
+      <td>
+        <code>ColorValue</code>
+      </td>
+      <td>
+        <code>gray</code>
+      </td>
+      <td>
+        The badge color — a value from the shared <code>Color</code> palette
+        (see <a href="#fill">Fill</a>). Reflected to the <code>fill</code>{' '}
+        attribute.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Fill
+
+`fill` accepts a color **value** from the shared `Color` constant — a palette
+swatch (`red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`,
+`cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, `rose`,
+`gray`, `white`, `black`).
+
+Unlike `<craft-indicator>`, the badge is constrained to the palette and does not
+take arbitrary CSS colors — `fill` is typed as `ColorValue`, so only known
+values type-check. Setting `fill` reflects the resolved color onto the host's
+`data-color` attribute, which scopes the `--c-color-*` tokens the badge styles
+read.
+
+<Canvas of={AllColors} />
+
+### Semantic colors
+
+The `Color` constant also exposes semantic aliases that resolve to palette
+values — `Color.Success` → `emerald`, `Color.Warning` → `orange`,
+`Color.Danger` → `red`, `Color.Info` → `blue`, `Color.Neutral` → `slate`, and
+`Color.Accent` → `red`. Prefer these when the color carries meaning so intent
+survives any future palette retune.
+
+```html
+<craft-badge fill="emerald">Success</craft-badge>
+```
+
+<Canvas of={SemanticColors} />
+
+## Slots
+
+<table>
+  <thead>
+    <tr>
+      <th>Slot</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <em>(default)</em>
+      </td>
+      <td>The label content, shown after the indicator.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>prefix</code>
+      </td>
+      <td>
+        Leading content. Defaults to a <code>&lt;craft-indicator&gt;</code>{' '}
+        filled from <code>fill</code>; slot your own element to replace it.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>suffix</code>
+      </td>
+      <td>Trailing content, shown after the label.</td>
+    </tr>
+  </tbody>
+</table>
+
+Slotting `prefix` overrides the default indicator — handy for an icon or a
+custom marker:
+
+<Canvas of={CustomPrefix} />
+
+## CSS parts
+
+<table>
+  <thead>
+    <tr>
+      <th>Part</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>badge</code>
+      </td>
+      <td>The pill wrapper.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>prefix</code>
+      </td>
+      <td>The leading slot, before the label.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>indicator</code>
+      </td>
+      <td>The default indicator rendered in the prefix slot.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>suffix</code>
+      </td>
+      <td>The trailing slot, after the label.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Styling
+
+The badge sizes itself in `em` and reads the generic colorable tokens, so it
+adapts to the surrounding text and to `fill` automatically:
+
+- Surface — `--c-color-fill-quiet`
+- Border — `--c-color-border-quiet`
+- Text — `--c-color-on-quiet`
+
+Because those tokens are scoped by the `data-color` attribute the component sets
+from `fill`, you normally change a badge's color through `fill` rather than by
+overriding the tokens. Set `font-size` on the host to scale the whole pill,
+including its indicator:
+
+```css
+craft-badge {
+  font-size: 0.875rem;
+}
+```
+
+## Accessibility
+
+The default indicator is decorative and is left unlabeled, since the badge's
+text already names the status. If you replace the `prefix` with a meaningful
+graphic, give it its own accessible name (for example a `label` on
+`<craft-indicator>` or `<craft-icon>`).

--- a/packages/craftcms-cp/src/components/badge/badge.stories.ts
+++ b/packages/craftcms-cp/src/components/badge/badge.stories.ts
@@ -1,0 +1,105 @@
+import type {Meta, StoryObj} from '@storybook/web-components-vite';
+
+import {html} from 'lit';
+import {expect} from 'storybook/test';
+
+import './badge.js';
+import type CraftBadge from './badge.js';
+import {Color, colors} from '@src/constants/colors';
+import {capitalize} from '@src/utilities/string';
+import '../icon/icon.js';
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
+const meta = {
+  title: 'Components/Badge',
+  component: 'craft-badge',
+  args: {
+    fill: 'gray',
+  },
+  argTypes: {
+    fill: {control: 'select', options: colors},
+  },
+  render: (args) => html`
+    <craft-badge fill=${args.fill}>
+      ${capitalize(String(args.fill))}
+    </craft-badge>
+  `,
+} satisfies Meta<CraftBadge>;
+
+export default meta;
+type Story = StoryObj<CraftBadge>;
+
+export const Default: Story = {
+  play: async ({canvasElement}) => {
+    const host = canvasElement.querySelector('craft-badge')!;
+    // The default prefix renders an indicator …
+    const indicator = host.shadowRoot!.querySelector('craft-indicator')!;
+    await expect(indicator).toBeTruthy();
+    // … filled in the loud tone of `fill` …
+    await expect(indicator.getAttribute('fill')).toBe(
+      'var(--c-color-gray-fill-loud)'
+    );
+    // … and the host reflects the resolved color for its own surface styling.
+    await expect(host.dataset.color).toBe('gray');
+  },
+};
+
+/** `fill` takes a color value from `Color` (e.g. `red`). */
+export const FromColorValue: Story = {
+  render: () => html`<craft-badge fill="red">Value: red</craft-badge>`,
+  play: async ({canvasElement}) => {
+    const badge = canvasElement.querySelector('craft-badge')!;
+    // The badge reflects the resolved color for its own surface styling.
+    await expect(badge.dataset.color).toBe('red');
+  },
+};
+
+export const AllColors: Story = {
+  render: () => html`
+    <div style="display: grid; gap: 0.5rem; justify-items: start">
+      ${Object.entries(Color).map(
+        ([key, value]) =>
+          html`<craft-badge fill=${value}>${capitalize(key)}</craft-badge>`
+      )}
+    </div>
+  `,
+};
+
+export const SemanticColors: Story = {
+  render: () => html`
+    <div style="display: grid; gap: 0.5rem; justify-items: start">
+      ${(
+        [
+          ['Neutral', Color.Neutral],
+          ['Accent', Color.Accent],
+          ['Success', Color.Success],
+          ['Warning', Color.Warning],
+          ['Danger', Color.Danger],
+          ['Info', Color.Info],
+        ] as const
+      ).map(
+        ([label, value]) =>
+          html`<craft-badge fill=${value}>${label}</craft-badge>`
+      )}
+    </div>
+  `,
+};
+
+export const CustomPrefix: Story = {
+  render: () => html`
+    <craft-badge fill=${Color.Green}>
+      <craft-icon slot="prefix" name="circle-check" label="Done"></craft-icon>
+      Custom prefix
+    </craft-badge>
+  `,
+  play: async ({canvasElement}) => {
+    const host = canvasElement.querySelector('craft-badge')!;
+    // A slotted prefix overrides the default indicator fallback.
+    const slot = host.shadowRoot!.querySelector<HTMLSlotElement>(
+      'slot[name="prefix"]'
+    )!;
+    const [prefix] = slot.assignedElements();
+    await expect(prefix).toBeTruthy();
+    await expect(prefix?.tagName.toLowerCase()).toBe('craft-icon');
+  },
+};

--- a/packages/craftcms-cp/src/components/badge/badge.styles.ts
+++ b/packages/craftcms-cp/src/components/badge/badge.styles.ts
@@ -1,0 +1,25 @@
+import {css} from 'lit';
+
+export default css`
+  :host {
+    display: inline-flex;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    background-color: var(--c-color-fill-quiet);
+    border: 1px solid var(--c-color-border-quiet);
+    color: var(--c-color-on-quiet);
+    border-radius: var(--c-radius-full);
+    font-size: 0.9em;
+  }
+
+  .badge__prefix {
+    padding-inline: calc(var(--c-spacing-md) / 2);
+  }
+
+  .badge__suffix {
+    padding-inline: calc(var(--c-spacing-md) / 2);
+  }
+`;

--- a/packages/craftcms-cp/src/components/badge/badge.ts
+++ b/packages/craftcms-cp/src/components/badge/badge.ts
@@ -1,0 +1,79 @@
+import {html, LitElement} from 'lit';
+import {property} from 'lit/decorators.js';
+import type {CSSResultGroup, PropertyValues} from 'lit';
+import styles from './badge.styles.js';
+import {Color, type ColorValue} from '@src/constants/colors';
+import '../indicator/indicator.js';
+import {classMap} from 'lit/directives/class-map.js';
+
+/**
+ * @summary A colored status pill: a `<craft-indicator>` dot (by default)
+ * followed by a label. `fill` sets the badge color from the shared `Color`
+ * palette — the surface renders in the quiet tone of that color and the
+ * indicator in the loud tone.
+ *
+ * @slot - The label content shown after the indicator.
+ * @slot prefix - The leading content; defaults to a `<craft-indicator>` whose
+ * fill is derived from `fill`.
+ * @slot suffix - The trailing content.
+ *
+ * @csspart badge - The badge wrapper.
+ * @csspart prefix - The leading slot, rendered before the label.
+ * @csspart indicator - The default indicator shown in the prefix slot.
+ * @csspart suffix - The trailing slot, rendered after the label.
+ *
+ * @since 1.0
+ */
+export default class CraftBadge extends LitElement {
+  static override styles: CSSResultGroup = [styles];
+
+  /** The badge color — a color value from `Color` (e.g. `red`, `emerald`). */
+  @property({reflect: true}) fill: ColorValue = Color.Gray;
+
+  /** The resolved color value used for the badge fill. */
+  private getFill(): ColorValue {
+    return this.fill;
+  }
+
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    // Set the colorable context from `fill` so the badge's own surface/border/
+    // text colors (which read --c-color-*) reflect the chosen color.
+    if (changed.has('fill')) {
+      this.dataset.color = this.getFill()
+    }
+  }
+
+  override render() {
+    return html`
+      <span
+        part="badge"
+        class="${classMap({
+          badge: true,
+        })}"
+      >
+        <span class="badge__prefix">
+          <slot name="prefix" part="prefix">
+            <craft-indicator
+              part="indicator"
+              fill=${this.getFill()}
+            ></craft-indicator>
+          </slot>
+        </span>
+        <slot></slot>
+        <span class="badge__suffix">
+          <slot name="suffix" part="suffix"></slot>
+        </span>
+      </span>
+    `;
+  }
+}
+
+if (!customElements.get('craft-badge')) {
+  customElements.define('craft-badge', CraftBadge);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'craft-badge': CraftBadge;
+  }
+}

--- a/packages/craftcms-cp/src/components/indicator/Indicator.mdx
+++ b/packages/craftcms-cp/src/components/indicator/Indicator.mdx
@@ -1,5 +1,9 @@
 import {Canvas, Meta} from '@storybook/addon-docs/blocks';
-import IndicatorMeta, {ArbitraryColor, ArbitrarySize, Default,} from './indicator.stories';
+import IndicatorMeta, {
+  ArbitraryColor,
+  ArbitrarySize,
+  Default,
+} from './indicator.stories';
 
 <Meta of={IndicatorMeta} name="Docs" />
 
@@ -168,8 +172,8 @@ wrapper to fine-tune it.
 
 - The dot is exposed as `role="img"`, and `label` becomes its `aria-label`.
 - A status dot conveys meaning through color alone, so set `label` whenever the
-indicator isn't purely decorative. If it only repeats adjacent visible text,
-it's fine to leave `label` unset.
+  indicator isn't purely decorative. If it only repeats adjacent visible text,
+  it's fine to leave `label` unset.
 
 ## Styling
 

--- a/packages/craftcms-cp/src/components/indicator/indicator.ts
+++ b/packages/craftcms-cp/src/components/indicator/indicator.ts
@@ -1,4 +1,4 @@
-import {css, html, LitElement} from 'lit';
+import {css, html, LitElement, nothing} from 'lit';
 import {property} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 import variantsStyles from '@src/styles/variants.styles';
@@ -84,10 +84,12 @@ export default class CraftIndicator extends LitElement {
   }
 
   protected override render(): unknown {
+    // Without a label the indicator is purely decorative, so omit the image role
+    // and name rather than exposing an unnamed `role="img"`.
     return html`<span
       style="--fill: ${this.getFill()}; --size: ${this.getSize()}"
-      aria-label="${this.label}"
-      role="img"
+      aria-label="${this.label ?? nothing}"
+      role="${this.label ? 'img' : nothing}"
       class="${classMap({
         indicator: true,
         'indicator--outlined': this.appearance === 'outlined',

--- a/packages/craftcms-cp/src/constants/colors.ts
+++ b/packages/craftcms-cp/src/constants/colors.ts
@@ -27,6 +27,15 @@ export const Color = {
   Warning: 'orange',
   Danger: 'red',
   Info: 'blue',
+
+  // Status
+  Pending: 'orange',
+  Off: 'red',
+  Suspended: 'red',
+  Expired: 'red',
+  Disabled: 'gray',
+  Inactive: 'gray',
+  On: 'emerald',
 } as const;
 
 export const colors = Object.values(Color);

--- a/packages/craftcms-cp/src/constants/colors.ts
+++ b/packages/craftcms-cp/src/constants/colors.ts
@@ -19,9 +19,17 @@ export const Color = {
   White: 'white',
   Gray: 'gray',
   Black: 'black',
+
+  // Semantic
+  Neutral: 'slate',
+  Accent: 'red',
+  Success: 'emerald',
+  Warning: 'orange',
+  Danger: 'red',
+  Info: 'blue',
 } as const;
 
 export const colors = Object.values(Color);
 
-export type ColorKey = (typeof Color)[keyof typeof Color];
-export type ColorValue = typeof colors;
+export type ColorKey = keyof typeof Color;
+export type ColorValue = (typeof Color)[keyof typeof Color];

--- a/packages/craftcms-cp/src/constants/statuses.ts
+++ b/packages/craftcms-cp/src/constants/statuses.ts
@@ -1,0 +1,60 @@
+import {colors, type ColorValue} from './colors';
+
+/**
+ * The known element statuses.
+ *
+ * Mirrors the statuses Craft's elements report (entries, users, etc.).
+ */
+export const Status = {
+  Enabled: 'enabled',
+  Disabled: 'disabled',
+  Live: 'live',
+  Pending: 'pending',
+  Expired: 'expired',
+  Active: 'active',
+  Suspended: 'suspended',
+  Inactive: 'inactive',
+} as const;
+
+export const statuses = Object.values(Status);
+
+export type StatusKey = (typeof Status)[keyof typeof Status];
+
+/**
+ * Maps a status name to a known color.
+ *
+ * Mirrors `\CraftCms\Cms\Shared\Enums\Color::tryFromStatus()` so the front-end
+ * resolves the same color as server-rendered status indicators. Unknown
+ * statuses fall back to `gray`.
+ */
+const statusColors: Record<string, ColorValue> = {
+  on: 'teal',
+  live: 'teal',
+  active: 'teal',
+  enabled: 'teal',
+  turquoise: 'teal',
+  off: 'red',
+  suspended: 'red',
+  expired: 'red',
+  warning: 'amber',
+  pending: 'orange',
+  grey: 'gray',
+};
+
+export function statusColor(status: string | null | undefined): ColorValue {
+  if (!status) {
+    return 'gray';
+  }
+
+  const mapped = statusColors[status];
+  if (mapped) {
+    return mapped;
+  }
+
+  // The status may itself be a known color name (mirrors `Color::tryFrom()`).
+  if ((colors as string[]).includes(status)) {
+    return status as ColorValue;
+  }
+
+  return 'gray';
+}

--- a/packages/craftcms-cp/src/constants/variants.ts
+++ b/packages/craftcms-cp/src/constants/variants.ts
@@ -1,3 +1,5 @@
+import {Volume} from '@src/constants/volume';
+
 export const Variant = {
   Default: 'default',
   Success: 'success',
@@ -8,5 +10,5 @@ export const Variant = {
 
 export const variants = Object.values(Variant);
 
-export type VariantKey = (typeof Variant)[keyof typeof Variant];
-export type VariantValue = typeof variants;
+export type VariantKey = keyof typeof Variant;
+export type VariantValue = (typeof Volume)[keyof typeof Volume];

--- a/packages/craftcms-cp/src/constants/volume.ts
+++ b/packages/craftcms-cp/src/constants/volume.ts
@@ -1,0 +1,10 @@
+export const Volume = {
+  Quiet: 'quiet',
+  Normal: 'normal',
+  Loud: 'loud',
+} as const;
+
+export const volumes = Object.values(Volume);
+
+export type VolumeKey = keyof typeof Volume;
+export type VolumeValue = (typeof Volume)[keyof typeof Volume];

--- a/packages/craftcms-cp/src/index.ts
+++ b/packages/craftcms-cp/src/index.ts
@@ -21,6 +21,7 @@ export {default as CraftInputPassword} from './components/input-password/input-p
 export {default as CraftSelectedFileList} from './components/input-file/selected-file-list.js';
 export {default as CraftChip} from './components/chip/chip.js';
 export {default as CraftStatus} from './components/status/status.js';
+export {default as CraftBadge} from './components/badge/badge.js';
 export {default as CraftTextarea} from './components/textarea/textarea.js';
 export {default as CraftButtonGroup} from './components/button-group/button-group.js';
 export {default as CraftSelect} from './components/select/select.js';

--- a/packages/craftcms-cp/src/styles/shared/colorable.css
+++ b/packages/craftcms-cp/src/styles/shared/colorable.css
@@ -220,6 +220,17 @@
   --c-color-black-on-quiet: var(--color-static-gray-100);
   --c-color-black-on-normal: var(--color-static-gray-100);
   --c-color-black-on-loud: var(--color-static-gray-100);
+
+  /* slate */
+  --c-color-slate-fill-quiet: var(--color-slate-50);
+  --c-color-slate-fill-normal: var(--color-slate-100);
+  --c-color-slate-fill-loud: var(--color-slate-600);
+  --c-color-slate-border-quiet: var(--color-slate-400);
+  --c-color-slate-border-normal: var(--color-slate-600);
+  --c-color-slate-border-loud: var(--color-slate-800);
+  --c-color-slate-on-quiet: var(--color-slate-800);
+  --c-color-slate-on-normal: var(--color-slate-950);
+  --c-color-slate-on-loud: var(--color-slate-50);
   /* Semantics colors - neutral */
   --c-color-neutral-fill-quiet: var(--color-slate-50);
   --c-color-neutral-fill-normal: var(--color-slate-100);
@@ -550,75 +561,87 @@
   --c-color-border-loud: var(--c-color-slate-border-loud);
   --c-color-on-loud: var(--c-color-slate-on-loud);
 }
-.cp-color-red,
-[data-color='red'] {
-  --c-color-fill-quiet: var(--c-color-red-fill-quiet);
-  --c-color-border-quiet: var(--c-color-red-border-quiet);
-  --c-color-on-quiet: var(--c-color-red-on-quiet);
-  --c-color-fill-normal: var(--c-color-red-fill-normal);
-  --c-color-border-normal: var(--c-color-red-border-normal);
-  --c-color-on-normal: var(--c-color-red-on-normal);
-  --c-color-fill-loud: var(--c-color-red-fill-loud);
-  --c-color-border-loud: var(--c-color-red-border-loud);
-  --c-color-on-loud: var(--c-color-red-on-loud);
+.cp-color-neutral,
+[data-color='neutral'] {
+  --c-color-fill-quiet: var(--c-color-neutral-fill-quiet);
+  --c-color-border-quiet: var(--c-color-neutral-border-quiet);
+  --c-color-on-quiet: var(--c-color-neutral-on-quiet);
+  --c-color-fill-normal: var(--c-color-neutral-fill-normal);
+  --c-color-border-normal: var(--c-color-neutral-border-normal);
+  --c-color-on-normal: var(--c-color-neutral-on-normal);
+  --c-color-fill-loud: var(--c-color-neutral-fill-loud);
+  --c-color-border-loud: var(--c-color-neutral-border-loud);
+  --c-color-on-loud: var(--c-color-neutral-on-loud);
 }
-.cp-color-blue,
-[data-color='blue'] {
-  --c-color-fill-quiet: var(--c-color-blue-fill-quiet);
-  --c-color-border-quiet: var(--c-color-blue-border-quiet);
-  --c-color-on-quiet: var(--c-color-blue-on-quiet);
-  --c-color-fill-normal: var(--c-color-blue-fill-normal);
-  --c-color-border-normal: var(--c-color-blue-border-normal);
-  --c-color-on-normal: var(--c-color-blue-on-normal);
-  --c-color-fill-loud: var(--c-color-blue-fill-loud);
-  --c-color-border-loud: var(--c-color-blue-border-loud);
-  --c-color-on-loud: var(--c-color-blue-on-loud);
+.cp-color-brand,
+[data-color='brand'] {
+  --c-color-fill-quiet: var(--c-color-brand-fill-quiet);
+  --c-color-border-quiet: var(--c-color-brand-border-quiet);
+  --c-color-on-quiet: var(--c-color-brand-on-quiet);
+  --c-color-fill-normal: var(--c-color-brand-fill-normal);
+  --c-color-border-normal: var(--c-color-brand-border-normal);
+  --c-color-on-normal: var(--c-color-brand-on-normal);
+  --c-color-fill-loud: var(--c-color-brand-fill-loud);
+  --c-color-border-loud: var(--c-color-brand-border-loud);
+  --c-color-on-loud: var(--c-color-brand-on-loud);
 }
-.cp-color-blue,
-[data-color='blue'] {
-  --c-color-fill-quiet: var(--c-color-blue-fill-quiet);
-  --c-color-border-quiet: var(--c-color-blue-border-quiet);
-  --c-color-on-quiet: var(--c-color-blue-on-quiet);
-  --c-color-fill-normal: var(--c-color-blue-fill-normal);
-  --c-color-border-normal: var(--c-color-blue-border-normal);
-  --c-color-on-normal: var(--c-color-blue-on-normal);
-  --c-color-fill-loud: var(--c-color-blue-fill-loud);
-  --c-color-border-loud: var(--c-color-blue-border-loud);
-  --c-color-on-loud: var(--c-color-blue-on-loud);
+.cp-color-accent,
+[data-color='accent'] {
+  --c-color-fill-quiet: var(--c-color-accent-fill-quiet);
+  --c-color-border-quiet: var(--c-color-accent-border-quiet);
+  --c-color-on-quiet: var(--c-color-accent-on-quiet);
+  --c-color-fill-normal: var(--c-color-accent-fill-normal);
+  --c-color-border-normal: var(--c-color-accent-border-normal);
+  --c-color-on-normal: var(--c-color-accent-on-normal);
+  --c-color-fill-loud: var(--c-color-accent-fill-loud);
+  --c-color-border-loud: var(--c-color-accent-border-loud);
+  --c-color-on-loud: var(--c-color-accent-on-loud);
 }
-.cp-color-emerald,
-[data-color='emerald'] {
-  --c-color-fill-quiet: var(--c-color-emerald-fill-quiet);
-  --c-color-border-quiet: var(--c-color-emerald-border-quiet);
-  --c-color-on-quiet: var(--c-color-emerald-on-quiet);
-  --c-color-fill-normal: var(--c-color-emerald-fill-normal);
-  --c-color-border-normal: var(--c-color-emerald-border-normal);
-  --c-color-on-normal: var(--c-color-emerald-on-normal);
-  --c-color-fill-loud: var(--c-color-emerald-fill-loud);
-  --c-color-border-loud: var(--c-color-emerald-border-loud);
-  --c-color-on-loud: var(--c-color-emerald-on-loud);
+.cp-color-info,
+[data-color='info'] {
+  --c-color-fill-quiet: var(--c-color-info-fill-quiet);
+  --c-color-border-quiet: var(--c-color-info-border-quiet);
+  --c-color-on-quiet: var(--c-color-info-on-quiet);
+  --c-color-fill-normal: var(--c-color-info-fill-normal);
+  --c-color-border-normal: var(--c-color-info-border-normal);
+  --c-color-on-normal: var(--c-color-info-on-normal);
+  --c-color-fill-loud: var(--c-color-info-fill-loud);
+  --c-color-border-loud: var(--c-color-info-border-loud);
+  --c-color-on-loud: var(--c-color-info-on-loud);
 }
-.cp-color-orange,
-[data-color='orange'] {
-  --c-color-fill-quiet: var(--c-color-orange-fill-quiet);
-  --c-color-border-quiet: var(--c-color-orange-border-quiet);
-  --c-color-on-quiet: var(--c-color-orange-on-quiet);
-  --c-color-fill-normal: var(--c-color-orange-fill-normal);
-  --c-color-border-normal: var(--c-color-orange-border-normal);
-  --c-color-on-normal: var(--c-color-orange-on-normal);
-  --c-color-fill-loud: var(--c-color-orange-fill-loud);
-  --c-color-border-loud: var(--c-color-orange-border-loud);
-  --c-color-on-loud: var(--c-color-orange-on-loud);
+.cp-color-success,
+[data-color='success'] {
+  --c-color-fill-quiet: var(--c-color-success-fill-quiet);
+  --c-color-border-quiet: var(--c-color-success-border-quiet);
+  --c-color-on-quiet: var(--c-color-success-on-quiet);
+  --c-color-fill-normal: var(--c-color-success-fill-normal);
+  --c-color-border-normal: var(--c-color-success-border-normal);
+  --c-color-on-normal: var(--c-color-success-on-normal);
+  --c-color-fill-loud: var(--c-color-success-fill-loud);
+  --c-color-border-loud: var(--c-color-success-border-loud);
+  --c-color-on-loud: var(--c-color-success-on-loud);
 }
-.cp-color-red,
-[data-color='red'] {
-  --c-color-fill-quiet: var(--c-color-red-fill-quiet);
-  --c-color-border-quiet: var(--c-color-red-border-quiet);
-  --c-color-on-quiet: var(--c-color-red-on-quiet);
-  --c-color-fill-normal: var(--c-color-red-fill-normal);
-  --c-color-border-normal: var(--c-color-red-border-normal);
-  --c-color-on-normal: var(--c-color-red-on-normal);
-  --c-color-fill-loud: var(--c-color-red-fill-loud);
-  --c-color-border-loud: var(--c-color-red-border-loud);
-  --c-color-on-loud: var(--c-color-red-on-loud);
+.cp-color-warning,
+[data-color='warning'] {
+  --c-color-fill-quiet: var(--c-color-warning-fill-quiet);
+  --c-color-border-quiet: var(--c-color-warning-border-quiet);
+  --c-color-on-quiet: var(--c-color-warning-on-quiet);
+  --c-color-fill-normal: var(--c-color-warning-fill-normal);
+  --c-color-border-normal: var(--c-color-warning-border-normal);
+  --c-color-on-normal: var(--c-color-warning-on-normal);
+  --c-color-fill-loud: var(--c-color-warning-fill-loud);
+  --c-color-border-loud: var(--c-color-warning-border-loud);
+  --c-color-on-loud: var(--c-color-warning-on-loud);
+}
+.cp-color-danger,
+[data-color='danger'] {
+  --c-color-fill-quiet: var(--c-color-danger-fill-quiet);
+  --c-color-border-quiet: var(--c-color-danger-border-quiet);
+  --c-color-on-quiet: var(--c-color-danger-on-quiet);
+  --c-color-fill-normal: var(--c-color-danger-fill-normal);
+  --c-color-border-normal: var(--c-color-danger-border-normal);
+  --c-color-on-normal: var(--c-color-danger-on-normal);
+  --c-color-fill-loud: var(--c-color-danger-fill-loud);
+  --c-color-border-loud: var(--c-color-danger-border-loud);
+  --c-color-on-loud: var(--c-color-danger-on-loud);
 }

--- a/src/Cp/Html/StatusHtml.php
+++ b/src/Cp/Html/StatusHtml.php
@@ -71,33 +71,28 @@ readonly class StatusHtml
             'color' => Color::Gray->value,
             'icon' => null,
             'label' => null,
-            'indicatorClass' => null,
         ];
 
         if ($config['color'] instanceof Color) {
             $config['color'] = $config['color']->value;
         }
 
+        // An icon, when supplied, replaces the badge's default indicator dot
+        // through the `prefix` slot.
+        $contents = '';
         if ($config['icon']) {
-            $html = Html::tag('span', Icons::svg($config['icon']), [
-                'class' => ['cp-icon', 'puny', $config['color']],
-            ]);
-        } else {
-            $html = $this->statusIndicatorHtml($config['color'], [
-                'label' => null,
-                'class' => $config['indicatorClass'] ?? $config['color'],
-            ]);
+            $contents .= Html::tag('craft-icon', '', array_merge(
+                Icons::resolveIconData($config['icon']),
+                ['slot' => 'prefix'],
+            ));
         }
 
         if ($config['label']) {
-            $html .= ' '.Html::tag('span', Html::encode($config['label']), ['class' => 'status-label-text']);
+            $contents .= Html::encode($config['label']);
         }
 
-        return Html::tag('span', $html, [
-            'class' => array_filter([
-                'status-label',
-                $config['color'],
-            ]),
+        return Html::tag('craft-badge', $contents, [
+            'fill' => $config['color'],
         ]);
     }
 
@@ -117,10 +112,6 @@ readonly class StatusHtml
         $config['label'] ??= match ($status) {
             'draft' => t('Draft'),
             default => ucfirst($status),
-        };
-        $config['indicatorClass'] = match ($status) {
-            'pending', 'off', 'suspended', 'expired', 'disabled', 'inactive' => $status,
-            default => $config['color']->value,
         };
 
         return $this->statusLabelHtml($config);

--- a/tests/Feature/Element/ElementAttributeRendererTest.php
+++ b/tests/Feature/Element/ElementAttributeRendererTest.php
@@ -94,7 +94,7 @@ it('renders status attribute', function () {
 
     $result = $this->renderer->render($entry, 'status');
 
-    expect((string) $result)->toContain('status-label');
+    expect((string) $result)->toContain('<craft-badge');
 });
 
 it('renders empty string for generatedField when not found', function () {

--- a/tests/Unit/Cp/StatusHtmlTest.php
+++ b/tests/Unit/Cp/StatusHtmlTest.php
@@ -63,8 +63,11 @@ describe('component status helpers', function () {
         $labelHtml = $statusHtml->componentStatusLabelHtml($component);
         $editedHtml = $statusHtml->editedStatusLabelHtml();
 
-        expect($labelHtml)->toContain('status-label')
+        expect($labelHtml)->toContain('<craft-badge')
+            ->and($labelHtml)->toContain('fill="yellow"')
             ->and($labelHtml)->toContain('Pending')
+            ->and($editedHtml)->toContain('<craft-badge')
+            ->and($editedHtml)->toContain('slot="prefix"')
             ->and($editedHtml)->toContain('Edited');
     });
 });


### PR DESCRIPTION
Creates a new `<craft-badge/>` component that composes an indicator (or icon) and a label and throws a quiet fill behind them based on a `fill` property. 