### PR TITLE
[6.x] Fix source table attribute normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Renamed `CraftCms\Cms\Twig\TemplateResolver` to `CraftCms\Cms\View\TemplateResolver`. ([#19148](https://github.com/craftcms/cms/pull/19148))
 - Fixed a bug where anonymous homepage and fallback site-template requests could bypass offline-site access enforcement. ([#19151](https://github.com/craftcms/cms/pull/19151))
 - Fixed an error that could occur during Craft 6 upgrades when the `migrations` table was missing its `track` column. ([#19168](https://github.com/craftcms/cms/pull/19168))
+- Fixed an error that occurred when saving Users source settings after selecting the Groups table column. ([#19184](https://github.com/craftcms/cms/pull/19184))
 
 ## 6.0.0-alpha.9 - 2026-06-23
 

--- a/src/Http/Controllers/Elements/ElementSourcesController.php
+++ b/src/Http/Controllers/Elements/ElementSourcesController.php
@@ -332,13 +332,11 @@ readonly class ElementSourcesController
 
     private function tableAttributeKeys(array $attributes): array|string
     {
-        $attributes = $attributes
-            |> (fn (array $attributes) => array_map(
-                fn (mixed $attribute) => data_get($attribute, 'value', $attribute),
-                $attributes,
-            ))
-            |> array_filter(...)
-            |> array_values(...);
+        $attributes = collect($attributes)
+            ->map(fn (mixed $attribute) => data_get($attribute, 'value', $attribute))
+            ->filter()
+            ->values()
+            ->all();
 
         return $attributes ?: '-';
     }

--- a/src/Http/Controllers/Elements/ElementSourcesController.php
+++ b/src/Http/Controllers/Elements/ElementSourcesController.php
@@ -262,7 +262,7 @@ readonly class ElementSourcesController
                 $postedSettings = $sourceSettings[$key];
 
                 if ($type !== ElementSources::TYPE_HEADING) {
-                    $sourceConfig['tableAttributes'] = array_values(array_filter($postedSettings['tableAttributes'] ?? [])) ?: '-';
+                    $sourceConfig['tableAttributes'] = $this->tableAttributeKeys($postedSettings['tableAttributes'] ?? []);
                 }
 
                 if (isset($postedSettings['defaultSort'])) {
@@ -328,5 +328,18 @@ readonly class ElementSourcesController
         return $this->asSuccess(t('Source settings saved'), data: [
             'disabledSourceKeys' => $disabledSourceKeys,
         ]);
+    }
+
+    private function tableAttributeKeys(array $attributes): array|string
+    {
+        $attributes = $attributes
+            |> (fn (array $attributes) => array_map(
+                fn (mixed $attribute) => data_get($attribute, 'value', $attribute),
+                $attributes,
+            ))
+            |> array_filter(...)
+            |> array_values(...);
+
+        return $attributes ?: '-';
     }
 }

--- a/tests/Feature/Http/Controllers/Elements/ElementSourcesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/ElementSourcesControllerTest.php
@@ -365,6 +365,30 @@ it('stores single-page source settings without page reordering', function () {
         ->and($projectConfig->get(sprintf('%s.%s', ProjectConfig::PATH_ELEMENT_SOURCE_PAGES, TestSinglePageElementSourcesElement::class)))->toBeNull();
 });
 
+it('normalizes posted table attribute options to attribute keys', function () {
+    $projectConfig = app(ProjectConfig::class);
+
+    $response = postJson(action([ElementSourcesController::class, 'store']), [
+        'elementType' => User::class,
+        'sourceOrder' => ['*'],
+        'sources' => [
+            '*' => [
+                'tableAttributes' => [
+                    '',
+                    'email',
+                    ['label' => 'Groups', 'value' => 'groups'],
+                ],
+                'enabled' => true,
+            ],
+        ],
+    ]);
+
+    $response->assertOk();
+
+    expect($projectConfig->get(sprintf('%s.%s.0.tableAttributes', ProjectConfig::PATH_ELEMENT_SOURCES, User::class)))
+        ->toBe(['email', 'groups']);
+});
+
 function normalizeConfig(mixed $value): mixed
 {
     if (! is_array($value)) {


### PR DESCRIPTION
### Description
Fixes source customization saving so posted table column option payloads are normalized to attribute keys before being stored.

### Related issues
Fixes #19182