### PR TITLE
[5.x] Fix GraphQL mutation cache detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
+- Added `craft\helpers\Gql::isMutation()`. ([#19285](https://github.com/craftcms/cms/pull/19285))
 - Fixed an error that could occur when saving an element with an eager-loaded relation field value. ([#19280](https://github.com/craftcms/cms/issues/19280))
 - Fixed a bug where bulk entry moves could assign entries to sections that didn’t support their entry types. ([#19268](https://github.com/craftcms/cms/pull/19268))
 - Fixed a bug where admin tables’ action buttons could fire when rendering. ([#19255](https://github.com/craftcms/cms/issues/19255))
 - Fixed an error that occurred when using the null-safe operator in a Twig template. ([#19279](https://github.com/craftcms/cms/issues/19279))
+- Fixed a bug where GraphQL mutation queries could be cached. ([#19285](https://github.com/craftcms/cms/pull/19285))
 - Fixed a [low-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) information disclosure vulnerability.
 
 ## 5.10.11 - 2026-07-15

--- a/src/controllers/GraphqlController.php
+++ b/src/controllers/GraphqlController.php
@@ -192,6 +192,7 @@ class GraphqlController extends Controller
 
         foreach ($queries as $key => [$query, $variables, $operationName]) {
             $query = trim($query);
+            $operationName = is_string($operationName) ? $operationName : null;
             try {
                 if (empty($query)) {
                     throw new InvalidValueException('No GraphQL query was supplied');
@@ -218,7 +219,7 @@ class GraphqlController extends Controller
                 ];
             }
 
-            if (str_starts_with($query, 'mutation')) {
+            if (GqlHelper::isMutation($query, $operationName)) {
                 $hasMutations = true;
             }
         }
@@ -231,7 +232,7 @@ class GraphqlController extends Controller
         $this->response->data = $singleQuery ? reset($result) : $result;
 
         // send no-cache headers?
-        if (!($cache ?? !$hasMutations)) {
+        if ($hasMutations || $cache === false) {
             $this->response->setNoCacheHeaders();
         }
 

--- a/src/helpers/Gql.php
+++ b/src/helpers/Gql.php
@@ -674,6 +674,7 @@ class Gql
      * @param string $query
      * @param string|null $operationName
      * @return bool
+     * @since 5.10.12
      */
     public static function isMutation(string $query, ?string $operationName = null): bool
     {

--- a/src/helpers/Gql.php
+++ b/src/helpers/Gql.php
@@ -19,12 +19,15 @@ use craft\models\GqlSchema;
 use craft\models\Section;
 use craft\models\Site;
 use craft\services\Gql as GqlService;
+use GraphQL\Error\Error;
 use GraphQL\Language\AST\ListValueNode;
 use GraphQL\Language\AST\VariableNode;
+use GraphQL\Language\Parser;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use GraphQL\Utils\AST;
 
 /**
  * Class Gql
@@ -663,5 +666,23 @@ class Gql
         }
         $tok = trim($tok);
         return in_array($tok, ['__schema', '__type']);
+    }
+
+    /**
+     * Returns whether the selected GraphQL operation is a mutation.
+     *
+     * @param string $query
+     * @param string|null $operationName
+     * @return bool
+     */
+    public static function isMutation(string $query, ?string $operationName = null): bool
+    {
+        try {
+            $document = Parser::parse($query);
+        } catch (Error) {
+            return false;
+        }
+
+        return AST::getOperationAST($document, $operationName)?->operation === 'mutation';
     }
 }

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -1433,7 +1433,7 @@ class Gql extends Component
         }
 
         // Do not cache mutations
-        if (preg_match('/^\s*mutation(?P<operationName>\s+\w+)?\s*(?P<variables>\(.*\))?\s*{/si', $query)) {
+        if (GqlHelper::isMutation($query, $operationName)) {
             return null;
         }
 


### PR DESCRIPTION
### Description

Backports the GraphQL mutation cache classification fix from #19284 so selected mutations are identified from the AST and are never cached as queries.