### PR TITLE
[6.x] Fix invalid URL console error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where the `craft:install` command would hang if run within a production environment.
 - Fixed a bug where “Replace relation” action buttons weren’t working.
+- Fixed a “Invalid URL” JavaScript error in the control panel. ([#19041](https://github.com/craftcms/cms/pull/19041))
 
 ## 6.0.0-alpha.6 - 2026-06-03
 

--- a/packages/craftcms-cp/src/services/Config.ts
+++ b/packages/craftcms-cp/src/services/Config.ts
@@ -30,7 +30,7 @@ export class ConfigService {
   }
 
   getCpUrl(path: string) {
-    return this.#buildUrl(this.#config.get('cpUrl'), path);
+    return this.#buildUrl(this.#config.get('baseCpUrl'), path);
   }
 
   getActionUrl(path: string) {

--- a/resources/js/common/types/globals.d.ts
+++ b/resources/js/common/types/globals.d.ts
@@ -84,6 +84,8 @@ interface CraftStatic {
   setCookie(name: string, value: string): any;
   getCookie(name: string): any;
   getUrl(path: string, params?: string | object, baseUrl?: string): string;
+  baseCpUrl: string;
+  getCpUrl(path: string, params?: string | object): string;
   cp?: {
     jobInfo?: unknown[];
     displayedJobInfo?: unknown;

--- a/resources/js/modules/navigation/components/CpQueueIndicator.ts
+++ b/resources/js/modules/navigation/components/CpQueueIndicator.ts
@@ -4,7 +4,7 @@ import {JobStatus} from '@craftcms/cp/types/queue.js';
 import type {JobInfo, JobUpdateDetail} from '@craftcms/cp';
 
 import '@craftcms/cp/components/progress/progress.ts.mjs';
-import {QueueService, ConfigService} from '@craftcms/cp';
+import {QueueService} from '@craftcms/cp';
 
 @customElement('cp-queue-indicator')
 class CpQueueIndicator extends LitElement {
@@ -31,7 +31,6 @@ class CpQueueIndicator extends LitElement {
   hasWaitingJobs: boolean = false;
 
   #queue: QueueService = QueueService.getInstance();
-  #config: ConfigService = ConfigService.getInstance();
 
   override connectedCallback() {
     super.connectedCallback();
@@ -110,7 +109,7 @@ class CpQueueIndicator extends LitElement {
       return null;
     }
 
-    return this.#config.getCpUrl('utilities/queue-manager');
+    return window.Craft.getCpUrl('utilities/queue-manager');
   }
 
   protected override render() {

--- a/src/Cp/Cp.php
+++ b/src/Cp/Cp.php
@@ -37,7 +37,7 @@ readonly class Cp
                 'csrfTokenValue' => csrf_token(),
                 'csrfTokenName' => '_token',
                 'actionUrl' => Url::actionUrl(),
-                'cpUrl' => Url::cpUrl(),
+                'baseCpUrl' => Url::cpUrl(),
                 'baseUrl' => Url::url(),
                 'systemName' => Cms::systemName(),
             ]);

--- a/src/Http/Middleware/HandleInertiaRequests.php
+++ b/src/Http/Middleware/HandleInertiaRequests.php
@@ -165,7 +165,7 @@ class HandleInertiaRequests extends Middleware
                 ] : null,
                 'readOnly' => ! $generalConfig->allowAdminChanges,
                 'allowAdminChanges' => $generalConfig->allowAdminChanges,
-                'cpUrl' => cp_url(),
+                'baseCpUrl' => cp_url(),
                 'actionUrl' => action_url(),
                 'baseApiUrl' => Api::craftApiEndpoint(),
                 'nav' => $nav->getItems(),


### PR DESCRIPTION
Fixes the `Uncaught (in promise) TypeError: Failed to construct 'URL': Invalid URL` error in the console.