### PR TITLE
Bugfix/19279 twig get attr adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed an error that could occur when saving an element with an eager-loaded relation field value. ([#19280](https://github.com/craftcms/cms/issues/19280))
 - Fixed a bug where bulk entry moves could assign entries to sections that didn’t support their entry types. ([#19268](https://github.com/craftcms/cms/pull/19268))
 - Fixed a bug where admin tables’ action buttons could fire when rendering. ([#19255](https://github.com/craftcms/cms/issues/19255))
+- Fixed an error that occurred when using the null-safe operator in a Twig template. ([#19279](https://github.com/craftcms/cms/issues/19279))
 - Fixed a [low-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) information disclosure vulnerability.
 
 ## 5.10.11 - 2026-07-15

--- a/src/web/twig/nodes/GetAttrNode.php
+++ b/src/web/twig/nodes/GetAttrNode.php
@@ -89,15 +89,45 @@ class GetAttrNode extends GetAttrExpression
             ;
         }
 
-        // DIFF: TemplateHelper::attribute() used instead of CoreExtension::getAttribute()
-        $compiler->raw(TemplateHelper::class . '::attribute($this->env, $this->source, ');
-
         if ($this->getAttribute('ignore_strict_check')) {
             $this->getNode('node')->setAttribute('ignore_strict_check', true);
         }
 
+        // DIFF: null-safe (`?.`) short-circuit support, ported from GetAttrExpression::compile()
+        $nullSafe = $this->getAttribute('null_safe');
+
+        if (null === $nullSafeNode = $nullSafe ? $this : null) {
+            $node = $this->getNode('node');
+            while ($node instanceof self) {
+                if ($node->getAttribute('null_safe')) {
+                    $nullSafeNode = $node;
+                    break;
+                }
+                $node = $node->getNode('node');
+            }
+        }
+
+        $isShortCircuited = false;
+        if (null !== $nullSafeNode && !$nullSafeNode->isShortCircuited()) {
+            $compiler
+                ->raw('((null === (' . $nullSafeNode->getVarName($compiler) . ' = ')
+                ->subcompile($nullSafeNode->getNode('node'))
+                ->raw(')) ? null : ');
+
+            $nullSafeNode->markAsShortCircuited();
+            $isShortCircuited = true;
+        }
+
+        // DIFF: TemplateHelper::attribute() used instead of CoreExtension::getAttribute()
+        $compiler->raw(TemplateHelper::class . '::attribute($this->env, $this->source, ');
+
+        if ($nullSafe) {
+            $compiler->raw($this->getVarName($compiler));
+        } else {
+            $compiler->subcompile($this->getNode('node'));
+        }
+
         $compiler
-            ->subcompile($this->getNode('node'))
             ->raw(', ')
             ->subcompile($this->getNode('attribute'))
         ;
@@ -120,5 +150,37 @@ class GetAttrNode extends GetAttrExpression
         if ($arrayAccessSandbox) {
             $compiler->raw(')');
         }
+
+        if ($isShortCircuited) {
+            $compiler->raw(')');
+        }
+    }
+
+    /**
+     * DIFF: reimplemented because GetAttrExpression's version is private.
+     */
+    private function isShortCircuited(): bool
+    {
+        return $this->getAttribute('is_short_circuited');
+    }
+
+    /**
+     * DIFF: reimplemented because GetAttrExpression's version is private.
+     */
+    private function markAsShortCircuited(): void
+    {
+        $this->setAttribute('is_short_circuited', true);
+    }
+
+    /**
+     * DIFF: reimplemented because GetAttrExpression's version is private.
+     */
+    private function getVarName(Compiler $compiler): string
+    {
+        if (null === $this->getAttribute('var_name')) {
+            $this->setAttribute('var_name', $compiler->getVarName());
+        }
+
+        return '$' . $this->getAttribute('var_name');
     }
 }

--- a/src/web/twig/nodevisitors/GetAttrAdjuster.php
+++ b/src/web/twig/nodevisitors/GetAttrAdjuster.php
@@ -48,6 +48,9 @@ class GetAttrAdjuster implements NodeVisitorInterface
             'is_defined_test' => $isDefinedTest,
             'ignore_strict_check' => $node->getAttribute('ignore_strict_check'),
             'optimizable' => $node->getAttribute('optimizable'),
+            'null_safe' => $node->getAttribute('null_safe'),
+            'is_short_circuited' => false,
+            'var_name' => null,
         ];
 
         if ($node->hasAttribute('spread')) {

--- a/tests/unit/web/twig/ExtensionTest.php
+++ b/tests/unit/web/twig/ExtensionTest.php
@@ -199,6 +199,55 @@ class ExtensionTest extends TestCase
     }
 
     /**
+     * @throws LoaderError
+     * @throws SyntaxError
+     */
+    public function testNullSafeOperator(): void
+    {
+        // property access on null short-circuits instead of erroring
+        $this->testRenderResult(
+            '',
+            '{{ user?.name }}',
+            ['user' => null]
+        );
+
+        // method call on null short-circuits
+        $this->testRenderResult(
+            '',
+            '{{ user?.getName() }}',
+            ['user' => null]
+        );
+
+        // chained null-safe access short-circuits at the first null
+        $this->testRenderResult(
+            '',
+            '{{ user?.profile?.name }}',
+            ['user' => null]
+        );
+
+        // non-null case still resolves normally
+        $this->testRenderResult(
+            'Bob',
+            '{{ user?.name }}',
+            ['user' => ['name' => 'Bob']]
+        );
+
+        // non-null case still resolves normally for method calls
+        $this->testRenderResult(
+            'Bob',
+            '{{ user?.getName() }}',
+            [
+                'user' => new class() {
+                    public function getName(): string
+                    {
+                        return 'Bob';
+                    }
+                },
+            ]
+        );
+    }
+
+    /**
      *
      */
     public function testEmptyTest(): void


### PR DESCRIPTION
### Description
Twig `3.23.0` added `null_safe` attribute to the `GetAttrExpression` ([link](https://github.com/twigphp/Twig/blob/v3.23.0/src/Node/Expression/GetAttrExpression.php#L39)). Version `3.24.0` added `is_short_circuited` and `var_name` ([link](https://github.com/twigphp/Twig/blob/v3.24.0/src/Node/Expression/GetAttrExpression.php#L39)).

Craft uses `GetAttrNode`, which extends `GetAttrExpression`, along with `GetAttrAdjuster`, but we haven’t updated those files to reflect the changes introduced in Twig. 

This PR updates `src/web/twig/nodes/GetAttrNode.php` and `src/web/twig/nodevisitors/GetAttrAdjuster.php` so that they’re in line with version `3.27.1` of the `Twig\Node\Expression\GetAttrExpression` and adds unit tests for the null safe operator.

### Related issues
#19279 
