### PR TITLE
[6.x] Fix legacy Codeception tests

### DIFF
--- a/yii2-adapter/tests/_bootstrap.php
+++ b/yii2-adapter/tests/_bootstrap.php
@@ -30,6 +30,7 @@ const CRAFT_TESTS_PATH = __DIR__;
 new TestCase('laravel')->createApplication();
 
 Config::set('auth.defaults.guard', 'web');
+Config::set('craft.app.components.errorHandler.silentExitOnException', false);
 
 $devMode = true;
 

--- a/yii2-adapter/tests/unit/gql/ScalarTypesTest.php
+++ b/yii2-adapter/tests/unit/gql/ScalarTypesTest.php
@@ -214,24 +214,24 @@ class ScalarTypesTest extends TestCase
         GqlEntityRegistry::setPrefix('');
 
         return [
-            [DateTime::getType(), new IntValueNode(['value' => 2]), null, GqlException::class],
+            [DateTime::getType(), new IntValueNode(['value' => '2']), null, GqlException::class],
 
             [Number::getType(), new StringValueNode(['value' => '2.4']), 2.4],
             [Number::getType(), new StringValueNode(['value' => 'fake']), 0.0],
-            [Number::getType(), new FloatValueNode(['value' => 2.4]), 2.4],
-            [Number::getType(), new IntValueNode(['value' => 2]), 2],
+            [Number::getType(), new FloatValueNode(['value' => '2.4']), 2.4],
+            [Number::getType(), new IntValueNode(['value' => '2']), 2],
             [Number::getType(), new NullValueNode([]), null],
             [Number::getType(), new BooleanValueNode(['value' => false]), null, GqlException::class],
 
             [QueryArgument::getType(), new StringValueNode(['value' => '2']), '2'],
-            [QueryArgument::getType(), new IntValueNode(['value' => 2]), 2],
+            [QueryArgument::getType(), new IntValueNode(['value' => '2']), 2],
             [QueryArgument::getType(), new BooleanValueNode(['value' => true]), true],
             [QueryArgument::getType(), new FloatValueNode(['value' => '2']), null, GqlException::class],
 
             [Money::getType(), new StringValueNode(['value' => '2.4']), 2.4],
             [Money::getType(), new StringValueNode(['value' => 'fake']), 0.0],
-            [Money::getType(), new FloatValueNode(['value' => 2.4]), 2.4],
-            [Money::getType(), new IntValueNode(['value' => 2]), 2],
+            [Money::getType(), new FloatValueNode(['value' => '2.4']), 2.4],
+            [Money::getType(), new IntValueNode(['value' => '2']), 2],
             [Money::getType(), new NullValueNode([]), null],
             [Money::getType(), new BooleanValueNode(['value' => false]), null, GqlException::class],
         ];

--- a/yii2-adapter/tests/unit/gql/mutations/GeneralMutationResolverTest.php
+++ b/yii2-adapter/tests/unit/gql/mutations/GeneralMutationResolverTest.php
@@ -123,7 +123,7 @@ class GeneralMutationResolverTest extends TestCase
     public function testPopulatingElementWithData(array $contentFields, array $arguments): void
     {
         $entry = $this->make(Entry::class, [
-            'setFieldValue' => Expected::exactly(count($contentFields)),
+            'setFieldValueFromRequest' => Expected::exactly(count($contentFields)),
         ]);
 
         $this->resolver->setResolutionData(ElementMutationResolver::CONTENT_FIELD_KEY, $contentFields);

--- a/yii2-adapter/tests/unit/helpers/CpHelperTest.php
+++ b/yii2-adapter/tests/unit/helpers/CpHelperTest.php
@@ -140,12 +140,12 @@ class CpHelperTest extends TestCase
         self::assertStringContainsString('id="inst-id"', $withInstructions);
         self::assertStringContainsString('<p><strong>Test</strong></p>', $withInstructions);
         // tip
-        self::assertStringContainsString('<p id="tip" class="notice has-icon"><span class="icon" aria-hidden="true"></span><span class="visually-hidden">Tip: </span><span><strong>Test</strong></span></p>', Cp::fieldHtml('<input>', [
+        self::assertMatchesRegularExpression('/<craft-callout\s+id="tip"\s+variant="info"[^>]*>.*<strong>Test<\/strong>.*<\/craft-callout>/s', Cp::fieldHtml('<input>', [
             'tipId' => 'tip',
             'tip' => '**Test**',
         ]));
         // warning
-        self::assertStringContainsString('<p id="warning" class="warning has-icon"><span class="icon" aria-hidden="true"></span><span class="visually-hidden">Warning: </span><span><strong>Test</strong></span></p>', Cp::fieldHtml('<input>', [
+        self::assertMatchesRegularExpression('/<craft-callout\s+id="warning"\s+variant="warning"[^>]*>.*<strong>Test<\/strong>.*<\/craft-callout>/s', Cp::fieldHtml('<input>', [
             'warningId' => 'warning',
             'warning' => '**Test**',
         ]));

--- a/yii2-adapter/tests/unit/web/twig/FieldTest.php
+++ b/yii2-adapter/tests/unit/web/twig/FieldTest.php
@@ -53,8 +53,8 @@ TWIG;
         self::assertStringContainsString('TEST HEADING', $html);
         self::assertStringContainsString('<label id="label" for="foo">TEST LABEL</label>', $html);
         self::assertStringContainsString('<div id="foo-instructions" class="instructions"><p>TEST INSTRUCTIONS</p>', $html);
-        self::assertStringContainsString('<p id="foo-tip" class="notice has-icon"><span class="icon" aria-hidden="true"></span><span class="visually-hidden">Tip: </span><span>TEST TIP</span></p>', $html);
-        self::assertStringContainsString('<p id="foo-warning" class="warning has-icon"><span class="icon" aria-hidden="true"></span><span class="visually-hidden">Warning: </span><span>TEST WARNING</span></p>', $html);
+        self::assertMatchesRegularExpression('/<craft-callout\s+id="foo-tip"\s+variant="info"[^>]*>.*TEST TIP.*<\/craft-callout>/s', $html);
+        self::assertMatchesRegularExpression('/<craft-callout\s+id="foo-warning"\s+variant="warning"[^>]*>.*TEST WARNING.*<\/craft-callout>/s', $html);
         self::assertStringContainsString('<input name="foo">', $html);
     }
 


### PR DESCRIPTION
### Description

Fixes legacy Codeception test discovery failures caused by invalid GraphQL AST fixtures, ensures uncaught setup errors return a failing exit code, and updates stale assertions for current field behavior.