### PR TITLE
[6.x] Fix return type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where the `craft:install` command would hang if run within a production environment.
+- Fixed an error that could occur when `CraftCms\Cms\Support\DateTimeHelper::toDateTime()` returned a `DateTimeInterface` implementation other than `DateTime`. ([#19079](https://github.com/craftcms/cms/pull/19079))
 - Fixed a bug where “Replace relation” action buttons weren’t working.
 - Fixed a “Invalid URL” JavaScript error in the control panel. ([#19041](https://github.com/craftcms/cms/pull/19041))
 - Fixed a bug where queue job progress labels weren’t getting translated.

--- a/src/Condition/BaseDateRangeConditionRule.php
+++ b/src/Condition/BaseDateRangeConditionRule.php
@@ -16,6 +16,7 @@ use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\Support\Url;
 use DateTimeInterface;
 use Exception;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Validation\Rule;
 use Override;
 
@@ -379,6 +380,12 @@ JS,
 
     private function _inclusiveEndDate(): DateTimeInterface
     {
-        return DateTimeHelper::toDateTime($this->_endDate)->modify('+1 day');
+        $endDate = DateTimeHelper::toDateTime($this->_endDate);
+
+        if ($endDate === false) {
+            throw new Exception('Invalid end date.');
+        }
+
+        return Date::instance($endDate)->modify('+1 day');
     }
 }

--- a/src/Support/DateTimeHelper.php
+++ b/src/Support/DateTimeHelper.php
@@ -72,11 +72,11 @@ class DateTimeHelper
      * @param  bool  $assumeSystemTimeZone  Whether it should be assumed that the value was set in the system timezone if
      *                                      the timezone was not specified. If this is `false`, UTC will be assumed.
      * @param  bool  $setToSystemTimeZone  Whether to set the resulting DateTime object to the system timezone.
-     * @return DateTime|false The DateTime object, or `false` if $object could not be converted to one
+     * @return DateTimeInterface|false The DateTime object, or `false` if $object could not be converted to one
      *
      * @throws Exception
      */
-    public static function toDateTime(mixed $value, bool $assumeSystemTimeZone = false, bool $setToSystemTimeZone = true): DateTime|false
+    public static function toDateTime(mixed $value, bool $assumeSystemTimeZone = false, bool $setToSystemTimeZone = true): DateTimeInterface|false
     {
         if ($value instanceof DateTime) {
             return $value;

--- a/yii2-adapter/legacy/i18n/Formatter.php
+++ b/yii2-adapter/legacy/i18n/Formatter.php
@@ -7,7 +7,7 @@
 
 namespace craft\i18n;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Support\Facades\Date;
 use InvalidArgumentException;
 use yii\base\InvalidConfigException;
@@ -74,7 +74,7 @@ class Formatter extends \yii\i18n\Formatter
 
     /**
      * @inheritdoc
-     * @param int|string|DateTime $value
+     * @param int|string|DateTimeInterface $value
      * @param string|null $format
      * @return string
      * @throws InvalidArgumentException
@@ -87,7 +87,7 @@ class Formatter extends \yii\i18n\Formatter
 
     /**
      * @inheritdoc
-     * @param int|string|DateTime $value
+     * @param int|string|DateTimeInterface $value
      * @param string|null $format
      * @return string
      * @throws InvalidArgumentException
@@ -100,7 +100,7 @@ class Formatter extends \yii\i18n\Formatter
 
     /**
      * @inheritdoc
-     * @param int|string|DateTime $value
+     * @param int|string|DateTimeInterface $value
      * @param string|null $format
      * @return string
      * @throws InvalidArgumentException
@@ -118,7 +118,7 @@ class Formatter extends \yii\i18n\Formatter
      * - If $value is from yesterday, "Yesterday" will be returned
      * - If $value is within the past 7 days, the weekday will be returned
      *
-     * @param int|string|DateTime $value The value to be formatted. The following
+     * @param int|string|DateTimeInterface $value The value to be formatted. The following
      * types of value are supported:
      * - an int representing a UNIX timestamp
      * - a string that can be [parsed to create a DateTime object](https://php.net/manual/en/datetime.formats.php).


### PR DESCRIPTION
Fixes a return type error (below) that happened when creating a user via the CLI

```
   TypeError

  CraftCms\Cms\Support\DateTimeHelper::toDateTime(): Return value must be of type DateTime|false, Carbon\CarbonImmutable returned

  at /tmp/packages/cms/src/Support/DateTimeHelper.php:86
     82▕             return $value;
     83▕         }
     84▕
     85▕         if ($value instanceof DateTimeInterface) {
  ➜  86▕             return Date::instance($value);
     87▕         }
     88▕
     89▕         if (! $value) {
     90▕             return false;

  1   /tmp/packages/cms/src/Element/Operations/ElementWrites.php:973
      CraftCms\Cms\Support\DateTimeHelper::toDateTime()

  2   /tmp/packages/cms/src/Element/Operations/ElementWrites.php:431
      CraftCms\Cms\Element\Operations\ElementWrites::updateModel()

Failed to run artisan craft:users/create: exit status 1
```

I'm pretty sure this is related to converting all of the date times to Carbon, but I didn't spend much time tracking the reason down.