### PR TITLE
Trim project config name comments to avoid trailing whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed a bug where timepicker menus weren’t auto-scrolling to the selected time when opened. ([#19142](https://github.com/craftcms/cms/issues/19142))
 - Fixed an error that could occur when reassigning entries to a new author when deleting a user. ([#19154](https://github.com/craftcms/cms/issues/19154))
 - Fixed a bug where the “All entries” and “All users” sources weren’t available to be selected within Entries/Users field settings. ([#19185](https://github.com/craftcms/cms/discussions/19185))
+- Fixed a bug where a component’s name that ended in a space could cause its project config files to be written with trailing whitespace on the name comments, resulting in spurious diffs in editors that trim trailing whitespace. ([#19198](https://github.com/craftcms/cms/pull/19198))
 
 ## 5.10.8.1 - 2026-06-23
 

--- a/src/services/ProjectConfig.php
+++ b/src/services/ProjectConfig.php
@@ -1650,8 +1650,12 @@ class ProjectConfig extends Component
 
             if (!empty($projectConfigNames)) {
                 foreach ($projectConfigNames as $uid => $name) {
+                    // Trim the name so the appended comment doesn’t end up with trailing
+                    // whitespace, which many editors strip on save (causing project config
+                    // diffs/conflicts). (Only affects the comment; the stored value is intact.)
+                    $name = trim((string)$name);
                     $uids[] = '/^(.*' . preg_quote($uid) . '.*)$/mi';
-                    $replacements[] = '$1 # ' . $name;
+                    $replacements[] = $name !== '' ? '$1 # ' . $name : '$1';
                 }
             }
 


### PR DESCRIPTION
### Description

When a component (field, entry type, section, etc.) has a name that **ends in a space**, Craft writes trailing whitespace into the project config YAML files.

`ProjectConfig::writeYamlFiles()` builds a UID → name map and appends a `# {name}` comment to every YAML line that references a component's UID:

```php
$replacements[] = '$1 # ' . $name;
```

If `$name` is e.g. `'Available service '`, the generated comment becomes `# Available service ` — with a trailing space. This shows up throughout the generated files, e.g.:

```yaml
    d819cfe0-81a2-4a8f-8b07-2dd4c8463287: 'Available service ' # Available service␠
```

Most editors (and many `.editorconfig` / format-on-save setups) strip trailing whitespace on save. When they do, Craft re-adds it on the next config write, producing an endless stream of spurious project config diffs and merge conflicts across a team — even when nobody has actually changed anything.

### Fix

Trim the name before using it as a comment, and skip the comment entirely if the name is empty after trimming (so a whitespace-only name doesn't leave a bare `# ` with its own trailing space):

```php
$name = trim((string)$name);
$uids[] = '/^(.*' . preg_quote($uid) . '.*)$/mi';
$replacements[] = $name !== '' ? '$1 # ' . $name : '$1';
```

This only affects the human-readable comment. The stored (quoted) value keeps the original name, including its trailing space, so no config semantics change.

### Notes on testing

The comment-building logic lives inline in `writeYamlFiles()`, which clears and rewrites the entire project config directory and is fully mocked out in the existing `ProjectConfigTest` suite, so there isn't a clean seam for an isolated unit test. I verified the behavior against the exact regex/replacement logic: before the fix the comment retains the trailing space; after it, the trailing space (and the empty-name edge case) are both gone.
