### PR TITLE
[6.x] Fix clearing asset alt text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Renamed the protected `CraftCms\Cms\FieldLayout\LayoutElements\BaseField::instructions()`, `tip()`, and `warning()` methods to `instructionsText()`, `tipText()`, and `warningText()`.
 - Fixed a styling issue. ([#19296](https://github.com/craftcms/cms/pull/19296))
 - Fixed a bug where Yii adapter plugins could cause legacy Control Panel assets to be omitted. ([#19302](https://github.com/craftcms/cms/pull/19302))
+- Fixed a bug where assets’ Alternative Text values could not be cleared. ([#19310](https://github.com/craftcms/cms/issues/19310))
 
 ## 6.0.0-alpha.14 - 2026-07-22
 

--- a/src/Asset/Elements/Asset.php
+++ b/src/Asset/Elements/Asset.php
@@ -1156,10 +1156,8 @@ class Asset extends Element
     public function setAttributesFromRequest(array $values): void
     {
         // alt='' actually means something, so we should preserve it.
-        $alt = Arr::pull($values, 'alt');
-
-        if ($alt !== null) {
-            $this->alt = $alt;
+        if (Arr::has($values, 'alt')) {
+            $this->alt = Arr::pull($values, 'alt') ?? '';
         }
 
         parent::setAttributesFromRequest($values);

--- a/tests/Feature/Http/Controllers/Elements/SaveElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/SaveElementControllerTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Asset\Elements\Asset;
+use CraftCms\Cms\Asset\Models\Asset as AssetModel;
+use CraftCms\Cms\Asset\Models\Volume;
+use CraftCms\Cms\Asset\Models\VolumeFolder;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\Contracts\NestedElementInterface;
@@ -446,6 +450,30 @@ describe('store', function () {
                 ->where('type', ElementActivityType::Save->value)
                 ->exists())
             ->toBeTrue();
+    });
+
+    it('can clear asset alt text', function () {
+        config()->set('filesystems.disks.save-element-controller-test', [
+            'driver' => 'local',
+            'root' => storage_path('framework/testing/save-element-controller-test'),
+        ]);
+
+        $volume = Volume::factory()->create(['fs' => 'disk:save-element-controller-test']);
+        $folder = VolumeFolder::factory()->create(['volumeId' => $volume->id]);
+        $asset = AssetModel::factory()->createElement([
+            'volumeId' => $volume->id,
+            'folderId' => $folder->id,
+            'alt' => 'Existing alt text',
+        ]);
+
+        postJson(action([SaveElementController::class, 'store']), [
+            'elementType' => Asset::class,
+            'elementId' => $asset->id,
+            'siteId' => $asset->siteId,
+            'alt' => '',
+        ])->assertOk();
+
+        expect(Asset::find()->id($asset->id)->one()->alt)->toBe('');
     });
 
     it('marks nested elements to update their owner search index before saving', function () {


### PR DESCRIPTION
### Description
Fixes asset saves so blank Alternative Text values remain cleared after Laravel normalizes empty request strings to `null`. Adds regression coverage for the full element save request.

### Related issues
Fixes #19310