### PR TITLE
[6.x] Use cursors for queries 

### DIFF
--- a/src/Asset/Folders.php
+++ b/src/Asset/Folders.php
@@ -330,10 +330,11 @@ class Folders
 
         Asset::find()
             ->folderId($allFolderIds)
+            ->cursor()
             ->each(function (Asset $asset) use ($deleteDir) {
                 $asset->keepFileOnDelete = ! $deleteDir;
                 Elements::deleteElement($asset, true);
-            }, 100);
+            });
 
         VolumeFolderModel::whereIn('id', $allFolderIds)->delete();
     }

--- a/src/Console/Commands/Utils/FixElementUidsCommand.php
+++ b/src/Console/Commands/Utils/FixElementUidsCommand.php
@@ -42,6 +42,7 @@ class FixElementUidsCommand extends Command
 
         $duplicateUidRowsQuery
             ->orderBy('id')
+            ->cursor()
             ->each(function (object $row) use (&$seenUids, $connection) {
                 if (isset($seenUids[$row->uid])) {
                     $newUid = Str::uuid();

--- a/src/Element/Jobs/UpdateElementSlugsAndUris.php
+++ b/src/Element/Jobs/UpdateElementSlugsAndUris.php
@@ -74,7 +74,7 @@ class UpdateElementSlugsAndUris extends Job
     {
         $this->totalToProcess += $query->count();
 
-        $query->each(function ($element) {
+        $query->cursor()->each(function ($element) {
             // totalToProcess can be 0 somehow (https://github.com/craftcms/cms/issues/16787)
             $this->setProgress((int) (($this->totalProcessed / max($this->totalToProcess, $this->totalProcessed + 1)) * 100));
             $this->totalProcessed++;
@@ -97,6 +97,6 @@ class UpdateElementSlugsAndUris extends Job
                     ->descendantDist(1);
                 $this->processElements($childQuery);
             }
-        }, 100);
+        });
     }
 }

--- a/src/Element/Operations/ElementDeletions.php
+++ b/src/Element/Operations/ElementDeletions.php
@@ -86,7 +86,7 @@ readonly class ElementDeletions
                         $query->unique();
                     }
 
