### PR TITLE
Fixed rendering fallback CP views on FE requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a bug where site routes weren't being registered for each localized site value.
 - Fixed a bug where POST requests to the `loginPath` weren’t being handled properly. ([#19220](https://github.com/craftcms/cms/pull/19220))
 - Fixed a bug where users were redirected to the previous page on logout. ([#19220](https://github.com/craftcms/cms/pull/19220))
+- Fixed a bug where requests to the `loginPath`, `setPasswordPath`, and `verifyEmailPath` were getting redirected to the control panel. ([#19229](https://github.com/craftcms/cms/pull/19229))
 
 ## 6.0.0-alpha.11 - 2026-07-07
 

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -3,13 +3,13 @@
   import {usePage} from '@inertiajs/vue3';
   import useCraftData from '@/common/composables/useCraftData';
   import AuthBase from '@/common/layouts/AuthBase.vue';
-  import {attemptLogin} from '@actions/Auth/LoginController';
   import '@/modules/auth/components/login/login-form.js';
 
   const props = defineProps<{
     errors?: Record<string, string[]>;
     authFormData?: Record<string, string>;
     oauthLoginButtons?: string[];
+    action: string;
   }>();
 
   const oauthLoginButtonsHtml = computed(
@@ -29,7 +29,7 @@
 <template>
   <AuthBase>
     <craft-login-form
-      :action="attemptLogin().url"
+      :action="props.action"
       show-reset-password
       show-remember-me
       :username="page.props.username"

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -29,7 +29,7 @@
 <template>
   <AuthBase>
     <craft-login-form
-      :action="props.action"
+      :action="action"
       show-reset-password
       show-remember-me
       :username="page.props.username"

--- a/resources/js/pages/auth/SetPassword.vue
+++ b/resources/js/pages/auth/SetPassword.vue
@@ -24,7 +24,7 @@
 <template>
   <AuthBase :title="title">
     <craft-set-password-form
-      :action="props.action"
+      :action="action"
       :uid="uid"
       :code="code"
       :initial-error="page.props.errors?.newPassword"

--- a/resources/js/pages/auth/SetPassword.vue
+++ b/resources/js/pages/auth/SetPassword.vue
@@ -3,13 +3,13 @@
   import {t} from '@craftcms/cp';
   import {usePage} from '@inertiajs/vue3';
   import AuthBase from '@/common/layouts/AuthBase.vue';
-  import {store} from '@actions/Auth/SetPasswordController';
   import '@/modules/auth/components/set-password/set-password-form.js';
 
   const props = defineProps<{
     uid: string;
     code: string;
     newUser: boolean;
+    action: string;
   }>();
 
   const page = usePage<{
@@ -19,16 +19,12 @@
   const title = computed(() =>
     props.newUser ? t('Set Your Password') : t('Set Your New Password')
   );
-
-  const action = computed(
-    () => store(undefined, {query: {uid: props.uid, code: props.code}}).url
-  );
 </script>
 
 <template>
   <AuthBase :title="title">
     <craft-set-password-form
-      :action="action"
+      :action="props.action"
       :uid="uid"
       :code="code"
       :initial-error="page.props.errors?.newPassword"

--- a/resources/js/pages/auth/VerifyEmail.vue
+++ b/resources/js/pages/auth/VerifyEmail.vue
@@ -3,21 +3,17 @@
   import {computed} from 'vue';
   import {usePage} from '@inertiajs/vue3';
   import AuthBase from '@/common/layouts/AuthBase.vue';
-  import {store} from '@actions/Auth/VerifyEmailController';
   import '@/modules/auth/components/verify-email/verify-email-form.js';
 
   const props = defineProps<{
     uid: string;
     code: string;
+    action: string;
   }>();
 
   const page = usePage<{
     errors?: Record<string, string>;
   }>();
-
-  const action = computed(
-    () => store(undefined, {query: {uid: props.uid, code: props.code}}).url
-  );
 
   const initialError = computed(
     () => page.props.errors?.code ?? page.props.errors?.uid
@@ -27,7 +23,7 @@
 <template>
   <AuthBase :title="t('Verify your email address')">
     <craft-verify-email-form
-      :action="action"
+      :action="props.action"
       :uid="uid"
       :code="code"
       :initial-error="initialError"

--- a/resources/js/pages/auth/VerifyEmail.vue
+++ b/resources/js/pages/auth/VerifyEmail.vue
@@ -5,7 +5,7 @@
   import AuthBase from '@/common/layouts/AuthBase.vue';
   import '@/modules/auth/components/verify-email/verify-email-form.js';
 
-  const props = defineProps<{
+  defineProps<{
     uid: string;
     code: string;
     action: string;
@@ -23,7 +23,7 @@
 <template>
   <AuthBase :title="t('Verify your email address')">
     <craft-verify-email-form
-      :action="props.action"
+      :action="action"
       :uid="uid"
       :code="code"
       :initial-error="initialError"

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -20,7 +20,9 @@ use CraftCms\Cms\Http\Controllers\Assets\UploadController as AssetsUploadControl
 use CraftCms\Cms\Http\Controllers\Auth\LoginController;
 use CraftCms\Cms\Http\Controllers\Auth\PasskeyController;
 use CraftCms\Cms\Http\Controllers\Auth\SessionInfoController;
+use CraftCms\Cms\Http\Controllers\Auth\SetPasswordController;
 use CraftCms\Cms\Http\Controllers\Auth\TwoFactorAuthenticationController;
+use CraftCms\Cms\Http\Controllers\Auth\VerifyEmailController;
 use CraftCms\Cms\Http\Controllers\BaseUpdaterController;
 use CraftCms\Cms\Http\Controllers\ConditionsController;
 use CraftCms\Cms\Http\Controllers\ConfigSyncController;
@@ -131,6 +133,8 @@ foreach ($sharedActionRouteGroups as [$prefix, $middleware]) {
         Route::post('users/login-with-passkey', [PasskeyController::class, 'login']);
         Route::post('users/login-modal', [LoginController::class, 'showLoginModal']);
         Route::any('users/redirect', [LoginController::class, 'redirect']);
+        Route::post('users/set-password', [SetPasswordController::class, 'store']);
+        Route::post('users/verify-email', [VerifyEmailController::class, 'store']);
         Route::any('users/session-info', [SessionInfoController::class, 'show'])
             ->middleware(StartSessionWithoutPersistence::class)
             ->withoutMiddleware([StartSession::class, ShareErrorsFromSession::class, PreventRequestForgery::class]);

--- a/src/Http/Controllers/Auth/AuthenticationController.php
+++ b/src/Http/Controllers/Auth/AuthenticationController.php
@@ -10,8 +10,8 @@ use CraftCms\Cms\Auth\Enums\CpAuthPath;
 use CraftCms\Cms\Auth\Events\InvalidUserToken;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Config\GeneralConfig;
+use CraftCms\Cms\Http\Middleware\HandleInertiaRequests;
 use CraftCms\Cms\Http\RespondsWithFlash;
-use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\User\Contracts\CraftUser;
 use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\User\Events\EmailVerified;
@@ -28,8 +28,6 @@ use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
-
-use function CraftCms\Cms\cp_url;
 
 abstract readonly class AuthenticationController
 {
@@ -101,23 +99,29 @@ abstract readonly class AuthenticationController
         return $this->asFailure($message, ['errorCode' => $authError?->value]);
     }
 
-    protected function renderViewWithFallback(string $cpTemplate, array $data = [], ?string $inertiaComponent = null, ?array $inertiaProps = null): View|InertiaResponse|Response
+    protected function renderViewWithFallback(string $inertiaComponent, ?array $inertiaProps = null, array $data = []): View|InertiaResponse|Response
     {
-        if ($inertiaComponent !== null && request()->isCpRequest()) {
-            return Inertia::render($inertiaComponent, $inertiaProps ?? $data);
-        }
+        $request = request();
 
-        if (view()->exists(request()->craftPath())) {
-            return view(request()->craftPath(), $data);
+        // if this is a front-end request and a template exists for the requested path, render it
+        if (! $request->isCpRequest() && view()->exists($request->craftPath())) {
+            return view($request->craftPath(), $data);
         }
 
         TemplateMode::set(TemplateMode::Cp);
 
-        if (! view()->exists('craftcms::'.$cpTemplate)) {
-            return redirect(cp_url($cpTemplate));
+        if ($request->isCpRequest()) {
+            return Inertia::render($inertiaComponent, $inertiaProps ?? $data);
         }
 
-        return view('craftcms::'.Str::start($cpTemplate, ''), $data);
+        // Front-end requests don't run through the `craft.cp` middleware group, so
+        // `HandleInertiaRequests` never gets a chance to prep the Inertia root view
+        // (headHtml/bodyHtml, shared props, etc). Invoke it manually since we're
+        // falling back to an Inertia-rendered response.
+        return app(HandleInertiaRequests::class)->handle(
+            $request,
+            fn (Request $request): Response => Inertia::render($inertiaComponent, $inertiaProps ?? $data)->toResponse($request),
+        );
     }
 
     protected function processTokenRequest(Request $request): Response|array

--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -30,6 +30,7 @@ use Illuminate\Validation\Rules\Password;
 use Symfony\Component\HttpFoundation\Response;
 use Tpetry\QueryExpressions\Function\String\Lower;
 
+use function CraftCms\Cms\action_url;
 use function CraftCms\Cms\cp_url;
 use function CraftCms\Cms\site_url;
 use function CraftCms\Cms\template;
@@ -54,14 +55,14 @@ readonly class LoginController extends AuthenticationController
         );
 
         return $this->renderViewWithFallback(
-            cpTemplate: 'login',
-            data: [
-                'action' => action([self::class, 'attemptLogin']),
-                'oauthLoginButtons' => $oauthLoginButtons,
-            ],
             inertiaComponent: 'auth/Login',
             inertiaProps: [
                 'username' => $generalConfig->rememberUsernameDuration ? $authMethods->getRememberedUsername() : '',
+                'oauthLoginButtons' => $oauthLoginButtons,
+                'action' => $request->isCpRequest() ? action([self::class, 'attemptLogin']) : action_url('users/login'),
+            ],
+            data: [
+                'action' => action([self::class, 'attemptLogin']),
                 'oauthLoginButtons' => $oauthLoginButtons,
             ],
         );

--- a/src/Http/Controllers/Auth/SetPasswordController.php
+++ b/src/Http/Controllers/Auth/SetPasswordController.php
@@ -24,6 +24,7 @@ use Inertia\Response as InertiaResponse;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
 
+use function CraftCms\Cms\action_url;
 use function CraftCms\Cms\t;
 
 readonly class SetPasswordController extends AuthenticationController
@@ -45,13 +46,18 @@ readonly class SetPasswordController extends AuthenticationController
 
         // Send them to the set password template.
         return $this->renderViewWithFallback(
-            cpTemplate: 'set-password',
+            inertiaComponent: 'auth/SetPassword',
+            inertiaProps: [
+                'code' => $code,
+                'uid' => $uid,
+                'newUser' => ! $user->password,
+                'action' => $request->isCpRequest() ? action([self::class, 'store']) : action_url('users/set-password'),
+            ],
             data: [
                 'code' => $code,
                 'uid' => $uid,
                 'newUser' => ! $user->password,
             ],
-            inertiaComponent: 'auth/SetPassword',
         );
     }
 

--- a/src/Http/Controllers/Auth/VerifyEmailController.php
+++ b/src/Http/Controllers/Auth/VerifyEmailController.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Password;
 use Inertia\Response as InertiaResponse;
 use Symfony\Component\HttpFoundation\Response;
 
+use function CraftCms\Cms\action_url;
 use function CraftCms\Cms\t;
 
 readonly class VerifyEmailController extends AuthenticationController
@@ -35,12 +36,16 @@ readonly class VerifyEmailController extends AuthenticationController
 
         // Send them to the set verify-email template
         return $this->renderViewWithFallback(
-            cpTemplate: 'verify-email',
+            inertiaComponent: 'auth/VerifyEmail',
+            inertiaProps: [
+                'uid' => $uid,
+                'code' => $code,
+                'action' => $request->isCpRequest() ? action([self::class, 'store']) : action_url('users/verify-email'),
+            ],
             data: [
                 'uid' => $uid,
                 'code' => $code,
             ],
-            inertiaComponent: 'auth/VerifyEmail',
         );
     }
 

--- a/tests/Unit/Asset/Elements/AssetMetadataAltTest.php
+++ b/tests/Unit/Asset/Elements/AssetMetadataAltTest.php
@@ -116,7 +116,7 @@ function createAssetMetadataAltJpegBytes(): string
     ob_start();
     imagejpeg($image);
 
-    return (string) ob_get_clean();
+    return ob_get_clean();
 }
 
 function createAssetMetadataAltTempJpeg(string $contents): string


### PR DESCRIPTION
Fixes a bug where front end routes that went through `AuthenticationController::renderViewWithFallback()` were getting redirected to the CP equivalent URL, rather than rendering the CP view on the requested FE URL.

Also updates the views to submit to a FE-compatible route, when rendered on the front end.