### PR TITLE
[5.x] Keep stale previews non-indexable

### DIFF
--- a/src/web/Application.php
+++ b/src/web/Application.php
@@ -202,7 +202,7 @@ class Application extends \yii\web\Application
                 $generalConfig->disallowRobots ||
                 $isCpRequest ||
                 $request->getToken() !== null ||
-                $request->getIsPreview() ||
+                $request->getHadPreviewToken() ||
                 ($request->getIsActionRequest() && !($request->getIsLoginRequest() && $request->getIsGet()))
             ) {
                 $headers->set('X-Robots-Tag', 'none');

--- a/src/web/Request.php
+++ b/src/web/Request.php
@@ -753,6 +753,19 @@ class Request extends \yii\web\Request
     }
 
     /**
+     * Returns whether the request initially had a preview token, even if invalid.
+     *
+     * @return bool
+     * @since 5.9.18
+     */
+    public function getHadPreviewToken(): bool
+    {
+        return $this->getQueryParam('x-craft-preview') !== null ||
+            $this->getQueryParam('x-craft-live-preview') !== null ||
+            $this->getHeaders()->get('X-Craft-Preview-Token') !== null;
+    }
+
+    /**
      * Returns whether this is a Live Preview request.
      *
      * ::: tip

--- a/tests/unit/web/RequestTest.php
+++ b/tests/unit/web/RequestTest.php
@@ -386,6 +386,22 @@ class RequestTest extends TestCase
         self::assertFalse($this->getInaccessibleProperty($this->request, '_isActionRequest'));
     }
 
+    public function testGetHadPreviewToken(): void
+    {
+        $this->request->setQueryParams(['x-craft-preview' => 'invalid']);
+
+        self::assertTrue($this->request->getHadPreviewToken());
+        self::assertFalse($this->request->getIsPreview());
+
+        $request = new Request([
+            'cookieValidationKey' => 'lashdao8u09ud09u09231uoij098wqe',
+        ]);
+        $request->getHeaders()->set('X-Craft-Preview-Token', 'invalid');
+
+        self::assertTrue($request->getHadPreviewToken());
+        self::assertFalse($request->getIsPreview());
+    }
+
     /**
      * @dataProvider acceptsDataProvider
      */


### PR DESCRIPTION
### Description

Keeps preview-intent URLs non-indexable even after their preview token becomes invalid or expires, without changing valid preview detection.

Related: https://github.com/craftcms/cloud/issues/166