### PR TITLE
[6.x] Inertia user addresses

### DIFF
--- a/packages/craftcms-legacy/cp/src/js/CP.js
+++ b/packages/craftcms-legacy/cp/src/js/CP.js
@@ -1221,7 +1221,7 @@ Craft.CP = Garnish.Base.extend(
 
     _invokeElementCopyCallbacks: function (elementInfo) {
       const buttonLabel = this._pasteElementsButtonLabel(elementInfo);
-      for (callback of this.copyElementCallbacks) {
+      for (const callback of this.copyElementCallbacks) {
         callback(elementInfo, buttonLabel);
       }
     },

--- a/resources/js/common/composables/useAppendHtml.ts
+++ b/resources/js/common/composables/useAppendHtml.ts
@@ -3,7 +3,7 @@ import {
   appendBodyHtml,
   type AppendHtmlDisposer,
 } from '@craftcms/cp';
-import {computed, watch, onBeforeUnmount} from 'vue';
+import {computed, nextTick, watch, onBeforeUnmount} from 'vue';
 import {usePage} from '@inertiajs/vue3';
 
 interface HtmlContent {
@@ -57,6 +57,8 @@ export function useAppendHtml(source?: HtmlContent) {
       async (value) => {
         disposeAll();
 
+        await nextTick();
+
         if (value.headHtml) {
           disposers.push(await appendHeadHtml(value.headHtml));
         }
@@ -65,7 +67,7 @@ export function useAppendHtml(source?: HtmlContent) {
           disposers.push(await appendBodyHtml(value.bodyHtml));
         }
       },
-      {immediate: true}
+      {immediate: true, flush: 'post'}
     );
   }
 

--- a/resources/js/pages/users/Addresses.vue
+++ b/resources/js/pages/users/Addresses.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+  import {usePage} from '@inertiajs/vue3';
+  import IndexLayout from '@/common/layouts/IndexLayout.vue';
+
+  defineOptions({
+    inheritAttrs: false,
+  });
+
+  interface AddressesPageProps extends Record<string, unknown> {
+    content?: string | null;
+    details?: string | null;
+  }
+
+  const props = usePage<AddressesPageProps>().props;
+</script>
+
+<template>
+  <IndexLayout>
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div v-if="props.content" class="p-4" v-html="props.content" />
+
+    <template v-if="props.details" #details>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div v-html="props.details" />
+    </template>
+  </IndexLayout>
+</template>

--- a/src/Cp/Html/ElementHtml.php
+++ b/src/Cp/Html/ElementHtml.php
@@ -744,6 +744,9 @@ JS, [
                     'buttonHtml' => Html::tag('craft-icon', '', [
                         'name' => 'ellipsis',
                     ]),
+                    'buttonAttributes' => [
+                        'class' => ['action-btn'],
+                    ],
                     'omitIfEmpty' => false,
                 ]);
             },

--- a/src/Http/Controllers/Users/AddressesController.php
+++ b/src/Http/Controllers/Users/AddressesController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Http\Controllers\Users;
 
 use CraftCms\Cms\Address\Elements\Address;
-use CraftCms\Cms\Element\Element;
 use CraftCms\Cms\Element\Elements;
 use CraftCms\Cms\Element\Validation\ElementRules;
 use CraftCms\Cms\Http\RespondsWithFlash;
@@ -29,21 +28,23 @@ readonly class AddressesController
 
         $response = $this->asEditUserScreen($user, self::SCREEN_ADDRESSES);
 
