### PR TITLE
Don’t log warnings in SSO user attribute mapping for native user properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- SSO user attribute mapping no longer logs a warning for native user properties.
+
 ## 5.10.12 - 2026-07-22
 
 - Added `craft\helpers\Gql::isMutation()`. ([#19285](https://github.com/craftcms/cms/pull/19285))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- SSO user attribute mapping no longer logs a warning for native user properties.
+- Fixed a bug where warnings were getting logged for SSO attributes that mapped to native user properties. ([#19294](https://github.com/craftcms/cms/pull/19294))
 
 ## 5.10.12 - 2026-07-22
 

--- a/src/auth/sso/mapper/SetUserValueTrait.php
+++ b/src/auth/sso/mapper/SetUserValueTrait.php
@@ -56,6 +56,8 @@ trait SetUserValueTrait
             );
 
             $user->{$this->craftProperty} = $value;
+        } else {
+            Craft::warning(sprintf("User field '%s' was not found", $this->craftProperty), 'auth');
         }
     }
 
@@ -80,17 +82,6 @@ trait SetUserValueTrait
             return null;
         }
 
-        $field = $fieldLayout->getFieldByHandle($fieldHandle);
-
-        if ($field !== null) {
-            // A custom field included in this field layout
-            Craft::info(sprintf("User field '%s' was found", $fieldHandle), 'Auth');
-        } elseif (!in_array($fieldHandle, $user->attributes(), true)) {
-            // Only log if we're missing a custom field. If it's "native" properties that will always exist
-            // (firstName, lastName, fullName, email), don't log.
-            Craft::warning(sprintf("User field '%s' was not found", $fieldHandle), 'auth');
-        }
-
-        return $field;
+        return $fieldLayout->getFieldByHandle($fieldHandle);
     }
 }

--- a/src/auth/sso/mapper/SetUserValueTrait.php
+++ b/src/auth/sso/mapper/SetUserValueTrait.php
@@ -82,19 +82,14 @@ trait SetUserValueTrait
 
         $field = $fieldLayout->getFieldByHandle($fieldHandle);
 
-        $field ? Craft::info(
-            sprintf(
-                "User field '%s' was found",
-                $fieldHandle
-            ),
-            'Auth'
-        ) : Craft::warning(
-            sprintf(
-                "User field '%s' was not found",
-                $fieldHandle
-            ),
-            'auth'
-        );
+        if ($field !== null) {
+            // A custom field included in this field layout
+            Craft::info(sprintf("User field '%s' was found", $fieldHandle), 'Auth');
+        } elseif (!in_array($fieldHandle, $user->attributes(), true)) {
+            // Only log if we're missing a custom field. If it's "native" properties that will always exist
+            // (firstName, lastName, fullName, email), don't log.
+            Craft::warning(sprintf("User field '%s' was not found", $fieldHandle), 'auth');
+        }
 
         return $field;
     }


### PR DESCRIPTION
Currently, every time an SSO user logs in, the logs fill up with warnings for common mappings like `email`, `firstName`, and `lastName`.

This PR changes it so it logs only warnings for missing custom fields that are being mapped but don’t exist in Craft.