### PR TITLE
[6.x] Move updater workflows to CP routes

### DIFF
--- a/resources/js/modules/updater/components/Update.vue
+++ b/resources/js/modules/updater/components/Update.vue
@@ -107,11 +107,7 @@
           <!-- Update button -->
           <Form
             v-else
-            :action="
-              UpdaterController.index[
-                '/{cpTrigger?}/{actionTrigger?}/updater'
-              ]()
-            "
+            :action="UpdaterController.index()"
             method="post"
             v-slot="{processing}"
           >

--- a/resources/js/modules/updater/components/Updates.vue
+++ b/resources/js/modules/updater/components/Updates.vue
@@ -181,7 +181,7 @@
     });
 
     router.post(
-      UpdaterController.index['/{cpTrigger?}/{actionTrigger?}/updater'](),
+      UpdaterController.index(),
       {
         return: 'utilities/updates',
         install,

--- a/resources/js/modules/updater/composables/useUpdater.ts
+++ b/resources/js/modules/updater/composables/useUpdater.ts
@@ -1,35 +1,16 @@
 import {computed, type ComputedRef, type Ref, ref} from 'vue';
 import {t} from '@craftcms/ui';
 import axios from 'axios';
-import {useHelpers} from '@/common/composables/useCraftData';
 
 /**
  * State returned from updater API endpoints
  */
-export interface UpdaterState {
-  status?: string;
-  error?: string;
-  errorDetails?: string;
-  nextAction?: string;
-  options?: UpdaterOption[];
-  finished?: boolean;
-  returnUrl?: string;
-  data: string;
-}
+export type UpdaterState = CraftCms.Cms.Update.Data.UpdaterState;
 
 /**
  * An option/button the user can click when faced with an error or decision
  */
-export interface UpdaterOption {
-  label: string;
-  url?: string;
-  email?: string;
-  subject?: string;
-  submit?: boolean;
-  nextAction?: string;
-  status?: string;
-  data?: string;
-}
+export type UpdaterOption = CraftCms.Cms.Update.Data.UpdaterOption;
 
 interface UseUpdaterReturn {
   state: Ref<UpdaterState>;
@@ -44,11 +25,7 @@ interface UseUpdaterReturn {
 /**
  * Composable for managing the updater workflow state machine
  */
-export function useUpdater(
-  actionPrefix: string,
-  initialState: UpdaterState
-): UseUpdaterReturn {
-  const {getActionUrl} = useHelpers();
+export function useUpdater(initialState: UpdaterState): UseUpdaterReturn {
   const state = ref<UpdaterState>({...initialState});
   const isLoading = ref(false);
 
@@ -58,13 +35,13 @@ export function useUpdater(
   /**
    * Execute an updater action via POST request
    */
-  async function executeAction(action: string): Promise<void> {
+  async function executeAction(actionUrl: string): Promise<void> {
     isLoading.value = true;
     let response;
 
     try {
       response = await axios.post(
-        getActionUrl(`${actionPrefix}/${action}`),
+        actionUrl,
         {data: state.value.data},
         {
           headers: {
@@ -102,12 +79,13 @@ export function useUpdater(
       options: newState.options,
       finished: newState.finished,
       returnUrl: newState.returnUrl ?? state.value.returnUrl,
-      nextAction: newState.nextAction,
+      nextUrl: newState.nextUrl,
+      finishUrl: newState.finishUrl,
     };
 
     // Auto-execute next action if specified
-    if (newState.nextAction) {
-      executeAction(newState.nextAction);
+    if (newState.nextUrl) {
+      executeAction(newState.nextUrl);
     }
   }
 
@@ -115,8 +93,8 @@ export function useUpdater(
    * Handle user clicking an option button
    */
   function handleOptionClick(option: UpdaterOption): void {
-    // If option has a nextAction, execute it
-    if (option.nextAction) {
+    // If option has a nextUrl, execute it
+    if (option.nextUrl) {
       // Clear error state and show new status
       state.value.error = undefined;
       state.value.errorDetails = undefined;
@@ -131,7 +109,7 @@ export function useUpdater(
         state.value.data = option.data;
       }
 
-      executeAction(option.nextAction);
+      executeAction(option.nextUrl);
     }
   }
 
@@ -159,7 +137,7 @@ export function useUpdater(
     // Try to disable maintenance mode
     axios
       .post(
-        getActionUrl(`${actionPrefix}/finish`),
+        state.value.finishUrl,
         {data: state.value.data},
         {
           headers: {

--- a/resources/js/pages/updater/Index.vue
+++ b/resources/js/pages/updater/Index.vue
@@ -14,7 +14,6 @@
   const props = defineProps<{
     title: string;
     initialState: UpdaterState;
-    actionPrefix: string;
     returnUrl: string;
   }>();
 
@@ -26,7 +25,7 @@
     executeAction,
     handleOptionClick,
     getEmailLink,
-  } = useUpdater(props.actionPrefix, props.initialState);
+  } = useUpdater(props.initialState);
 
   /**
    * Parse status text to support markdown-like formatting
@@ -72,8 +71,8 @@
 
   // Start the update process when the page loads
   onMounted(() => {
-    if (props.initialState.nextAction) {
-      executeAction(props.initialState.nextAction);
+    if (props.initialState.nextUrl) {
+      executeAction(props.initialState.nextUrl);
     }
   });
 

--- a/resources/templates/_special/dbupdate.twig
+++ b/resources/templates/_special/dbupdate.twig
@@ -3,9 +3,8 @@
 
 {% block message %}
     <p>{{ "To complete the update, some changes must be made to your database."|t('app') }}</p>
-    <form method="post" class="buttons">
+    <form method="post" action="{{ cpUrl('updates') }}" class="buttons">
         {{ csrfInput() }}
-        {{ actionInput('updater') }}
         {{ hiddenInput('return', Request.path()) }}
         <button type="submit" class="btn submit">{{ 'Finish up'|t('app') }}</button>
     </form>

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -27,7 +27,6 @@ use CraftCms\Cms\Http\Controllers\Auth\TwoFactorAuthenticationController;
 use CraftCms\Cms\Http\Controllers\Auth\VerifyEmailController;
 use CraftCms\Cms\Http\Controllers\BaseUpdaterController;
 use CraftCms\Cms\Http\Controllers\ConditionsController;
-use CraftCms\Cms\Http\Controllers\ConfigSyncController;
 use CraftCms\Cms\Http\Controllers\Dashboard\Widgets\CraftSupportController;
 use CraftCms\Cms\Http\Controllers\Dashboard\Widgets\FeedController;
 use CraftCms\Cms\Http\Controllers\Dashboard\Widgets\NewUsersController;
@@ -67,7 +66,6 @@ use CraftCms\Cms\Http\Controllers\NestedElementsController;
 use CraftCms\Cms\Http\Controllers\PluginsController;
 use CraftCms\Cms\Http\Controllers\PluginStore\InstallController as PluginStoreInstallController;
 use CraftCms\Cms\Http\Controllers\PluginStore\PluginStoreController;
-use CraftCms\Cms\Http\Controllers\PluginStore\RemoveController;
 use CraftCms\Cms\Http\Controllers\PreviewController;
 use CraftCms\Cms\Http\Controllers\QueueController;
 use CraftCms\Cms\Http\Controllers\RelationalFieldsController;
@@ -76,7 +74,6 @@ use CraftCms\Cms\Http\Controllers\Settings\FilesystemsController;
 use CraftCms\Cms\Http\Controllers\Settings\SectionsController;
 use CraftCms\Cms\Http\Controllers\Settings\VolumesController;
 use CraftCms\Cms\Http\Controllers\StructuresController;
-use CraftCms\Cms\Http\Controllers\Updates\UpdaterController;
 use CraftCms\Cms\Http\Controllers\Updates\UpdatesController;
 use CraftCms\Cms\Http\Controllers\Users\ActivateController;
 use CraftCms\Cms\Http\Controllers\Users\AuthMethodController;
@@ -193,21 +190,6 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
     Route::any('app/get-utilities-badge-count', [UtilitiesController::class, 'badgeCount']);
     Route::any('app/icon-svg', [IconController::class, 'svg']);
     Route::any('app/icon-picker-options', [IconController::class, 'pickerOptions']);
-
-    // Updater
-    Route::prefix('updater')->group(function () {
-        Route::post('/', [UpdaterController::class, 'index']);
-        Route::post(UpdaterController::ACTION_FORCE_UPDATE, [UpdaterController::class, 'forceUpdate']);
-        Route::post(UpdaterController::ACTION_BACKUP, [UpdaterController::class, 'backup']);
-        Route::post(UpdaterController::ACTION_SERVER_CHECK, [UpdaterController::class, 'serverCheck']);
-        Route::post(UpdaterController::ACTION_REVERT, [UpdaterController::class, 'revert']);
-        Route::post(UpdaterController::ACTION_MIGRATE, [UpdaterController::class, 'migrate']);
-        Route::post(BaseUpdaterController::ACTION_PRECHECK, [UpdaterController::class, 'precheck']);
-        Route::post(BaseUpdaterController::ACTION_RECHECK_COMPOSER, [UpdaterController::class, 'recheckComposer']);
-        Route::post(BaseUpdaterController::ACTION_COMPOSER_INSTALL, [UpdaterController::class, 'composerInstall']);
-        Route::post(BaseUpdaterController::ACTION_COMPOSER_REMOVE, [UpdaterController::class, 'composerRemove']);
-        Route::post(BaseUpdaterController::ACTION_FINISH, [UpdaterController::class, 'finish']);
-    });
 
     /**
      * Actions needing auth
@@ -435,21 +417,6 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
         Route::post('project-config/discard', [ProjectConfigController::class, 'discard']);
         Route::get('project-config/download', [ProjectConfigController::class, 'download']);
 
-        // Project Config sync
-        Route::prefix('config-sync')->middleware([RequireAdmin::class])->group(function () {
-            Route::post('/', [ConfigSyncController::class, 'index']);
-            Route::post(ConfigSyncController::ACTION_RETRY, [ConfigSyncController::class, 'retry']);
-            Route::post(ConfigSyncController::ACTION_APPLY_YAML_CHANGES, [ConfigSyncController::class, 'applyYamlChanges']);
-            Route::post(ConfigSyncController::ACTION_REGENERATE_YAML, [ConfigSyncController::class, 'regenerateYaml']);
-            Route::post(ConfigSyncController::ACTION_UNINSTALL_PLUGIN, [ConfigSyncController::class, 'uninstallPlugin']);
-            Route::post(ConfigSyncController::ACTION_INSTALL_PLUGIN, [ConfigSyncController::class, 'installPlugin']);
-            Route::post(BaseUpdaterController::ACTION_PRECHECK, [ConfigSyncController::class, 'precheck']);
-            Route::post(BaseUpdaterController::ACTION_RECHECK_COMPOSER, [ConfigSyncController::class, 'recheckComposer']);
-            Route::post(BaseUpdaterController::ACTION_COMPOSER_INSTALL, [ConfigSyncController::class, 'composerInstall']);
-            Route::post(BaseUpdaterController::ACTION_COMPOSER_REMOVE, [ConfigSyncController::class, 'composerRemove']);
-            Route::post(BaseUpdaterController::ACTION_FINISH, [ConfigSyncController::class, 'finish']);
-        });
-
         // Sections
         Route::get('sections/table-data', [SectionsController::class, 'tableData']);
         Route::get('sections/edit/{section}', [SectionsController::class, 'edit']);
@@ -520,15 +487,5 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
             Route::post(BaseUpdaterController::ACTION_FINISH, [PluginStoreInstallController::class, 'finish']);
         });
 
-        Route::prefix('pluginstore/remove')->middleware([
-            RequireAdminChanges::class,
-        ])->group(function () {
-            Route::post('/', [RemoveController::class, 'index']);
-            Route::post(BaseUpdaterController::ACTION_PRECHECK, [RemoveController::class, 'precheck']);
-            Route::post(BaseUpdaterController::ACTION_RECHECK_COMPOSER, [RemoveController::class, 'recheckComposer']);
-            Route::post(BaseUpdaterController::ACTION_COMPOSER_INSTALL, [RemoveController::class, 'composerInstall']);
-            Route::post(BaseUpdaterController::ACTION_COMPOSER_REMOVE, [RemoveController::class, 'composerRemove']);
-            Route::post(BaseUpdaterController::ACTION_FINISH, [RemoveController::class, 'finish']);
-        });
     });
 });

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -70,6 +70,7 @@ use function CraftCms\Cms\cp_url;
 Route::get('install', [InstallController::class, 'index']);
 
 Route::prefix('updates')->name('updates.')->group(function () {
+    Route::post('/', [UpdaterController::class, 'index'])->name('index');
     Route::post(UpdaterController::ACTION_FORCE_UPDATE, [UpdaterController::class, 'forceUpdate'])->name('force-update');
     Route::post(UpdaterController::ACTION_BACKUP, [UpdaterController::class, 'backup'])->name('backup');
     Route::post(UpdaterController::ACTION_SERVER_CHECK, [UpdaterController::class, 'serverCheck'])->name('server-check');
@@ -413,6 +414,4 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
             Route::delete('{handle}', [FilesystemsController::class, 'destroy']);
         });
     });
-
-    Route::post('updates', [UpdaterController::class, 'index'])->name('updates.index');
 });

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -10,6 +10,8 @@ use CraftCms\Cms\Http\Controllers\Auth\LoginController;
 use CraftCms\Cms\Http\Controllers\Auth\SetPasswordController;
 use CraftCms\Cms\Http\Controllers\Auth\TwoFactorAuthenticationController;
 use CraftCms\Cms\Http\Controllers\Auth\VerifyEmailController;
+use CraftCms\Cms\Http\Controllers\BaseUpdaterController;
+use CraftCms\Cms\Http\Controllers\ConfigSyncController;
 use CraftCms\Cms\Http\Controllers\ContentIndexController;
 use CraftCms\Cms\Http\Controllers\Dashboard\DashboardController;
 use CraftCms\Cms\Http\Controllers\Elements\EditElementController;
@@ -26,6 +28,7 @@ use CraftCms\Cms\Http\Controllers\Gql\TokensController;
 use CraftCms\Cms\Http\Controllers\InstallController;
 use CraftCms\Cms\Http\Controllers\PluginsController;
 use CraftCms\Cms\Http\Controllers\PluginStore\PluginStoreController;
+use CraftCms\Cms\Http\Controllers\PluginStore\RemoveController;
 use CraftCms\Cms\Http\Controllers\Settings\AddressSettingsController;
 use CraftCms\Cms\Http\Controllers\Settings\EmailSettingsController;
 use CraftCms\Cms\Http\Controllers\Settings\EntryTypesController;
@@ -66,6 +69,19 @@ use function CraftCms\Cms\cp_url;
  */
 Route::get('install', [InstallController::class, 'index']);
 
+Route::prefix('updates')->name('updates.')->group(function () {
+    Route::post(UpdaterController::ACTION_FORCE_UPDATE, [UpdaterController::class, 'forceUpdate'])->name('force-update');
+    Route::post(UpdaterController::ACTION_BACKUP, [UpdaterController::class, 'backup'])->name('backup');
+    Route::post(UpdaterController::ACTION_SERVER_CHECK, [UpdaterController::class, 'serverCheck'])->name('server-check');
+    Route::post(UpdaterController::ACTION_REVERT, [UpdaterController::class, 'revert'])->name('revert');
+    Route::post(UpdaterController::ACTION_MIGRATE, [UpdaterController::class, 'migrate'])->name('migrate');
+    Route::post(BaseUpdaterController::ACTION_PRECHECK, [UpdaterController::class, 'precheck'])->name('precheck');
+    Route::post(BaseUpdaterController::ACTION_RECHECK_COMPOSER, [UpdaterController::class, 'recheckComposer'])->name('recheck-composer');
+    Route::post(BaseUpdaterController::ACTION_COMPOSER_INSTALL, [UpdaterController::class, 'composerInstall'])->name('composer-install');
+    Route::post(BaseUpdaterController::ACTION_COMPOSER_REMOVE, [UpdaterController::class, 'composerRemove'])->name('composer-remove');
+    Route::post(BaseUpdaterController::ACTION_FINISH, [UpdaterController::class, 'finish'])->name('finish');
+});
+
 Route::middleware('craft.web')->group(function () {
     Route::get(CpAuthPath::Login->value, [LoginController::class, 'showLogin']);
     Route::post(CpAuthPath::Login->value, [LoginController::class, 'attemptLogin'])->middleware('throttle:'.LoginRateLimiter::NAME);
@@ -104,6 +120,15 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
     Route::middleware(RequireAdminChanges::class)->group(function () {
         Route::get('settings/addresses', [AddressSettingsController::class, 'index']);
         Route::post('settings/addresses', [AddressSettingsController::class, 'store']);
+    });
+
+    Route::prefix('pluginstore/remove')->middleware(RequireAdminChanges::class)->group(function () {
+        Route::post('/', [RemoveController::class, 'index']);
+        Route::post(BaseUpdaterController::ACTION_PRECHECK, [RemoveController::class, 'precheck']);
+        Route::post(BaseUpdaterController::ACTION_RECHECK_COMPOSER, [RemoveController::class, 'recheckComposer']);
+        Route::post(BaseUpdaterController::ACTION_COMPOSER_INSTALL, [RemoveController::class, 'composerInstall']);
+        Route::post(BaseUpdaterController::ACTION_COMPOSER_REMOVE, [RemoveController::class, 'composerRemove']);
+        Route::post(BaseUpdaterController::ACTION_FINISH, [RemoveController::class, 'finish']);
     });
 
     /**
@@ -185,6 +210,20 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
     Route::middleware([
         RequireAdmin::class,
     ])->group(function () {
+        Route::prefix('config-sync')->group(function () {
+            Route::post('/', [ConfigSyncController::class, 'index']);
+            Route::post(ConfigSyncController::ACTION_RETRY, [ConfigSyncController::class, 'retry']);
+            Route::post(ConfigSyncController::ACTION_APPLY_YAML_CHANGES, [ConfigSyncController::class, 'applyYamlChanges']);
+            Route::post(ConfigSyncController::ACTION_REGENERATE_YAML, [ConfigSyncController::class, 'regenerateYaml']);
+            Route::post(ConfigSyncController::ACTION_UNINSTALL_PLUGIN, [ConfigSyncController::class, 'uninstallPlugin']);
+            Route::post(ConfigSyncController::ACTION_INSTALL_PLUGIN, [ConfigSyncController::class, 'installPlugin']);
+            Route::post(BaseUpdaterController::ACTION_PRECHECK, [ConfigSyncController::class, 'precheck']);
+            Route::post(BaseUpdaterController::ACTION_RECHECK_COMPOSER, [ConfigSyncController::class, 'recheckComposer']);
+            Route::post(BaseUpdaterController::ACTION_COMPOSER_INSTALL, [ConfigSyncController::class, 'composerInstall']);
+            Route::post(BaseUpdaterController::ACTION_COMPOSER_REMOVE, [ConfigSyncController::class, 'composerRemove']);
+            Route::post(BaseUpdaterController::ACTION_FINISH, [ConfigSyncController::class, 'finish']);
+        });
+
         // Index page
         Route::get('settings', SettingsIndexController::class)
             ->name('settings.index');
@@ -375,5 +414,5 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
         });
     });
 
-    Route::post('updates', [UpdaterController::class, 'index']);
+    Route::post('updates', [UpdaterController::class, 'index'])->name('updates.index');
 });

--- a/src/Http/Controllers/BaseUpdaterController.php
+++ b/src/Http/Controllers/BaseUpdaterController.php
@@ -11,6 +11,7 @@ use CraftCms\Cms\Support\Composer;
 use CraftCms\Cms\Support\Facades\HtmlStack;
 use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\Support\PHP;
+use CraftCms\Cms\Update\Data\UpdaterState;
 use CraftCms\Cms\Update\Updates;
 use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use CraftCms\Cms\View\LegacyAssets\UpdaterAsset;
@@ -21,6 +22,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,6 +51,8 @@ abstract class BaseUpdaterController
 
     /** @var array The data associated with the current update */
     protected array $data = [];
+
+    protected bool $usesStepUrls = true;
 
     public function __construct(
         protected Request $request,
@@ -310,7 +314,38 @@ abstract class BaseUpdaterController
         // Encode and hash the data
         $state['data'] = $this->hashedData();
 
-        return new JsonResponse($state);
+        if (! $this->usesStepUrls) {
+            return new JsonResponse($state);
+        }
+
+        return new JsonResponse($this->clientState($state)->toArray());
+    }
+
+    protected function clientState(array $state): UpdaterState
+    {
+        if (isset($state['nextAction'])) {
+            $state['nextUrl'] = $this->stepUrl($state['nextAction']);
+            unset($state['nextAction']);
+        }
+
+        foreach ($state['options'] ?? [] as $index => $option) {
+            if (! isset($option['nextAction'])) {
+                continue;
+            }
+
+            $option['nextUrl'] = $this->stepUrl($option['nextAction']);
+            unset($option['nextAction']);
+            $state['options'][$index] = $option;
+        }
+
+        $state['finishUrl'] = $this->stepUrl(self::ACTION_FINISH);
+
+        return UpdaterState::fromArray($state);
+    }
+
+    private function stepUrl(string $action): string
+    {
+        return action([static::class, Str::camel($action)]);
     }
 
     /**

--- a/src/Http/Controllers/ConfigSyncController.php
+++ b/src/Http/Controllers/ConfigSyncController.php
@@ -62,8 +62,7 @@ class ConfigSyncController extends BaseUpdaterController
 
         return Inertia::render('updater/Index', [
             'title' => $this->pageTitle(),
-            'initialState' => $state,
-            'actionPrefix' => 'config-sync',
+            'initialState' => $this->clientState($state),
             'returnUrl' => $this->returnUrl(),
         ])->toResponse($this->request);
     }

--- a/src/Http/Controllers/PluginStore/InstallController.php
+++ b/src/Http/Controllers/PluginStore/InstallController.php
@@ -28,6 +28,10 @@ class InstallController extends BaseUpdaterController
 
     public const string ACTION_MIGRATE = 'migrate';
 
+    // TODO: Remove this once the Plugin Store installer has been ported to Inertia.
+    #[Override]
+    protected bool $usesStepUrls = false;
+
     public function __construct(
         Request $request,
         GeneralConfig $generalConfig,

--- a/src/Http/Controllers/PluginStore/RemoveController.php
+++ b/src/Http/Controllers/PluginStore/RemoveController.php
@@ -31,8 +31,7 @@ class RemoveController extends BaseUpdaterController
 
         return Inertia::render('updater/Index', [
             'title' => $this->pageTitle(),
-            'initialState' => $state,
-            'actionPrefix' => 'pluginstore/remove',
+            'initialState' => $this->clientState($state),
             'returnUrl' => $this->returnUrl(),
         ])->toResponse($this->request);
     }

--- a/src/Http/Controllers/Updates/UpdaterController.php
+++ b/src/Http/Controllers/Updates/UpdaterController.php
@@ -70,8 +70,7 @@ class UpdaterController extends BaseUpdaterController
 
         return Inertia::render('updater/Index', [
             'title' => $this->pageTitle(),
-            'initialState' => $state,
-            'actionPrefix' => 'updater',
+            'initialState' => $this->clientState($state),
             'returnUrl' => Url::cpUrl($this->data['returnUrl'] ?? $this->generalConfig->getPostCpLoginRedirect()),
         ])->toResponse($this->request);
     }

--- a/src/Http/Middleware/CheckForUpdates.php
+++ b/src/Http/Middleware/CheckForUpdates.php
@@ -8,7 +8,6 @@ use Closure;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\Shared\Models\Info;
-use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\Path;
 use CraftCms\Cms\Support\File;
 use CraftCms\Cms\Update\Updates;
@@ -73,6 +72,10 @@ readonly class CheckForUpdates
 
     private function processUpdate(Request $request, Closure $next): mixed
     {
+        if ($request->routeIs('craft.cp.updates.*')) {
+            return $next($request);
+        }
+
         if ($request->isCpRequest() && (! $request->isActionRequest() || str_contains($request->path(), 'users/login'))) {
             if ($this->updates->wasCraftBreakpointSkipped()) {
                 throw new RuntimeException(t('You need to be on at least Craft CMS {version} before you can manually update to Craft CMS {targetVersion}.', [
@@ -92,7 +95,6 @@ readonly class CheckForUpdates
             $actionSegments = $request->actionSegments();
 
             if (
-                Arr::first($actionSegments) === 'updater' ||
                 $actionSegments === ['app', 'health-check'] ||
                 $actionSegments === ['app', 'migrate'] ||
                 $actionSegments === ['pluginstore', 'install', 'migrate']

--- a/src/Update/Data/UpdaterOption.php
+++ b/src/Update/Data/UpdaterOption.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Update\Data;
+
+use CraftCms\Cms\Support\Arr;
+use Illuminate\Contracts\Support\Arrayable;
+use Spatie\TypeScriptTransformer\Attributes\Optional;
+
+/**
+ * @internal
+ */
+class UpdaterOption implements Arrayable
+{
+    public function __construct(
+        public string $label,
+        #[Optional]
+        public ?string $url = null,
+        #[Optional]
+        public ?string $email = null,
+        #[Optional]
+        public ?string $subject = null,
+        #[Optional]
+        public ?bool $submit = null,
+        #[Optional]
+        public ?string $nextUrl = null,
+        #[Optional]
+        public ?string $status = null,
+        #[Optional]
+        public ?string $data = null,
+        #[Optional]
+        public ?bool $finished = null,
+        #[Optional]
+        public ?string $returnUrl = null,
+        #[Optional]
+        public ?string $error = null,
+        #[Optional]
+        public ?string $errorDetails = null,
+        /** @var UpdaterOption[]|null */
+        #[Optional]
+        public ?array $options = null,
+    ) {}
+
+    public static function fromArray(array $state): self
+    {
+        $state['options'] = isset($state['options']) ? array_map(self::fromArray(...), $state['options']) : null;
+
+        return new self(...$state);
+    }
+
+    #[\Override]
+    public function toArray(): array
+    {
+        $state = get_object_vars($this);
+        $state['options'] = $this->options === null ? null : array_map(fn (self $option) => $option->toArray(), $this->options);
+
+        return Arr::whereNotNull($state);
+    }
+}

--- a/src/Update/Data/UpdaterState.php
+++ b/src/Update/Data/UpdaterState.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Update\Data;
+
+use CraftCms\Cms\Support\Arr;
+use Illuminate\Contracts\Support\Arrayable;
+use Spatie\TypeScriptTransformer\Attributes\Optional;
+
+/**
+ * @internal
+ */
+class UpdaterState implements Arrayable
+{
+    public function __construct(
+        public string $data,
+        public string $finishUrl,
+        #[Optional]
+        public ?string $status = null,
+        #[Optional]
+        public ?string $error = null,
+        #[Optional]
+        public ?string $errorDetails = null,
+        #[Optional]
+        public ?string $nextUrl = null,
+        /** @var UpdaterOption[]|null */
+        #[Optional]
+        public ?array $options = null,
+        #[Optional]
+        public ?bool $finished = null,
+        #[Optional]
+        public ?string $returnUrl = null,
+    ) {}
+
+    public static function fromArray(array $state): self
+    {
+        $state['options'] = isset($state['options']) ? array_map(UpdaterOption::fromArray(...), $state['options']) : null;
+
+        return new self(...$state);
+    }
+
+    #[\Override]
+    public function toArray(): array
+    {
+        $state = get_object_vars($this);
+        $state['options'] = $this->options === null ? null : array_map(fn (UpdaterOption $option) => $option->toArray(), $this->options);
+
+        return Arr::whereNotNull($state);
+    }
+}

--- a/tests/Feature/Http/Controllers/ConfigSyncControllerTest.php
+++ b/tests/Feature/Http/Controllers/ConfigSyncControllerTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Crypt;
 use Inertia\Testing\AssertableInertia;
 
+use function CraftCms\Cms\cp_url;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\post;
 use function Pest\Laravel\postJson;
@@ -28,33 +29,38 @@ beforeEach(function () {
 });
 
 dataset('routes', [
-    [ConfigSyncController::class, 'index'],
-    [ConfigSyncController::class, 'retry'],
-    [ConfigSyncController::class, 'applyYamlChanges'],
-    [ConfigSyncController::class, 'regenerateYaml'],
-    [ConfigSyncController::class, 'uninstallPlugin'],
-    [ConfigSyncController::class, 'installPlugin'],
-    [ConfigSyncController::class, 'precheck'],
-    [ConfigSyncController::class, 'recheckComposer'],
-    [ConfigSyncController::class, 'composerInstall'],
-    [ConfigSyncController::class, 'composerRemove'],
-    [ConfigSyncController::class, 'finish'],
+    'index',
+    'retry',
+    'applyYamlChanges',
+    'regenerateYaml',
+    'uninstallPlugin',
+    'installPlugin',
+    'precheck',
+    'recheckComposer',
+    'composerInstall',
+    'composerRemove',
+    'finish',
 ]);
 
-it('requires authentication all routes', function (string $controller, string $action) {
-    auth()->logout();
-
-    postJson(action([$controller, $action]))->assertUnauthorized();
+it('uses normal CP routes', function (string $action) {
+    expect(parse_url(action([ConfigSyncController::class, $action]), PHP_URL_PATH))
+        ->toStartWith(parse_url(cp_url('config-sync'), PHP_URL_PATH));
 })->with('routes');
 
-test('all routes validate data', function (string $controller, string $action) {
+it('requires authentication all routes', function (string $action) {
+    auth()->logout();
+
+    postJson(action([ConfigSyncController::class, $action]))->assertUnauthorized();
+})->with('routes');
+
+test('all routes validate data', function (string $action) {
     if ($action === 'index') {
-        post(action([$controller, $action]))->assertOk();
+        post(action([ConfigSyncController::class, $action]))->assertOk();
 
         return;
     }
 
-    postJson(action([$controller, $action]), [
+    postJson(action([ConfigSyncController::class, $action]), [
         'data' => 'invalid-data',
     ])->assertJsonValidationErrors([
         'data',
@@ -67,7 +73,7 @@ test('index returns Inertia Updater page', function () {
             ->component('updater/Index')
             ->has('title')
             ->has('initialState')
-            ->has('actionPrefix')
+            ->where('initialState.finishUrl', action([ConfigSyncController::class, 'finish']))
             ->has('returnUrl')
         );
 });

--- a/tests/Feature/Http/Controllers/PluginStore/InstallControllerTest.php
+++ b/tests/Feature/Http/Controllers/PluginStore/InstallControllerTest.php
@@ -25,15 +25,15 @@ beforeEach(function () {
 });
 
 dataset('routes', [
-    [InstallController::class, 'index'],
-    [InstallController::class, 'craftInstall'],
-    [InstallController::class, 'enable'],
-    [InstallController::class, 'migrate'],
-    [InstallController::class, 'precheck'],
-    [InstallController::class, 'recheckComposer'],
-    [InstallController::class, 'composerInstall'],
-    [InstallController::class, 'composerRemove'],
-    [InstallController::class, 'finish'],
+    'index',
+    'craftInstall',
+    'enable',
+    'migrate',
+    'precheck',
+    'recheckComposer',
+    'composerInstall',
+    'composerRemove',
+    'finish',
 ]);
 
 it('aborts when allow updates is false', function () {
@@ -42,26 +42,26 @@ it('aborts when allow updates is false', function () {
     postJson(action([InstallController::class, 'index']))->assertForbidden();
 });
 
-it('requires authentication, adminChanges and admin for all routes', function (string $controller, string $action) {
+it('requires authentication, adminChanges and admin for all routes', function (string $action) {
     auth()->logout();
 
-    postJson(action([$controller, $action]))->assertUnauthorized();
+    postJson(action([InstallController::class, $action]))->assertUnauthorized();
 
     CraftCms\Cms\User\Models\User::first()->update(['admin' => false]);
     actingAs(User::find()->one());
 
-    postJson(action([$controller, $action]))->assertForbidden();
+    postJson(action([InstallController::class, $action]))->assertForbidden();
 
     CraftCms\Cms\User\Models\User::first()->update(['admin' => true]);
     actingAs(User::find()->one());
     Cms::config()->allowAdminChanges(false);
 
-    postJson(action([$controller, $action]))->assertForbidden();
+    postJson(action([InstallController::class, $action]))->assertForbidden();
 })->with('routes');
 
-test('all routes validate data', function (string $controller, string $action) {
+test('all routes validate data', function (string $action) {
     if ($action === 'index') {
-        postJson(action([$controller, $action]))
+        postJson(action([InstallController::class, $action]))
             ->assertJsonValidationErrors([
                 'packageName',
                 'handle',
@@ -72,7 +72,7 @@ test('all routes validate data', function (string $controller, string $action) {
         return;
     }
 
-    postJson(action([$controller, $action]), [
+    postJson(action([InstallController::class, $action]), [
         'data' => 'invalid-data',
     ])->assertJsonValidationErrors([
         'data',

--- a/tests/Feature/Http/Controllers/PluginStore/RemoveControllerTest.php
+++ b/tests/Feature/Http/Controllers/PluginStore/RemoveControllerTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Cms;
-use CraftCms\Cms\Http\Controllers\BaseUpdaterController;
 use CraftCms\Cms\Http\Controllers\PluginStore\RemoveController;
 use CraftCms\Cms\Support\Composer;
 use CraftCms\Cms\Support\Json;
@@ -11,6 +10,7 @@ use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Crypt;
 use Inertia\Testing\AssertableInertia;
 
+use function CraftCms\Cms\cp_url;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\postJson;
 use function Pest\Laravel\swap;
@@ -24,34 +24,39 @@ beforeEach(function () {
 });
 
 dataset('routes', [
-    [RemoveController::class, 'index'],
-    [RemoveController::class, 'precheck'],
-    [RemoveController::class, 'recheckComposer'],
-    [RemoveController::class, 'composerInstall'],
-    [RemoveController::class, 'composerRemove'],
-    [RemoveController::class, 'finish'],
+    'index',
+    'precheck',
+    'recheckComposer',
+    'composerInstall',
+    'composerRemove',
+    'finish',
 ]);
 
-it('requires authentication, adminChanges and admin for all routes', function (string $controller, string $action) {
+it('uses normal CP routes', function (string $action) {
+    expect(parse_url(action([RemoveController::class, $action]), PHP_URL_PATH))
+        ->toStartWith(parse_url(cp_url('pluginstore/remove'), PHP_URL_PATH));
+})->with('routes');
+
+it('requires authentication, adminChanges and admin for all routes', function (string $action) {
     auth()->logout();
 
-    postJson(action([$controller, $action]))->assertUnauthorized();
+    postJson(action([RemoveController::class, $action]))->assertUnauthorized();
 
     CraftCms\Cms\User\Models\User::first()->update(['admin' => false]);
     actingAs(User::find()->one());
 
-    postJson(action([$controller, $action]))->assertForbidden();
+    postJson(action([RemoveController::class, $action]))->assertForbidden();
 
     CraftCms\Cms\User\Models\User::first()->update(['admin' => true]);
     actingAs(User::find()->one());
     Cms::config()->allowAdminChanges(false);
 
-    postJson(action([$controller, $action]))->assertForbidden();
+    postJson(action([RemoveController::class, $action]))->assertForbidden();
 })->with('routes');
 
-test('all routes validate data', function (string $controller, string $action) {
+test('all routes validate data', function (string $action) {
     if ($action === 'index') {
-        postJson(action([$controller, $action]))
+        postJson(action([RemoveController::class, $action]))
             ->assertJsonValidationErrors([
                 'packageName',
             ]);
@@ -59,7 +64,7 @@ test('all routes validate data', function (string $controller, string $action) {
         return;
     }
 
-    postJson(action([$controller, $action]), [
+    postJson(action([RemoveController::class, $action]), [
         'data' => 'invalid-data',
     ])->assertJsonValidationErrors([
         'data',
@@ -72,6 +77,8 @@ test('index', function () {
     ])
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('updater/Index')
+            ->where('initialState.nextUrl', action([RemoveController::class, 'precheck']))
+            ->where('initialState.finishUrl', action([RemoveController::class, 'finish']))
         );
 });
 
@@ -90,7 +97,7 @@ test('composer-remove', function () {
         'data' => $this->hashedData,
     ])->assertJsonFragment([
         'status' => 'The plugin was removed successfully.',
-        'nextAction' => BaseUpdaterController::ACTION_FINISH,
+        'nextUrl' => action([RemoveController::class, 'finish']),
     ]);
 });
 

--- a/tests/Feature/Http/Controllers/Updates/UpdaterControllerTest.php
+++ b/tests/Feature/Http/Controllers/Updates/UpdaterControllerTest.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Crypt;
 use Inertia\Testing\AssertableInertia;
 
+use function CraftCms\Cms\cp_url;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\post;
 use function Pest\Laravel\postJson;
@@ -28,22 +29,27 @@ beforeEach(function () {
 });
 
 dataset('routes', [
-    [UpdaterController::class, 'index'],
-    [UpdaterController::class, 'forceUpdate'],
-    [UpdaterController::class, 'backup'],
-    [UpdaterController::class, 'serverCheck'],
-    [UpdaterController::class, 'revert'],
-    [UpdaterController::class, 'migrate'],
-    [UpdaterController::class, 'precheck'],
-    [UpdaterController::class, 'recheckComposer'],
-    [UpdaterController::class, 'composerInstall'],
-    [UpdaterController::class, 'composerRemove'],
-    [UpdaterController::class, 'finish'],
+    'index',
+    'forceUpdate',
+    'backup',
+    'serverCheck',
+    'revert',
+    'migrate',
+    'precheck',
+    'recheckComposer',
+    'composerInstall',
+    'composerRemove',
+    'finish',
 ]);
 
-test('all routes validate data', function (string $controller, string $action) {
+it('uses normal CP routes', function (string $action) {
+    expect(parse_url(action([UpdaterController::class, $action]), PHP_URL_PATH))
+        ->toStartWith(parse_url(cp_url('updates'), PHP_URL_PATH));
+})->with('routes');
+
+test('all routes validate data', function (string $action) {
     if ($action === 'index') {
-        postJson(action([$controller, $action]), [
+        postJson(action([UpdaterController::class, $action]), [
             'install' => [],
         ])->assertJsonValidationErrors([
             'packageNames',
@@ -52,7 +58,7 @@ test('all routes validate data', function (string $controller, string $action) {
         return;
     }
 
-    postJson(action([$controller, $action]), [
+    postJson(action([UpdaterController::class, $action]), [
         'data' => 'invalid-data',
     ])->assertJsonValidationErrors([
         'data',
@@ -86,7 +92,8 @@ test('index returns Inertia Updater page', function () {
             ->component('updater/Index')
             ->has('title')
             ->has('initialState')
-            ->has('actionPrefix')
+            ->where('initialState.nextUrl', action([UpdaterController::class, 'precheck']))
+            ->where('initialState.finishUrl', action([UpdaterController::class, 'finish']))
             ->has('returnUrl')
         );
 });

--- a/tests/Feature/Http/Controllers/Updates/UpdaterControllerTest.php
+++ b/tests/Feature/Http/Controllers/Updates/UpdaterControllerTest.php
@@ -47,6 +47,12 @@ it('uses normal CP routes', function (string $action) {
         ->toStartWith(parse_url(cp_url('updates'), PHP_URL_PATH));
 })->with('routes');
 
+it('allows the index route without authentication', function () {
+    auth()->logout();
+
+    post(action([UpdaterController::class, 'index']))->assertOk();
+});
+
 test('all routes validate data', function (string $action) {
     if ($action === 'index') {
         postJson(action([UpdaterController::class, $action]), [

--- a/tests/Feature/Http/Middleware/CheckForUpdatesTest.php
+++ b/tests/Feature/Http/Middleware/CheckForUpdatesTest.php
@@ -10,6 +10,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
+use function CraftCms\Cms\cp_url;
+
 beforeEach(function () {
     $this->updates = $this->mock(Updates::class);
     $this->updates->shouldReceive('isCraftSchemaVersionCompatible')->andReturn(true)->byDefault();
@@ -96,7 +98,10 @@ it('renders db update page for cp request when craft update pending', function (
 
     $response = $middleware->handle($request, fn () => 'passed');
 
-    expect($response->getContent())->toContain('Complete the Update');
+    expect($response->getContent())
+        ->toContain('Complete the Update')
+        ->toContain(sprintf('action="%s"', cp_url('updates')))
+        ->not->toContain('name="action"');
 });
 
 it('renders db update page for cp request when plugin update pending', function () {

--- a/tests/Feature/Http/Middleware/CheckForUpdatesTest.php
+++ b/tests/Feature/Http/Middleware/CheckForUpdatesTest.php
@@ -7,6 +7,7 @@ use CraftCms\Cms\Http\Middleware\CheckForUpdates;
 use CraftCms\Cms\Update\Updates;
 use CraftCms\Cms\View\TemplateMode;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 beforeEach(function () {
@@ -134,11 +135,12 @@ it('aborts 503 for site request when plugin update pending', function () {
     $middleware->handle($request, fn () => 'passed');
 })->throws(HttpException::class);
 
-it('allows updater action requests when update pending', function () {
+it('allows updater CP routes when update pending', function () {
     $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
 
     $middleware = app(CheckForUpdates::class);
-    $request = Request::create('/actions/updater/migrate');
+    $request = Request::create('/'.Cms::config()->cpTrigger.'/updates/migrate');
+    $request->setRouteResolver(fn () => Route::getRoutes()->getByName('craft.cp.updates.migrate'));
 
     $result = $middleware->handle($request, fn () => 'passed');
 

--- a/tests/Feature/Http/Middleware/MaintenanceModeExceptionsTest.php
+++ b/tests/Feature/Http/Middleware/MaintenanceModeExceptionsTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Http\Controllers\ConfigSyncController;
+use CraftCms\Cms\Http\Controllers\Updates\UpdaterController;
 use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Crypt;
@@ -37,15 +39,21 @@ test('migrate action route is accessible during maintenance mode', function () {
     expect($response->status())->not->toBe(503);
 });
 
-test('updater action routes with query strings are accessible during maintenance mode', function () {
-    $cpTrigger = Cms::config()->cpTrigger;
-    $actionTrigger = Cms::config()->actionTrigger;
+test('updater routes with query strings are accessible during maintenance mode', function () {
     $data = Crypt::encrypt(Json::encode([
         'postPrecheckState' => [],
     ]));
 
-    $response = postJson("/{$cpTrigger}/{$actionTrigger}/updater/precheck?site=default", [
+    $response = postJson(action([UpdaterController::class, 'precheck']).'?site=default', [
         'data' => $data,
+    ]);
+
+    expect($response->status())->not->toBe(503);
+});
+
+test('config sync finish route is accessible during maintenance mode', function () {
+    $response = postJson(action([ConfigSyncController::class, 'finish']), [
+        'data' => Crypt::encrypt(Json::encode([])),
     ]);
 
     expect($response->status())->not->toBe(503);

--- a/tests/Unit/Update/Data/UpdaterStateTest.php
+++ b/tests/Unit/Update/Data/UpdaterStateTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Update\Data\UpdaterState;
+
+test('serializes updater state and options', function () {
+    $state = [
+        'data' => 'encrypted',
+        'finishUrl' => 'https://example.test/admin/updates/finish',
+        'error' => 'Choose an option',
+        'options' => [
+            [
+                'label' => 'Continue',
+                'nextUrl' => 'https://example.test/admin/updates/migrate',
+                'submit' => false,
+            ],
+        ],
+    ];
+
+    expect(UpdaterState::fromArray($state)->toArray())->toEqual($state);
+});

--- a/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
+++ b/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
@@ -17,6 +17,7 @@ use CraftCms\Cms\Http\ViewModels\UserProfileViewModel;
 use CraftCms\Cms\Http\ViewModels\UserSignInProvidersViewModel;
 use CraftCms\Cms\Image\Data\ImageTransform;
 use CraftCms\Cms\Route\Data\Route;
+use CraftCms\Cms\Update\Data\UpdaterState;
 use CraftCms\Cms\Update\Data\Updates;
 use CraftCms\Cms\User\Data\Permission;
 use CraftCms\Cms\User\Data\PermissionGroup;
@@ -52,6 +53,7 @@ class TypeScriptTransformerServiceProvider extends TypeScriptTransformerApplicat
                     PermissionGroup::class,
                     Route::class,
                     Updates::class,
+                    UpdaterState::class,
                     HtmlFragment::class,
                     FieldEditViewModel::class,
                     UserPermissionsViewModel::class,


### PR DESCRIPTION
### Description

- Moves config sync, core updater, and plugin removal endpoints from CP action routes to regular CP routes. 
- Uses Typescript transformed DTOs for the responses

Plugin store installation is currently kept backwards compatible until we get around to porting that one.