-        $response->contentHtml(function () use ($user) {
-            $config = [
-                'showInGrid' => true,
-                'canCreate' => Gate::check('editUsers'),
-            ];
+        $response
+            ->contentHtml(function () use ($user) {
+                $config = [
+                    'showInGrid' => true,
+                    'canCreate' => Gate::check('save', $user),
+                ];
 
-            // Use an element index view if there's more than 50 addresses
-            $total = Address::find()->owner($user)->count();
-            if ($total > 50) {
-                return $user->getAddressManager()->getIndexHtml($user, $config);
-            }
+                // Use an element index view if there's more than 50 addresses
+                $total = Address::find()->owner($user)->count();
+                if ($total > 50) {
+                    return $user->getAddressManager()->getIndexHtml($user, $config);
+                }
 
-            return Html::tag('h2', t('Addresses')).
-                $user->getAddressManager()->getCardsHtml($user, $config);
-        });
+                return Html::tag('h2', t('Addresses')).
+                    $user->getAddressManager()->getCardsHtml($user, $config);
+            })
+            ->inertiaPage('users/Addresses');
 
         return $response;
     }

--- a/src/Http/Responses/CpScreenResponse.php
+++ b/src/Http/Responses/CpScreenResponse.php
@@ -15,6 +15,7 @@ use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Support\Url;
+use CraftCms\Cms\View\HtmlStack as HtmlStackService;
 use CraftCms\Cms\View\LegacyAssets\ContentWindowAsset;
 use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use CraftCms\Cms\View\TemplateMode;
