### PR TITLE
Fix yii2-adapter jQuery asset resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 6
 
+## Unreleased
+
+- Fixed a bug where the legacy `yii\web\JqueryAsset` wasn’t resolving properly. ([#19264](https://github.com/craftcms/cms/pull/19264))
+
 ## 6.0.0-alpha.13 - 2026-07-16
 
 - Updated logout routes to require CSRF-protected POST requests. ([#19252](https://github.com/craftcms/cms/pull/19252/changes/ff6f20717a48e7ede5fbbe47487e7bb8ef71da78))

--- a/yii2-adapter/legacy/helpers/App.php
+++ b/yii2-adapter/legacy/helpers/App.php
@@ -48,8 +48,10 @@ use yii\db\sqlite\Schema as SqliteSchema;
 use yii\mutex\FileMutex;
 use yii\mutex\MysqlMutex;
 use yii\mutex\PgsqlMutex;
+use yii\web\JqueryAsset as YiiJqueryAsset;
 use yii\web\JsonParser;
 use function CraftCms\Cms\backTraceAsString;
+use function CraftCms\Cms\craftAsset;
 use function CraftCms\Cms\maxPowerCaptain;
 use function CraftCms\Cms\normalizeValue;
 use function CraftCms\Cms\normalizeVersion;
@@ -604,6 +606,14 @@ class App
             'fileMode' => $generalConfig->defaultFileMode,
             'dirMode' => $generalConfig->defaultDirMode,
             'appendTimestamp' => true,
+            'bundles' => [
+                YiiJqueryAsset::class => [
+                    'sourcePath' => null,
+                    'js' => [
+                        craftAsset('legacy/jquery/dist/jquery.js'),
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/yii2-adapter/tests-laravel/View/CpAssetOrderTest.php
+++ b/yii2-adapter/tests-laravel/View/CpAssetOrderTest.php
@@ -7,6 +7,7 @@ use CraftCms\Cms\Support\Facades\HtmlStack;
 use CraftCms\Cms\View\Enums\Position;
 use CraftCms\Cms\View\HtmlStack as HtmlStackService;
 use yii\web\AssetBundle;
+use yii\web\JqueryAsset as YiiJqueryAsset;
 
 class CpAssetDependentAssetBundle extends AssetBundle
 {
@@ -18,6 +19,19 @@ class CpAssetDependentAssetBundle extends AssetBundle
 
     public $js = [
         'dependent.js',
+    ];
+}
+
+class YiiJqueryDependentAssetBundle extends AssetBundle
+{
+    public $baseUrl = 'https://example.test/assets';
+
+    public $depends = [
+        YiiJqueryAsset::class,
+    ];
+
+    public $js = [
+        'depends-on-yii-jquery.js',
     ];
 }
 
@@ -40,6 +54,20 @@ it('renders the internal CP asset files before Yii asset bundle dependents', fun
     expect($html)->toContain('legacy/jquery/dist/jquery.js')
         ->and($html)->toContain('https://example.test/assets/dependent.js')
         ->and(strpos($html, 'legacy/jquery/dist/jquery.js'))->toBeLessThan(strpos($html, 'https://example.test/assets/dependent.js'));
+});
+
+it('resolves Yii jQuery asset bundles to the internal jQuery asset', function() {
+    $view = Craft::$app->getView();
+
+    $view->registerAssetBundle(YiiJqueryDependentAssetBundle::class);
+
+    $html = $view->placeholderHtml()['bodyEndHtml'];
+
+    expect($html)
+        ->toContain('legacy/jquery/dist/jquery.js')
+        ->and($html)->toContain('https://example.test/assets/depends-on-yii-jquery.js')
+        ->and(strpos($html, 'legacy/jquery/dist/jquery.js'))->toBeLessThan(strpos($html, 'https://example.test/assets/depends-on-yii-jquery.js'))
+        ->and($html)->not->toContain('cpresources');
 });
 
 it('uses the current scoped HtmlStack after scoped instances are flushed', function() {


### PR DESCRIPTION
## Summary
- Override `yii\web\JqueryAsset` in the adapter asset manager config so it uses Craft's packaged jQuery asset URL instead of publishing from `cpresources`.
- Add a regression test for a Yii asset bundle that depends on `yii\web\JqueryAsset`, including script order and no `cpresources` URL.

Fixes #19262
Linear: CMS-2288