### PR TITLE
Bugfix/filling gaps and eager loading

### DIFF
--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -9,9 +9,13 @@ namespace craft\fields;
 
 use Craft;
 use craft\base\ElementInterface;
+use craft\behaviors\EventBehavior;
+use craft\db\FixedOrderExpression;
 use craft\elements\Category;
 use craft\elements\db\CategoryQuery;
+use craft\elements\db\ElementQuery;
 use craft\elements\ElementCollection;
+use craft\events\CancelableEvent;
 use craft\gql\arguments\elements\Category as CategoryArguments;
 use craft\gql\interfaces\elements\Category as CategoryInterface;
 use craft\gql\resolvers\elements\Category as CategoryResolver;
@@ -105,27 +109,36 @@ class Categories extends BaseRelationField
      */
     public function normalizeValue(mixed $value, ?ElementInterface $element): mixed
     {
-        if (is_array($value) && $this->maintainHierarchy) {
-            /** @var Category[] $categories */
-            $categories = Category::find()
-                ->siteId($this->targetSiteId($element))
-                ->id(array_values(array_filter($value)))
-                ->status(null)
-                ->all();
+        $query = parent::normalizeValue($value, $element);
 
-            // Fill in any gaps
-            $structuresService = Craft::$app->getStructures();
-            $structuresService->fillGapsInElements($categories);
+        // Fill in gaps and enforce the branch limit, but only once this query actually gets
+        // executed on its own - if it's about to be discarded in favor of eager-loaded results
+        // (e.g. via `.eagerly()`), there's no point doing this work just to throw it away.
+        if (is_array($value) && $this->maintainHierarchy && $query instanceof ElementQuery) {
+            $query->attachBehavior(self::class, new EventBehavior([
+                ElementQuery::EVENT_BEFORE_PREPARE => function(CancelableEvent $event, ElementQuery $query) use ($element) {
+                    /** @var Category[] $categories */
+                    $categories = Category::find()
+                        ->siteId($this->targetSiteId($element))
+                        ->id($query->where['elements.id'] ?? [])
+                        ->status(null)
+                        ->all();
 
-            // Enforce the branch limit
-            if ($this->branchLimit) {
-                $structuresService->applyBranchLimitToElements($categories, $this->branchLimit);
-            }
+                    $structuresService = Craft::$app->getStructures();
+                    $structuresService->fillGapsInElements($categories);
 
-            $value = array_map(fn(Category $category) => $category->id, $categories);
+                    if ($this->branchLimit) {
+                        $structuresService->applyBranchLimitToElements($categories, $this->branchLimit);
+                    }
+
+                    $finalIds = array_map(fn(Category $category) => $category->id, $categories);
+                    $query->where(['elements.id' => $finalIds]);
+                    $query->orderBy([new FixedOrderExpression('elements.id', $finalIds, Craft::$app->getDb())]);
+                },
+            ]));
         }
 
-        return parent::normalizeValue($value, $element);
+        return $query;
     }
 
     /**

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -143,6 +143,74 @@ class Categories extends BaseRelationField
 
     /**
      * @inheritdoc
+     *
+     * Note: when Categories field is used across multiple field layouts (e.g. several entry types in
+     * the same section), calling `.eagerly()` without an explicit alias on a loop of mixed-type
+     * elements will re-trigger this method once per distinct field-layout provider, each time
+     * recomputing results for every source element that has this field, not just its own type's
+     * subset. (`ElementQuery`'s default eager-loading alias is derived from the *triggering*
+     * element's own provider handle, even though eager-loading map resolution itself matches by
+     * field ID across all providers.) Pass an explicit alias (`.eagerly('someAlias')`) in that
+     * scenario so every element shares one dedup key and only the first trigger actually runs.
+     */
+    public function getEagerLoadingMap(array $sourceElements): array|null|false
+    {
+        $map = parent::getEagerLoadingMap($sourceElements);
+
+        // if we're not maintaining hierarchy, go with the default behavior
+        if (!$this->maintainHierarchy || !is_array($map) || empty($map['map'])) {
+            return $map;
+        }
+
+        // array keyed by the sourceId with value containing all its target IDs
+        $targetIdsBySource = [];
+        foreach ($map['map'] as $mapping) {
+            $targetIdsBySource[$mapping['source']][] = $mapping['target'];
+        }
+
+        // Fetch every referenced category in one batched query, rather than per source element
+        // (this allows us to lower the number of queries needed to complete the task)
+        $allTargetIds = array_values(array_unique(array_merge(...array_values($targetIdsBySource))));
+        /** @var Category[] $categoriesById */
+        $categoriesById = Category::find()
+            ->siteId($sourceElements[0]->siteId)
+            ->id($allTargetIds)
+            ->status(null)
+            ->indexBy('id')
+            ->all();
+
+        $structuresService = Craft::$app->getStructures();
+        $newMap = [];
+
+        // now for each source, fill the gaps and apply branch limit
+        foreach ($targetIdsBySource as $sourceId => $targetIds) {
+            $categories = array_values(array_filter(array_map(
+                fn($id) => $categoriesById[$id] ?? null,
+                $targetIds,
+            )));
+
+            // Fill in any gaps
+            $structuresService->fillGapsInElements($categories);
+
+            // Enforce the branch limit
+            if ($this->branchLimit) {
+                $structuresService->applyBranchLimitToElements($categories, $this->branchLimit);
+            }
+
+            foreach ($categories as $category) {
+                $newMap[] = ['source' => $sourceId, 'target' => $category->id];
+            }
+        }
+
+        // update the map
+        $map['map'] = $newMap;
+
+        /** @phpstan-ignore-next-line */
+        return $map;
+    }
+
+    /**
+     * @inheritdoc
      */
     protected function inputHtml(mixed $value, ?ElementInterface $element, bool $inline): string
     {


### PR DESCRIPTION
### Description

#### Issues:
- The number of queries used to retrieve a set of elements with the Categories field that has `maintainHierarchy` turned on is different depending on whether you don’t eager-load vs eager-load with `.with()` vs lazy eager-load with `.eagerly()` vs lazy eager-load with `.eagerly()` with alias (`.eagerly('myAlias')`).
- What’s more, the results you get also differ between non-eager-loaded and any of the eager-loaded queries if there are actual gaps to fill.


#### Steps to reproduce:
1. clean craft cms installation
2. a categories group with all default settings
3. a categories field with all the default settings
4. 9 categories in that group, all on the top level
5. a channel-type section with revisions turned off and with 3 entry types
6. each of those entry types has a title and the categories field mentioned above
7. 5 entries in that section, entry 1 uses entry type 1, entry 2 uses entry type 2 and entries 3-5 use entry type 3; the first one has the first 3 categories in the categories field, the second one has the middle 3, and the remaining have the last 3 categories each
8. following twig template
```
<!DOCTYPE html>
<html lang="en-US">
<head>
    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
    <meta charset="utf-8"/>
    <title>Welcome to Craft CMS</title>
</head>
<body class="ltr">
{% set myEntries = craft.entries().section('sect1').type(['et1','et2','et3']).all() %}
{#{% set myEntries = craft.entries().section('sect1').type(['et1','et2','et3']).with(['myCategories']).all() %}#}
{% for myEntry in myEntries %}
    <h2>{{ myEntry.title }}</h2>
{#    {% set myCategories = myEntry.myCategories.eagerly('myAlias').all() %}#}
    {% set myCategories = myEntry.myCategories.all() %}
    <ul>
        {% for myCategory in myCategories %}
            <li>{{ myCategory.title }}</li>
        {% endfor %}
    </ul>
{% endfor %}

</body>
</html>
```
9. ensure you have debug toolbar on for your account
10. access the template in the browser and note the number of queries; uncomment/modify relevant parts to test `with`, `eagerly` and `eagerly('myAlias')` and check the number of db calls for each
11. edit the categories field and turn on `maintainHierarchy`
12. repeat step 10
13. add another category (title, e.g. "fill me in"), place it under the 7th category (on top level) and then make the 8th category its child
14. repeat step 10 again

#### Results before this PR:
```
--------------------------------------------------------------------------------------------------------
        			| `mH` off	| `mH` on, no gaps	| `mH` on, with gaps	| gaps situation
--------------------------------------------------------------------------------------------------------
no eager-loading	|   51		|	56				|	59 					| all gaps filled in
--------------------------------------------------------------------------------------------------------
.with()				|	47		|	47				|	47 					| no gaps filled in
--------------------------------------------------------------------------------------------------------
.eagerly() 			|	49		|	54				|	57 					| 1 out of 3 that needed it
--------------------------------------------------------------------------------------------------------
.eagerly('myAlias')	|	47		|	52				|	55 					| 1 out of 3 that needed it
--------------------------------------------------------------------------------------------------------
```

#### Results with this PR:
```
--------------------------------------------------------------------------------------------------------
        			| `mH` off	| `mH` on, no gaps	| `mH` on, with gaps	| gaps situation
--------------------------------------------------------------------------------------------------------
no eager-loading	|   51		|	56				|	59 					| all gaps filled in
--------------------------------------------------------------------------------------------------------
.with()				|	47		|	48				|	51 					| all gaps filled in
--------------------------------------------------------------------------------------------------------
.eagerly() 			|	49		|	52				|	61 					| all gaps filled in
--------------------------------------------------------------------------------------------------------
.eagerly('myAlias')	|	47		|	48				|	51 					| all gaps filled in
--------------------------------------------------------------------------------------------------------
```

- with `maintainHierarchy` off, the count and results are the same
- with `maintainHierarchy` on, but no gaps to fill, the `.with()` and `.eagerly('myAlias')` require the same number of queries to achieve the same results; 
`.eagerly()` requires less queries than before; the higher count compared to `.with()` and `.eagerly('myAlias')` comes from multiple field layout providers
- with `maintainHierarchy` on, and gaps to fill, the `.with()` and `.eagerly('myAlias')` require the same number of queries to achieve the same results; 
`.eagerly()` requires more queries than before, and the higher count compared to `.with()` and `.eagerly('myAlias')` comes from multiple field layout providers and the fact that it “re-triggers its full eager-loading computation once per distinct field-layout provider that shares the field”


#### More info:
- first commit defers filling the gaps (when normalising Categories field value) until `ElementQuery::EVENT_BEFORE_PREPARE` (similar to what `BaseRelationField` does with multi-instance relation fields and joining in the relations table values)
- the second commit (written mostly by Claude) ensures the gaps are filled, and the branch limit is applied when eager loading the Categories field with `maintainHierarchy` on

#### New recommendation:
- if you’re eager-loading a Categories field (especially with `maintainHierarchy` turned on) used across multiple field layout providers (e.g. multiple entry types), it’s advisable to pass an alias to the `.eagerly()` method to optimise the number of queries needed to fulfil the task



If anyone has a better idea on how to fix this, LMK.

An argument could also be made that since we’re not filling in the gaps for other Relation fields that support maintaining hierarchy (e.g. Entries) and since `.with()` was not filling in the gaps before, then `.eagerly()` shouldn’t do it either. If that’s what we want to go with, LMK and I can adjust.


### Related issues
n/a; original discrepancy in the number of queries came from @tommysvr 
