### PR TITLE
[6.x] Add relative time formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added `CraftCms\Yii2Adapter\Database\DeprecatedTable`.
+- Added `CraftCms\Cms\Translation\Formatter::asRelativeTime()`. ([#19146](https://github.com/craftcms/cms/pull/19146))
 - `craft\elements\Category::find()` now returns a `CraftCms\Yii2Adapter\Element\Queries\CategoryQuery` object. ([#19120](https://github.com/craftcms/cms/pull/19120))
 - `craft\elements\GlobalSet::find()` now returns a `CraftCms\Yii2Adapter\Element\Queries\GlobalSetQuery` object. ([#19120](https://github.com/craftcms/cms/pull/19120))
 - `craft\elements\Tag::find()` now returns a `CraftCms\Yii2Adapter\Element\Queries\TagQuery` object. ([#19120](https://github.com/craftcms/cms/pull/19120))

--- a/src/Translation/Formatter.php
+++ b/src/Translation/Formatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Translation;
 
 use Carbon\CarbonInterface;
+use Carbon\CarbonInterval;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Support\DateTimeHelper;
 use CraftCms\Cms\Support\Str;
@@ -375,6 +376,41 @@ class Formatter
         }
 
         return $this->asDecimalFallback($multipliedValue, $decimals).'%';
+    }
+
+    public function asRelativeTime(DateInterval|string|int|DateTimeInterface|null $value, string|int|DateTimeInterface|null $referenceTime = null): string
+    {
+        if (is_null($value)) {
+            return '';
+        }
+
+        if ($value instanceof DateInterval) {
+            return CarbonInterval::instance($value)
+                ->locale($this->locale)
+                ->forHumans(CarbonInterface::DIFF_RELATIVE_TO_NOW, false, 1);
+        }
+
+        $dateThen = DateTimeHelper::toDateTime(
+            value: $value,
+            assumeSystemTimeZone: false,
+            setToSystemTimeZone: false,
+        ) ?: throw new InvalidArgumentException("'$value' is not a valid date time value.");
+
+        $dateThen = Date::instance($dateThen)->setTimezone($this->timeZone);
+
+        $dateNow = $referenceTime === null
+            ? Date::now($this->timeZone)
+            : (DateTimeHelper::toDateTime(
+                value: $referenceTime,
+                assumeSystemTimeZone: false,
+                setToSystemTimeZone: false,
+            ) ?: throw new InvalidArgumentException("'$referenceTime' is not a valid date time value."));
+
+        $dateNow = Date::instance($dateNow)->setTimezone($this->timeZone);
+
+        return $dateThen
+            ->locale($this->locale)
+            ->diffForHumans($dateNow, CarbonInterface::DIFF_RELATIVE_TO_NOW);
     }
 
     public function asSize(string|int|float|null $bytes, ?int $decimals = null): string

--- a/tests/Unit/Translation/FormatterTest.php
+++ b/tests/Unit/Translation/FormatterTest.php
@@ -6,9 +6,14 @@ use CraftCms\Cms\Cms;
 use CraftCms\Cms\Support\Facades\I18N;
 use CraftCms\Cms\Translation\Formatter;
 use CraftCms\Cms\Translation\Locale;
+use Illuminate\Support\Facades\Date;
 
 beforeEach(function () {
     $this->formatter = app(Formatter::class);
+});
+
+afterEach(function () {
+    Date::setTestNow();
 });
 
 test('asInteger', function (mixed $value, string $output, ?string $locale = null) {
@@ -271,6 +276,38 @@ test('asDuration', function () {
 
     // null display
     $this->assertSame('', $this->formatter->asDuration(null));
+});
+
+test('asRelativeTime', function (mixed $input, string $output, mixed $referenceTime = null, ?string $locale = null) {
+    $this->formatter->locale = $locale;
+    $this->formatter->timeZone = 'UTC';
+
+    Date::setTestNow(new DateTimeImmutable('2021-01-01 12:00:00', new DateTimeZone('UTC')));
+
+    expect($this->formatter->asRelativeTime($input, $referenceTime))->toBe($output);
+})->with(function () {
+    $referenceTime = new DateTimeImmutable('2021-01-01 12:00:00', new DateTimeZone('UTC'));
+    $futureInterval = new DateInterval('PT2H');
+    $futureInterval->invert = true;
+
+    return [
+        'null display' => [null, ''],
+        'past date' => [new DateTimeImmutable('2021-01-01 10:00:00', new DateTimeZone('UTC')), '2 hours ago', $referenceTime],
+        'future date' => [new DateTimeImmutable('2021-01-01 14:00:00', new DateTimeZone('UTC')), '2 hours from now', $referenceTime],
+        'same date' => [new DateTimeImmutable('2021-01-01 12:00:00', new DateTimeZone('UTC')), '0 seconds ago', $referenceTime],
+        'past date interval' => [new DateInterval('PT2H'), '2 hours ago'],
+        'future date interval' => [$futureInterval, '2 hours from now'],
+        'default reference time' => [new DateTimeImmutable('2021-01-01 11:58:00', new DateTimeZone('UTC')), '2 minutes ago'],
+        'integer date value' => [3600, '1578 years from now', $referenceTime],
+        'localized output' => [new DateTimeImmutable('2021-01-01 10:00:00', new DateTimeZone('UTC')), '2 uur geleden', $referenceTime, 'nl-BE'],
+    ];
+});
+
+test('asRelativeTime rejects invalid date time values', function () {
+    $this->formatter->timeZone = 'UTC';
+
+    expect(fn () => $this->formatter->asRelativeTime(0))
+        ->toThrow(InvalidArgumentException::class, "'0' is not a valid date time value.");
 });
 
 test('asTimestamp', function (mixed $input, string $output, ?string $locale = null) {


### PR DESCRIPTION
### Description

Adds `Formatter::asRelativeTime()` with Carbon-backed relative output and existing Craft date normalization for date inputs.

It slightly changes the output compared to the legacy Yii version:

Case | Yii | Carbon
-- | -- | --
same time | just now | 0 seconds ago
past 1 second | a second ago | 1 second ago
future 1 second | in a second | 1 second from now
past 1 minute | a minute ago | 1 minute ago
future 1 minute | in a minute | 1 minute from now
past 1 hour | an hour ago | 1 hour ago
future 1 hour | in an hour | 1 hour from now
past 2 hours | 2 hours ago | 2 hours ago
future 2 hours | in 2 hours | 2 hours from now
future 2 days/months/years | in 2 days | 2 days from now

If this is an issue I can change the implementation to match Yii's formatting, but that would mean taking ownership of all the necessary translations to make that happen

### Related issues

Fixes #19144