### PR TITLE
[6.x] Fix system timezone default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a “File name is not a string” error that could occur when an error was encountered when rendering a string template. ([#19122](https://github.com/craftcms/cms/pull/19122))
 - Fixed a bug where parsed site names would get saved to the project config. ([#19123](https://github.com/craftcms/cms/issues/19123))
 - Fixed several issues that occurred when Craft was configured with a custom (or no) `cpTrigger`. ([#19127](https://github.com/craftcms/cms/pull/19127))
+- Fixed a bug where Craft wasn’t applying the Settings → General timezone to PHP’s default timezone. ([#19138](https://github.com/craftcms/cms/pull/19138))
 - Fixed a bug where entry queries weren’t fetching structure data by default.
 - Fixed a bug where top-level structure elements were always repositioned to the end of the structure on save.
 - Fixed a bug where the Settings index page didn’t include “Globals”, “Categories”, or “Tags” links, when the concepts were supported. ([#19120](https://github.com/craftcms/cms/pull/19120))

--- a/src/Cms.php
+++ b/src/Cms.php
@@ -70,14 +70,33 @@ readonly class Cms
         }
 
         if (! $timezone) {
-            $timezone = Cms::config()->timezone ?? ProjectConfig::get('system.timeZone');
+            return self::systemTimezone();
         }
+
+        return self::validatedTimezone($timezone);
+    }
+
+    public static function systemTimezone(): string
+    {
+        $timezone = Cms::config()->timezone ?? ProjectConfig::get('system.timeZone') ?? config('app.timezone', 'UTC');
+
+        return self::validatedTimezone($timezone);
+    }
+
+    public static function setDefaultTimezone(?string $timezone = null): void
+    {
+        $timezone = Cms::config()->timezone ?? $timezone ?? ProjectConfig::get('system.timeZone') ?? config('app.timezone', 'UTC');
+
+        date_default_timezone_set(self::validatedTimezone($timezone));
+    }
+
+    private static function validatedTimezone(?string $timezone): string
+    {
+        $timezone = Env::parse($timezone);
 
         if (! $timezone) {
-            $timezone = config('app.timezone', 'UTC');
+            return 'UTC';
         }
-
-        $timezone = Env::parse($timezone);
 
         if ($timezone !== 'UTC') {
             // Make sure that ICU supports this timezone

--- a/src/ProjectConfig/ProjectConfigServiceProvider.php
+++ b/src/ProjectConfig/ProjectConfigServiceProvider.php
@@ -78,6 +78,13 @@ class ProjectConfigServiceProvider extends ServiceProvider
         ]);
 
         $projectConfig
+            // System settings
+            ->onAdd(ProjectConfig::PATH_SYSTEM, fn (ConfigEvent $event) => Cms::setDefaultTimezone($event->newValue['timeZone'] ?? config('app.timezone', 'UTC')))
+            ->onUpdate(ProjectConfig::PATH_SYSTEM, fn (ConfigEvent $event) => Cms::setDefaultTimezone($event->newValue['timeZone'] ?? config('app.timezone', 'UTC')))
+            ->onRemove(ProjectConfig::PATH_SYSTEM, fn () => Cms::setDefaultTimezone(config('app.timezone', 'UTC')))
+            ->onAdd(ProjectConfig::PATH_SYSTEM.'.timeZone', fn (ConfigEvent $event) => Cms::setDefaultTimezone($event->newValue))
+            ->onUpdate(ProjectConfig::PATH_SYSTEM.'.timeZone', fn (ConfigEvent $event) => Cms::setDefaultTimezone($event->newValue))
+            ->onRemove(ProjectConfig::PATH_SYSTEM.'.timeZone', fn () => Cms::setDefaultTimezone(config('app.timezone', 'UTC')))
             // Address field layout
             ->onAdd(ProjectConfig::PATH_ADDRESS_FIELD_LAYOUTS, fn (ConfigEvent $event) => app(Addresses::class)->handleChangedAddressFieldLayout($event))
             ->onUpdate(ProjectConfig::PATH_ADDRESS_FIELD_LAYOUTS, fn (ConfigEvent $event) => app(Addresses::class)->handleChangedAddressFieldLayout($event))

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -95,6 +95,7 @@ class AppServiceProvider extends ServiceProvider
 
         $this->setNamespace();
         $this->bootAliases();
+        Cms::setDefaultTimezone();
 
         $this->app->booted(function () {
             /**

--- a/tests/Feature/Http/Controllers/Settings/GeneralSettingsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/GeneralSettingsControllerTest.php
@@ -57,6 +57,9 @@ it('exposes timezone options on the settings screen', function () {
 });
 
 it('can save settings', function () {
+    Cms::config()->timezone = null;
+    date_default_timezone_set('UTC');
+
     post(action([GeneralSettingsController::class, 'store']), [
         'name' => 'A new app name',
         'live' => true,
@@ -68,7 +71,8 @@ it('can save settings', function () {
     expect(ProjectConfig::get('system.name'))->toBe('A new app name')
         ->and(ProjectConfig::get('system.live'))->toBe(true)
         ->and(ProjectConfig::get('system.retryDuration'))->toBe(60)
-        ->and(ProjectConfig::get('system.timeZone'))->toBe('America/New_York');
+        ->and(ProjectConfig::get('system.timeZone'))->toBe('America/New_York')
+        ->and(date_default_timezone_get())->toBe('America/New_York');
 });
 
 it('clears retryDuration when not provided', function () {
@@ -121,6 +125,8 @@ it('can save settings with environment variables', function () {
     putenv('GENERAL_SETTINGS_NAME=Env App');
     putenv('GENERAL_SETTINGS_LIVE=true');
     putenv('GENERAL_SETTINGS_TIMEZONE=America/New_York');
+    Cms::config()->timezone = null;
+    date_default_timezone_set('UTC');
 
     post(action([GeneralSettingsController::class, 'store']), [
         'name' => '$GENERAL_SETTINGS_NAME',
@@ -131,7 +137,8 @@ it('can save settings with environment variables', function () {
 
     expect(ProjectConfig::get('system.name'))->toBe('$GENERAL_SETTINGS_NAME')
         ->and(ProjectConfig::get('system.live'))->toBe('$GENERAL_SETTINGS_LIVE')
-        ->and(ProjectConfig::get('system.timeZone'))->toBe('$GENERAL_SETTINGS_TIMEZONE');
+        ->and(ProjectConfig::get('system.timeZone'))->toBe('$GENERAL_SETTINGS_TIMEZONE')
+        ->and(date_default_timezone_get())->toBe('America/New_York');
 });
 
 it('validates resolved environment variable live values', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -73,6 +73,7 @@ class TestCase extends Orchestra
         // This is needed because AppServiceProvider::setTimezone() runs during boot,
         // before RefreshDatabase has prepared the database, potentially reading stale data
         Cms::config()->timezone('America/Los_Angeles');
+        Cms::setDefaultTimezone();
 
         // Tests run in Cp by default
         TemplateMode::set(TemplateMode::Cp);

--- a/tests/Unit/CmsTest.php
+++ b/tests/Unit/CmsTest.php
@@ -79,6 +79,18 @@ it('uses the logged-in CP user timezone preference first', function () {
     expect(Cms::timezone())->toBe('Europe/Brussels');
 });
 
+it('resolves the system timezone without CP user preferences', function () {
+    Cms::config()->cpTrigger = 'admin';
+    Cms::config()->timezone = null;
+    Config::set('app.timezone', 'UTC');
+    app()->instance('request', Request::create('/admin'));
+
+    Users::shouldReceive('getUserPreference')->never();
+    ProjectConfig::shouldReceive('get')->once()->with('system.timeZone')->andReturn('Europe/Brussels');
+
+    expect(Cms::systemTimezone())->toBe('Europe/Brussels');
+});
+
 it('falls back through configured timezone sources', function (?string $configTimezone, ?string $projectConfigTimezone, string $appTimezone, string $expected) {
     Cms::config()->cpTrigger = 'admin';
     Cms::config()->timezone = $configTimezone;
@@ -88,6 +100,22 @@ it('falls back through configured timezone sources', function (?string $configTi
     ProjectConfig::shouldReceive('get')->with('system.timeZone')->andReturn($projectConfigTimezone);
 
     expect(Cms::timezone())->toBe($expected);
+})->with([
+    'general config' => ['Europe/Amsterdam', 'Europe/Brussels', 'UTC', 'Europe/Amsterdam'],
+    'project config' => [null, 'Europe/Brussels', 'UTC', 'Europe/Brussels'],
+    'app config' => [null, null, 'America/New_York', 'America/New_York'],
+]);
+
+it('sets the PHP default timezone from system timezone sources', function (?string $configTimezone, ?string $projectConfigTimezone, string $appTimezone, string $expected) {
+    Cms::config()->timezone = $configTimezone;
+    Config::set('app.timezone', $appTimezone);
+    ProjectConfig::shouldReceive('get')->with('system.timeZone')->andReturn($projectConfigTimezone);
+
+    date_default_timezone_set('UTC');
+
+    Cms::setDefaultTimezone();
+
+    expect(date_default_timezone_get())->toBe($expected);
 })->with([
     'general config' => ['Europe/Amsterdam', 'Europe/Brussels', 'UTC', 'Europe/Amsterdam'],
     'project config' => [null, 'Europe/Brussels', 'UTC', 'Europe/Brussels'],

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -72,7 +72,7 @@ class UnitTestCase extends Orchestra
         app()->setLocale('en-US');
 
         Cms::config()->timezone('America/Los_Angeles');
-        date_default_timezone_set('America/Los_Angeles');
+        Cms::setDefaultTimezone();
 
         if (($token = getenv('TEST_TOKEN')) !== false) {
             $compiledTemplatesPath = storage_path("runtime/compiled_templates_$token");


### PR DESCRIPTION
### Description
Fixes Craft's PHP default timezone sync so the Settings -> General/project-config timezone is applied after Laravel bootstrap and when system timezone project config changes, while preserving the GeneralConfig override and CP user preference behavior.

### Related issues
- Fixes #19136