### PR TITLE
[5.x] Use App for merging configurations.

### DIFF
--- a/src/services/Config.php
+++ b/src/services/Config.php
@@ -168,7 +168,7 @@ class Config extends Component
         Typecast::properties($configClass, $config);
 
         if ($existingConfig !== null) {
-            Craft::configure($existingConfig, $config);
+            App::configure($existingConfig, $config);
             $config = $existingConfig;
         } else {
             $config = new $configClass($config);


### PR DESCRIPTION
### Description

Switches from using Craft global object (which doesn't exist) to App global object (which does) to use the configure method for merging configuration files.

### Related issues

#19082 