### PR TITLE
[6.x] Add hook support & HtmlFragment + HtmlFragmentRenderer

### DIFF
--- a/packages/craftcms-cp/src/utilities/dom.test.ts
+++ b/packages/craftcms-cp/src/utilities/dom.test.ts
@@ -40,9 +40,12 @@ describe('appendHeadHtml', () => {
 
   test('appends a script element to head', async () => {
     const {appendHeadHtml} = await freshImport();
-    await appendHeadHtml(
+    const append = appendHeadHtml(
       '<script src="https://example.com/script.js"></script>'
     );
+    document.head.querySelector('script')!.dispatchEvent(new Event('load'));
+    await append;
+
     const scripts = document.head.querySelectorAll('script');
     expect(scripts.length).toBe(1);
     expect(scripts[0]!.getAttribute('src')).toBe(
@@ -80,9 +83,12 @@ describe('appendHeadHtml', () => {
 
   test('preserves script attributes when appending', async () => {
     const {appendHeadHtml} = await freshImport();
-    await appendHeadHtml(
+    const append = appendHeadHtml(
       '<script src="https://example.com/b.js" type="module" defer></script>'
     );
+    document.head.querySelector('script')!.dispatchEvent(new Event('load'));
+    await append;
+
     const script = document.head.querySelector('script')!;
     expect(script.getAttribute('src')).toBe('https://example.com/b.js');
     expect(script.getAttribute('type')).toBe('module');
@@ -106,10 +112,28 @@ describe('appendBodyHtml', () => {
 
   test('appends script with src to body', async () => {
     const {appendBodyHtml} = await freshImport();
-    await appendBodyHtml('<script src="https://example.com/body.js"></script>');
+    const append = appendBodyHtml(
+      '<script src="https://example.com/body.js"></script>'
+    );
+    document.body.querySelector('script')!.dispatchEvent(new Event('load'));
+    await append;
+
     const scripts = document.body.querySelectorAll('script');
     expect(scripts.length).toBe(1);
     expect(scripts[0]!.getAttribute('src')).toBe('https://example.com/body.js');
+  });
+
+  test('appends elements to a provided parent', async () => {
+    const {appendElementHtml} = await freshImport();
+    const parent = document.createElement('div');
+
+    const dispose = await appendElementHtml('<p id="child">Hello</p>', parent);
+
+    expect(parent.querySelector('#child')!.textContent).toBe('Hello');
+
+    dispose();
+
+    expect(parent.querySelector('#child')).toBeNull();
   });
 });
 
@@ -150,8 +174,12 @@ describe('JS deduplication', () => {
   test('does not add duplicate script src', async () => {
     const {appendBodyHtml} = await freshImport();
     const js = '<script src="https://example.com/dup.js"></script>';
+    const firstAppend = appendBodyHtml(js);
+    document.body.querySelector('script')!.dispatchEvent(new Event('load'));
+    await firstAppend;
+
     await appendBodyHtml(js);
-    await appendBodyHtml(js);
+
     const scripts = document.body.querySelectorAll('script');
     expect(scripts.length).toBe(1);
   });
@@ -163,5 +191,23 @@ describe('JS deduplication', () => {
     await appendBodyHtml(inline);
     const scripts = document.body.querySelectorAll('script');
     expect(scripts.length).toBe(2);
+  });
+
+  test('waits for external scripts before appending subsequent nodes', async () => {
+    const {appendElementHtml} = await freshImport();
+    const parent = document.createElement('div');
+    const append = appendElementHtml(
+      '<script src="https://example.com/ordered.js"></script><span id="after-script"></span>',
+      parent
+    );
+
+    await Promise.resolve();
+
+    expect(parent.querySelector('#after-script')).toBeNull();
+
+    parent.querySelector('script')!.dispatchEvent(new Event('load'));
+    await append;
+
+    expect(parent.querySelector('#after-script')).not.toBeNull();
   });
 });

--- a/packages/craftcms-cp/src/utilities/dom.ts
+++ b/packages/craftcms-cp/src/utilities/dom.ts
@@ -8,7 +8,14 @@ let existingJs: string[] | null = null;
  */
 export type AppendHtmlDisposer = () => void;
 
-async function appendHtml(
+function waitForScript(script: HTMLScriptElement): Promise<void> {
+  return new Promise((resolve) => {
+    script.addEventListener('load', () => resolve(), {once: true});
+    script.addEventListener('error', () => resolve(), {once: true});
+  });
+}
+
+export async function appendElementHtml(
   html: string,
   parent: HTMLElement
 ): Promise<AppendHtmlDisposer> {
@@ -72,6 +79,8 @@ async function appendHtml(
 
     if (node instanceof HTMLScriptElement) {
       const script = document.createElement('script');
+      let scriptLoaded: Promise<void> | null = null;
+
       Array.from(node.attributes).forEach((attr) => {
         script.setAttribute(attr.name, attr.value);
       });
@@ -91,12 +100,18 @@ async function appendHtml(
         existingJs.push(src);
         jsAdded.push(src);
         script.async = false;
+        scriptLoaded = waitForScript(script);
       } else {
         script.textContent = node.textContent;
       }
 
       parent.appendChild(script);
       appended.push(script);
+
+      if (scriptLoaded) {
+        await scriptLoaded;
+      }
+
       continue;
     }
 
@@ -116,7 +131,7 @@ async function appendHtml(
 export async function appendHeadHtml(
   html: string
 ): Promise<AppendHtmlDisposer> {
-  return appendHtml(html, document.head);
+  return appendElementHtml(html, document.head);
 }
 
 /**
@@ -127,5 +142,5 @@ export async function appendHeadHtml(
 export async function appendBodyHtml(
   html: string
 ): Promise<AppendHtmlDisposer> {
-  return appendHtml(html, document.body);
+  return appendElementHtml(html, document.body);
 }

--- a/resources/js/common/components/HtmlFragmentRenderer.vue
+++ b/resources/js/common/components/HtmlFragmentRenderer.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+  import {
+    appendBodyHtml,
+    appendElementHtml,
+    appendHeadHtml,
+    type AppendHtmlDisposer,
+  } from '@craftcms/cp';
+  import {onBeforeUnmount, ref, watch} from 'vue';
+
+  const props = defineProps<{
+    fragment?: CraftCms.Cms.View.HtmlFragment | null;
+  }>();
+
+  const container = ref<HTMLElement | null>(null);
+  const disposers: AppendHtmlDisposer[] = [];
+  let lastKey = '';
+  let runId = 0;
+
+  const disposeAll = () => {
+    while (disposers.length) {
+      disposers.pop()?.();
+    }
+  };
+
+  const remember = async (
+    promise: Promise<AppendHtmlDisposer>,
+    currentRunId: number
+  ): Promise<boolean> => {
+    const dispose = await promise;
+
+    if (currentRunId !== runId) {
+      dispose();
+
+      return false;
+    }
+
+    disposers.push(dispose);
+
+    return true;
+  };
+
+  watch(
+    () => ({
+      element: container.value,
+      html: props.fragment?.html ?? '',
+      headHtml: props.fragment?.headHtml ?? '',
+      bodyHtml: props.fragment?.bodyHtml ?? '',
+    }),
+    async ({element, html, headHtml, bodyHtml}) => {
+      const key = `${headHtml}\u0000${html}\u0000${bodyHtml}`;
+
+      if (!element || key === '\u0000\u0000') {
+        runId++;
+        lastKey = '';
+        disposeAll();
+
+        return;
+      }
+
+      if (key === lastKey) {
+        return;
+      }
+
+      runId++;
+      const currentRunId = runId;
+      lastKey = key;
+      disposeAll();
+
+      if (
+        headHtml &&
+        !(await remember(appendHeadHtml(headHtml), currentRunId))
+      ) {
+        return;
+      }
+
+      if (
+        html &&
+        !(await remember(appendElementHtml(html, element), currentRunId))
+      ) {
+        return;
+      }
+
+      if (
+        bodyHtml &&
+        !(await remember(appendBodyHtml(bodyHtml), currentRunId))
+      ) {
+        return;
+      }
+    },
+    {immediate: true}
+  );
+
+  onBeforeUnmount(() => {
+    runId++;
+    disposeAll();
+  });
+</script>
+
+<template>
+  <div v-if="fragment" ref="container"></div>
+</template>

--- a/resources/js/pages/users/Preferences.vue
+++ b/resources/js/pages/users/Preferences.vue
@@ -6,6 +6,7 @@
   import CraftCombobox from '@/common/form/CraftCombobox.vue';
   import Select from '@/common/form/Select.vue';
   import CheckboxGroup from '@/common/form/CheckboxGroup.vue';
+  import HtmlFragmentRenderer from '@/common/components/HtmlFragmentRenderer.vue';
   import {useSettingsSave} from '@/modules/settings/composables/useSettingsSave';
   import {update} from '@actions/Users/PreferencesController';
 
@@ -16,6 +17,7 @@
   type UserPreferencesViewModel =
     CraftCms.Cms.Http.ViewModels.UserPreferencesViewModel & {
       details?: string | null;
+      prefsHook?: CraftCms.Cms.View.HtmlFragment | null;
     };
 
   interface UserPreferencesForm {
@@ -318,7 +320,7 @@
         </section>
       </template>
 
-      <!-- TODO: {% hook 'cp.users.edit.prefs' %} -->
+      <HtmlFragmentRenderer :fragment="props.prefsHook" />
     </div>
 
     <template v-if="props.details" #details>

--- a/src/Http/ViewModels/UserPreferencesViewModel.php
+++ b/src/Http/ViewModels/UserPreferencesViewModel.php
@@ -8,10 +8,14 @@ use CraftCms\Cms\Cms;
 use CraftCms\Cms\Cp\SelectOptions;
 use CraftCms\Cms\Support\DateTimeHelper;
 use CraftCms\Cms\Support\Env;
+use CraftCms\Cms\Support\Facades\HtmlStack;
 use CraftCms\Cms\Support\Facades\I18N;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
 use CraftCms\Cms\Translation\Locale;
 use CraftCms\Cms\User\Elements\User;
+use CraftCms\Cms\View\HtmlFragment;
+use CraftCms\Cms\View\TemplateGlobals;
+use CraftCms\Cms\View\TemplateHooks;
 use Illuminate\Contracts\Support\Arrayable;
 
 use function CraftCms\Cms\t;
@@ -38,6 +42,8 @@ class UserPreferencesViewModel implements Arrayable
     public string $orientation;
 
     public bool $isAdmin;
+
+    public ?HtmlFragment $prefsHook = null;
 
     public function __construct(
         private readonly User $user,
@@ -69,6 +75,18 @@ class UserPreferencesViewModel implements Arrayable
         $this->timeZoneOptions = $this->timeZoneOptions();
         $this->orientation = I18N::getLocale()->getOrientation();
         $this->isAdmin = $user->isAdmin();
+
+        $context = [
+            ...app(TemplateGlobals::class)->resolve(),
+            'user' => $user,
+            'isNewUser' => false,
+        ];
+
+        $fragment = HtmlStack::capture(function () use ($context): string {
+            return app(TemplateHooks::class)->invoke('cp.users.edit.prefs', $context);
+        });
+
+        $this->prefsHook = $fragment->isEmpty() ? null : $fragment;
     }
 
     public function toArray(): array
@@ -82,6 +100,7 @@ class UserPreferencesViewModel implements Arrayable
             'timeZoneOptions' => $this->timeZoneOptions,
             'orientation' => $this->orientation,
             'isAdmin' => $this->isAdmin,
+            'prefsHook' => $this->prefsHook,
         ];
     }
 

--- a/src/Http/ViewModels/UserPreferencesViewModel.php
+++ b/src/Http/ViewModels/UserPreferencesViewModel.php
@@ -82,9 +82,7 @@ class UserPreferencesViewModel implements Arrayable
             'isNewUser' => false,
         ];
 
-        $fragment = HtmlStack::capture(function () use ($context): string {
-            return app(TemplateHooks::class)->invoke('cp.users.edit.prefs', $context);
-        });
+        $fragment = HtmlStack::capture(fn (): string => app(TemplateHooks::class)->invoke('cp.users.edit.prefs', $context));
 
         $this->prefsHook = $fragment->isEmpty() ? null : $fragment;
     }

--- a/src/Support/Facades/HtmlStack.php
+++ b/src/Support/Facades/HtmlStack.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string bodyHtml(bool $clear = true)
  * @method static string bodyBeginHtml(bool $clear = true)
  * @method static string bodyEndHtml(bool $clear = true)
+ * @method static \CraftCms\Cms\View\HtmlFragment capture(callable $render)
  * @method static void startBuffer(array|string $keys)
  * @method static mixed clearBuffer(array|string $keys)
  * @method static void startCssBuffer()

--- a/src/View/HtmlFragment.php
+++ b/src/View/HtmlFragment.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\View;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+readonly class HtmlFragment implements Arrayable, JsonSerializable
+{
+    public function __construct(
+        public string $html = '',
+        public string $headHtml = '',
+        public string $bodyHtml = '',
+    ) {}
+
+    public function isEmpty(): bool
+    {
+        return $this->html === ''
+            && $this->headHtml === ''
+            && $this->bodyHtml === '';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'html' => $this->html,
+            'headHtml' => $this->headHtml,
+            'bodyHtml' => $this->bodyHtml,
+        ];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/src/View/HtmlStack.php
+++ b/src/View/HtmlStack.php
@@ -26,6 +26,19 @@ use Stringable;
 #[Scoped]
 class HtmlStack
 {
+    private const FragmentBufferKeys = [
+        'js',
+        'scripts',
+        'jsFiles',
+        'cssFiles',
+        'css',
+        'html',
+        'jsImports',
+        'metaTags',
+        'linkTags',
+        'icons',
+    ];
+
     /** @var array<int, array<string, string>> */
     private array $js = [];
 
@@ -64,6 +77,8 @@ class HtmlStack
      * @var array<string, list<mixed>>
      */
     private array $buffers = [];
+
+    private bool $suppressAssetRenderingEvents = false;
 
     /**
      * Registers inline JavaScript code.
@@ -276,7 +291,7 @@ class HtmlStack
      */
     public function headHtml(bool $clear = true): string
     {
-        event(new ViewAssetsRendering);
+        $this->dispatchAssetsRenderingEvent();
 
         $head = Position::Head->value;
 
@@ -332,7 +347,7 @@ class HtmlStack
      */
     public function bodyBeginHtml(bool $clear = true): string
     {
-        event(new ViewAssetsRendering);
+        $this->dispatchAssetsRenderingEvent();
 
         $body = Position::BodyBegin->value;
 
@@ -358,7 +373,7 @@ class HtmlStack
      */
     public function bodyEndHtml(bool $clear = true): string
     {
-        event(new ViewAssetsRendering);
+        $this->dispatchAssetsRenderingEvent();
 
         $body = Position::BodyEnd->value;
 
@@ -387,6 +402,28 @@ class HtmlStack
         }
 
         return $parts->implode(PHP_EOL);
+    }
+
+    public function capture(callable $render): HtmlFragment
+    {
+        $this->dispatchAssetsRenderingEvent();
+        $this->startBuffer(self::FragmentBufferKeys);
+        $wasSuppressingAssetRenderingEvents = $this->suppressAssetRenderingEvents;
+
+        try {
+            $html = (string) $render();
+            $this->dispatchAssetsRenderingEvent();
+            $this->suppressAssetRenderingEvents = true;
+
+            return new HtmlFragment(
+                $html,
+                $this->headHtml(),
+                $this->bodyHtml(),
+            );
+        } finally {
+            $this->suppressAssetRenderingEvents = $wasSuppressingAssetRenderingEvents;
+            $this->clearBuffer(self::FragmentBufferKeys);
+        }
     }
 
     /**
@@ -754,6 +791,15 @@ class HtmlStack
                 ]),
             )
             ->map(fn (string|Stringable $part) => (string) $part);
+    }
+
+    private function dispatchAssetsRenderingEvent(): void
+    {
+        if ($this->suppressAssetRenderingEvents) {
+            return;
+        }
+
+        event(new ViewAssetsRendering);
     }
 
     private function readyJs(): string

--- a/src/View/HtmlStack.php
+++ b/src/View/HtmlStack.php
@@ -26,7 +26,7 @@ use Stringable;
 #[Scoped]
 class HtmlStack
 {
-    private const FragmentBufferKeys = [
+    private const array FragmentBufferKeys = [
         'js',
         'scripts',
         'jsFiles',

--- a/tests/Feature/Http/Controllers/User/PreferencesControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/PreferencesControllerTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use CraftCms\Cms\Support\Facades\HtmlStack;
 use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\User\Models\User as UserModel;
+use CraftCms\Cms\View\TemplateHooks;
 use Inertia\Testing\AssertableInertia;
 
 use function CraftCms\Cms\cp_url;
@@ -36,7 +38,28 @@ test('index shows preferences page', function () {
             ->has('weekStartDayOptions', 7)
             ->has('timeZoneOptions')
             ->has('subnav')
-            ->has('details'));
+            ->has('details')
+            ->where('prefsHook', null));
+});
+
+test('index includes preferences hook output and assets', function () {
+    app(TemplateHooks::class)->register('cp.users.edit.prefs', function (array &$context, bool &$handled): string {
+        expect($context['user'])->toBeInstanceOf(User::class)
+            ->and($context['isNewUser'])->toBeFalse();
+
+        HtmlStack::cssFile('/prefs-hook.css');
+        HtmlStack::js('window.prefsHookReady = true');
+
+        return '<div data-hook="prefs">Preferences hook</div>';
+    });
+
+    get(cp_url('myaccount/preferences'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('users/Preferences')
+            ->where('prefsHook.html', '<div data-hook="prefs">Preferences hook</div>')
+            ->where('prefsHook.headHtml', fn (string $html): bool => str_contains($html, '/prefs-hook.css'))
+            ->where('prefsHook.bodyHtml', fn (string $html): bool => str_contains($html, 'window.prefsHookReady = true')));
 });
 
 test('update saves language', function () {

--- a/tests/Unit/View/HtmlStackCaptureTest.php
+++ b/tests/Unit/View/HtmlStackCaptureTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\View\Enums\Position;
+use CraftCms\Cms\View\HtmlFragment;
+use CraftCms\Cms\View\HtmlStack;
+use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
+use CraftCms\Cms\View\LegacyAssets\LegacyAssetInterface;
+
+class TestPreCaptureFragmentAsset implements LegacyAssetInterface
+{
+    public array $depends = [];
+
+    public function register(HtmlStack $htmlStack): void
+    {
+        $htmlStack->jsFile('/pre-capture-fragment.js', ['position' => Position::Head->value]);
+    }
+}
+
+class TestCapturedFragmentAsset implements LegacyAssetInterface
+{
+    public array $depends = [];
+
+    public function register(HtmlStack $htmlStack): void
+    {
+        $htmlStack->js('window.capturedFragmentAsset = true;');
+    }
+}
+
+beforeEach(function () {
+    app()->forgetScopedInstances();
+
+    $this->htmlStack = app(HtmlStack::class);
+});
+
+it('serializes html fragments', function () {
+    $fragment = new HtmlFragment(
+        '<p>Hook</p>',
+        '<style>.hook{}</style>',
+        '<script>window.hook = true;</script>',
+    );
+
+    expect($fragment->isEmpty())->toBeFalse()
+        ->and($fragment->toArray())->toBe([
+            'html' => '<p>Hook</p>',
+            'headHtml' => '<style>.hook{}</style>',
+            'bodyHtml' => '<script>window.hook = true;</script>',
+        ])
+        ->and($fragment->jsonSerialize())->toBe($fragment->toArray())
+        ->and(new HtmlFragment()->isEmpty())->toBeTrue();
+});
+
+it('captures html with registered head and body assets', function () {
+    $fragment = $this->htmlStack->capture(function (): string {
+        $this->htmlStack->css('.prefs-hook { color: red; }');
+        $this->htmlStack->jsFile('/prefs-hook.js');
+        $this->htmlStack->js('window.prefsHookReady = true');
+
+        return '<div data-hook="prefs">Preferences hook</div>';
+    });
+
+    expect($fragment->html)->toBe('<div data-hook="prefs">Preferences hook</div>')
+        ->and($fragment->headHtml)->toContain('.prefs-hook { color: red; }')
+        ->and($fragment->bodyHtml)->toContain('/prefs-hook.js')
+        ->and($fragment->bodyHtml)->toContain('window.prefsHookReady = true')
+        ->and($this->htmlStack->headHtml())->toBe('')
+        ->and($this->htmlStack->bodyHtml())->toBe('');
+});
+
+it('isolates captured assets from the outer stack', function () {
+    $this->htmlStack->cssFile('/outer.css');
+
+    $fragment = $this->htmlStack->capture(function (): string {
+        $this->htmlStack->cssFile('/inner.css');
+
+        return '';
+    });
+
+    $outerHeadHtml = $this->htmlStack->headHtml();
+
+    expect($fragment->headHtml)->toContain('/inner.css')
+        ->and($fragment->headHtml)->not->toContain('/outer.css')
+        ->and($outerHeadHtml)->toContain('/outer.css')
+        ->and($outerHeadHtml)->not->toContain('/inner.css');
+});
+
+it('supports nested captures', function () {
+    $inner = null;
+
+    $outer = $this->htmlStack->capture(function () use (&$inner): string {
+        $this->htmlStack->cssFile('/outer-captured.css');
+
+        $inner = $this->htmlStack->capture(function (): string {
+            $this->htmlStack->cssFile('/inner-captured.css');
+
+            return '<p>Inner</p>';
+        });
+
+        return '<p>Outer</p>';
+    });
+
+    expect($inner)->toBeInstanceOf(HtmlFragment::class)
+        ->and($inner->html)->toBe('<p>Inner</p>')
+        ->and($inner->headHtml)->toContain('/inner-captured.css')
+        ->and($inner->headHtml)->not->toContain('/outer-captured.css')
+        ->and($outer->html)->toBe('<p>Outer</p>')
+        ->and($outer->headHtml)->toContain('/outer-captured.css')
+        ->and($outer->headHtml)->not->toContain('/inner-captured.css');
+});
+
+it('keeps preexisting pending legacy assets outside the fragment', function () {
+    app(InternalAssetRegistry::class)->register(TestPreCaptureFragmentAsset::class);
+
+    $fragment = $this->htmlStack->capture(fn (): string => '');
+    $outerHeadHtml = $this->htmlStack->headHtml();
+
+    expect($fragment->isEmpty())->toBeTrue()
+        ->and($outerHeadHtml)->toContain('/pre-capture-fragment.js');
+});
+
+it('captures pending legacy assets registered during render', function () {
+    $fragment = $this->htmlStack->capture(function (): string {
+        app(InternalAssetRegistry::class)->register(TestCapturedFragmentAsset::class);
+
+        return '';
+    });
+
+    expect($fragment->bodyHtml)->toContain('window.capturedFragmentAsset = true')
+        ->and($this->htmlStack->bodyHtml())->toBe('');
+});

--- a/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
+++ b/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
@@ -17,6 +17,7 @@ use CraftCms\Cms\Update\Data\Updates;
 use CraftCms\Cms\User\Data\Permission;
 use CraftCms\Cms\User\Data\PermissionGroup;
 use CraftCms\Cms\User\Data\UserSettings;
+use CraftCms\Cms\View\HtmlFragment;
 use DateTimeInterface;
 use Spatie\LaravelTypeScriptTransformer\TypeScriptTransformerApplicationServiceProvider;
 use Spatie\TypeScriptTransformer\Transformers\EnumTransformer;
@@ -45,6 +46,7 @@ class TypeScriptTransformerServiceProvider extends TypeScriptTransformerApplicat
                     PermissionGroup::class,
                     Route::class,
                     Updates::class,
+                    HtmlFragment::class,
                     UserPermissionsViewModel::class,
                     UserPreferencesViewModel::class,
                     UserSettings::class,


### PR DESCRIPTION
### Description

Separate PR for this to keep it reviewable, this adds `{% hook 'cp.users.edit.prefs' %}` support to the preferences page by running the hook and capturing any HTML, scripts, assets, ... 

`HtmlFragmentRenderer` then displays this HTML, executing any scripts within the HTML or that have been registered through the `HtmlStack`

