### PR TITLE
[6.x] Fix user element auth boundary lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed errors that could occur when Craft user elements were expected but the authenticated user was resolved as a Laravel user model. ([#19051](https://github.com/craftcms/cms/pull/19051))
 - Fixed a bug where the `craft:install` command would hang if run within a production environment.
 - Fixed a bug where “Replace relation” action buttons weren’t working.
 - Fixed a “Invalid URL” JavaScript error in the control panel. ([#19041](https://github.com/craftcms/cms/pull/19041))

--- a/src/Element/Operations/ElementWrites.php
+++ b/src/Element/Operations/ElementWrites.php
@@ -42,7 +42,6 @@ use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\Support\Query;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Support\Url;
-use CraftCms\Cms\User\Elements\User;
 use Exception;
 use Illuminate\Container\Attributes\Singleton;
 use Illuminate\Database\Query\Builder;
@@ -885,8 +884,7 @@ readonly class ElementWrites
     ): bool {
         $propagateToSite = $this->sites->getSiteById($siteElement->siteId);
 
-        /** @var ?User $user */
-        $user = Auth::craftUser();
+        $user = Auth::craftUser()?->asElement();
         $message = t('Validation errors for site: “{siteName}“', [
             'siteName' => $propagateToSite?->getName(),
         ]);

--- a/src/Http/Controllers/Elements/ElementIndex/ElementIndexController.php
+++ b/src/Http/Controllers/Elements/ElementIndex/ElementIndexController.php
@@ -123,7 +123,7 @@ readonly class ElementIndexController
         /** @var ElementInterface|null $element */
         $element = (clone $elementQuery)
             ->draftOf($this->request->integer('id'))
-            ->draftCreator($this->request->craftUser())
+            ->draftCreator($this->request->craftUser()?->asElement())
             ->provisionalDrafts()
             ->status(null)
             ->one();

--- a/src/Http/Controllers/Elements/SaveElementController.php
+++ b/src/Http/Controllers/Elements/SaveElementController.php
@@ -105,7 +105,7 @@ readonly class SaveElementController
         $provisional = $element::find()
             ->provisionalDrafts()
             ->draftOf($element->id)
-            ->draftCreator($this->request->craftUser())
+            ->draftCreator($this->request->craftUser()?->asElement())
             ->siteId($element->siteId)
             ->status(null)
             ->one();

--- a/tests/Feature/Http/Controllers/Elements/ElementIndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/ElementIndexControllerTest.php
@@ -11,6 +11,7 @@ use CraftCms\Cms\Entry\Models\Entry as EntryModel;
 use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ElementIndexController;
 use CraftCms\Cms\Support\Facades\Elements;
 use CraftCms\Cms\User\Elements\User;
+use CraftCms\Cms\User\Models\User as UserModel;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\postJson;
@@ -189,6 +190,7 @@ it('prefers the current users provisional draft for element table html', functio
     $draft = app(Drafts::class)->createDraft($entry, auth()->id(), provisional: true);
     $draft->title = 'Draft Title';
     Elements::saveElement($draft);
+    actingAs(UserModel::findOrFail(auth()->id()));
 
     postJson(action([ElementIndexController::class, 'elementTableHtml']), [
         'context' => ElementSources::CONTEXT_INDEX,

--- a/tests/Feature/Http/Controllers/Elements/SaveElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/SaveElementControllerTest.php
@@ -380,6 +380,7 @@ describe('store', function () {
                 'slug' => 'canonical-title',
             ]);
         app(Drafts::class)->createDraft($entry, auth()->id(), provisional: true);
+        actingAs(UserModel::findOrFail(auth()->id()));
 
         $elements = new class(app(ElementPlaceholders::class)) extends ElementsService
         {

--- a/tests/Unit/Element/ElementWrites/PropagateElementTest.php
+++ b/tests/Unit/Element/ElementWrites/PropagateElementTest.php
@@ -21,6 +21,7 @@ use CraftCms\Cms\Site\Data\Site;
 use CraftCms\Cms\Site\Sites;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\User\Elements\User;
+use CraftCms\Cms\User\Models\User as UserModel;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
@@ -287,7 +288,7 @@ it('adds a plain validation error when a propagated save fails', function () {
 });
 
 it('adds a linked validation error when the current user can fix the propagated site', function () {
-    Auth::setUser(new AuthorizedUser);
+    Auth::setUser(new AuthorizedAuthUser);
     swapUrlRequest('/admin/entries/100?foo=bar&site=primary');
 
     $this->executor->returnValue = false;
@@ -605,6 +606,21 @@ class TrackingField extends Field
 
 class AuthorizedUser extends User
 {
+    #[Override]
+    public function can($abilities, $arguments = []): bool
+    {
+        return $abilities === 'editSite:secondary-uid';
+    }
+}
+
+class AuthorizedAuthUser extends UserModel
+{
+    #[Override]
+    public function asElement(): User
+    {
+        return new AuthorizedUser;
+    }
+
     #[Override]
     public function can($abilities, $arguments = []): bool
     {


### PR DESCRIPTION
### Description
Fixes auth-boundary mismatches where Laravel auth users were passed into APIs that require Craft user elements. Existing-entry saves and element-index provisional draft rendering now pass `asElement()` into `draftCreator()`, and cross-site validation error handling converts the auth user before calling element authorization.

### Related issues
Fixes #19042