### PR TITLE
[6.x] Make user deletion transactional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Removed `CraftCms\Cms\Plugin\Plugin::registerPlugin()`. `register()` should be used instead. ([#19263](https://github.com/craftcms/cms/pull/19263))
 - Fixed a bug where the legacy `yii\web\JqueryAsset` wasn’t resolving properly. ([#19264](https://github.com/craftcms/cms/pull/19264))
 - Fixed a bug where bulk entry moves could assign entries to sections that didn’t support their entry types. ([#19267](https://github.com/craftcms/cms/pull/19267))
+- Fixed bugs that could prevent authored content from being deleted or reassigned safely when deleting users. ([#19273](https://github.com/craftcms/cms/pull/19273))
 - Fixed an issue where disabled and archived user accounts could still authenticate. ([#19265](https://github.com/craftcms/cms/pull/19265))
 - Fixed a [high-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) authorization bypass vulnerability.
 

--- a/src/Entry/Entries.php
+++ b/src/Entry/Entries.php
@@ -28,6 +28,7 @@ use Exception;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
 use Throwable;
 use Tpetry\QueryExpressions\Language\Alias;
 
@@ -301,6 +302,10 @@ class Entries
     public function reassignEntries(int|array $oldUserId, int $newUserId): int
     {
         $oldUserIds = Arr::wrap($oldUserId);
+
+        if (in_array($newUserId, $oldUserIds, true)) {
+            throw new InvalidArgumentException('The new author must be different from the old author.');
+        }
 
         $count = DB::table(Table::ENTRIES_AUTHORS)
             ->whereIn('authorId', $oldUserIds)

--- a/src/User/Commands/DeleteCommand.php
+++ b/src/User/Commands/DeleteCommand.php
@@ -6,12 +6,15 @@ namespace CraftCms\Cms\User\Commands;
 
 use CraftCms\Cms\Console\CraftCommand;
 use CraftCms\Cms\Element\Elements;
+use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Support\Facades\Entries;
 use CraftCms\Cms\User\Models\User;
 use CraftCms\Cms\User\Users;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Illuminate\Support\Facades\DB;
 use Override;
+use Throwable;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\suggest;
@@ -41,13 +44,16 @@ class DeleteCommand extends Command implements PromptsForMissingInput
             return self::FAILURE;
         }
 
-        if ($this->option('delete-content') && $this->option('inheritor')) {
+        $deleteContent = (bool) $this->option('delete-content');
+        $inheritor = $this->option('inheritor');
+
+        if ($deleteContent && $inheritor) {
             $this->components->error('Only one of --delete-content or --inheritor may be specified.');
 
             return self::FAILURE;
         }
 
-        if (! ($inheritor = $this->option('inheritor')) && $this->input->isInteractive() && confirm('Transfer this user’s content to an existing user?')) {
+        if (! $deleteContent && ! $inheritor && $this->input->isInteractive() && confirm('Transfer this user’s content to an existing user?')) {
             $inheritor = suggest(
                 label: 'Which user should inherit the content?',
                 options: User::whereNot('id', $user->id)->pluck('username', 'id'),
@@ -66,6 +72,12 @@ class DeleteCommand extends Command implements PromptsForMissingInput
                 return self::FAILURE;
             }
 
+            if ($inheritor->id === $user->id) {
+                $this->components->error('A user cannot inherit their own content.');
+
+                return self::FAILURE;
+            }
+
             if (! confirm("Delete user “{$user->username}” and transfer their content to user “{$inheritor->username}”?")) {
                 $this->components->warn('Aborted');
 
@@ -77,21 +89,45 @@ class DeleteCommand extends Command implements PromptsForMissingInput
             return self::SUCCESS;
         }
 
-        if (! $inheritor && ! $this->option('delete-content')) {
-            $this->components->error('You must specify either --delete-content or --inheritor to proceed.');
-
-            return self::FAILURE;
-        }
-
         $fail = false;
+        $hardDelete = (bool) $this->option('hard');
         $this->components->task(
             'Deleting the user',
-            function () use ($inheritor, $elements, $user, &$fail) {
-                if ($inheritor) {
-                    Entries::reassignEntries($user->id, $inheritor->id);
-                }
+            function () use ($inheritor, $elements, $hardDelete, $user, &$fail) {
+                DB::beginTransaction();
 
-                $fail = ! $elements->deleteElement($user, $this->option('hard'));
+                try {
+                    if ($inheritor) {
+                        Entries::reassignEntries($user->id, $inheritor->id);
+                    } else {
+                        foreach (Entry::find()
+                            ->authorId($user->id)
+                            ->site('*')
+                            ->unique()
+                            ->status(null)
+                            ->cursor() as $entry) {
+                            if (! $elements->deleteElement($entry, $hardDelete)) {
+                                $fail = true;
+                                DB::rollBack();
+
+                                return;
+                            }
+                        }
+                    }
+
+                    if (! $elements->deleteElement($user, $hardDelete)) {
+                        $fail = true;
+                        DB::rollBack();
+
+                        return;
+                    }
+
+                    DB::commit();
+                } catch (Throwable $e) {
+                    DB::rollBack();
+
+                    throw $e;
+                }
             }
         );
 

--- a/tests/Feature/Console/Commands/User/DeleteCommandTest.php
+++ b/tests/Feature/Console/Commands/User/DeleteCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Database\Table;
+use CraftCms\Cms\Element\Events\ElementDeleting;
+use CraftCms\Cms\Element\Models\Element as ElementModel;
+use CraftCms\Cms\Entry\Models\Entry;
+use CraftCms\Cms\User\Elements\User as UserElement;
+use CraftCms\Cms\User\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+it('deletes authored content', function (bool $hardDelete) {
+    $user = User::factory()->create(['username' => 'deleted-user']);
+    $entry = Entry::factory()
+        ->hasAttached($user, ['sortOrder' => 1], 'authors')
+        ->createElement();
+
+    $this->artisan('craft:users:delete', [
+        'user' => $user->id,
+        '--delete-content' => true,
+        '--hard' => $hardDelete,
+    ])
+        ->expectsConfirmation('Delete user “deleted-user” and their content?', 'yes')
+        ->assertSuccessful();
+
+    $userRecord = ElementModel::withTrashed()->find($user->id);
+    $entryRecord = ElementModel::withTrashed()->find($entry->id);
+
+    expect($userRecord === null)->toBe($hardDelete)
+        ->and($entryRecord === null)->toBe($hardDelete)
+        ->and($userRecord?->dateDeleted !== null)->toBe(! $hardDelete)
+        ->and($entryRecord?->dateDeleted !== null)->toBe(! $hardDelete);
+})->with([
+    'soft deletion' => false,
+    'hard deletion' => true,
+]);
+
+it('deletes multi-author entries', function () {
+    $user = User::factory()->create(['username' => 'deleted-user']);
+    $otherAuthor = User::factory()->create();
+    $entry = Entry::factory()
+        ->hasAttached($user, ['sortOrder' => 1], 'authors')
+        ->hasAttached($otherAuthor, ['sortOrder' => 2], 'authors')
+        ->createElement();
+
+    $this->artisan('craft:users:delete', [
+        'user' => $user->id,
+        '--delete-content' => true,
+    ])
+        ->expectsConfirmation('Delete user “deleted-user” and their content?', 'yes')
+        ->assertSuccessful();
+
+    expect(ElementModel::withTrashed()->find($entry->id)?->dateDeleted)->not()->toBeNull();
+});
+
+it('records an interactive choice to delete content', function () {
+    $user = User::factory()->create(['username' => 'deleted-user']);
+    $entry = Entry::factory()
+        ->hasAttached($user, ['sortOrder' => 1], 'authors')
+        ->createElement();
+
+    $this->artisan('craft:users:delete', ['user' => $user->id])
+        ->expectsConfirmation('Transfer this user’s content to an existing user?', 'no')
+        ->expectsConfirmation('Delete user “deleted-user” and their content?', 'yes')
+        ->assertSuccessful();
+
+    expect(ElementModel::withTrashed()->find($entry->id)?->dateDeleted)->not()->toBeNull();
+});
+
+it('rejects the deleted user as their own content inheritor', function () {
+    $user = User::factory()->create(['username' => 'deleted-user']);
+
+    $this->artisan('craft:users:delete', [
+        'user' => $user->id,
+        '--inheritor' => $user->id,
+        '--no-interaction' => true,
+    ])
+        ->expectsOutputToContain('A user cannot inherit their own content.')
+        ->assertFailed();
+
+    expect(ElementModel::find($user->id))->not()->toBeNull();
+});
+
+it('rolls back content reassignment when user deletion fails', function () {
+    $user = User::factory()->create(['username' => 'deleted-user']);
+    $inheritor = User::factory()->create(['username' => 'inheritor']);
+    $entry = Entry::factory()
+        ->hasAttached($user, ['sortOrder' => 1], 'authors')
+        ->create();
+
+    Event::listen(ElementDeleting::class, function (ElementDeleting $event) use ($user) {
+        if ($event->element instanceof UserElement && $event->element->id === $user->id) {
+            $event->isValid = false;
+        }
+    });
+
+    $this->artisan('craft:users:delete', [
+        'user' => $user->id,
+        '--inheritor' => $inheritor->id,
+    ])
+        ->expectsConfirmation('Delete user “deleted-user” and transfer their content to user “inheritor”?', 'yes')
+        ->expectsOutputToContain('Couldn’t delete the user.')
+        ->assertFailed();
+
+    expect(DB::table(Table::ENTRIES_AUTHORS)
+        ->where('entryId', $entry->id)
+        ->pluck('authorId')
+        ->all())->toBe([$user->id]);
+});

--- a/tests/Feature/Entry/EntriesTest.php
+++ b/tests/Feature/Entry/EntriesTest.php
@@ -160,6 +160,13 @@ it('can reassign entries to a new author', function () {
     Event::assertDispatched(fn (ElementCachesInvalidated $event): bool => $event->tags === ['element::'.EntryElement::class]);
 });
 
+it('cannot reassign entries to the same author', function () {
+    $author = User::factory()->create();
+
+    expect(fn () => $this->entries->reassignEntries($author->id, $author->id))
+        ->toThrow(InvalidArgumentException::class, 'The new author must be different from the old author.');
+});
+
 it('does not reassign entries that already have the new author', function () {
     $oldAuthor = User::factory()->create();
     $newAuthor = User::factory()->create();


### PR DESCRIPTION
### Description

Makes user deletion transactional, correctly deletes authored content, and prevents users from inheriting their own content.

### Related issues

- [PT-3204](https://linear.app/craftcms/issue/PT-3204)
- [PT-3205](https://linear.app/craftcms/issue/PT-3205)
- [PT-3206](https://linear.app/craftcms/issue/PT-3206)