### PR TITLE
[6.x] Fix GraphQL mutation cache detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Fixed bugs that could prevent authored content from being deleted or reassigned safely when deleting users. ([#19273](https://github.com/craftcms/cms/pull/19273))
 - Fixed an issue where disabled and archived user accounts could still authenticate. ([#19265](https://github.com/craftcms/cms/pull/19265))
 - Fixed issues with `craft:users:set-password` password validation, exit statuses, and session invalidation. ([#19272](https://github.com/craftcms/cms/pull/19272))
+- Fixed a bug where selected GraphQL mutations could be mistaken for cacheable queries. ([#19284](https://github.com/craftcms/cms/pull/19284))
 - Fixed a [high-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) authorization bypass vulnerability.
 
 ## 6.0.0-alpha.13 - 2026-07-16

--- a/src/Gql/Gql.php
+++ b/src/Gql/Gql.php
@@ -1018,7 +1018,7 @@ class Gql
         }
 
         // Do not cache mutations
-        if (preg_match('/^\s*mutation(?P<operationName>\s+\w+)?\s*(?P<variables>\(.*\))?\s*{/si', $query)) {
+        if (GqlHelper::isMutation($query, $operationName)) {
             return null;
         }
 

--- a/src/Gql/GqlHelper.php
+++ b/src/Gql/GqlHelper.php
@@ -16,12 +16,15 @@ use CraftCms\Cms\Section\Data\Section;
 use CraftCms\Cms\Site\Data\Site;
 use CraftCms\Cms\Support\Facades\Sections;
 use CraftCms\Cms\Support\Facades\Sites;
+use GraphQL\Error\Error;
 use GraphQL\Language\AST\ListValueNode;
 use GraphQL\Language\AST\VariableNode;
+use GraphQL\Language\Parser;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Utils\AST;
 use Illuminate\Support\Facades\Log;
 
 class GqlHelper
@@ -441,5 +444,16 @@ class GqlHelper
         $tok = trim($tok);
 
         return in_array($tok, ['__schema', '__type']);
+    }
+
+    public static function isMutation(string $query, ?string $operationName = null): bool
+    {
+        try {
+            $document = Parser::parse($query);
+        } catch (Error) {
+            return false;
+        }
+
+        return AST::getOperationAST($document, $operationName)?->operation === 'mutation';
     }
 }

--- a/src/Http/Controllers/Gql/ApiController.php
+++ b/src/Http/Controllers/Gql/ApiController.php
@@ -67,6 +67,7 @@ readonly class ApiController extends GqlController
 
         foreach ($queries as $key => [$query, $variables, $operationName]) {
             $query = is_string($query) ? trim($query) : trim((string) ($query ?? ''));
+            $operationName = is_string($operationName) ? $operationName : null;
 
             try {
                 if ($query === '') {
@@ -77,7 +78,7 @@ readonly class ApiController extends GqlController
                     $schema,
                     $query,
                     is_array($variables) ? $variables : null,
-                    is_string($operationName) ? $operationName : null,
+                    $operationName,
                     app()->hasDebugModeEnabled(),
                 );
             } catch (ValueError $e) {
@@ -98,7 +99,7 @@ readonly class ApiController extends GqlController
                 ];
             }
 
-            if (str_starts_with($query, 'mutation')) {
+            if (GqlHelper::isMutation($query, $operationName)) {
                 $hasMutations = true;
             }
         }
@@ -109,7 +110,7 @@ readonly class ApiController extends GqlController
 
         $response = new GqlResponse($singleQuery ? reset($result) : $result);
 
-        if (! ($cache ?? ! $hasMutations)) {
+        if ($hasMutations || $cache === false) {
             $response->nocache();
         }
 

--- a/tests/Feature/Gql/GqlTest.php
+++ b/tests/Feature/Gql/GqlTest.php
@@ -171,6 +171,21 @@ it('fills the cache when querying through the new service', function () {
     expect($gql->getCachedResult($cacheKey))->toBe($result);
 });
 
+it('does not create cache keys for mutations', function (string $query, ?string $operationName) {
+    Cms::config()->enableGraphqlCaching = true;
+
+    $gql = app(Gql::class);
+    $schema = $gql->getPublicSchema();
+
+    $cacheKeyMethod = new ReflectionMethod(Gql::class, '_getCacheKey');
+
+    expect($cacheKeyMethod->invoke($gql, $schema, $query, null, null, $operationName))->toBeNull();
+})->with([
+    'comment-prefixed mutation' => ["# comment\nmutation { bogus }", null],
+    'fragment-prefixed mutation' => ['fragment PingFields on Query { ping } mutation { bogus }', null],
+    'named mutation after a query' => ['query Read { ping } mutation Write { bogus }', 'Write'],
+]);
+
 it('flushes graphql registries and loaders', function () {
     UserInterface::getType();
     $typeName = User::GQL_TYPE_NAME;

--- a/tests/Feature/Http/Controllers/Gql/ApiControllerTest.php
+++ b/tests/Feature/Http/Controllers/Gql/ApiControllerTest.php
@@ -132,7 +132,7 @@ it('denies access when the schema has no site permissions', function () {
         ->assertSee('Schema doesn’t have access');
 });
 
-it('adds no-cache headers for mutations unless caching is forced', function () {
+it('always adds no-cache headers for mutations', function () {
     $response = get(action_url('graphql/api').'?query=mutation%20%7Bbogus%7D')
         ->assertOk()
         ->assertHeader('Pragma', 'no-cache')
@@ -146,11 +146,30 @@ it('adds no-cache headers for mutations unless caching is forced', function () {
     $response = get(action_url('graphql/api').'?query=mutation%20%7Bbogus%7D', [
         'X-Craft-Gql-Cache' => 'cache',
     ])->assertOk()
-        ->assertHeaderMissing('Pragma')
-        ->assertHeaderMissing('Expires');
+        ->assertHeader('Pragma', 'no-cache')
+        ->assertHeader('Expires', '0');
 
     expect($response->headers->get('Cache-Control'))
-        ->not->toBe('no-cache, no-store, must-revalidate');
+        ->toContain('no-cache')
+        ->toContain('no-store')
+        ->toContain('must-revalidate');
+});
+
+it('adds no-cache headers for the selected mutation operation', function () {
+    $url = action_url('graphql/api').'?'.http_build_query([
+        'query' => 'query Read { __typename } mutation Write { bogus }',
+        'operationName' => 'Write',
+    ]);
+
+    $response = get($url)
+        ->assertOk()
+        ->assertHeader('Pragma', 'no-cache')
+        ->assertHeader('Expires', '0');
+
+    expect($response->headers->get('Cache-Control'))
+        ->toContain('no-cache')
+        ->toContain('no-store')
+        ->toContain('must-revalidate');
 });
 
 function setActiveSchema(GqlSchema $schema): void


### PR DESCRIPTION
### Description

Ensures GraphQL mutations are identified from the selected AST operation and are never cached as queries.