### PR TITLE
Cleanup `Volume::attributeLabels()`

### DIFF
--- a/src/models/Volume.php
+++ b/src/models/Volume.php
@@ -226,7 +226,6 @@ class Volume extends Model implements
         return [
             'handle' => Craft::t('app', 'Handle'),
             'name' => Craft::t('app', 'Name'),
-            'url' => Craft::t('app', 'URL'),
             'fsHandle' => Craft::t('app', 'Asset Filesystem'),
             'subpath' => Craft::t('app', 'Subpath'),
             'transformFsHandle' => Craft::t('app', 'Transform Filesystem'),


### PR DESCRIPTION
### Description

I was checking my PHPStan extension [mspirkov/yii2-phpstan-rules](https://github.com/mspirkov/yii2-phpstan-rules) on your project and found this error. It seems to be dead code that can be removed, as the `url` property in the `Volume` model does not exist, and I did not find any implicit use of this code anywhere.

<img width="665" height="147" alt="image" src="https://github.com/user-attachments/assets/ec42c13f-f369-4a77-8f23-0df32e627c46" />
