### PR TITLE
[6.x] Fix Blade view composer names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added fluent APIs for creating and modifying `CraftCms\Cms\FieldLayout\FieldLayout`, `CraftCms\Cms\FieldLayout\FieldLayoutTab`, and field layout elements, including dependency-injected closure values.
 - Added support for configuring field layout field instruction positions.
+- Fixed a bug where Blade templates rendered through Craft used path-based view names, preventing named Laravel view composers from running. ([#19177](https://github.com/craftcms/cms/issues/19177))
 - Changed `craft:resave:all` to discover registered `craft:resave:*` Artisan commands directly, rather than relying on a resolving event. ([#19270](https://github.com/craftcms/cms/pull/19270))
 - Changed `CraftCms\Cms\Search\Events\SearchPerformed` to be a readonly, immutable event; its `$results` and `$scores` properties can no longer be overridden by listeners. `CraftCms\Cms\Search\Events\SearchScoresResolving` should be used to override scores instead. ([#19308](https://github.com/craftcms/cms/pull/19308))
 - Added `CraftCms\Cms\Asset\AssetFileKinds`. ([#19270](https://github.com/craftcms/cms/pull/19270))

--- a/src/Blade/BladeRenderer.php
+++ b/src/Blade/BladeRenderer.php
@@ -7,9 +7,14 @@ namespace CraftCms\Cms\Blade;
 use CraftCms\Cms\View\Contracts\TemplateRendererInterface;
 use CraftCms\Cms\View\TemplateMode;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\View\Factory;
+use Illuminate\View\View;
+use Illuminate\View\ViewName;
 
 class BladeRenderer implements TemplateRendererInterface
 {
+    public function __construct(private readonly Factory $factory) {}
+
     public function supports(string $file): bool
     {
         return str_ends_with($file, '.blade.php');
@@ -21,9 +26,20 @@ class BladeRenderer implements TemplateRendererInterface
         ?TemplateMode $templateMode = null,
         ?string $resolvedTemplate = null,
     ): string {
-        return $resolvedTemplate
-            ? view()->file($resolvedTemplate, $variables)->render()
-            : view($template, $variables)->render();
+        if ($resolvedTemplate === null) {
+            return view($template, $variables)->render();
+        }
+
+        $view = new View(
+            $this->factory,
+            $this->factory->getEngineFromPath($resolvedTemplate),
+            ViewName::normalize($template),
+            $resolvedTemplate,
+            $variables,
+        );
+        $this->factory->callCreator($view);
+
+        return $view->render();
     }
 
     public function renderString(

--- a/tests/Unit/View/BladeRendererTest.php
+++ b/tests/Unit/View/BladeRendererTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CraftCms\Aliases\Aliases;
+use CraftCms\Cms\Support\File as Path;
 use CraftCms\Cms\View\Events\TemplateRendering;
 use CraftCms\Cms\View\TemplateEngine;
 use CraftCms\Cms\View\TemplateManager;
@@ -80,7 +81,7 @@ it('preserves logical view names for Craft-resolved Blade templates', function (
 
     View::composer('index-view', function (LaravelView $view) use (&$viewName, &$viewPath) {
         $viewName = $view->name();
-        $viewPath = $view->getPath();
+        $viewPath = Path::normalizePath($view->getPath());
         $view->with('name', 'Composed');
     });
 
@@ -88,7 +89,7 @@ it('preserves logical view names for Craft-resolved Blade templates', function (
 
     expect($output)->toBe('Indexed Composed')
         ->and($viewName)->toBe('index-view')
-        ->and($viewPath)->toBe($this->tempDir.'/index-view/index.blade.php');
+        ->and($viewPath)->toBe(Path::normalizePath($this->tempDir.'/index-view/index.blade.php'));
 });
 
 it('runs creators for Craft-resolved Blade templates', function () {

--- a/tests/Unit/View/BladeRendererTest.php
+++ b/tests/Unit/View/BladeRendererTest.php
@@ -9,6 +9,8 @@ use CraftCms\Cms\View\TemplateManager;
 use CraftCms\Cms\View\TemplateMode;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
+use Illuminate\View\View as LaravelView;
 
 beforeEach(function () {
     $this->tempDir = sys_get_temp_dir().'/craft-blade-renderer-test-'.uniqid();
@@ -27,6 +29,8 @@ Hello, {{ $name }}!
 BLADE);
 
     File::put($this->tempDir.'/partial.blade.php', 'Named {{ $name }}');
+    File::ensureDirectoryExists($this->tempDir.'/index-view');
+    File::put($this->tempDir.'/index-view/index.blade.php', 'Indexed {{ $name }}');
     File::ensureDirectoryExists($this->tempDir.'/nested');
     File::put($this->tempDir.'/nested/partial.blade.php', 'Nested {{ $name }}');
     File::put($this->tempDir.'/twig-partial.twig', 'Twig {{ name }}');
@@ -68,6 +72,33 @@ it('renders named Laravel views', function () {
     $output = $this->bladeRenderer->renderTemplate('blade-test::partial', ['name' => 'Blade'], TemplateMode::Site);
 
     expect($output)->toBe('Named Blade');
+});
+
+it('preserves logical view names for Craft-resolved Blade templates', function () {
+    $viewName = null;
+    $viewPath = null;
+
+    View::composer('index-view', function (LaravelView $view) use (&$viewName, &$viewPath) {
+        $viewName = $view->name();
+        $viewPath = $view->getPath();
+        $view->with('name', 'Composed');
+    });
+
+    $output = $this->manager->renderTemplate('index-view', ['name' => 'Original'], renderer: TemplateEngine::Blade);
+
+    expect($output)->toBe('Indexed Composed')
+        ->and($viewName)->toBe('index-view')
+        ->and($viewPath)->toBe($this->tempDir.'/index-view/index.blade.php');
+});
+
+it('runs creators for Craft-resolved Blade templates', function () {
+    View::creator('index-view', function (LaravelView $view) {
+        $view->with('name', 'Created');
+    });
+
+    $output = $this->manager->renderTemplate('index-view', ['name' => 'Original'], renderer: TemplateEngine::Blade);
+
+    expect($output)->toBe('Indexed Created');
 });
 
 it('renders slash-style Laravel view names', function () {


### PR DESCRIPTION
### Description

Preserves logical Laravel view names for Blade templates while rendering Craft-resolved file paths, allowing named view creators and composers to run without losing Craft’s site-specific, index-template, and custom-root resolution.

### Related issues

- Fixes #19177