### PR TITLE
[6.x] Add Cloudflare Pages deploy workflows for Storybook

### DIFF
--- a/.github/workflows/storybook-deploy-cp.yml
+++ b/.github/workflows/storybook-deploy-cp.yml
@@ -1,0 +1,94 @@
+name: 'Deploy / Storybook (craftcms-cp)'
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 6.x
+    paths:
+      - 'packages/craftcms-cp/**'
+  pull_request:
+    paths:
+      - 'packages/craftcms-cp/**'
+
+concurrency:
+  group: storybook-deploy-cp-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '22'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: 'Build + Deploy'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+        env:
+          CRAFT_FONTAWESOME_TOKEN: ${{ secrets.CRAFT_FONTAWESOME_TOKEN }}
+
+      - name: Build Storybook
+        run: npm run build:storybook --workspace=@craftcms/cp
+
+      - name: Determine deploy branch
+        id: branch
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy packages/craftcms-cp/storybook-static --project-name=craftcms-cp-storybook --branch=${{ steps.branch.outputs.value }}
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `${{ steps.deploy.outputs.deployment-url }}`;
+            const marker = '<!-- storybook-preview-comment:cp -->';
+            const body = `${marker}\n**@craftcms/cp Storybook preview:** ${url}`;
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/storybook-deploy-cp.yml
+++ b/.github/workflows/storybook-deploy-cp.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/craftcms-cp/storybook-static --project-name=craftcms-cp-storybook --branch=${{ steps.branch.outputs.value }}
+          command: pages deploy packages/craftcms-cp/storybook-static --project-name=craftcms-ui-storybook --branch=${{ steps.branch.outputs.value }}
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/storybook-deploy-resources.yml
+++ b/.github/workflows/storybook-deploy-resources.yml
@@ -1,0 +1,119 @@
+name: 'Deploy / Storybook (resources)'
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 6.x
+    paths:
+      - 'resources/js/**'
+      - 'packages/craftcms-cp/src/**'
+      - 'src/**/*.php'
+  pull_request:
+    paths:
+      - 'resources/js/**'
+      - 'packages/craftcms-cp/src/**'
+      - 'src/**/*.php'
+
+concurrency:
+  group: storybook-deploy-resources-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '22'
+  PHP_VERSION: '8.5'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: 'Build + Deploy'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress
+
+      - name: Install npm dependencies
+        run: npm ci
+        env:
+          CRAFT_FONTAWESOME_TOKEN: ${{ secrets.CRAFT_FONTAWESOME_TOKEN }}
+
+      - name: Build @craftcms/garnish
+        run: npm run build:garnish
+
+      - name: Build @craftcms/cp
+        run: npm run build:cp
+
+      - name: Generate TypeScript types
+        run: npm run generate:types
+
+      - name: Generate Wayfinder routes
+        run: npm run generate:wayfinder
+
+      - name: Build Storybook
+        run: npm run build:storybook
+
+      - name: Determine deploy branch
+        id: branch
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy storybook-static --project-name=craftcms-storybook --branch=${{ steps.branch.outputs.value }}
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `${{ steps.deploy.outputs.deployment-url }}`;
+            const marker = '<!-- storybook-preview-comment:resources -->';
+            const body = `${marker}\n**resources/js Storybook preview:** ${url}`;
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/storybook-deploy-cp.yml` to build and deploy the `@craftcms/cp` Storybook (`packages/craftcms-cp`) to a Cloudflare Pages project (`craftcms-cp-storybook`)
- Adds `.github/workflows/storybook-deploy-resources.yml` to build and deploy the `resources/js` Storybook (root `.storybook/` config) to a separate Cloudflare Pages project (`craftcms-storybook`), including the PHP/Composer + Wayfinder + `@craftcms/cp` build steps that config depends on
- Both workflows deploy PR previews (commented on the PR, updated in place across pushes) and treat pushes to `6.x` as production deploys

## Requires (one-time, not in this PR)
- `wrangler pages project create craftcms-ui-storybook --production-branch=6.x`
- `wrangler pages project create craftcms-storybook --production-branch=6.x`
- Repo secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`

## Test plan
- [ ] Cloudflare Pages projects created and secrets added to the repo
- [ ] Open a PR touching `packages/craftcms-cp/**` and confirm the preview deploy + PR comment appear
- [ ] Open a PR touching `resources/js/**` and confirm the preview deploy + PR comment appear (verify the PHP/Wayfinder build steps succeed)
- [ ] Merge to `6.x` and confirm both production Storybook URLs update

🤖 Generated with [Claude Code](https://claude.com/claude-code)