### PR TITLE
Fix TypeError when saving an element with an eager-loaded relation field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed an error that could occur when saving an element with an eager-loaded relation field value. ([#19280](https://github.com/craftcms/cms/issues/19280))
 - Fixed a bug where bulk entry moves could assign entries to sections that didn’t support their entry types. ([#19268](https://github.com/craftcms/cms/pull/19268))
 - Fixed a bug where admin tables’ action buttons could fire when rendering. ([#19255](https://github.com/craftcms/cms/issues/19255))
 - Fixed a [low-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) information disclosure vulnerability.

--- a/src/fields/BaseRelationField.php
+++ b/src/fields/BaseRelationField.php
@@ -994,6 +994,8 @@ JS, [
     {
         if ($element !== null && $element->hasEagerLoadedElements($this->handle)) {
             $value = $element->getEagerLoadedElements($this->handle)->all();
+        } elseif ($value instanceof ElementCollection) {
+            $value = $value->all();
         } else {
             $value = $this->_all($value, $element)->all();
         }


### PR DESCRIPTION
## What this fixes

Saving an element whose relation field value was eager-loaded on the source query throws a `TypeError`. Reproduction from #19280:

```php
$entry = Entry::find()->with([['myField']])->one();
$entry->setFieldValue('headline', 'bar');
Craft::$app->getElements()->saveElement($entry); // TypeError
```

The error:

```
TypeError: craft\fields\BaseRelationField::_all(): Argument #1 ($query) must be of type craft\elements\db\ElementQueryInterface, craft\elements\ElementCollection given
```

## Root cause

When a relation value is eager-loaded, it is a `craft\elements\ElementCollection`, not an `ElementQueryInterface`. `BaseRelationField::normalizeValueForInput()`'s else branch passed that value straight into `_all()`, whose signature requires an `ElementQueryInterface`, so PHP raised a `TypeError` before the save could complete.

The sibling `serializeValue()` method already guards this exact case a few lines above:

```php
/** @var ElementQueryInterface|ElementCollection $value */
if ($value instanceof ElementCollection) {
    return $value->ids()->all();
}
return $this->_all($value, $element)->ids();
```

`normalizeValueForInput()` was the one remaining path that still handed a collection to `_all()`.

## The fix

Mirror the existing guard: when the value is already an `ElementCollection`, materialize it with `->all()` instead of calling `_all()`. This matches the eager-loaded branch directly above it, which also produces an array of elements via `->all()` and deliberately bypasses `_all()`'s query prepping. `ElementCollection` is already imported in the file, so no new use-statement is needed.

```php
if ($element !== null && $element->hasEagerLoadedElements($this->handle)) {
    $value = $element->getEagerLoadedElements($this->handle)->all();
} elseif ($value instanceof ElementCollection) {
    $value = $value->all();
} else {
    $value = $this->_all($value, $element)->all();
}
```

Also added a CHANGELOG entry under Unreleased.

Fixes #19280

---
AI was used for assistance.
