### PR TITLE
Fix duplicated Content Block nested fields in element index columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where Content Block fields’ nested fields could be listed multiple times in element index column settings, when the same field was used by multiple entry types. ([#19197](https://github.com/craftcms/cms/pull/19197))
 - Fixed a bug where the `site`/`siteId` params weren’t being respected on eager-loaded `localized` queries. ([#18588](https://github.com/craftcms/cms/issues/18588))
 - Fixed a bug where it wasn’t possible to enter decimal values after tabbing into a Money field. ([#19156](https://github.com/craftcms/cms/issues/19156))
 - Fixed a bug where the search inputs on the Entry Types and Fields settings index pages were case-sensitive on PostgreSQL. ([#19158](https://github.com/craftcms/cms/issues/19158))

--- a/src/base/Element.php
+++ b/src/base/Element.php
@@ -6238,16 +6238,18 @@ JS,
     {
         $parts = explode('.', $attribute);
         $uid = StringHelper::removeLeft(array_shift($parts), 'contentBlock:');
-        $layoutElement = $this->getFieldLayout()?->getElementByUid($uid);
 
-        if (!$layoutElement instanceof CustomField) {
-            return '';
+        $field = null;
+        $layoutElement = $this->getFieldLayout()?->getElementByUid($uid);
+        if ($layoutElement instanceof CustomField) {
+            try {
+                $field = $layoutElement->getField();
+            } catch (FieldNotFoundException) {
+            }
         }
 
-        try {
-            $field = $layoutElement->getField();
-        } catch (FieldNotFoundException) {
-            return '';
+        if (!$field instanceof ContentBlockField) {
+            $field = $this->_contentBlockFieldFromLayoutElementUid($uid);
         }
 
         if (!$field instanceof ContentBlockField) {
@@ -6255,7 +6257,62 @@ JS,
         }
 
         $block = $this->getFieldValue($field->handle);
-        return $block->getAttributeHtml(implode('.', $parts));
+        return $block?->getAttributeHtml(implode('.', $parts)) ?? '';
+    }
+
+    /**
+     * Returns the Content Block field referenced by a table attribute key.
+     *
+     * Content Block table attributes are deduplicated across the layouts of an element source (see
+     * [[\craft\services\ElementSources::getTableAttributesForFieldLayouts()]]), so the layout element
+     * UID in the key may belong to a different entry type’s layout than this element’s. This resolves
+     * it to the matching instance — by field UID and effective handle — in this element’s own layout.
+     *
+     * (Separate from [[_getFieldFromAlternativeLayouts()]], which matches on the raw handle override
+     * and so can’t resolve Content Blocks that keep their default handle.)
+     *
+     * @param string $layoutElementUid
+     * @return ContentBlockField|null
+     */
+    private function _contentBlockFieldFromLayoutElementUid(string $layoutElementUid): ?ContentBlockField
+    {
+        // Find the Content Block field + effective handle that the UID refers to,
+        // in any of this element type’s layouts
+        $fieldUid = null;
+        $handle = null;
+        foreach (Craft::$app->getFields()->getLayoutsByType(static::class) as $fieldLayout) {
+            $layoutElement = $fieldLayout->getElementByUid($layoutElementUid);
+            if (!$layoutElement instanceof CustomField) {
+                continue;
+            }
+            try {
+                $field = $layoutElement->getField();
+            } catch (FieldNotFoundException) {
+                continue;
+            }
+            if ($field instanceof ContentBlockField) {
+                $fieldUid = $field->uid;
+                $handle = $field->handle;
+            }
+            break;
+        }
+
+        if ($fieldUid === null) {
+            return null;
+        }
+
+        // Return the matching Content Block instance in this element’s own layout
+        foreach ($this->getFieldLayout()?->getCustomFields() ?? [] as $field) {
+            if (
+                $field instanceof ContentBlockField &&
+                $field->uid === $fieldUid &&
+                $field->handle === $handle
+            ) {
+                return $field;
+            }
+        }
+
+        return null;
     }
 
     private function generatedFieldAttributeHtml(string $attribute): string

--- a/src/services/ElementSources.php
+++ b/src/services/ElementSources.php
@@ -643,6 +643,8 @@ class ElementSources extends Component
         /** @var CustomField[][] $groupedFieldElements */
         $groupedFieldElements = [];
         $groupedFieldInstances = [];
+        /** @var CustomField[] $groupedContentBlocks */
+        $groupedContentBlocks = [];
 
         foreach ($fieldLayouts as $fieldLayout) {
             foreach ($fieldLayout->getTabs() as $tab) {
@@ -667,9 +669,11 @@ class ElementSources extends Component
                         (!$user || $user->admin || ($layoutElement->getUserCondition()?->matchElement($user) ?? true))
                     ) {
                         if ($field instanceof ContentBlock) {
-                            foreach ($this->getTableAttributesForFieldLayouts([$field->getFieldLayout()]) as $key => $attribute) {
-                                $attributes["contentBlock:{$field->layoutElement->uid}.$key"] = $attribute;
-                            }
+                            // Combine it with any other instances of the same Content Block field
+                            // (from other layouts) that share the same handle, so its nested fields
+                            // are only listed once
+                            $key = $field->uid . ' - ' . ($layoutElement->handle ?? $field->handle);
+                            $groupedContentBlocks[$key] ??= $layoutElement;
                         } elseif ($layoutElement->handle === null) {
                             // The handle wasn't overridden, so combine it with any other instances (from other layouts)
                             // where the handle also wasn't overridden
@@ -693,6 +697,14 @@ class ElementSources extends Component
                         'label' => Craft::t('site', $field['name']),
                     ];
                 }
+            }
+        }
+
+        foreach ($groupedContentBlocks as $layoutElement) {
+            /** @var ContentBlock $field */
+            $field = $layoutElement->getField();
+            foreach ($this->getTableAttributesForFieldLayouts([$field->getFieldLayout()]) as $key => $attribute) {
+                $attributes["contentBlock:$layoutElement->uid.$key"] = $attribute;
             }
         }
 


### PR DESCRIPTION
### Description

When the same Content Block field is used in the field layouts of multiple entry types within one section, the entry index’s **Table Columns** picker (under the “View” button) lists each of the Content Block’s nested fields **once per entry type**. With, say, 10 entry types sharing one Content Block field, every nested field shows up 10 times, making it impossible to tell which one to pick.

Ordinary fields shared across multiple layouts are already deduplicated for table columns — that was added in #18220 (for #18209), mirroring the condition-builder work in #15781. Content Block fields were never included in that dedup, so their nested fields still multiply.

#### Steps to reproduce

1. Create a Content Block field (e.g. “CTA”) with a couple of nested fields.
2. Create several entry types that each include that Content Block field in their layout.
3. Put them all in one channel/structure section.
4. On that section’s entry index, click **View** → look at **Table Columns**.
5. Each nested field is listed once per entry type.

### This PR

Applies the same treatment #18220 gave multi-instance fields, to Content Block fields:

- **`ElementSources::getTableAttributesForFieldLayouts()`** — Content Block instances are now grouped across the source’s field layouts by field UID + effective handle (`$groupedContentBlocks`), so each nested field is contributed once, keyed off a single representative layout element.
- **`Element::contentBlockAttributeHtml()`** — because the deduplicated column key now references one representative layout element UID (which may belong to a different entry type’s layout than the element being rendered), a new private helper `_contentBlockFieldFromLayoutElementUid()` resolves the Content Block field by field UID + effective handle within the element’s own layout. This parallels the existing `_getFieldFromAlternativeLayouts()` used for multi-instance fields, but matches on the *effective* handle (that method matches the raw layout-element handle override, which is null for non-overridden Content Blocks).

Card and thumbnail rendering are intentionally untouched: those paths resolve against each element’s own layout using per-entry-type card config keys, so they never hit the cross-layout case.

### Related

- #18220 / #18209 (the same fix for multi-instance fields)
- #15781 (the same fix for the condition builder)
