### PR TITLE
[6.x] Fix legacy showCardsInGrid compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where the `craft:install` command would hang if run within a production environment.
 - Fixed a bug where “Replace relation” action buttons weren’t working.
 - Fixed a “Invalid URL” JavaScript error in the control panel. ([#19041](https://github.com/craftcms/cms/pull/19041))
+- Fixed an error that could occur during Craft 6 upgrades when legacy relational or Matrix field settings included `showCardsInGrid`. ([#19047](https://github.com/craftcms/cms/pull/19047))
 - Fixed a bug where queue job progress labels weren’t getting translated.
 - Fixed a bug where the control panel sidebar and Queue Manager were showing completed jobs.
 - Relocated `CraftCms\Cms\Element\Validation\Events\ValidationRulesResolving` to `CraftCms\Cms\Validation\Events\ValidationRulesResolving` to reflect its broader applicability to components and rulesets.

--- a/yii2-adapter/src/CompatibilityMixins.php
+++ b/yii2-adapter/src/CompatibilityMixins.php
@@ -13,7 +13,9 @@ use CraftCms\Cms\Dashboard\Widgets\Widget;
 use CraftCms\Cms\Element\Actions\ElementAction;
 use CraftCms\Cms\Element\Element;
 use CraftCms\Cms\Element\Queries\ElementQuery;
+use CraftCms\Cms\Field\BaseRelationField;
 use CraftCms\Cms\Field\Field;
+use CraftCms\Cms\Field\Matrix;
 use CraftCms\Cms\Filesystem\Data\FsListing as FilesystemFsListing;
 use CraftCms\Cms\Filesystem\Filesystems\Filesystem as FilesystemComponent;
 use CraftCms\Cms\Gql\Data\GqlSchema;
@@ -48,6 +50,11 @@ readonly class CompatibilityMixins
 
             YiiEvent::trigger($this, $name, $event);
         });
+
+        foreach ([BaseRelationField::class, Matrix::class] as $fieldClass) {
+            $fieldClass::macro('setShowCardsInGrid', function(mixed $value): void {
+            });
+        }
 
         foreach (LegacyBehaviorCatalog::mixinTargets() as $class) {
             $class::mixin(new LegacyBehaviorMixin());


### PR DESCRIPTION
### Description

Adds Yii adapter compatibility shims for the deprecated `showCardsInGrid` field setting so Craft 5 relational and Matrix field configs can be instantiated during Craft 6 upgrades without restoring the removed property on the field classes.

### Related issues

Fixes #19046
