### PR TITLE
[6.x] Correct SetPasswordCommand behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed a bug where the legacy `yii\web\JqueryAsset` wasn’t resolving properly. ([#19264](https://github.com/craftcms/cms/pull/19264))
 - Fixed a bug where bulk entry moves could assign entries to sections that didn’t support their entry types. ([#19267](https://github.com/craftcms/cms/pull/19267))
 - Fixed an issue where disabled and archived user accounts could still authenticate. ([#19265](https://github.com/craftcms/cms/pull/19265))
+- Fixed issues with `craft:users:set-password` password validation, exit statuses, and session invalidation. ([#19272](https://github.com/craftcms/cms/pull/19272))
 - Fixed a [high-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) authorization bypass vulnerability.
 
 ## 6.0.0-alpha.13 - 2026-07-16

--- a/src/User/Commands/SetPasswordCommand.php
+++ b/src/User/Commands/SetPasswordCommand.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\User\Commands;
 
 use CraftCms\Cms\Console\CraftCommand;
 use CraftCms\Cms\Element\Elements;
+use CraftCms\Cms\User\Users;
 use CraftCms\Cms\User\Validation\UserRules;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
@@ -25,7 +26,7 @@ class SetPasswordCommand extends Command implements PromptsForMissingInput
     #[Override]
     protected $aliases = ['users/set-password', 'users/setPassword', 'users:setPassword'];
 
-    public function handle(Elements $elements): int
+    public function handle(Elements $elements, Users $users): int
     {
         if (! $user = $this->getUser()) {
             return self::FAILURE;
@@ -34,10 +35,24 @@ class SetPasswordCommand extends Command implements PromptsForMissingInput
         $user->ruleset->useScenario(UserRules::SCENARIO_PASSWORD);
         $user->newPassword = $this->argument('password');
 
+        $saved = false;
+
         $this->components->task(
             'Saving the user',
-            fn () => $elements->saveElement($user, false),
+            function () use ($elements, $user, &$saved) {
+                return $saved = $elements->saveElement($user);
+            },
         );
+
+        if (! $saved) {
+            foreach ($user->errors()->all() as $error) {
+                $this->components->error($error);
+            }
+
+            return self::FAILURE;
+        }
+
+        $users->invalidateUserSessions($user);
 
         return self::SUCCESS;
     }

--- a/src/User/Users.php
+++ b/src/User/Users.php
@@ -844,6 +844,19 @@ class Users
         }
     }
 
+    public function invalidateUserSessions(User $user): void
+    {
+        DB::transaction(function () use ($user) {
+            $userModel = UserModel::findOrFail($user->id);
+            $userModel->setRememberToken(Str::random(60));
+            $userModel->save();
+
+            DB::table(Table::SESSIONS)
+                ->where('user_id', $user->id)
+                ->delete();
+        });
+    }
+
     /**
      * Unsuspends a user.
      *

--- a/tests/Feature/Console/Commands/User/SetPasswordCommandTest.php
+++ b/tests/Feature/Console/Commands/User/SetPasswordCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Database\Table;
+use CraftCms\Cms\Element\Events\ElementSaving;
+use CraftCms\Cms\User\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
+
+test('rejects passwords that do not satisfy the password policy', function () {
+    $user = User::factory()->create();
+    $originalPassword = $user->password;
+
+    $this->artisan('craft:users:set-password', [
+        'user' => $user->id,
+        'password' => 'short',
+    ])
+        ->expectsOutputToContain('should contain at least 8 characters')
+        ->assertFailed();
+
+    expect($user->fresh()->password)->toBe($originalPassword);
+});
+
+test('fails when the user cannot be saved', function () {
+    $user = User::factory()->create();
+    $originalPassword = $user->password;
+
+    Event::listen(function (ElementSaving $event) use ($user) {
+        if ($event->element->id === $user->id) {
+            $event->isValid = false;
+        }
+    });
+
+    $this->artisan('craft:users:set-password', [
+        'user' => $user->id,
+        'password' => 'new-password',
+    ])->assertFailed();
+
+    expect($user->fresh()->password)->toBe($originalPassword);
+});
+
+test('revokes existing sessions after changing the password', function () {
+    $user = User::factory()->create([
+        'rememberToken' => 'old-remember-token',
+    ]);
+
+    DB::table(Table::SESSIONS)->insert([
+        'id' => 'existing-session',
+        'user_id' => $user->id,
+        'payload' => '',
+        'last_activity' => now()->timestamp,
+    ]);
+
+    $this->artisan('craft:users:set-password', [
+        'user' => $user->id,
+        'password' => 'new-password',
+    ])->assertSuccessful();
+
+    $user->refresh();
+
+    expect(Hash::check('new-password', $user->password))->toBeTrue()
+        ->and($user->rememberToken)->not()->toBe('old-remember-token')
+        ->and(DB::table(Table::SESSIONS)->where('user_id', $user->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
### Description

Enforces password validation for `craft:users:set-password`, returns a failing exit status when the user cannot be saved, and invalidates the user’s existing sessions and remember token after a successful password change.

### Related issues

Fixes PT-3244, PT-3245, and PT-3396.