### PR TITLE
[6.x] Fix Craft 6 migration track upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Renamed `CraftCms\Cms\Twig\PageLifecycle` to `CraftCms\Cms\View\PageLifecycle`. ([#19148](https://github.com/craftcms/cms/pull/19148))
 - Renamed `CraftCms\Cms\Twig\TemplateResolver` to `CraftCms\Cms\View\TemplateResolver`. ([#19148](https://github.com/craftcms/cms/pull/19148))
 - Fixed a bug where anonymous homepage and fallback site-template requests could bypass offline-site access enforcement. ([#19151](https://github.com/craftcms/cms/pull/19151))
+- Fixed an error that could occur during Craft 6 upgrades when the `migrations` table was missing its `track` column. ([#19168](https://github.com/craftcms/cms/pull/19168))
 
 ## 6.0.0-alpha.9 - 2026-06-23
 

--- a/src/Database/Commands/MigrateCommand.php
+++ b/src/Database/Commands/MigrateCommand.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\Console\CraftCommand;
 use CraftCms\Cms\Console\PromptTask;
 use CraftCms\Cms\Database\Commands\Concerns\BackupTrait;
 use CraftCms\Cms\Database\Events\MigratorsResolving;
+use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Plugin\Plugins;
 use CraftCms\Cms\Support\Str;
@@ -237,6 +238,8 @@ class MigrateCommand extends Command implements Isolatable
      */
     private function prepareDatabase(): void
     {
+        app(LaravelMigrations::class)->ensureMigrationTableTrackColumn();
+
         if ($this->getMigrator('craft')->repositoryExists()) {
             return;
         }

--- a/tests/Feature/Database/Commands/MigrateCommandTest.php
+++ b/tests/Feature/Database/Commands/MigrateCommandTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Database\Table;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 use function Pest\Laravel\artisan;
 
@@ -22,4 +24,23 @@ it('runs migrations', function () {
         ->run();
 
     expect(DB::table(Table::MIGRATIONS)->count())->toBeGreaterThan(0);
+});
+
+it('adds the migration track column before checking pending migrations', function () {
+    Schema::dropIfExists(Table::MIGRATIONS);
+    Schema::create(Table::MIGRATIONS, function (Blueprint $table) {
+        $table->id();
+        $table->string('migration');
+        $table->integer('batch');
+    });
+
+    artisan('craft:migrate:all', [
+        '--force' => true,
+        '--no-backup' => true,
+        '--track' => 'craft',
+    ])
+        ->expectsConfirmation('Apply the above migrations?', 'yes')
+        ->assertSuccessful();
+
+    expect(Schema::hasColumn(Table::MIGRATIONS, 'track'))->toBeTrue();
 });


### PR DESCRIPTION
### Description
Adds the missing Craft 6 migration-table track-column repair before migration status is queried, so upgraded Craft 5 projects can run Craft migrations.

### Related issues
Fixes #19165
