### PR TITLE
Stream the Set Status bulk action with Db::each() to avoid OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where the “Delete” element edit page action wasn’t working properly when editing a provisional draft.
 - Fixed a bug where `craft\helpers\App::parseEnv()` wasn’t returning boolean values for environment variable names that resolved to `true`/`false` values. ([#19029](https://github.com/craftcms/cms/issues/19029))
 - Fixed a styling issue.
+- Fixed a bug where the “Set Status” bulk element action could exhaust the memory limit on large selections. ([#19070](https://github.com/craftcms/cms/issues/19070))
 
 ## 5.10.5 - 2026-06-02
 

--- a/src/elements/actions/SetStatus.php
+++ b/src/elements/actions/SetStatus.php
@@ -12,6 +12,7 @@ use craft\base\Element;
 use craft\base\ElementAction;
 use craft\base\ElementInterface;
 use craft\elements\db\ElementQueryInterface;
+use craft\helpers\Db;
 
 /**
  * SetStatus represents a Set Status element action.
@@ -87,10 +88,12 @@ JS, [static::class]);
         $elementsService = Craft::$app->getElements();
         $user = Craft::$app->getUser()->getIdentity();
 
-        $elements = $query->all();
         $failCount = 0;
+        $total = 0;
 
-        foreach ($elements as $element) {
+        foreach (Db::each($query) as $element) {
+            $total++;
+
             if (!$elementsService->canSave($element, $user)) {
                 continue;
             }
@@ -132,8 +135,8 @@ JS, [static::class]);
         }
 
         // Did all of them fail?
-        if ($failCount === count($elements)) {
-            if (count($elements) === 1) {
+        if ($failCount === $total) {
+            if ($total === 1) {
                 $this->setMessage(Craft::t('app', 'Could not update status due to a validation error.'));
             } else {
                 $this->setMessage(Craft::t('app', 'Could not update statuses due to validation errors.'));
@@ -145,7 +148,7 @@ JS, [static::class]);
         if ($failCount !== 0) {
             $this->setMessage(Craft::t('app', 'Status updated, with some failures due to validation errors.'));
         } else {
-            if (count($elements) === 1) {
+            if ($total === 1) {
                 $this->setMessage(Craft::t('app', 'Status updated.'));
             } else {
                 $this->setMessage(Craft::t('app', 'Statuses updated.'));


### PR DESCRIPTION
Fixes #19070

**Problem**
Currently, `SetStatus::performAction()` loads the entire selection into memory using `$query->all()` and holds it during the `saveElement()` loop. This causes peak memory to grow linearly with the selection size, meaning large bulk status changes easily hit the `memory_limit` (HTTP 500). See #19070 for a repro.

**Solution**
This PR switches the query to stream the elements using `Db::each()`, exactly like `Elements::resaveElements()` does. This ensures each element is freed from memory right after it gets saved. 

This is strictly a performance fix: events, validation, revisions, and results remain completely unchanged. With this fix, the ~9,500-entry selection from the issue completes with a stable ~175 MB peak instead of crashing partway through.

*Note:* Since we no longer have an array to count, I added a `$total` query to replace `count($elements)`. This ensures the 'all failed' check and singular/plural flash messages continue to work exactly as before.