### PR TITLE
Capitalize first word in deletion blocker messages

### DIFF
--- a/src/elements/deletionblockers/RelationDeletionBlocker.php
+++ b/src/elements/deletionblockers/RelationDeletionBlocker.php
@@ -13,6 +13,7 @@ use craft\elements\ElementCollection;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Cp;
 use craft\helpers\Html;
+use craft\helpers\StringHelper;
 
 /**
  * Class RelationDeletionBlocker
@@ -63,14 +64,14 @@ class RelationDeletionBlocker extends BaseDeletionBlocker
         /** @var class-string<ElementInterface> $targetElementType */
         $targetElementType = $this->elements->first()::class;
 
-        return Craft::t('app', 'The {numTargets, plural, =1{{targetTypeSingular} is} other{{targetTypePlural} are}} related by {numRelations, number} other {numRelations, plural, =1{{sourceTypeSingular}} other{{sourceTypePlural}}}.', [
+        return StringHelper::upperCaseFirst(Craft::t('app', 'The {numTargets, plural, =1{{targetTypeSingular} is} other{{targetTypePlural} are}} related by {numRelations, number} other {numRelations, plural, =1{{sourceTypeSingular}} other{{sourceTypePlural}}}.', [
             'sourceTypeSingular' => $this->sourceElementType::lowerDisplayName(),
             'sourceTypePlural' => $this->sourceElementType::pluralLowerDisplayName(),
             'targetTypeSingular' => $targetElementType::lowerDisplayName(),
             'targetTypePlural' => $targetElementType::pluralLowerDisplayName(),
             'numRelations' => $this->relationCount,
             'numTargets' => $this->elements->count(),
-        ]);
+        ]));
     }
 
     public function getDetails(): ?string
@@ -134,12 +135,12 @@ JS, [
                     'numRelations' => $this->relationCount,
                 ]),
                 'callback' => Html::jsWithVars(fn($message) => "resolve($message);", [
-                    Craft::t('app', 'The {numRelations, plural, =1{relation} other {relations}} will be removed once the {numTargets, plural, =1{{targetTypeSingular} is} other{{targetTypePlural} are}} deleted.', [
+                    StringHelper::upperCaseFirst(Craft::t('app', 'The {numRelations, plural, =1{relation} other {relations}} will be removed once the {numTargets, plural, =1{{targetTypeSingular} is} other{{targetTypePlural} are}} deleted.', [
                         'targetTypeSingular' => $targetElementType::lowerDisplayName(),
                         'targetTypePlural' => $targetElementType::pluralLowerDisplayName(),
                         'numRelations' => $this->relationCount,
                         'numTargets' => $numTargets,
-                    ]),
+                    ])),
                 ]),
             ],
         ];


### PR DESCRIPTION
### Description

A couple of the strings added for the deletion blocker feature in 5.10 begin with an element type name produced by `lowerDisplayName()` and `pluralLowerDisplayName()`. When the count is 1, the sentence starts with a lowercase word. In English this goes unnoticed because the strings are prefixed with `'The'`, but languages without an article render a sentence starting in lowercase. 

For example, in Norwegian the message renders as:

`artikkel er relatert til 1 annen artikkel.`

Wrapping each formatted message in `StringHelper::upperCaseFirst()` capitalizes the first letter regardless of locale, fixing the casing without affecting the element type names elsewhere in the sentence.

Again, examples in Norwegian:

Before:
<img width="368" height="146" alt="CleanShot 2026-06-19 at 23 08 12" src="https://github.com/user-attachments/assets/52c26c70-4ffa-4a35-92e7-d92357b0b132" />

After:
<img width="356" height="138" alt="CleanShot 2026-06-19 at 23 08 40" src="https://github.com/user-attachments/assets/51edf2f1-3046-421f-9057-e68352afe49b" />

_As a side note:_ even with this fix, the Norwegian translation specifically, isn't quite grammatically correct 🫠  The element type names are inserted in their indefinite base form ("artikkel", "relasjon"), but in these sentences Norwegian would use the definite form ("artikkel**en**", "relasjon**en**") — equivalent to the English "The article…" / "The relation…".

I don't think his can be solved in the static translation itself, because the ICU message string only receives the base form of the name and has no way to derive the definite form (the suffix varies by gender and inflection: artikkel → artikkelen, side → siden, produkt → produktet). I'm guessing this problem would have to be addressed in the code, e.g. by passing the definite form as a separate value. I'm unsure how to best approach that, though – but, just thought I'd mention it.

(FWIW, I'm also submitting some proposed changes to the Norwegian translations in Crowdin, that should help improve the above situation a little bit 😃)

### Related issues

