### PR TITLE
[6.x] Fix Twig string template exception reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a “This password does not use the Bcrypt algorithm” error that could occur when logging in with a user whose password was set in an earlier version of Craft.
+- Fixed a “File name is not a string” error that could occur when an error was encountered when rendering a string template. ([#19122](https://github.com/craftcms/cms/pull/19122))
 
 ## 6.0.0-alpha.8 - 2026-06-17
 

--- a/src/Twig/TwigExceptionMapper.php
+++ b/src/Twig/TwigExceptionMapper.php
@@ -90,7 +90,7 @@ readonly class TwigExceptionMapper
 
         $template = new $class(Twig::get());
         $src = $template->getSourceContext();
-        $templatePath = $src->getPath() ?: null;
+        $templatePath = $src->getPath() ?: $src->getName();
         $templateLine = null;
 
         if ($line !== null) {

--- a/tests/Unit/Twig/TwigExceptionMapperTest.php
+++ b/tests/Unit/Twig/TwigExceptionMapperTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Twig\TemplateRenderer;
+use CraftCms\Cms\Twig\Twig;
 use CraftCms\Cms\Twig\TwigExceptionMapper;
+use CraftCms\Cms\View\TemplateMode;
 
 it('ignores missing compiled template files', function () {
     $path = storage_path('runtime/compiled_templates/missing.php');
@@ -10,4 +13,28 @@ it('ignores missing compiled template files', function () {
     @unlink($path);
 
     expect((new TwigExceptionMapper)->resolveTemplatePathAndLine($path, 1))->toBeFalse();
+});
+
+it('keeps string template filenames reportable', function () {
+    app(Twig::class)->get(TemplateMode::Site)->enableStrictVariables();
+
+    try {
+        app(TemplateRenderer::class)->renderString('{{ app("CraftCms\\\\Cms\\\\Twig\\\\TemplateRenderer").renderString("{{ someVar }}") }}');
+    } catch (Throwable $exception) {
+        $trace = app(TwigExceptionMapper::class)->map($exception)->getTrace();
+
+        $files = collect($trace)
+            ->filter(fn (array $frame) => array_key_exists('file', $frame))
+            ->pluck('file')
+            ->all();
+
+        expect($files)
+            ->not->toBeEmpty()
+            ->each->toBeString()
+            ->and(collect($files)->contains(fn (string $file) => str_starts_with($file, '__string_template__')))->toBeTrue();
+
+        return;
+    }
+
+    $this->fail('Expected the nested string template to throw.');
 });


### PR DESCRIPTION
### Description

Fixes Twig exception mapping for inline string templates so Laravel exception reporting keeps valid string filenames instead of receiving null trace file values.
