### PR TITLE
[6.x] Prevent reentrant legacy app resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a styling issue. ([#19296](https://github.com/craftcms/cms/pull/19296))
+- Fixed a bug where Yii adapter plugins could cause legacy Control Panel assets to be omitted. ([#19302](https://github.com/craftcms/cms/pull/19302))
 
 ## 6.0.0-alpha.14 - 2026-07-22
 

--- a/yii2-adapter/src/LegacyApp.php
+++ b/yii2-adapter/src/LegacyApp.php
@@ -56,6 +56,7 @@ readonly class LegacyApp
             $craftApp->language = app()->getLocale();
 
             Craft::$app = $craftApp;
+            $laravelApp->instance('Craft', $craftApp);
             Craft::populateCustomFieldBehavior();
 
             /**

--- a/yii2-adapter/tests-laravel/Legacy/LegacyAppTest.php
+++ b/yii2-adapter/tests-laravel/Legacy/LegacyAppTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use craft\base\Plugin;
+use CraftCms\Cms\Plugin\Plugins;
+use CraftCms\Cms\Support\Facades\HtmlStack;
+use CraftCms\Cms\Twig\Events\PageEnded;
+use CraftCms\Cms\View\Enums\Position;
+use CraftCms\Yii2Adapter\LegacyApp;
+use Illuminate\Support\Facades\Event;
+
+it('does not resolve a second legacy app while loading legacy plugins', function() {
+    LegacyAppTestPlugin::$resolvedCraftApp = null;
+
+    $loading = false;
+    $loadCount = 0;
+    $plugins = Mockery::mock(Plugins::class);
+    $plugins->shouldReceive('getAllPlugins')->andReturnUsing(function() use (&$loading, &$loadCount) {
+        $loadCount++;
+
+        if ($loading) {
+            return [];
+        }
+
+        $loading = true;
+
+        try {
+            return [
+                'legacy-app-test' => LegacyAppTestPlugin::create([
+                    'handle' => 'legacy-app-test',
+                    'name' => 'Legacy App Test',
+                    'packageName' => 'craftcms/legacy-app-test',
+                    'version' => '1.0.0',
+                    'basePath' => __DIR__,
+                ]),
+            ];
+        } finally {
+            $loading = false;
+        }
+    });
+
+    app()->instance(Plugins::class, $plugins);
+    Event::forget(PageEnded::class);
+    app()->forgetInstance('Craft');
+
+    new LegacyApp()->register($this->app);
+    app('Craft');
+
+    HtmlStack::clear();
+    HtmlStack::js('window.legacyAppTest = true', Position::Head);
+    event($event = new PageEnded());
+
+    expect($loadCount)->toBe(1)
+        ->and(app('Craft'))->toBe(Craft::$app)
+        ->and(LegacyAppTestPlugin::$resolvedCraftApp)->toBe(Craft::$app)
+        ->and($event->headHtml)->toContain('window.legacyAppTest = true;');
+});
+
+class LegacyAppTestPlugin extends Plugin
+{
+    public static ?object $resolvedCraftApp = null;
+
+    public static function config(): array
+    {
+        self::$resolvedCraftApp = app('Craft');
+
+        return [];
+    }
+}


### PR DESCRIPTION
### Description

Prevents reentrant `Craft` singleton resolution while Yii compatibility events and legacy plugins are initialized by registering the constructed legacy app with Laravel before booting compatibility integrations. 

Adds regression coverage ensuring plugin initialization resolves the same app instance and page head assets remain intact.

### Related issues

- Fixes #19298