### PR TITLE
[6.x] Fix localized site routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 6
 
+## Unreleased
+
+- Fixed a bug where site routes weren't being registered for each localized site value.
+
 ## 6.0.0-alpha.11 - 2026-07-07
 
 - Users can now connect their accounts to one or more Socialite providers. ([#19202](https://github.com/craftcms/cms/pull/19202))

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,26 +18,34 @@ $routes = app(CraftRoutes::class);
 
 if (Edition::get()->registersFrontendUserRoutes()) {
     if (Cms::config()->loginPath !== false) {
-        Route::get(Cms::config()->loginPath, [LoginController::class, 'showLogin']);
-        Route::post(Cms::config()->loginPath, [LoginController::class, 'attemptLogin']);
         Route::get(CpAuthPath::TwoFactorChallenge->value, [TwoFactorAuthenticationController::class, 'showForm']);
     }
 
-    if (Cms::config()->verifyEmailPath !== false) {
-        Route::get(Cms::config()->verifyEmailPath, [VerifyEmailController::class, 'show']);
-        Route::post(Cms::config()->verifyEmailPath, [VerifyEmailController::class, 'store']);
-    }
-
-    if (Cms::config()->setPasswordPath !== false) {
-        Route::get(Cms::config()->setPasswordPath, [SetPasswordController::class, 'show']);
-        Route::post(Cms::config()->setPasswordPath, [SetPasswordController::class, 'store']);
-    }
-
-    Route::middleware('auth')->group(function () {
-        if (Cms::config()->logoutPath !== false) {
-            Route::get(Cms::config()->logoutPath, [LoginController::class, 'logout']);
+    /*
+     * These paths can be localized per site, so a route is registered for every
+     * site's value. Changing them or the sites requires re-running `route:cache`
+     * on installs that cache routes.
+     */
+    if (Cms::isInstalled()) {
+        foreach ($routes->localizedConfigPaths('getLoginPath') as $path) {
+            Route::get($path, [LoginController::class, 'showLogin']);
+            Route::post($path, [LoginController::class, 'attemptLogin']);
         }
-    });
+
+        foreach ($routes->localizedConfigPaths('getVerifyEmailPath') as $path) {
+            Route::get($path, [VerifyEmailController::class, 'show']);
+            Route::post($path, [VerifyEmailController::class, 'store']);
+        }
+
+        foreach ($routes->localizedConfigPaths('getSetPasswordPath') as $path) {
+            Route::get($path, [SetPasswordController::class, 'show']);
+            Route::post($path, [SetPasswordController::class, 'store']);
+        }
+
+        foreach ($routes->localizedConfigPaths('getLogoutPath') as $path) {
+            Route::get($path, [LoginController::class, 'logout'])->middleware('auth');
+        }
+    }
 }
 
 if (OAuth::isAvailable()) {

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -69,7 +69,7 @@ class AuthServiceProvider extends ServiceProvider
                 return Cms::config()->cpTrigger.'/login';
             }
 
-            return Cms::config()->loginPath;
+            return Cms::config()->getLoginPath();
         });
 
         RedirectIfAuthenticated::redirectUsing(fn (Request $request) => URL::defaultReturnUrl());

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -72,8 +72,10 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         AuthenticationException::redirectUsing(function () {
-            if (! request()->isCpRequest() && Cms::config()->loginPath !== false) {
-                return Url::siteUrl(Cms::config()->getLoginPath());
+            $loginPath = Cms::config()->getLoginPath();
+
+            if (! request()->isCpRequest() && $loginPath !== false) {
+                return Url::siteUrl($loginPath);
             }
 
             return Url::cpUrl(CpAuthPath::Login->value);

--- a/src/Route/Routes.php
+++ b/src/Route/Routes.php
@@ -11,6 +11,7 @@ use CraftCms\Cms\Route\Events\RouteDeleted;
 use CraftCms\Cms\Route\Events\RouteDeleting;
 use CraftCms\Cms\Route\Events\RouteSaved;
 use CraftCms\Cms\Route\Events\RouteSaving;
+use CraftCms\Cms\Site\Data\Site;
 use CraftCms\Cms\Site\Events\SiteDeleted;
 use CraftCms\Cms\Site\Exceptions\SiteNotFoundException;
 use CraftCms\Cms\Site\Sites;
@@ -86,6 +87,21 @@ class Routes
         private readonly ProjectConfig $projectConfig,
         private readonly Sites $sites,
     ) {}
+
+    /**
+     * Returns the unique localized values of a GeneralConfig path setting across all sites,
+     * for settings that can be defined per site (a site handle keyed array or callable).
+     *
+     * @return Collection<int, string>
+     */
+    public function localizedConfigPaths(string $getter): Collection
+    {
+        return $this->sites->getAllSites()
+            ->map(fn (Site $site) => Cms::config()->$getter($site->handle))
+            ->filter(fn (mixed $path) => is_string($path) && $path !== '')
+            ->unique()
+            ->values();
+    }
 
     /**
      * Returns the routes defined in the project config.

--- a/src/Route/Routes.php
+++ b/src/Route/Routes.php
@@ -92,7 +92,7 @@ class Routes
      * Returns the unique localized values of a GeneralConfig path setting across all sites,
      * for settings that can be defined per site (a site handle keyed array or callable).
      *
-     * @return Collection<int, string>
+     * @return Collection<int, non-empty-string>
      */
     public function localizedConfigPaths(string $getter): Collection
     {

--- a/src/View/TemplateGlobals.php
+++ b/src/View/TemplateGlobals.php
@@ -57,11 +57,11 @@ readonly class TemplateGlobals
             'language' => app()->getLocale(),
             'devMode' => $this->app->hasDebugModeEnabled(),
             'isInstalled' => $isInstalled,
-            'loginUrl' => $this->generalConfig->loginPath !== false
-                ? Url::siteUrl($this->generalConfig->getLoginPath())
+            'loginUrl' => is_string($loginPath = $this->generalConfig->getLoginPath())
+                ? Url::siteUrl($loginPath)
                 : null,
-            'logoutUrl' => $this->generalConfig->logoutPath !== false
-                ? Url::siteUrl($this->generalConfig->getLogoutPath())
+            'logoutUrl' => is_string($logoutPath = $this->generalConfig->getLogoutPath())
+                ? Url::siteUrl($logoutPath)
                 : null,
             'setPasswordUrl' => $setPasswordRequestPath !== null ? Url::siteUrl($setPasswordRequestPath) : null,
             'now' => now(),

--- a/tests/Feature/Http/Controllers/Auth/LoginControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/LoginControllerTest.php
@@ -17,6 +17,7 @@ use Illuminate\Auth\Events\Failed;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Route;
 use Inertia\Testing\AssertableInertia;
 
 use function CraftCms\Cms\cp_url;
@@ -242,6 +243,22 @@ test('attemptLogin accepts username when useEmailAsUsername is false', function 
 
     postJson(action([LoginController::class, 'attemptLogin']), [
         'loginName' => $user->username,
+        'password' => 'craftcms2018!!',
+    ])->assertOk();
+
+    expect(Auth::check())->toBeTrue();
+});
+
+test('login routes are registered for localized loginPath values', function () {
+    Cms::config()->isSystemLive = true;
+    Cms::config()->loginPath = ['siteWithCustomPath' => 'aanmelden'];
+
+    Route::middleware(['web', 'craft', 'craft.web'])->group(dirname(__DIR__, 5).'/routes/web.php');
+
+    $user = User::findOne();
+
+    postJson('/aanmelden', [
+        'loginName' => $user->email,
         'password' => 'craftcms2018!!',
     ])->assertOk();
 


### PR DESCRIPTION
### Description

Fixes route registration so each frontend route is correctly registered for localized sites when configured.

### Related issues

[CMS-2264](https://linear.app/craftcms/issue/CMS-2264/login-route-should-support-localized-values)