### PR TITLE
fix: Avoid entry author insert deadlocks

### DIFF
--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -3147,7 +3147,7 @@ JS;
             $this->_oldAuthorIds = array_map(fn($id) => (int)$id, $oldAuthorIds);
         }
 
-        Db::delete(Table::ENTRIES_AUTHORS, ['entryId' => $this->id]);
+        Db::deleteIfExists(Table::ENTRIES_AUTHORS, ['entryId' => $this->id]);
 
         if (!empty($this->_authorIds)) {
             $data = [];

--- a/tests/unit/services/EntriesTest.php
+++ b/tests/unit/services/EntriesTest.php
@@ -8,6 +8,9 @@
 namespace crafttests\unit\services;
 
 use Craft;
+use craft\db\Command;
+use craft\db\Query;
+use craft\db\Table;
 use craft\elements\Entry;
 use craft\elements\User;
 use craft\services\Entries;
@@ -15,6 +18,7 @@ use craft\test\TestCase;
 use crafttests\fixtures\EntryFixture;
 use crafttests\fixtures\UserFixture;
 use UnitTester;
+use yii\db\Exception as DbException;
 
 /**
  * Unit tests for the Entries service.
@@ -54,6 +58,11 @@ class EntriesTest extends TestCase
     protected User $userB;
 
     /**
+     * @var User
+     */
+    protected User $userC;
+
+    /**
      * @return array
      */
     public function _fixtures(): array
@@ -87,6 +96,98 @@ class EntriesTest extends TestCase
     }
 
     /**
+     * @throws \Throwable
+     */
+    public function testSaveNewEntryAuthors(): void
+    {
+        $entry = $this->createEntry([$this->userA->id, $this->userB->id]);
+        $db = Craft::$app->getDb();
+        $commandClass = $db->commandClass;
+        $db->commandClass = EntriesTestCommand::class;
+        EntriesTestCommand::$executedSql = [];
+
+        try {
+            $this->tester->saveElement($entry);
+
+            self::assertSame([
+                [$this->userA->id, 1],
+                [$this->userB->id, 2],
+            ], $this->authorRows($entry));
+            self::assertSame([], EntriesTestCommand::authorDeleteQueries());
+
+            /** @var Entry $savedEntry */
+            $savedEntry = Entry::find()->id($entry->id)->status(null)->one();
+            self::assertSame([$this->userA->id, $this->userB->id], $savedEntry->getAuthorIds());
+        } finally {
+            $db->commandClass = $commandClass;
+            if ($entry->id) {
+                $this->tester->deleteElement($entry);
+            }
+        }
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function testUpdateEntryAuthors(): void
+    {
+        $entry = $this->createEntry([$this->userA->id, $this->userB->id]);
+        $this->tester->saveElement($entry);
+
+        try {
+            $entry->setAuthorIds([$this->userB->id, $this->userA->id]);
+            $this->tester->saveElement($entry);
+            self::assertSame([
+                [$this->userB->id, 1],
+                [$this->userA->id, 2],
+            ], $this->authorRows($entry));
+
+            $entry->setAuthorIds([$this->userB->id, $this->userC->id]);
+            $this->tester->saveElement($entry);
+            self::assertSame([
+                [$this->userB->id, 1],
+                [$this->userC->id, 2],
+            ], $this->authorRows($entry));
+
+            $entry->setAuthorIds([]);
+            $this->tester->saveElement($entry);
+            self::assertSame([], $this->authorRows($entry));
+        } finally {
+            $this->tester->deleteElement($entry);
+        }
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function testAuthorInsertFailureRollsBackChanges(): void
+    {
+        $entry = $this->createEntry([$this->userA->id, $this->userB->id]);
+        $this->tester->saveElement($entry);
+
+        $db = Craft::$app->getDb();
+        $commandClass = $db->commandClass;
+        $db->commandClass = EntriesTestCommand::class;
+        EntriesTestCommand::$failAuthorInsert = true;
+        $entry->setAuthorIds([$this->userB->id, $this->userC->id]);
+
+        try {
+            $this->tester->saveElement($entry);
+            self::fail('The author insert should have failed.');
+        } catch (DbException $e) {
+            self::assertSame('Forced entries_authors insert failure.', $e->getMessage());
+            self::assertSame([
+                [$this->userA->id, 1],
+                [$this->userB->id, 2],
+            ], $this->authorRows($entry));
+        } finally {
+            EntriesTestCommand::$failAuthorInsert = false;
+            $db->commandClass = $commandClass;
+            $this->tester->deleteElement($entry);
+        }
+    }
+
+    /**
      * @inheritdoc
      */
     protected function _before(): void
@@ -97,6 +198,7 @@ class EntriesTest extends TestCase
 
         $this->userA = User::find()->username('user2')->one();
         $this->userB = User::find()->username('user3')->one();
+        $this->userC = User::find()->username('user4')->one();
 
         $this->entryA = new Entry([
             'sectionId' => 1000,
@@ -124,5 +226,60 @@ class EntriesTest extends TestCase
         $this->tester->deleteElement($this->entryB);
 
         parent::_after();
+    }
+
+    private function createEntry(array $authorIds): Entry
+    {
+        return new Entry([
+            'sectionId' => 1011,
+            'typeId' => 1011,
+            'title' => 'Save Authors Test',
+            'authorIds' => $authorIds,
+        ]);
+    }
+
+    private function authorRows(Entry $entry): array
+    {
+        $rows = (new Query())
+            ->select(['authorId', 'sortOrder'])
+            ->from(Table::ENTRIES_AUTHORS)
+            ->where(['entryId' => $entry->id])
+            ->orderBy(['sortOrder' => SORT_ASC])
+            ->all();
+
+        return array_map(fn(array $row) => [
+            (int)$row['authorId'],
+            (int)$row['sortOrder'],
+        ], $rows);
+    }
+}
+
+class EntriesTestCommand extends Command
+{
+    public static array $executedSql = [];
+
+    public static bool $failAuthorInsert = false;
+
+    public function execute()
+    {
+        $sql = $this->getRawSql();
+        self::$executedSql[] = $sql;
+
+        if (
+            self::$failAuthorInsert &&
+            preg_match('/^INSERT\s+INTO\b.*entries_authors/is', $sql)
+        ) {
+            throw new DbException('Forced entries_authors insert failure.');
+        }
+
+        return parent::execute();
+    }
+
+    public static function authorDeleteQueries(): array
+    {
+        return array_values(array_filter(
+            self::$executedSql,
+            fn(string $sql) => preg_match('/^DELETE\s+FROM\b.*entries_authors/is', $sql),
+        ));
     }
 }


### PR DESCRIPTION
Entry saves currently make `Entry::_saveAuthors()` issue an unconditional delete against `entries_authors` before inserting the desired author rows. For a new entry there is nothing to delete, and MySQL/MariaDB can retain a next-key or supremum gap lock that conflicts with another transaction inserting a different new entry’s author row; the deadlock reports in the issue show this exact pair of lock holders and insert-intention waiters. The problem is reproducible through core entry and draft creation paths without third-party plugins, and the unconditional delete remains present on the current `5.x` branch. Craft already provides and uses `Db::deleteIfExists()` specifically to avoid unnecessary deletes and their deadlock risk.

Save a new entry with one or multiple authors when no `entries_authors` row exists, then reload it and verify every author and sort order was persisted without an unconditional delete of the missing association.

## Description

Change the author persistence call site in `src/elements/Entry.php` to use `Db::deleteIfExists()` before the existing batch insert, so new entries skip the locking delete while updates with existing author rows continue to replace those rows. Preserve the current old-author lookup, sort-order construction, dirty-attribute tracking, and transaction boundaries; no queue-runner mutex, retry loop, schema migration, or broad element-save change is needed. Extend `tests/unit/services/EntriesTest.php`, whose fixtures and setup already exercise authored entry saves, with focused coverage for creating an authored entry without a prior join row and for replacing or clearing existing author rows on update.

Fixes #15768
