### PR TITLE
Use View::make() for Blade template rendering in DynamicRoute

### DIFF
--- a/src/Route/DynamicRoute.php
+++ b/src/Route/DynamicRoute.php
@@ -64,7 +64,7 @@ class DynamicRoute
         }
 
         if (Str::endsWith($resolvedTemplate, '.blade.php')) {
-            return view()->file($resolvedTemplate, $variables)->render();
+            return view()->make($template, $variables)->render();
         }
 
         return pageTemplate($template, $variables);


### PR DESCRIPTION
### Description
This updates Blade rendering in DynamicRoute to use `view()->make($template, $variables)` instead of `view()->file($resolvedTemplate, $variables)`.

#### Why:

`View::file()` sets both the view name and path to the resolved file path.
That results in path-based Blade view names (e.g. `/var/www/app/resources/views/welcome.blade.php`).
Path-based names make named view composers (e.g. `View::composer('welcome', ...)`) not behave as expected.
Using `View::make()` preserves Laravel’s logical view naming for composer matching while still resolving the same Blade template file for rendering.

### Related issues
#19177