-                    $query->each(function (ElementInterface $element) use ($prevailingElement, $mergedElement) {
+                    $query->cursor()->each(function (ElementInterface $element) use ($prevailingElement, $mergedElement) {
                         foreach ($element->getFieldLayout()?->getCustomFields() ?? [] as $field) {
                             $fieldValue = $element->getCustomFieldRawValue($field->handle);
                             if (

--- a/src/Element/Operations/ElementUris.php
+++ b/src/Element/Operations/ElementUris.php
@@ -135,7 +135,7 @@ readonly class ElementUris
             return;
         }
 
-        $query->each(fn (ElementInterface $child) => $this->updateElementSlugAndUri(
+        $query->cursor()->each(fn (ElementInterface $child) => $this->updateElementSlugAndUri(
             element: $child,
             updateOtherSites: $updateOtherSites,
             updateDescendants: true,

--- a/src/Element/Operations/ElementWrites.php
+++ b/src/Element/Operations/ElementWrites.php
@@ -177,7 +177,6 @@ readonly class ElementWrites
 
                     event(new ElementResaved($query, $element, $position, $throwable));
                 });
-                /** @phpstan-ignore-next-line */
             } catch (QueryAbortedException) {
                 // Fail silently
             }
@@ -244,7 +243,6 @@ readonly class ElementWrites
                     BulkOps::trackElement($element);
                     $this->elementCaches->invalidateForElement($element);
                 });
-                /** @phpstan-ignore-next-line */
             } catch (QueryAbortedException) {
                 // Fail silently
             }

--- a/src/Element/Operations/ElementWrites.php
+++ b/src/Element/Operations/ElementWrites.php
@@ -138,7 +138,7 @@ readonly class ElementWrites
             $position = 0;
 
             try {
-                $query->each(function (ElementInterface $element) use ($continueOnError, $query, &$position, $skipRevisions, $touch, $updateSearchIndex) {
+                $query->cursor()->each(function (ElementInterface $element) use ($continueOnError, $query, &$position, $skipRevisions, $touch, $updateSearchIndex) {
                     $position++;
 
                     $element->ruleset->useScenario(ElementRules::SCENARIO_ESSENTIALS);
@@ -201,7 +201,7 @@ readonly class ElementWrites
             $position = 0;
 
             try {
-                $query->each(function (ElementInterface $element) use ($continueOnError, $query, &$position, $siteIds) {
+                $query->cursor()->each(function (ElementInterface $element) use ($continueOnError, $query, &$position, $siteIds) {
                     $position++;
 
                     event(new ElementPropagating($query, $element, $position));

--- a/src/Entry/Entries.php
+++ b/src/Entry/Entries.php
@@ -233,17 +233,17 @@ class Entries
                         Structures::remove($oldSection->structureId, $entry);
 
                         // remove drafts and revisions from the structure, too
-                        $draftsQuery->each(function (Entry $draft) use ($oldSection) {
+                        $draftsQuery->cursor()->each(function (Entry $draft) use ($oldSection) {
                             if ($draft->lft) {
                                 Structures::remove($oldSection->structureId, $draft);
                             }
-                        }, 100);
+                        });
 
-                        $revisionsQuery->each(function (Entry $revision) use ($oldSection) {
+                        $revisionsQuery->cursor()->each(function (Entry $revision) use ($oldSection) {
                             if ($revision->lft) {
                                 Structures::remove($oldSection->structureId, $revision);
                             }
-                        }, 100);
+                        });
                     }
 
                     // if we're moving it to a Structure section, place it at the root

--- a/src/Section/Sections.php
+++ b/src/Section/Sections.php
@@ -806,9 +806,10 @@ class Sections
             ->status(null)
             ->withStructure(false)
             ->orderBy('id')
+            ->cursor()
             ->each(function (Entry $entry) use ($sectionModel) {
                 Structures::appendToRoot($sectionModel->structureId, $entry, Mode::Insert);
-            }, 100);
+            });
     }
 
     /**

--- a/src/Section/Sections.php
+++ b/src/Section/Sections.php
@@ -942,11 +942,11 @@ class Sections
             ->id(['not', $entry->id])
             ->status(null);
 
-        $otherEntriesQuery->each(function (Entry $entryToDelete) use ($entry) {
+        $otherEntriesQuery->cursor()->each(function (Entry $entryToDelete) use ($entry) {
             if (! $entryToDelete->getIsDraft() || $entry->canonicalId !== $entry->id) {
                 $this->elements->deleteElement($entryToDelete, true);
             }
-        }, 100);
+        });
 
         return $entry;
     }

--- a/src/User/Users.php
+++ b/src/User/Users.php
@@ -1000,6 +1000,7 @@ class Users
                     ->whereColumn('password_reset_tokens.email', 'users.email')
                     ->where('password_reset_tokens.created_at', '>=', now()->subSeconds(Cms::config()->purgePendingUsersDuration));
             })
+            ->cursor()
             ->each(function (User $user) {
                 try {
                     $this->elements->deleteElement($user);

--- a/tests/Unit/Element/ElementWrites/PropagateElementsTest.php
+++ b/tests/Unit/Element/ElementWrites/PropagateElementsTest.php
@@ -24,6 +24,7 @@ use CraftCms\Cms\Support\Facades\Sites;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\LazyCollection;
 
 class TestPropagateElementsActionElement extends Element
 {
@@ -163,13 +164,9 @@ function createQueryMock(array $elements): ElementQueryInterface
 {
     $query = Mockery::mock(ElementQueryInterface::class);
 
-    $query->shouldReceive('each')
+    $query->shouldReceive('cursor')
         ->once()
-        ->andReturnUsing(function (callable $callback) use ($elements): void {
-            foreach ($elements as $element) {
-                $callback($element);
-            }
-        });
+        ->andReturn(LazyCollection::make(fn () => yield from $elements));
 
     return $query;
 }
@@ -332,7 +329,7 @@ it('swallows aborted queries and still dispatches the final event', function () 
     Event::fake([ElementsPropagating::class, ElementsPropagated::class]);
 
     $query = Mockery::mock(ElementQueryInterface::class);
-    $query->shouldReceive('each')
+    $query->shouldReceive('cursor')
         ->once()
         ->andThrow(new QueryAbortedException);
 

--- a/tests/Unit/Element/ElementWrites/ResaveElementsTest.php
+++ b/tests/Unit/Element/ElementWrites/ResaveElementsTest.php
@@ -23,6 +23,7 @@ use CraftCms\Cms\Field\Contracts\ElementContainerFieldInterface;
 use CraftCms\Cms\Search\Search;
 use CraftCms\Cms\Site\Sites;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\LazyCollection;
 
 beforeEach(function () {
     Event::fake([
@@ -186,16 +187,9 @@ it('fails silently when the query aborts', function () {
 function mockResaveQuery(array $elements): ElementQueryInterface
 {
     $query = Mockery::mock(ElementQueryInterface::class);
-    $query->shouldReceive('each')
+    $query->shouldReceive('cursor')
         ->once()
-        ->with(Mockery::type(Closure::class))
-        ->andReturnUsing(function (Closure $callback) use ($elements) {
-            foreach ($elements as $element) {
-                $callback($element);
-            }
-
-            return null;
-        });
+        ->andReturn(LazyCollection::make(fn () => yield from $elements));
 
     return $query;
 }
@@ -203,9 +197,8 @@ function mockResaveQuery(array $elements): ElementQueryInterface
 function mockAbortedResaveQuery(): ElementQueryInterface
 {
     $query = Mockery::mock(ElementQueryInterface::class);
-    $query->shouldReceive('each')
+    $query->shouldReceive('cursor')
         ->once()
-        ->with(Mockery::type(Closure::class))
         ->andThrow(new QueryAbortedException);
 
     return $query;

--- a/yii2-adapter/legacy/elements/db/ElementQuery.php
+++ b/yii2-adapter/legacy/elements/db/ElementQuery.php
@@ -49,6 +49,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema as SchemaFacade;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
@@ -4024,6 +4025,18 @@ class ElementQuery extends Query implements ElementQueryInterface
     public function whereIn($column, $values, $boolean = 'and', $not = false): static
     {
         return $this->andWhere(['in', $column, $values]);
+    }
+
+    /**
+     * @return LazyCollection<int, TElement|array>
+     */
+    public function cursor(): LazyCollection
+    {
+        return LazyCollection::make(function() {
+            foreach (Db::each($this) as $element) {
+                yield $element;
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
### Description
Switch mutating query loops from chunked `each()` iteration to `cursor()->each()`.

I moved everything to `->each` when porting, but `->cursor()` is a better match for the previous behavior 