### PR TITLE
[6.x] Fix Yii asset hash initialization

### DIFF
--- a/yii2-adapter/legacy/web/View.php
+++ b/yii2-adapter/legacy/web/View.php
@@ -2188,7 +2188,7 @@ JS;
                 $jsName = Json::encode($name);
                 // WARNING: the curly braces are needed here no matter what PhpStorm thinks
                 // https://youtrack.jetbrains.com/issue/WI-60044
-                $js .= "  Craft.{$property}.push($jsName);\n";
+                $js .= "  (Craft.{$property} ??= []).push($jsName);\n";
             }
         }
         $js .= '}';

--- a/yii2-adapter/tests-laravel/View/CpAssetOrderTest.php
+++ b/yii2-adapter/tests-laravel/View/CpAssetOrderTest.php
@@ -70,6 +70,18 @@ it('resolves Yii jQuery asset bundles to the internal jQuery asset', function() 
         ->and($html)->not->toContain('cpresources');
 });
 
+it('initializes registered asset arrays before appending hashes', function() {
+    $view = Craft::$app->getView();
+    $view->registeredAssetBundles = ['bundle-hash'];
+    $view->registeredJsFiles = ['js-file-hash'];
+
+    $html = $view->placeholderHtml()['headHtml'];
+
+    expect($html)
+        ->toContain('(Craft.registeredAssetBundles ??= []).push("bundle-hash");')
+        ->and($html)->toContain('(Craft.registeredJsFiles ??= []).push("js-file-hash");');
+});
+
 it('uses the current scoped HtmlStack after scoped instances are flushed', function() {
     $view = Craft::$app->getView();
 


### PR DESCRIPTION
### Description

Initializes the Yii adapter’s registered asset arrays before appending hashes, preventing legacy control panel initialization from aborting when plugin asset bundles are loaded.

### Related issues

- Fixes #19298