### PR TITLE
[6.x] Focus styles and system name

### DIFF
--- a/packages/craftcms-legacy/cp/src/css/_cp.scss
+++ b/packages/craftcms-legacy/cp/src/css/_cp.scss
@@ -32,15 +32,6 @@ body {
     cursor: move !important;
     cursor: grabbing !important;
   }
-
-  :focus {
-    outline-style: solid;
-    outline-color: transparent;
-  }
-
-  :focus-visible {
-    box-shadow: var(--focus-ring);
-  }
 }
 
 .skip-link {

--- a/packages/craftcms-ui/src/components/button/button.styles.ts
+++ b/packages/craftcms-ui/src/components/button/button.styles.ts
@@ -8,6 +8,7 @@ export default css`
     );
     --_active-color: var(--c-color-on-loud);
     --_active-border-color: var(--c-color-border-loud);
+    --_focus-outline-color: transparent;
     cursor: pointer;
     font: inherit;
     display: inline-flex;
@@ -41,8 +42,12 @@ export default css`
 
   :host(:focus:not([disabled])),
   :host(:focus-visible) {
-    outline: var(--c-focus-outline-width) solid var(--c-color-focus-outline);
+    outline: var(--c-focus-outline-width) solid var(--_focus-outline-color);
     outline-offset: var(--c-focus-outline-offset);
+  }
+
+  :host(:focus-visible) {
+    --_focus-outline-color: var(--c-color-focus-outline);
   }
 
   @media (hover: hover) {

--- a/packages/craftcms-ui/src/components/button/button.styles.ts
+++ b/packages/craftcms-ui/src/components/button/button.styles.ts
@@ -39,6 +39,12 @@ export default css`
     );
   }
 
+  :host(:focus:not([disabled])),
+  :host(:focus-visible) {
+    outline: var(--c-focus-outline-width) solid var(--c-color-focus-outline);
+    outline-offset: var(--c-focus-outline-offset);
+  }
+
   @media (hover: hover) {
     :host(:hover) {
       background-color: hsl(

--- a/packages/craftcms-ui/src/styles/shared/base.css
+++ b/packages/craftcms-ui/src/styles/shared/base.css
@@ -19,7 +19,7 @@ body {
   pointer interaction. Placeholder treatment — adjust as needed.
 */
 :focus-visible {
-  outline: 2px solid var(--c-text-link);
+  outline: 2px solid var(--c-color-focus-outline);
   outline-offset: 2px;
 }
 

--- a/packages/craftcms-ui/src/styles/shared/base.css
+++ b/packages/craftcms-ui/src/styles/shared/base.css
@@ -19,8 +19,8 @@ body {
   pointer interaction. Placeholder treatment — adjust as needed.
 */
 :focus-visible {
-  outline: 2px solid var(--c-color-focus-outline);
-  outline-offset: 2px;
+  outline: var(--c-focus-outline-width) solid var(--c-color-focus-outline);
+  outline-offset: var(--c-focus-outline-offset);
 }
 
 h1,

--- a/packages/craftcms-ui/src/styles/shared/tokens.css
+++ b/packages/craftcms-ui/src/styles/shared/tokens.css
@@ -7,6 +7,8 @@
 
   --c-leading-normal: 1.42;
 
+  --c-color-focus-outline: var(--color-blue-500);
+
   /* Surface tokens (replaces --c-bg-*) */
   --c-surface-default: var(--color-base-100);
   --c-surface-raised: var(--color-base-50);

--- a/packages/craftcms-ui/src/styles/shared/tokens.css
+++ b/packages/craftcms-ui/src/styles/shared/tokens.css
@@ -7,7 +7,10 @@
 
   --c-leading-normal: 1.42;
 
+  /* Focus outline tokens */
   --c-color-focus-outline: var(--color-blue-500);
+  --c-focus-outline-offset: 2px;
+  --c-focus-outline-width: 2px;
 
   /* Surface tokens (replaces --c-bg-*) */
   --c-surface-default: var(--color-base-100);

--- a/resources/js/common/layouts/AppLayout.vue
+++ b/resources/js/common/layouts/AppLayout.vue
@@ -406,6 +406,7 @@
   }
 
   .cp__header {
+    --c-color-focus-outline: var(--color-blue-300);
     color: var(--color-slate-200);
     background-color: var(--color-slate-950);
   }

--- a/resources/js/common/layouts/AuthBase.vue
+++ b/resources/js/common/layouts/AuthBase.vue
@@ -82,7 +82,7 @@
   .cp-login__powered-by {
     display: block;
     margin-block-start: calc(70rem / 16);
-    opacity: 0.8;
+    opacity: 0.92;;
     text-align: center;
 
     &:hover,

--- a/src/Cp/Cp.php
+++ b/src/Cp/Cp.php
@@ -130,6 +130,7 @@ readonly class Cp
             'registeredAssetBundles' => [], // force encode as JS object
             'registeredJsFiles' => [], // force encode as JS object
             'right' => $orientation === 'ltr' ? 'right' : 'left',
+            'systemName' => Cms::systemName(),
             'systemUid' => Cms::systemUid(),
             'timepickerOptions' => self::timepickerOptions($formattingLocale, $orientation),
             'timezone' => Cms::timezone(),


### PR DESCRIPTION
### Description
- Re-implements system name in document title
- Adds variables for focus outlines and uses in global `:focus-visible` styles and button component styles
- Darken CMS logo on login screen


### Related issues

