### PR TITLE
[6.x] Reject self-referencing Content Block fields at save time

### DIFF
--- a/src/Field/ContentBlock.php
+++ b/src/Field/ContentBlock.php
@@ -18,9 +18,11 @@ use CraftCms\Cms\Element\Validation\ElementRules;
 use CraftCms\Cms\Field\Contracts\ElementContainerFieldInterface;
 use CraftCms\Cms\Field\Elements\ContentBlock as ContentBlockElement;
 use CraftCms\Cms\Field\Enums\TranslationMethod;
+use CraftCms\Cms\Field\Exceptions\FieldNotFoundException;
 use CraftCms\Cms\Field\Exceptions\InvalidFieldException;
 use CraftCms\Cms\FieldLayout\Contracts\FieldLayoutProviderInterface;
 use CraftCms\Cms\FieldLayout\FieldLayout;
+use CraftCms\Cms\FieldLayout\LayoutElements\CustomField as CustomFieldElement;
 use CraftCms\Cms\Gql\GqlHelper as Gql;
 use CraftCms\Cms\Gql\Resolvers\Elements\ContentBlock as ContentBlockResolver;
 use CraftCms\Cms\Gql\Types\Generators\ContentBlock as ContentBlockGenerator;
@@ -148,9 +150,43 @@ class ContentBlock extends Field implements ElementContainerFieldInterface, Fiel
         }
     }
 
