### PR TITLE
Fix authenticated user must implement CraftUser error

### DIFF
--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -48,7 +48,9 @@ class AuthServiceProvider extends ServiceProvider
     #[Override]
     public function register(): void
     {
-        if (! class_exists($this->app->make(Repository::class)->get('auth.providers.users.model'))) {
+        $configuredModel = $this->app->make(Repository::class)->get('auth.providers.users.model');
+
+        if (! is_string($configuredModel) || ! is_a($configuredModel, CraftUser::class, true)) {
             $this->app->make(Repository::class)->set('auth.providers.users.model', User::class);
         }
 


### PR DESCRIPTION
Whilst setting up a new Craft 6 instance I ran into a `The authenticated user must implement CraftCms\Cms\User\Contracts\CraftUser to be used by Craft.` error when trying to log in after installing Craft via the CLI (`artisan craft:install`).

This fixes the issue. 

One question Claud had that I'm not sure of the answer to:

> Do you want the framework to keep silently taking over the provider like this, or would you prefer it to log/warn when it overrides a mismatched model? 

I'm not 100% sure of our intent here, so this fix may not be 100% correct but here's the explanation from Claude:

---

`AuthServiceProvider::register()` only re-pointed the auth provider at Craft's `User` model when the configured model class **didn't exist**:

```php
if (! class_exists($this->app->make(Repository::class)->get('auth.providers.users.model'))) {
    $this->app->make(Repository::class)->set('auth.providers.users.model', User::class);
}

A standard Laravel app ships with App\Models\User, which does exist but does not implement CraftCms\Cms\User\Contracts\CraftUser. Because the class existed, Craft skipped the override, so Auth::user() returned a plain App\Models\User. On the next request, currentUser() (src/helpers.php:91) rejected the non-Craft user and threw an AuthenticationException, surfacing as a 500 during CP login.

The guard's original intent was to avoid clobbering a developer's custom user model — but a Craft user model is required to implement CraftUser, so "the class exists" was the wrong condition.

### Fix

This fix checks whether the configured model actually implements CraftUser, rather than merely whether the class exists