### PR TITLE
Adds missing "Delete {type}" static translation string to CpAsset

### DIFF
--- a/src/web/assets/cp/CpAsset.php
+++ b/src/web/assets/cp/CpAsset.php
@@ -198,6 +198,7 @@ JS;
             'Delete selected {type}',
             'Delete them',
             'Delete',
+            'Delete {type}',
             'Descending',
             'Desktop',
             'Device type',

--- a/src/web/assets/cp/CpAsset.php
+++ b/src/web/assets/cp/CpAsset.php
@@ -199,6 +199,7 @@ JS;
             'Delete them',
             'Delete',
             'Delete {type}',
+            'Delete {types}',
             'Descending',
             'Desktop',
             'Device type',


### PR DESCRIPTION
### Description

Adds missing `'Delete {type}'` and `'Delete {types}'` translation strings to `CpAsset`, which affected the new deletion blocker in 5.10.

Examples in Norwegian:

Before
<img width="706" height="424" alt="CleanShot 2026-06-19 at 23 41 22" src="https://github.com/user-attachments/assets/629692de-c3ec-4d42-addb-bfa305314f45" />

After
<img width="693" height="415" alt="CleanShot 2026-06-19 at 23 41 37" src="https://github.com/user-attachments/assets/b500201f-0ccc-484e-9717-852c0405daee" />

### Related issues

