### PR TITLE
[6.x] Fix hyphenated prop bindings on craft- web components

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -51,6 +51,11 @@ export default tseslint.config(
       // I don't find this useful when writing in typescript.
       'vue/require-default-prop': 'off',
 
+      // Lion/WebAwesome web components expose camelCase DOM properties (e.g.
+      // .choiceValue). Hyphenating them would bind the wrong property name, so
+      // camelCase prop bindings on custom elements are required, not optional.
+      'vue/attribute-hyphenation': 'off',
+
       // Formatting rules — Prettier handles these
       'vue/html-self-closing': 'off',
       'vue/max-attributes-per-line': 'off',

--- a/resources/js/common/components/FileUpload.vue
+++ b/resources/js/common/components/FileUpload.vue
@@ -78,7 +78,7 @@
     :help-text="helpText"
     :disabled="disabled"
     :multiple="multiple"
-    .upload-response="uploadResponse"
+    .uploadResponse="uploadResponse"
     @file-removed="handleFileRemoved"
     @file-list-changed="handleListChange"
     :has-feedback-for="error ? 'error' : ''"

--- a/resources/js/common/form/CheckboxGroup.vue
+++ b/resources/js/common/form/CheckboxGroup.vue
@@ -19,7 +19,7 @@
   );
 
   function handleValueChange(event: CustomEvent) {
-    const target = event.target as CraftCheckbox;
+    const target = event.currentTarget as CraftCheckbox;
     emit('update:modelValue', target.modelValue);
   }
 </script>
@@ -28,14 +28,14 @@
   <craft-checkbox-group
     :name="name"
     :label="label"
-    .model-value="modelValue"
+    .modelValue="modelValue"
     @model-value-changed="handleValueChange"
     :disabled="disabled"
   >
     <template v-if="allowSelectAll">
       <craft-checkbox-indeterminate :label="t('All')">
         <template v-for="option in options" :key="option.value">
-          <craft-checkbox .choice-value="option.value">
+          <craft-checkbox .choiceValue="option.value">
             <label slot="label"
               ><slot name="label" :option="option">{{
                 option.label
@@ -48,7 +48,7 @@
     </template>
     <template v-else>
       <template v-for="option in options" :key="option.value">
-        <craft-checkbox .choice-value="option.value">
+        <craft-checkbox .choiceValue="option.value">
           <label slot="label"
             ><slot name="label" :option="option">{{
               option.label

--- a/resources/js/modules/sites/components/DeleteSiteModal.vue
+++ b/resources/js/modules/sites/components/DeleteSiteModal.vue
@@ -75,20 +75,20 @@
             {siteName: site.name}
           )
         "
-        .model-value="form.contentDestination"
+        .modelValue="form.contentDestination"
         @model-value-changed="
           form.contentDestination = $event.target.modelValue
         "
       >
         <craft-radio
           :label="t('Transfer it')"
-          .choice-value="'transfer'"
+          .choiceValue="'transfer'"
           :checked="'transfer' === form.contentDestination"
         >
         </craft-radio>
         <craft-radio
           :label="t('Delete it')"
-          .choice-value="'delete'"
+          .choiceValue="'delete'"
           :checked="'delete' === form.contentDestination"
         ></craft-radio>
       </craft-radio-group>
@@ -104,7 +104,7 @@
             :label="t('Transfer content to')"
             id="transfer-to"
             name="transferContentTo"
-            .model-value="form.transferContentTo"
+            .modelValue="form.transferContentTo"
             @model-value-changed="
               form.transferContentTo = $event.target.modelValue
             "

--- a/resources/js/modules/sites/components/SiteFields.vue
+++ b/resources/js/modules/sites/components/SiteFields.vue
@@ -66,7 +66,7 @@
     :help-text="t('Which group should this site belong to?')"
     name="group"
     id="group"
-    .model-value="form.group"
+    .modelValue="form.group"
     @model-value-changed="form.group = $event.target?.modelValue"
     :disabled="readOnly"
   >


### PR DESCRIPTION
## Summary

Vue's `.prop` binding shorthand uses the **literal** attribute name and does not camelize it. So bindings like `.choice-value`, `.model-value`, and `.upload-response` set junk DOM properties that the underlying Lion-based `craft-*` web components never read. The components fell back to their default values (e.g. an empty-string `choiceValue`), which is why checkbox/radio/select values came through empty.

This switches those bindings to the camelCase property names the components actually expose, and disables the `vue/attribute-hyphenation` ESLint rule — for these custom elements, camelCase prop bindings are required, not optional.

## Changes

- **`CheckboxGroup.vue`** — `.choice-value` → `.choiceValue`, `.model-value` → `.modelValue` (this was the originally-reported empty-value bug)
- **`FileUpload.vue`** — `.upload-response` → `.uploadResponse` (`craft-input-file`)
- **`DeleteSiteModal.vue`** — `.model-value` → `.modelValue`, `.choice-value` → `.choiceValue` (`craft-radio-group` / `craft-radio` / `craft-select`)
- **`SiteFields.vue`** — `.model-value` → `.modelValue` (`craft-select`)
- **`eslint.config.ts`** — disable `vue/attribute-hyphenation` with an explanatory comment

The camelCase property names (`modelValue`, `choiceValue`, `uploadResponse`) were verified against the Lion source and the generated `dist/vue/Craft*.vue` wrappers, which all use the same camelCase `.prop` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)