### PR TITLE
[6.x] Entry index Inertia tweaks

### DIFF
--- a/resources/js/modules/elements/ElementSources.vue
+++ b/resources/js/modules/elements/ElementSources.vue
@@ -59,6 +59,16 @@
   // fall back to the source the server says is active.
   const activeKey = computed(() => pendingSource.value ?? props.activeSource);
 
+  const visitOptions = {
+    except: ['sources', 'publishableSections'],
+    preserveState: true,
+    preserveScroll: true,
+  };
+
+  function prefetchSource(key: string) {
+    router.prefetch(sourceUrl(key), visitOptions, {cacheFor: 0});
+  }
+
   function visitSource(key: string) {
     if (key === activeKey.value) {
       return;
@@ -73,9 +83,7 @@
       // behind the New-entry button don't change — so skip re-sending those two
       // rather than re-fetching the entire page. Mirrors the partial-reload
       // approach the sort/pagination/view-mode composables already use.
-      except: ['sources', 'publishableSections'],
-      preserveState: true,
-      preserveScroll: true,
+      ...visitOptions,
       onFinish: () => {
         // Hand control back to the server prop once this visit settles. The
         // key guard means a superseded (cancelled) visit from rapid switching
@@ -106,6 +114,7 @@
               :href="sourceUrl(child.key)"
               :active="child.key === activeKey"
               :data-group="source.heading"
+              @mousedown.exact="prefetchSource(child.key)"
               @click.exact.prevent="visitSource(child.key)"
             >
               {{ child.label }}
@@ -117,6 +126,7 @@
         <craft-nav-item
           :href="sourceUrl(source.key)"
           :active="source.key === activeKey"
+          @mousedown.exact="prefetchSource(source.key)"
           @click.exact.prevent="visitSource(source.key)"
         >
           {{ source.label }}

--- a/resources/js/modules/elements/ElementSources.vue
+++ b/resources/js/modules/elements/ElementSources.vue
@@ -5,15 +5,12 @@
   import type {ElementIndexRoute} from '@/modules/elements/composables/useElementIndexVisits';
   import type {Source, SourceHeading} from '@/modules/elements/types/sources';
 
-  const props = withDefaults(
-    defineProps<{
-      sources: Array<Source>;
-      route: ElementIndexRoute;
-      activeSource?: string | null;
-      viewMode?: string | null;
-    }>(),
-    {activeSource: null, viewMode: null}
-  );
+  const props = defineProps<{
+    sources: Array<Source>;
+    route: ElementIndexRoute;
+    activeSource?: string | null;
+    viewMode?: string | null;
+  }>();
 
   const {site} = useCraftData();
 
@@ -62,21 +59,11 @@
   // fall back to the source the server says is active.
   const activeKey = computed(() => pendingSource.value ?? props.activeSource);
 
-  function onSourceClick(event: MouseEvent, key: string) {
-    if (event.metaKey || event.ctrlKey || event.shiftKey) {
-      return;
-    }
-
-    event.preventDefault();
-
+  function visitSource(key: string) {
     if (key === activeKey.value) {
       return;
     }
 
-    visitSource(key);
-  }
-
-  function visitSource(key: string) {
     // Reflect the selection right away, before the request goes out.
     pendingSource.value = key;
 
@@ -119,7 +106,7 @@
               :href="sourceUrl(child.key)"
               :active="child.key === activeKey"
               :data-group="source.heading"
-              @click="onSourceClick($event, child.key)"
+              @click.exact.prevent="visitSource(child.key)"
             >
               {{ child.label }}
             </craft-nav-item>
@@ -130,7 +117,7 @@
         <craft-nav-item
           :href="sourceUrl(source.key)"
           :active="source.key === activeKey"
-          @click="onSourceClick($event, source.key)"
+          @click.exact.prevent="visitSource(source.key)"
         >
           {{ source.label }}
         </craft-nav-item>
@@ -138,5 +125,3 @@
     </template>
   </craft-nav-list>
 </template>
-
-<style scoped lang="scss"></style>

--- a/resources/js/modules/elements/composables/useElementIndexLoading.ts
+++ b/resources/js/modules/elements/composables/useElementIndexLoading.ts
@@ -25,7 +25,11 @@ export function useElementIndexLoading() {
     offHandlers.push(
       router.on('start', (event) => {
         const {visit} = event.detail;
-        if (visit.method === 'get' && visit.url.pathname === indexPath) {
+        if (
+          !visit.prefetch &&
+          visit.method === 'get' &&
+          visit.url.pathname === indexPath
+        ) {
           loading.value = true;
         }
       })


### PR DESCRIPTION
### Description

Two small improvements:

- Use `@click.exact.prevent` instead of manually checking modifiers for source links
- Add a prefetch on mousedown which speeds up the perceived load times

One fix:
- `useElementIndexLoading` was also showing the spinner for prefetch requests, which it now doesn't