### PR TITLE
[6.x] Use write connection on most POST requests

### DIFF
--- a/src/Database/DatabaseServiceProvider.php
+++ b/src/Database/DatabaseServiceProvider.php
@@ -106,6 +106,10 @@ class DatabaseServiceProvider extends ServiceProvider
 
     public function boot(Repository $config, Connection $db, \Illuminate\Cache\Repository $cache): void
     {
+        if ($this->app->runningInConsole()) {
+            $db->useWriteConnectionWhenReading();
+        }
+
         Aliases::set('@migrations', '@package/Database/Migrations');
 
         $this->commands([

--- a/src/Http/Middleware/UseWriteConnection.php
+++ b/src/Http/Middleware/UseWriteConnection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http\Middleware;
+
+use Closure;
+use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ElementIndexController;
+use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ElementIndexSourcesController;
+use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ExportElementIndexController;
+use CraftCms\Cms\Http\Controllers\Gql\ApiController as GqlApiController;
+use Illuminate\Database\Connection;
+use Illuminate\Http\Request;
+
+readonly class UseWriteConnection
+{
+    private const array READ_ONLY_ACTIONS = [
+        ElementIndexController::class.'@countElements',
+        ElementIndexController::class.'@getElements',
+        ElementIndexController::class.'@getMoreElements',
+        ElementIndexSourcesController::class.'@getSourceTreeHtml',
+        ExportElementIndexController::class,
+        GqlApiController::class,
+    ];
+
+    public function __construct(
+        private Connection $db,
+    ) {}
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $isReadOnlyAction = in_array($request->route()?->getAction('uses'), self::READ_ONLY_ACTIONS, true);
+
+        $this->db->useWriteConnectionWhenReading(
+            ! $request->isMethodSafe() &&
+            ! $isReadOnlyAction,
+        );
+
+        return $next($request);
+    }
+}

--- a/src/Route/RouteServiceProvider.php
+++ b/src/Route/RouteServiceProvider.php
@@ -29,6 +29,7 @@ use CraftCms\Cms\Http\Middleware\RunQueue;
 use CraftCms\Cms\Http\Middleware\SetHeaders;
 use CraftCms\Cms\Http\Middleware\ShowBrokenImage;
 use CraftCms\Cms\Http\Middleware\UpdateLocale;
+use CraftCms\Cms\Http\Middleware\UseWriteConnection;
 use CraftCms\Cms\Route\Data\Route;
 use CraftCms\Cms\Site\Events\SiteDeleted;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
@@ -163,6 +164,7 @@ class RouteServiceProvider extends ServiceProvider
         $router->aliasMiddleware('password.confirm', RequireConfirmedPassword::class);
 
         collect([
+            UseWriteConnection::class,
             ForgetTriggerParameters::class,
             EnsureInstalled::class,
             AddLogContext::class,

--- a/tests/Unit/Database/DatabaseServiceProviderTest.php
+++ b/tests/Unit/Database/DatabaseServiceProviderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Database\DatabaseServiceProvider;
+use Illuminate\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Facades\DB;
+
+it('uses the write connection for console requests', function () {
+    $db = DB::connection();
+    $writePdo = new PDO('sqlite::memory:');
+    $readPdo = new PDO('sqlite::memory:');
+    $db->setPdo($writePdo);
+    $db->setReadPdo($readPdo);
+    $db->useWriteConnectionWhenReading(false);
+
+    new DatabaseServiceProvider(app())->boot(
+        app(Repository::class),
+        $db,
+        app(CacheRepository::class),
+    );
+
+    expect($db->getReadPdo())->toBe($writePdo);
+});

--- a/tests/Unit/Http/Middleware/UseWriteConnectionTest.php
+++ b/tests/Unit/Http/Middleware/UseWriteConnectionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ElementIndexController;
+use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ElementIndexSourcesController;
+use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ExportElementIndexController;
+use CraftCms\Cms\Http\Controllers\Gql\ApiController as GqlApiController;
+use CraftCms\Cms\Http\Middleware\UseWriteConnection;
+use Illuminate\Database\Connection;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\DB;
+
+it('uses the write connection for unsafe requests', function (string $method) {
+    $db = Mockery::mock(Connection::class);
+    $db->expects('useWriteConnectionWhenReading')->with(true)->once()->andReturnSelf();
+    $request = Request::create('/articles', $method);
+
+    $response = new UseWriteConnection($db)->handle($request, fn () => 'response');
+
+    expect($response)->toBe('response');
+})->with(['POST', 'PATCH', 'DELETE']);
+
+it('keeps safe requests on the read connection', function (string $method) {
+    $db = Mockery::mock(Connection::class);
+    $db->expects('useWriteConnectionWhenReading')->with(false)->once()->andReturnSelf();
+    $request = Request::create('/articles', $method);
+
+    $response = new UseWriteConnection($db)->handle($request, fn () => 'response');
+
+    expect($response)->toBe('response');
+})->with(['GET', 'HEAD']);
+
+it('keeps read-only controller actions on the read connection', function (string $controller, string $method) {
+    $db = Mockery::mock(Connection::class);
+    $db->expects('useWriteConnectionWhenReading')->with(false)->once()->andReturnSelf();
+    $request = Request::create('/renamed-endpoint', 'POST');
+    $route = new Route(['POST'], '/renamed-endpoint', $method === '__invoke' ? $controller : [$controller, $method]);
+    $request->setRouteResolver(fn () => $route);
+
+    $response = new UseWriteConnection($db)->handle($request, fn () => 'response');
+
+    expect($response)->toBe('response');
+})->with([
+    'count elements' => [ElementIndexController::class, 'countElements'],
+    'export' => [ExportElementIndexController::class, '__invoke'],
+    'get elements' => [ElementIndexController::class, 'getElements'],
+    'get more elements' => [ElementIndexController::class, 'getMoreElements'],
+    'get source tree HTML' => [ElementIndexSourcesController::class, 'getSourceTreeHtml'],
+    'GraphQL API' => [GqlApiController::class, '__invoke'],
+]);
+
+it('resets the write connection after an unsafe request', function () {
+    $db = DB::connection();
+    $writePdo = new PDO('sqlite::memory:');
+    $readPdo = new PDO('sqlite::memory:');
+    $writePdo->exec("CREATE TABLE markers (value TEXT); INSERT INTO markers VALUES ('write')");
+    $readPdo->exec("CREATE TABLE markers (value TEXT); INSERT INTO markers VALUES ('read')");
+    $db->setPdo($writePdo);
+    $db->setReadPdo($readPdo);
+    $middleware = new UseWriteConnection($db);
+
+    $writeValue = $middleware->handle(
+        Request::create('/articles', 'POST'),
+        fn () => $db->table('markers')->value('value'),
+    );
+    $readValue = $middleware->handle(
+        Request::create('/articles', 'GET'),
+        fn () => $db->table('markers')->value('value'),
+    );
+
+    expect($writeValue)->toBe('write')
+        ->and($readValue)->toBe('read');
+});

--- a/tests/Unit/Route/RouteServiceProviderTest.php
+++ b/tests/Unit/Route/RouteServiceProviderTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Http\Middleware\UseWriteConnection;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Routing\Router;
+
+it('only applies write connection routing to Craft routes', function () {
+    $router = app(Router::class);
+
+    expect(app(Kernel::class)->getGlobalMiddleware())->not->toContain(UseWriteConnection::class)
+        ->and($router->getMiddlewareGroups()['craft'][0])->toBe(UseWriteConnection::class);
+});


### PR DESCRIPTION
### Description

5.x already did this but was something I missed when porting over the database logic. 

This forces the write connection on almost all Craft's POST requests (except a fixed set of "safe" requests) and on console commands if Laravel is configured to use read/write replicas.
