### PR TITLE
[6.x] Fix plugin asset publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a “This password does not use the Bcrypt algorithm” error that could occur when logging in with a user whose password was set in an earlier version of Craft.
 - Fixed a “File name is not a string” error that could occur when an error was encountered when rendering a string template. ([#19122](https://github.com/craftcms/cms/pull/19122))
 - Fixed a bug where parsed site names would get saved to the project config. ([#19123](https://github.com/craftcms/cms/issues/19123))
+- Fixed a bug where plugin `$styles`, `$scripts`, and `$publishables` weren’t published automatically when the plugin was installed or enabled. ([#19137](https://github.com/craftcms/cms/pull/19137))
 - Fixed several issues that occurred when Craft was configured with a custom (or no) `cpTrigger`. ([#19127](https://github.com/craftcms/cms/pull/19127))
 - Fixed a bug where entry queries weren’t fetching structure data by default.
 - Fixed a bug where top-level structure elements were always repositioned to the end of the structure on save.

--- a/src/Plugin/Concerns/HasFrontendAssets.php
+++ b/src/Plugin/Concerns/HasFrontendAssets.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\Plugin\Contracts\PluginInterface;
 use CraftCms\Cms\Plugin\Events\PluginDisabling;
 use CraftCms\Cms\Plugin\Events\PluginEnabling;
 use CraftCms\Cms\Plugin\Events\PluginEvent;
+use CraftCms\Cms\Plugin\Events\PluginInstalling;
 use CraftCms\Cms\Plugin\Events\PluginUninstalling;
 use CraftCms\Cms\Plugin\Plugin;
 use CraftCms\Cms\Support\Arr;
@@ -40,24 +41,18 @@ trait HasFrontendAssets
 
     public function registerHasFrontendAssets(): void
     {
-        Event::listen(PluginEnabling::class, function (PluginEnabling $event) {
+        Event::listen([PluginEnabling::class, PluginInstalling::class], function (PluginEvent $event) {
             if (! $event->plugin instanceof static) {
                 return;
             }
 
-            if (! $config = $event->plugin->vite) {
-                return;
+            if ($config = $event->plugin->vite) {
+                [$source, $target] = $this->getSourceAndTarget($event->plugin, $config);
+
+                File::copyDirectory($source, $this->app->publicPath($target));
             }
 
-            [$source, $target] = $this->getSourceAndTarget($event->plugin, $config);
-
-            File::copyDirectory($source, $this->app->publicPath($target));
-
-            foreach (array_merge($event->plugin->styles, $event->plugin->scripts) as $asset) {
-                $destination = Str::afterLast($asset, '/');
-
-                File::copy($asset, public_path("vendor/{$event->plugin->packageName}/{$destination}"));
-            }
+            $event->plugin->copyPublishableFiles($event->plugin->frontendAssetPublishPaths());
         });
 
         Event::listen([PluginDisabling::class, PluginUninstalling::class], function (PluginEvent $event) {
@@ -111,7 +106,7 @@ trait HasFrontendAssets
         $name = static::getInstance()->packageName;
         $version = md5(static::getInstance()->version);
 
-        $assets = collect(array_merge($this->styles, $this->scripts))->mapWithKeys(fn ($public, $resource) => [$resource => $this->app->publicPath($this->getPublishablePath($public))])->all();
+        $assets = $this->frontendAssetPublishPaths();
 
         foreach ($this->styles as $public) {
             $public = "$public?v=$version";
@@ -145,5 +140,12 @@ trait HasFrontendAssets
         $ns = static::getInstance()->packageName;
 
         return "vendor/{$ns}/$path";
+    }
+
+    private function frontendAssetPublishPaths(): array
+    {
+        return collect(array_merge($this->styles, $this->scripts))
+            ->mapWithKeys(fn ($public, $resource) => [$resource => $this->app->publicPath($this->getPublishablePath($public))])
+            ->all();
     }
 }

--- a/src/Plugin/Concerns/PublishesFiles.php
+++ b/src/Plugin/Concerns/PublishesFiles.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Plugin\Concerns;
 use CraftCms\Cms\Plugin\Events\PluginDisabling;
 use CraftCms\Cms\Plugin\Events\PluginEnabling;
 use CraftCms\Cms\Plugin\Events\PluginEvent;
+use CraftCms\Cms\Plugin\Events\PluginInstalling;
 use CraftCms\Cms\Plugin\Events\PluginUninstalling;
 use CraftCms\Cms\Plugin\Plugin;
 use CraftCms\Cms\Support\File;
@@ -30,20 +31,12 @@ trait PublishesFiles
 
     public function registerPublishesFiles(): void
     {
-        Event::listen(PluginEnabling::class, function (PluginEnabling $event) {
+        Event::listen([PluginEnabling::class, PluginInstalling::class], function (PluginEvent $event) {
             if (! $event->plugin instanceof static) {
                 return;
             }
 
-            foreach ($event->plugin->publishables as $from => $to) {
-                if (File::isDirectory($from)) {
-                    File::copyDirectory($from, public_path("vendor/{$event->plugin->packageName}/{$to}"));
-
-                    continue;
-                }
-
-                File::copy($from, public_path("vendor/{$event->plugin->packageName}/{$to}/"));
-            }
+            $event->plugin->copyPublishableFiles($event->plugin->publishableFilePaths());
         });
 
         Event::listen([PluginDisabling::class, PluginUninstalling::class], function (PluginEvent $event) {
@@ -58,10 +51,8 @@ trait PublishesFiles
     public function bootPublishesFiles(): void
     {
         $handle = self::getInstance()->handle;
-        $name = self::getInstance()->packageName;
 
-        $publishes = Collection::make($this->publishables)
-            ->map(fn (string $to) => public_path("vendor/{$name}/{$to}"));
+        $publishes = Collection::make($this->publishableFilePaths());
 
         if ($publishes->isNotEmpty()) {
             $this->publishes($publishes->all(), $handle);
@@ -71,5 +62,12 @@ trait PublishesFiles
     public function asset(string $path): string
     {
         return asset("vendor/$this->packageName/$path");
+    }
+
+    private function publishableFilePaths(): array
+    {
+        return Collection::make($this->publishables)
+            ->map(fn (string $to) => public_path("vendor/{$this->packageName}/{$to}"))
+            ->all();
     }
 }

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -162,7 +162,7 @@ abstract class Plugin extends ServiceProvider implements PluginInterface
                 continue;
             }
 
-            File::ensureDirectoryExists(dirname($to));
+            File::ensureDirectoryExists(dirname((string) $to));
             File::copy($from, $to);
         }
     }

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -153,6 +153,20 @@ abstract class Plugin extends ServiceProvider implements PluginInterface
 
     public function bootPlugin(): void {}
 
+    protected function copyPublishableFiles(array $paths): void
+    {
+        foreach ($paths as $from => $to) {
+            if (File::isDirectory($from)) {
+                File::copyDirectory($from, $to);
+
+                continue;
+            }
+
+            File::ensureDirectoryExists(dirname($to));
+            File::copy($from, $to);
+        }
+    }
+
     protected function registerSerializableClasses(array $classes): void
     {
         $existing = $this->app->make(Repository::class)->get('cache.serializable_classes');

--- a/tests/Feature/Plugin/PluginsTest.php
+++ b/tests/Feature/Plugin/PluginsTest.php
@@ -9,6 +9,7 @@ use CraftCms\Cms\Plugin\Events\SavingPluginSettings;
 use CraftCms\Cms\Plugin\Exceptions\InvalidPluginException;
 use CraftCms\Cms\Plugin\Plugins;
 use CraftCms\Cms\Shared\Enums\LicenseKeyStatus;
+use CraftCms\Cms\Support\File;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Tests\TestClasses\TestPlugin\src\TestPlugin;
 use CraftCms\Cms\View\TemplateMode;
@@ -28,8 +29,48 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    File::deleteDirectory(storage_path('framework/testing/test-plugin-assets'));
+    File::deleteDirectory(public_path('vendor/craftcms/test-plugin'));
+    TestPlugin::$customPublishables = [];
+    TestPlugin::$customStyles = [];
+    TestPlugin::$customScripts = [];
+
     app()->forgetInstance(Plugins::class);
 });
+
+function configureTestPluginAssets(): array
+{
+    $sourcePath = storage_path('framework/testing/test-plugin-assets');
+    $targetPath = public_path('vendor/craftcms/test-plugin');
+
+    File::deleteDirectory($sourcePath);
+    File::deleteDirectory($targetPath);
+    File::ensureDirectoryExists("{$sourcePath}/css");
+    File::ensureDirectoryExists("{$sourcePath}/js");
+    File::ensureDirectoryExists("{$sourcePath}/docs");
+
+    File::put("{$sourcePath}/css/test.css", 'body { color: red; }');
+    File::put("{$sourcePath}/js/test.js", 'window.testPlugin = true;');
+    File::put("{$sourcePath}/docs/readme.txt", 'Test plugin readme');
+
+    TestPlugin::$customPublishables = [
+        "{$sourcePath}/docs/readme.txt" => 'docs/readme.txt',
+    ];
+
+    TestPlugin::$customStyles = [
+        "{$sourcePath}/css/test.css" => 'css/test.css',
+    ];
+
+    TestPlugin::$customScripts = [
+        "{$sourcePath}/js/test.js" => 'js/test.js',
+    ];
+
+    return [
+        "{$targetPath}/css/test.css",
+        "{$targetPath}/js/test.js",
+        "{$targetPath}/docs/readme.txt",
+    ];
+}
 
 it('can load plugins', function () {
     app()->forgetInstance(Plugins::class);
@@ -111,6 +152,33 @@ it('can uninstall and install a plugin', function () {
 
     expect($this->plugins->isPluginInstalled('test-plugin'))->toBeTrue();
     expect($this->plugins->isPluginEnabled('test-plugin'))->toBeTrue();
+});
+
+it('publishes configured files when enabling a plugin', function () {
+    $paths = configureTestPluginAssets();
+
+    TestPlugin::getInstance()->register();
+
+    $this->plugins->enablePlugin('test-plugin');
+
+    foreach ($paths as $path) {
+        expect(File::exists($path))->toBeTrue();
+    }
+});
+
+it('publishes configured files when installing a plugin', function () {
+    $this->plugins->enablePlugin('test-plugin');
+    $this->plugins->uninstallPlugin('test-plugin');
+
+    $paths = configureTestPluginAssets();
+
+    TestPlugin::getInstance()->register();
+
+    $this->plugins->installPlugin('test-plugin');
+
+    foreach ($paths as $path) {
+        expect(File::exists($path))->toBeTrue();
+    }
 });
 
 it('ignores missing transaction exceptions during uninstall commits', function () {

--- a/tests/TestClasses/TestPlugin/src/TestPlugin.php
+++ b/tests/TestClasses/TestPlugin/src/TestPlugin.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\Database\Migration;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Element\Element;
 use CraftCms\Cms\Field\Contracts\FieldInterface;
+use CraftCms\Cms\Plugin\Contracts\PluginInterface;
 use CraftCms\Cms\Plugin\Plugin;
 use CraftCms\Cms\Utility\Utility;
 use CraftCms\Cms\Validation\Contracts\Validatable;
@@ -27,6 +28,15 @@ class TestPlugin extends Plugin
 
     /** @var class-string<Request> */
     public static string $settingsRequestClass = Request::class;
+
+    /** @var array<string, string> */
+    public static array $customPublishables = [];
+
+    /** @var array<string, string> */
+    public static array $customStyles = [];
+
+    /** @var array<string, string> */
+    public static array $customScripts = [];
 
     public ?string $basePathOverride = null;
 
@@ -141,6 +151,24 @@ class TestPlugin extends Plugin
             'standard',
             'pro',
         ];
+    }
+
+    #[Override]
+    public static function create(array $config): PluginInterface
+    {
+        if (self::$customPublishables !== []) {
+            $config['publishables'] = self::$customPublishables;
+        }
+
+        if (self::$customStyles !== []) {
+            $config['styles'] = self::$customStyles;
+        }
+
+        if (self::$customScripts !== []) {
+            $config['scripts'] = self::$customScripts;
+        }
+
+        return parent::create($config);
     }
 
     #[Override]


### PR DESCRIPTION
### Description
Fixes automatic publishing of plugin `$styles`, `$scripts`, and `$publishables` on install and enable by sharing the same publish path map used for manual vendor publishing.

### Related issues
Fixes #19036