### PR TITLE
[5.x] Prevent incompatible bulk entry moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where bulk entry moves could assign entries to sections that didn’t support their entry types. ([#19268](https://github.com/craftcms/cms/pull/19268))
+
 ## 5.10.11 - 2026-07-15
 
 - Added `craft\gql\base\MutationResolver::requireAllowedSite()`.

--- a/src/controllers/EntriesController.php
+++ b/src/controllers/EntriesController.php
@@ -424,7 +424,7 @@ class EntriesController extends BaseEntriesController
 
                 $sectionEntryTypes = array_map(fn($et) => $et->id, $section->entryTypes);
 
-                return !empty(array_intersect($entryTypes, $sectionEntryTypes));
+                return !empty($entryTypes) && empty(array_diff($entryTypes, $sectionEntryTypes));
             })
             ->sortBy(fn(Section $section) => $section->getUiLabel())
             ->all();
@@ -489,6 +489,13 @@ class EntriesController extends BaseEntriesController
             if (!$entry->canMove()) {
                 throw new ForbiddenHttpException('User is not authorized to perform this action.');
             }
+        }
+
+        $sectionEntryTypeIds = array_map(fn($entryType) => $entryType->id, $section->getEntryTypes());
+        $entryTypeIds = array_unique(array_map(fn(Entry $entry) => $entry->typeId, $entries));
+
+        if (!empty(array_diff($entryTypeIds, $sectionEntryTypeIds))) {
+            throw new BadRequestHttpException('Not all entries have a type supported by the target section.');
         }
 
         $errors = [];

--- a/src/services/Entries.php
+++ b/src/services/Entries.php
@@ -2214,6 +2214,12 @@ SQL)->execute();
             throw new Exception('Attempting to move a nested element.');
         }
 
+        $sectionEntryTypeIds = array_map(fn($entryType) => $entryType->id, $section->getEntryTypes());
+
+        if (!in_array($entry->typeId, $sectionEntryTypeIds, true)) {
+            throw new Exception('Entry type is not supported by the target section.');
+        }
+
         // Ensure all fields have been normalized
         $entry->getFieldValues();
 


### PR DESCRIPTION
### Description

Prevent bulk entry moves from persisting entry types that are unsupported by the destination section.