@@ -35,6 +36,19 @@ use function CraftCms\Cms\template;
 class CpScreenResponse implements Responsable
 {
     use Conditionable;
+
+    private const array INERTIA_ASSET_BUFFER_KEYS = [
+        'js',
+        'scripts',
+        'css',
+        'jsFiles',
+        'cssFiles',
+        'html',
+        'metaTags',
+        'linkTags',
+        'jsImports',
+        'icons',
+    ];
 
     /**
      * @var string|null The Inertia page component to render.
@@ -811,7 +825,26 @@ class CpScreenResponse implements Responsable
     private function response(Request $request): Response
     {
         $isForm = (bool) $this->action;
+        $bufferingInertiaAssets = false;
 
+        if ($this->inertiaPage) {
+            // Flush globally pending CP assets before buffering page-specific Inertia assets.
+            HtmlStack::headHtml(false);
+            HtmlStack::startBuffer(self::INERTIA_ASSET_BUFFER_KEYS);
+            $bufferingInertiaAssets = true;
+        }
+
+        try {
+            return $this->buildResponse($request, $isForm, $bufferingInertiaAssets);
+        } finally {
+            if ($bufferingInertiaAssets) {
+                HtmlStack::clearBuffer(self::INERTIA_ASSET_BUFFER_KEYS);
+            }
+        }
+    }
+
+    private function buildResponse(Request $request, bool $isForm, bool &$bufferingInertiaAssets): Response
+    {
         if ($this->prepareScreen) {
             call_user_func($this->prepareScreen, $this, $isForm ? 'main-form' : 'main');
         }
@@ -911,6 +944,9 @@ class CpScreenResponse implements Responsable
                 unset($templateProps['subnav']);
             }
 
+            $bufferingInertiaAssets = false;
+            $templateProps = array_merge($templateProps, $this->renderBufferedInertiaAssets());
+
             return Inertia::render($this->inertiaPage, $this->inertiaProps)
                 ->with($templateProps)
                 ->toResponse($request);
@@ -922,6 +958,25 @@ class CpScreenResponse implements Responsable
             $templateProps,
             TemplateMode::Cp
         ));
+    }
+
+    private function renderBufferedInertiaAssets(): array
+    {
+        $htmlStack = app(HtmlStackService::class);
+        $buffer = $htmlStack->clearBuffer(self::INERTIA_ASSET_BUFFER_KEYS);
+
+        $htmlStack->startBuffer(self::INERTIA_ASSET_BUFFER_KEYS);
+
+        try {
+            $htmlStack->applyBuffer($buffer);
+
+            return [
+                'headHtml' => $htmlStack->headHtml(),
+                'bodyHtml' => $htmlStack->bodyHtml(),
+            ];
+        } finally {
+            $htmlStack->clearBuffer(self::INERTIA_ASSET_BUFFER_KEYS);
+        }
     }
 
     private function contextMenu(?string $namespace = null): ?string

--- a/tests/Feature/Http/Controllers/User/AddressesControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/AddressesControllerTest.php
@@ -2,12 +2,15 @@
 
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\Table;
+use CraftCms\Cms\Edition;
 use CraftCms\Cms\Element\Queries\AddressQuery;
 use CraftCms\Cms\Http\Controllers\Users\AddressesController;
 use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\User\Models\User as UserModel;
 use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia;
 
+use function CraftCms\Cms\cp_url;
 use function CraftCms\Cms\currentUser;
 use function CraftCms\Cms\t;
 use function Pest\Laravel\actingAs;
@@ -26,10 +29,68 @@ it('requires login', function () {
     postJson(action([AddressesController::class, 'destroy']))->assertUnauthorized();
 });
 
-test('index', function () {
-    get(action([AddressesController::class, 'index']))
+test('index shows addresses page for own account', function () {
+    postJson(action([AddressesController::class, 'store']), [
+        'userId' => auth()->id(),
+        'title' => 'Home',
+        'addressLine1' => '123 Fake Street',
+        'administrativeArea' => 'CA',
+        'locality' => 'San Francisco',
+        'postalCode' => '94107',
+    ])->assertOk();
+
+    get(cp_url('myaccount/addresses'))
         ->assertOk()
-        ->assertSee(t('Addresses'));
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('users/Addresses')
+            ->where('content', fn (string $content) => str_contains($content, t('Addresses')) && str_contains($content, 'action-btn'))
+            ->where('headHtml', fn (string $headHtml) => ! str_contains($headHtml, 'legacy/cp/dist/cp.js'))
+            ->where('bodyHtml', fn (string $bodyHtml) => str_contains($bodyHtml, 'new Craft.NestedElementManager'))
+            ->has('subnav')
+            ->has('details'));
+});
+
+test('index shows addresses page for other users', function () {
+    Edition::set(Edition::Pro);
+
+    $otherUser = UserModel::factory()->createElement();
+
+    get(cp_url("users/{$otherUser->id}/addresses"))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('users/Addresses')
+            ->has('content')
+            ->has('subnav')
+            ->has('details'));
+});
+
+test('users can create addresses for their own account without editUsers', function () {
+    $user = UserModel::factory()
+        ->withPermissions(['accessCp'])
+        ->createElement();
+
+    actingAs($user);
+
+    get(cp_url('myaccount/addresses'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('bodyHtml', fn (string $bodyHtml) => str_contains($bodyHtml, '"canCreate":true')));
+});
+
+test('users without editUsers cannot create addresses for other users', function () {
+    Edition::set(Edition::Pro);
+
+    $user = UserModel::factory()
+        ->withPermissions(['accessCp', 'viewUsers'])
+        ->createElement();
+    $otherUser = UserModel::factory()->createElement();
+
+    actingAs($user);
+
+    get(cp_url("users/{$otherUser->id}/addresses"))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('bodyHtml', fn (string $bodyHtml) => str_contains($bodyHtml, '"canCreate":false')));
 });
 
 test('store & destroy', function () {


### PR DESCRIPTION
### Description

Ports user addresses as a small Inertia wrapper around the legacy `NestedElementManager`.

Fixes / adapts a few bridges between Inertia and old JS code:

- Separated root CP assets from Inertia page-specific legacy assets in `CpScreenResponse`.
- Flushed global CP assets before buffering Inertia page assets, so `jQuery`, `Craft`, and `Craft.NestedElementManager` exist before page boot scripts run.
- Captured page-specific `headHtml` / `bodyHtml` and passed them as Inertia props.
- Made `useAppendHtml()` append after Vue’s DOM flush with `nextTick` + `flush: 'post'`, so `v-html` content exists before `new Craft.NestedElementManager(...)` runs.
- Added the legacy `.action-btn` class back onto generated element action menu triggers, so `NestedElementManager.initElement()` can find and wire the three-dots menu.
- Fixed `CP.js` copy callbacks with `for (const callback of ...)`, so the nested manager’s Copy/Paste update path doesn’t throw under strict execution.