### PR TITLE
[6.x] Add CP component registry

### DIFF
--- a/resources/js/bootstrap/components.test.ts
+++ b/resources/js/bootstrap/components.test.ts
@@ -1,0 +1,52 @@
+import {describe, expect, it, vi} from 'vitest';
+import {createCpComponentRegistry} from './components';
+import type {Component} from 'vue';
+
+const testComponent = {name: 'TestComponent'} as Component;
+const alternateComponent = {name: 'AlternateComponent'} as Component;
+
+describe('CP component registry', () => {
+  it('installs registered components', () => {
+    const registry = createCpComponentRegistry();
+    const app = {
+      component: vi.fn(),
+    };
+
+    registry.register('TestComponent', testComponent);
+    registry.install(app as any);
+
+    expect(app.component).toHaveBeenCalledWith('TestComponent', testComponent);
+  });
+
+  it('registers components added after install', () => {
+    const registry = createCpComponentRegistry();
+    const app = {
+      component: vi.fn(),
+    };
+
+    registry.install(app as any);
+    registry.register('TestComponent', testComponent);
+
+    expect(app.component).toHaveBeenCalledWith('TestComponent', testComponent);
+  });
+
+  it('allows duplicate registrations with the same value', () => {
+    const registry = createCpComponentRegistry();
+
+    registry.register('TestComponent', testComponent);
+
+    expect(() => {
+      registry.register('TestComponent', testComponent);
+    }).not.toThrow();
+  });
+
+  it('fails duplicate registrations with a different value', () => {
+    const registry = createCpComponentRegistry();
+
+    registry.register('TestComponent', testComponent);
+
+    expect(() => {
+      registry.register('TestComponent', alternateComponent);
+    }).toThrow('CP component already registered: TestComponent');
+  });
+});

--- a/resources/js/bootstrap/components.ts
+++ b/resources/js/bootstrap/components.ts
@@ -1,0 +1,92 @@
+import type {App, Component} from 'vue';
+import {defineAsyncComponent} from 'vue';
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type CpComponentModule = {
+  default: Component;
+};
+
+export type CpComponentLoader = () => MaybePromise<
+  Component | CpComponentModule
+>;
+
+export type CpComponentRegistration = Component | CpComponentLoader;
+
+export interface CpComponentRegistry {
+  register(name: string, componentOrLoader: CpComponentRegistration): void;
+  install(app: App): void;
+}
+
+function isLoader(
+  componentOrLoader: CpComponentRegistration
+): componentOrLoader is CpComponentLoader {
+  if (typeof componentOrLoader !== 'function') {
+    return false;
+  }
+
+  return !('render' in componentOrLoader) && !('setup' in componentOrLoader);
+}
+
+function asyncComponent(loader: CpComponentLoader): Component {
+  return defineAsyncComponent(async () => {
+    const component = await loader();
+
+    if ('default' in component) {
+      return component.default;
+    }
+
+    return component;
+  });
+}
+
+export function createCpComponentRegistry(): CpComponentRegistry {
+  const components = new Map<string, CpComponentRegistration>();
+  let app: App | null = null;
+
+  function registerWithApp(
+    app: App,
+    name: string,
+    componentOrLoader: CpComponentRegistration
+  ) {
+    app.component(
+      name,
+      isLoader(componentOrLoader)
+        ? asyncComponent(componentOrLoader)
+        : componentOrLoader
+    );
+  }
+
+  return {
+    register(name, componentOrLoader) {
+      const existingComponent = components.get(name);
+
+      if (
+        existingComponent !== undefined &&
+        existingComponent !== componentOrLoader
+      ) {
+        throw new Error(`CP component already registered: ${name}`);
+      }
+
+      if (existingComponent !== undefined) {
+        return;
+      }
+
+      components.set(name, componentOrLoader);
+      if (app) {
+        registerWithApp(app, name, componentOrLoader);
+      }
+    },
+
+    install(installedApp) {
+      if (app === installedApp) {
+        return;
+      }
+
+      app = installedApp;
+      components.forEach((componentOrLoader, name) => {
+        registerWithApp(installedApp, name, componentOrLoader);
+      });
+    },
+  };
+}

--- a/resources/js/bootstrap/cp.ts
+++ b/resources/js/bootstrap/cp.ts
@@ -17,6 +17,7 @@ import DeprecationErrorsToolbar from '@/modules/utilities/components/deprecation
 import {setTranslations} from '@craftcms/cp/utilities/translate.ts.mjs';
 import {setUrlDefaults} from '@/wayfinder';
 import {inertiaPageRegistry, resolveInertiaPage} from './inertia-pages.js';
+import {createCpComponentRegistry} from './components.js';
 
 let bootedCallbacks: Array<(instance: any) => void> = [];
 let bootingCallbacks: Array<(instance: any) => void> = [];
@@ -24,6 +25,7 @@ let bootingCallbacks: Array<(instance: any) => void> = [];
 // Instantiate services
 const config = ConfigService.getInstance();
 const queue = QueueService.getInstance();
+const components = createCpComponentRegistry();
 
 function routeSegment(value: unknown): string {
   if (value === null || value === undefined) {
@@ -51,6 +53,10 @@ const Cp = {
 
   get $inertia() {
     return inertiaPageRegistry;
+  },
+
+  get $components() {
+    return components;
   },
 
   booted(callback: (instance: any) => void) {
@@ -119,6 +125,8 @@ const Cp = {
         app.component('ProjectConfig', ProjectConfig);
         app.component('AssetIndexes', AssetIndexes);
         app.component('SystemMessages', SystemMessages);
+
+        components.install(app);
       },
     });
 

--- a/resources/js/common/types/globals.d.ts
+++ b/resources/js/common/types/globals.d.ts
@@ -1,4 +1,5 @@
 import type {CpServices} from '@craftcms/cp/types/globals.d.ts';
+import type {CpComponentRegistry} from '@/bootstrap/components';
 import type {InertiaPageRegistry} from '@/bootstrap/inertia-pages';
 
 declare module '@tanstack/vue-table' {
@@ -54,6 +55,7 @@ type Site = {
 };
 
 interface CpStatic extends CpServices {
+  $components: CpComponentRegistry;
   $inertia: InertiaPageRegistry;
 }
 


### PR DESCRIPTION
### Description

Control Panel Components

Plugins can register Vue components with the Control Panel app from any CP asset bundle. Registered components can then be used by dynamic CP HTML rendered through Inertia-backed screens.

Use kebab-case names when the component will be referenced from HTML generated by PHP or Twig.

Registering a Component

```javascript
import MyPluginWidget from './MyPluginWidget.vue';

Cp.$components.register('my-plugin-widget', MyPluginWidget);
```

Components registered before the Control Panel app starts are installed during app boot. Components registered after the app has started are installed immediately.

Then render the component tag from the server:

```twig
<my-plugin-widget entry-id="{{ entry.id }}"></my-plugin-widget>
```

Lazy Components

Pass a loader when the component should be code-split by the plugin build:

```javascript
Cp.$components.register('my-plugin-widget', () => import('./MyPluginWidget.vue'));
```

Loaders may return a Vue component directly, or a module with a default component export.

Register each component name once. Registering the same component for the same name again is ignored. Registering the same name with a different component throws an error so conflicting plugin assets fail loudly.
