### PR TITLE
local fs path validation - use isRestrictedDir()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where bulk entry moves could assign entries to sections that didn’t support their entry types. ([#19268](https://github.com/craftcms/cms/pull/19268))
 - Fixed a bug where admin tables’ action buttons could fire when rendering. ([#19255](https://github.com/craftcms/cms/issues/19255))
+- Fixed a [low-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) information disclosure vulnerability.
 
 ## 5.10.11 - 2026-07-15
 

--- a/src/fs/Local.php
+++ b/src/fs/Local.php
@@ -130,8 +130,8 @@ class Local extends Fs implements LocalFsInterface
      */
     public function validatePath(string $attribute, ?array $params, InlineValidator $validator): void
     {
-        if (Craft::$app->getSecurity()->isSystemDir($this->getRootPath())) {
-            $validator->addError($this, $attribute, Craft::t('app', 'Local filesystems cannot be located within or above system directories.'));
+        if (Craft::$app->getSecurity()->isRestrictedDir($this->getRootPath())) {
+            $validator->addError($this, $attribute, Craft::t('app', 'Local filesystems cannot be located within or above system directories or in restricted directories.'));
         }
     }
 

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -992,7 +992,7 @@ return [
     'Loading' => 'Loading',
     'Local Folder' => 'Local Folder',
     'Local copies of remote images, generated thumbnails' => 'Local copies of remote images, generated thumbnails',
-    'Local filesystems cannot be located within or above system directories or in restricted directories.' => 'Local filesystems cannot be located within or above system directories or in restricted directories.',
+    'Local filesystems cannot be located within or above system directories.' => 'Local filesystems cannot be located within or above system directories.',
     'Locality' => 'Locality',
     'Localizing relations' => 'Localizing relations',
     'Location' => 'Location',

--- a/src/translations/en/app.php
+++ b/src/translations/en/app.php
@@ -992,7 +992,7 @@ return [
     'Loading' => 'Loading',
     'Local Folder' => 'Local Folder',
     'Local copies of remote images, generated thumbnails' => 'Local copies of remote images, generated thumbnails',
-    'Local filesystems cannot be located within or above system directories.' => 'Local filesystems cannot be located within or above system directories.',
+    'Local filesystems cannot be located within or above system directories or in restricted directories.' => 'Local filesystems cannot be located within or above system directories or in restricted directories.',
     'Locality' => 'Locality',
     'Localizing relations' => 'Localizing relations',
     'Location' => 'Location',


### PR DESCRIPTION
### Description
When validating Local FS Base Path, use the new `Security::isRestrictedDir()` method. In addition to disallowing Craft-specific system directories, it’ll also disallow other sensitive directories.


### Related issues
n/a