-    private function ensureNoRecursion(self $field): bool
+    private function ensureNoRecursion(self $field, array $ancestorUids = []): bool
     {
-        return array_all($field->getFieldLayout()->getCustomFields(), fn ($customField) => ! ($customField instanceof self && ($customField->id === $this->id || ! $this->ensureNoRecursion($customField))));
+        if ($field->uid !== null) {
+            $ancestorUids[] = $field->uid;
+        }
+
+        /** @var CustomFieldElement $layoutElement */
+        foreach ($field->getFieldLayout()->getElementsByType(CustomFieldElement::class) as $layoutElement) {
+            try {
+                $customField = $layoutElement->getField();
+            } catch (FieldNotFoundException) {
+                // The referenced field may not be saved yet (e.g. this field's own first save),
+                // so the raw UUID is all there is to compare against
+                if (in_array($layoutElement->getFieldUid(), $ancestorUids, true)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (! $customField instanceof self) {
+                continue;
+            }
+
+            if (
+                ($customField->id !== null && $customField->id === $this->id) ||
+                in_array($customField->uid, $ancestorUids, true)
+            ) {
+                return false;
+            }
+
+            if (! $this->ensureNoRecursion($customField, $ancestorUids)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function getFieldLayoutProviders(): array

--- a/tests/Feature/Field/FieldsTest.php
+++ b/tests/Feature/Field/FieldsTest.php
@@ -6,6 +6,7 @@ use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Entry\Elements\Entry as EntryElement;
 use CraftCms\Cms\Entry\Models\EntryType;
 use CraftCms\Cms\Field\Color;
+use CraftCms\Cms\Field\ContentBlock;
 use CraftCms\Cms\Field\Entries;
 use CraftCms\Cms\Field\Enums\TranslationMethod;
 use CraftCms\Cms\Field\Events\CompatibleFieldTypesResolving;
@@ -342,6 +343,100 @@ it('can hard delete a field layout by id', function () {
 
     expect(FieldLayoutModel::withTrashed()->find($layout->id))->toBeNull()
         ->and($this->fields->getLayoutById($layout->id))->toBeNull();
+});
+
+it('rejects saving a content block field whose nested layout references itself', function () {
+    // On a first save the field doesn't exist in the database yet, so the
+    // self-reference can't be caught by resolving the nested field by UID —
+    // the raw fieldUid has to be compared against the field's own uid.
+    $fieldUid = (string) Str::uuid();
+
+    $field = $this->fields->createField([
+        'type' => ContentBlock::class,
+        'name' => 'Recursive Block',
+        'handle' => 'recursiveBlock',
+        'uid' => $fieldUid,
+        'settings' => [
+            'viewMode' => 'grouped',
+            'fieldLayouts' => [
+                (string) Str::uuid() => [
+                    'tabs' => [[
+                        'uid' => (string) Str::uuid(),
+                        'elements' => [[
+                            'type' => CustomFieldElement::class,
+                            'uid' => (string) Str::uuid(),
+                            'width' => 100,
+                            'required' => false,
+                            'fieldUid' => $fieldUid,
+                        ]],
+                    ]],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($this->fields->saveField($field))->toBeFalse()
+        ->and($field->errors()->first('fieldLayout'))->toBe('Including a Content Block field recursively is not allowed.')
+        ->and(FieldModel::count())->toBe(0);
+});
+
+it('rejects re-saving a content block field with its own layout element added', function () {
+    $field = $this->fields->createField([
+        'type' => ContentBlock::class,
+        'name' => 'Recursive Block',
+        'handle' => 'recursiveBlock',
+    ]);
+
+    expect($this->fields->saveField($field))->toBeTrue();
+
+    $field->setFieldLayouts([
+        (string) Str::uuid() => [
+            'tabs' => [[
+                'uid' => (string) Str::uuid(),
+                'elements' => [[
+                    'type' => CustomFieldElement::class,
+                    'uid' => (string) Str::uuid(),
+                    'fieldUid' => $field->uid,
+                ]],
+            ]],
+        ],
+    ]);
+
+    expect($this->fields->saveField($field))->toBeFalse()
+        ->and($field->errors()->first('fieldLayout'))->toBe('Including a Content Block field recursively is not allowed.');
+});
+
+it('allows nesting a different content block field', function () {
+    $innerField = $this->fields->createField([
+        'type' => ContentBlock::class,
+        'name' => 'Inner Block',
+        'handle' => 'innerBlock',
+    ]);
+
+    expect($this->fields->saveField($innerField))->toBeTrue();
+
+    $outerField = $this->fields->createField([
+        'type' => ContentBlock::class,
+        'name' => 'Outer Block',
+        'handle' => 'outerBlock',
+        'settings' => [
+            'fieldLayouts' => [
+                (string) Str::uuid() => [
+                    'tabs' => [[
+                        'uid' => (string) Str::uuid(),
+                        'elements' => [[
+                            'type' => CustomFieldElement::class,
+                            'uid' => (string) Str::uuid(),
+                            'fieldUid' => $innerField->uid,
+                        ]],
+                    ]],
+                ],
+            ],
+        ],
+    ]);
+
+    expect($this->fields->saveField($outerField))->toBeTrue()
+        ->and(FieldModel::count())->toBe(2);
 });
 
 it('can find field usages', function () {


### PR DESCRIPTION
## What changed

`ContentBlock::ensureNoRecursion()` now iterates the nested layout's `CustomField` layout elements directly instead of `FieldLayout::getCustomFields()`:

- When a nested field **can't be resolved from the DB** (`FieldNotFoundException`), the element's raw `fieldUid` is compared against the field's own `uid`, catching self-references before the field row exists.
- When it **can** be resolved, the original `id` comparison is kept (now null-guarded so two unsaved fields don't false-positive), plus a `uid` comparison.
- An ancestor-UID list is threaded through the recursion, so indirect cycles are caught at any depth — and validating a field that nests an *already-corrupted* self-referencing field terminates instead of recursing infinitely.

## Why

Recursion validation had a first-save blind spot: `ensureNoRecursion()` relied on resolving nested fields via `Fields::getFieldByUid()`. On a field's **first** save the row doesn't exist yet, so a self-referencing `fieldUid` in the nested layout threw `FieldNotFoundException`, which was swallowed — and the self-reference passed validation. This actually happened in dev: a saved field's settings JSON contained its own UID as a nested `CustomField` `fieldUid`. Upstream Craft 5 rejects this with "Including a Content Block field recursively is not allowed."

## Tests

Three new Pest feature tests in `tests/Feature/Field/FieldsTest.php` (written test-first; the first one reproduced the bug before the fix):

1. Saving a content block field whose nested layout references itself fails validation (first-save path, no DB row).
2. Re-saving an existing content block field with its own layout element added fails validation (DB-resolvable path).
3. Nesting a *different* content block field still saves (guards against over-rejection — non-cyclic nesting is legal).

## Notes for reviewers

- The field-picker UI (`FieldLayout::getAvailableCustomFields()`) doesn't exclude the field being edited — same as upstream Craft 5, which also relies on save-time rejection. Hiding it from the picker is a possible follow-up UX improvement, tracked separately.
- Complements the in-progress construction-safety change (deferring layout creation in `setFieldLayouts()`), which makes *loading* corrupted rows safe; this PR stops the corruption from being saved in the first place. The two touch different regions of the same files and merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)