### PR TITLE
Fix `parseEnv()` alias regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where `craft\helpers\App::parseEnv()` wasn’t resolving aliases for environment variables that referenced an alias (e.g. `@root/storage/rebrand`). ([#19029](https://github.com/craftcms/cms/issues/19029))
+
 ## 5.10.6 - 2026-06-16
 
 - Forward slashes in query strings are now encoded. ([#19057](https://github.com/craftcms/cms/pull/19057))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug where `craft\helpers\App::parseEnv()` wasn’t resolving aliases for environment variables that referenced an alias (e.g. `@root/storage/rebrand`). ([#19029](https://github.com/craftcms/cms/issues/19029))
+- Fixed a bug where `craft\helpers\App::parseEnv()` wasn’t resolving aliases for environment variables that referenced an alias (e.g. `@root/storage/rebrand`). ([#19108](https://github.com/craftcms/cms/issues/19108))
 
 ## 5.10.6 - 2026-06-16
 

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -246,7 +246,17 @@ class App
             }
 
             $result = (string)$result;
-            return $result === '' ? null : $result;
+
+            if ($result === '') {
+                return null;
+            }
+
+            // the value could itself reference an alias (e.g. `@root/storage/rebrand`)
+            if (str_starts_with($result, '@')) {
+                $result = Craft::getAlias($result, false) ?: $result;
+            }
+
+            return $result;
         }
 
         // …/$VAR/…

--- a/tests/unit/helpers/AppHelperTest.php
+++ b/tests/unit/helpers/AppHelperTest.php
@@ -104,6 +104,7 @@ class AppHelperTest extends TestCase
             'TEST_2' => 'foo${TEST_1}bar',
             'TEST_3' => 'true',
             'TEST_4' => 'false',
+            'TEST_ALIAS' => '@vendor/foo/bar',
             'TEST_DEFAULT_SITE_API_KEY' => 'abcdef',
             'TEST_EMPTY' => '',
         ];
@@ -121,6 +122,7 @@ class AppHelperTest extends TestCase
         self::assertSame('foo/footesting1bar/bar', App::parseEnv('foo/$TEST_2/bar'));
         self::assertSame(true, App::parseEnv('$TEST_3'));
         self::assertSame(false, App::parseEnv('$TEST_4'));
+        self::assertSame(Craft::getAlias('@vendor/foo/bar'), App::parseEnv('$TEST_ALIAS'));
         self::assertSame('defaultSite', App::parseEnv('$CRAFT_SITE'));
         self::assertSame('DEFAULT_SITE', App::parseEnv('$CRAFT_SITE_UPPER'));
         self::assertSame('abcdef', App::parseEnv('$TEST_${CRAFT_SITE_UPPER}_API_KEY'));


### PR DESCRIPTION
5.10.6 ([#19029](<https://github.com/craftcms/cms/issues/19029>)) added an early-return branch in `App::parseEnv()` for bare `$VAR` references, skipping the subsequent alias-resolution.

So, when an env var references an alias (e.g. `CRAFT_REBRAND_PATH=@root/storage/rebrand`) `@root` is unresolved.

On Craft Cloud this surfaced as `Failed to create directory "@root": mkdir(): Read-only file system` when the rebrand path was exercised [as documented](https://craftcms.com/docs/cloud/rebrand-assets.html).

This restores alias resolution for the bare `$VAR` case while preserving the boolean/empty handling introduced in craftcms/cms#19029.

Fixes https://github.com/craftcms/cloud/issues/171 