### PR TITLE
[6.x] Testbench Playwright tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "check-prettier": "prettier --check ./resources",
+    "test:e2e": "playwright test",
+    "test:e2e:ddev": "craft-playwright test",
     "fix-prettier": "prettier --write ./resources",
     "prepare": "husky",
     "prebuild": "npm run fix-prettier",

--- a/packages/craftcms-playwright/README.md
+++ b/packages/craftcms-playwright/README.md
@@ -1,5 +1,15 @@
 # Playwright tests setup for Craft CMS
 
+This package provides two Playwright config factories:
+
+- `getWorkbenchConfig()` — runs tests against the Testbench workbench install (`composer serve`),
+  no docker required. This is the repo's default `playwright.config.ts`; see
+  `tests-playwright/README.md`.
+- `getConfig()` — the original ddev-based harness documented below, used via
+  `playwright.ddev.config.cjs`.
+
+## ddev harness
+
 At the moment, you can run the commands listed under Usage on your host machine. You'll need docker, node and ideally nvm.
 
 ## Installation
@@ -16,8 +26,8 @@ All commands should be run from the cms repo’s location
 - run `npx craft-playwright test` to boot up docker environment, install Craft CMS in it, run all the tests and shut down the docker environment
 - run `npx craft-playwright test elementindex/sorting` to boot up docker environment, install Craft CMS in it, run only “elementindex/sorting” tests and shut down the docker environment
 - `npx craft-playwright boot` can be used to set up the docker env & install Craft CMS in it. 
-  - After which you can run `npx playwright test` to run tests.
-  - You can run specific tests via `npx playwright test elements/inituielements`
+  - After which you can run `npx playwright test --config=playwright.ddev.config.cjs` to run tests.
+  - You can run specific tests via `npx playwright test --config=playwright.ddev.config.cjs elements/inituielements`
   - To shut down the testing environment, use `npx craft-playwright down`.
 - You can add the `--ui` flag to tun tests in interactive UI mode
 - You can add the `--debug` flag to tun tests in interactive UI mode with debugger that lets you step over the test line by line

--- a/packages/craftcms-playwright/src/cli.js
+++ b/packages/craftcms-playwright/src/cli.js
@@ -29,9 +29,15 @@ const logger = require('./playwright/logger');
     });
 
     pre.on('close', () => {
-      const tests = spawn('npx', ['playwright', 'test'].concat(args), {
-        stdio: 'inherit',
-      });
+      const tests = spawn(
+        'npx',
+        ['playwright', 'test', '--config=playwright.ddev.config.cjs'].concat(
+          args
+        ),
+        {
+          stdio: 'inherit',
+        }
+      );
 
       tests.on('error', (error) => {
         logger.fatal(error);

--- a/packages/craftcms-playwright/src/index.js
+++ b/packages/craftcms-playwright/src/index.js
@@ -1,6 +1,7 @@
 /* jshint esversion: 9, strict: false */
 const base = require('@playwright/test');
 const baseConfig = require('./playwright/config/config');
+const {getWorkbenchConfig} = require('./playwright/config/workbench');
 const events = require('./playwright/events');
 const {Setup} = require('./playwright/fixtures/setup');
 const {Entry} = require('./playwright/fixtures/entry');
@@ -55,6 +56,7 @@ module.exports = {
   getConfig: (config = {}) => {
     return {...baseConfig, ...config};
   },
+  getWorkbenchConfig,
   test: test,
   expect: base.expect,
   events,

--- a/packages/craftcms-playwright/src/playwright/config/global-setup.js
+++ b/packages/craftcms-playwright/src/playwright/config/global-setup.js
@@ -13,10 +13,15 @@ module.exports = async (config) => {
   const page = await context.newPage();
 
   await page.goto(new URL('./login', baseURL).href);
-  await page.fill('.login-username', username);
-  await page.fill('.login-password', password);
 
-  await page.click('.login-form button[type="submit"]');
+  // The login form is the `craft-login-form` web component; its inputs are
+  // nested inside `craft-input`/`craft-input-password`, which also carry the
+  // `name` attribute themselves — target the native `<input>`s specifically
+  // (Playwright's CSS engine pierces the shadow DOM to reach them).
+  await page.fill('input[name="username"]', username);
+  await page.fill('input[name="password"]', password);
+
+  await page.click('[type="submit"]');
   await page.waitForURL('**/admin/dashboard');
 
   const title = page.locator('h1');

--- a/packages/craftcms-playwright/src/playwright/config/workbench.js
+++ b/packages/craftcms-playwright/src/playwright/config/workbench.js
@@ -1,0 +1,103 @@
+/* jshint esversion: 9, strict: false */
+const path = require('path');
+const crypto = require('crypto');
+const {devices} = require('@playwright/test');
+
+/**
+ * Playwright config for testing the CP against the Testbench workbench
+ * install (`composer serve`) — no docker/ddev required. The ddev-based
+ * config lives in ./config.js and is used by the `craft-playwright` CLI.
+ *
+ * Playwright boots `workbench:serve` itself (or reuses one already running
+ * on the stable port) and authenticates via the workbench's
+ * `/_workbench/login/{userId}` route (see tests-playwright/workbench.setup.ts).
+ *
+ * Env vars:
+ * - E2E_PORT      override the serve port (default: same stable port that
+ *                 `workbench:serve` derives from the repo path)
+ * - E2E_BASE_URL  point at an already-running install instead
+ * - E2E_FRESH     pass --fresh to workbench:serve (rebuild + reseed the db)
+ * - CI            disables reuse of an already-running server
+ */
+module.exports = {
+  getWorkbenchConfig: (config = {}) => {
+    const repoRoot = config.repoRoot ?? process.cwd();
+    const testDir = './tests-playwright';
+
+    // Mirrors Workbench\App\Console\Commands\ServeCommand::port()
+    const stablePort =
+      8000 +
+      (parseInt(
+        crypto.createHash('sha256').update(repoRoot).digest('hex').slice(0, 4),
+        16
+      ) %
+        1000);
+
+    const port = process.env.E2E_PORT
+      ? parseInt(process.env.E2E_PORT, 10)
+      : stablePort;
+    const origin = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${port}`;
+
+    // Tests use paths relative to the CP root (`./dashboard`), matching the
+    // ddev config's convention. Absolute paths (`/admin/entries`) work too.
+    const cpTrigger = process.env.CRAFT_CP_TRIGGER ?? 'admin';
+    const baseURL = new URL(`./${cpTrigger}/`, origin).href;
+
+    const storageState = path.join(testDir, '.auth/user.json');
+
+    return {
+      testDir,
+      outputDir: path.join(testDir, 'test-results'),
+      fullyParallel: false,
+      // All tests share one sqlite install; keep them sequential.
+      workers: 1,
+      forbidOnly: !!process.env.CI,
+      retries: process.env.CI ? 2 : 0,
+      reporter: process.env.CI ? [['list'], ['github']] : [['list']],
+      timeout: 30 * 1000,
+      expect: {timeout: 10 * 1000},
+      use: {
+        baseURL,
+        trace: 'on-first-retry',
+      },
+      projects: [
+        {
+          name: 'setup',
+          testMatch: /.*\.setup\.ts/,
+          use: {baseURL},
+        },
+        {
+          name: 'chromium',
+          use: {
+            ...devices['Desktop Chrome'],
+            storageState,
+          },
+          dependencies: ['setup'],
+          // Suites not yet runnable against the workbench install. They were
+          // written for the ddev harness (Codeception fixtures, empty
+          // install) or are blocked by known CP bugs — see
+          // tests-playwright/README.md before un-ignoring one.
+          testIgnore: config.testIgnore ?? [
+            '**/tests/elementindex/**', // needs Codeception fixtures (testSorting section)
+            '**/tests/elements/**', // needs Codeception fixtures
+            '**/tests/matrix/**', // needs Codeception fixtures (testMatrix section)
+            '**/tests/pluginstore/**', // needs plugins + external network
+            '**/tests/navigation/**', // blocked: /admin/dashboard 500s (Sites twig global)
+            '**/tests/settings/**', // written against an empty install; workbench seeds content
+          ],
+        },
+      ],
+      webServer: {
+        command: `php vendor/bin/testbench workbench:serve --port=${port}${
+          process.env.E2E_FRESH ? ' --fresh' : ''
+        }`,
+        url: new URL('./login', baseURL).href,
+        cwd: repoRoot,
+        reuseExistingServer: !process.env.CI,
+        // --fresh runs the full Craft install + seeders
+        timeout: 180 * 1000,
+      },
+      ...config.overrides,
+    };
+  },
+};

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,3 +1,0 @@
-const craftPlaywright = require('@craftcms/playwright');
-
-export default craftPlaywright.getConfig();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,10 @@
+import craftPlaywright from '@craftcms/playwright';
+
+/**
+ * Default Playwright config: runs tests-playwright/ against the Testbench
+ * workbench install (`composer serve`). Run with `npm run test:e2e`.
+ *
+ * The ddev-based harness uses playwright.ddev.config.cjs via the
+ * `craft-playwright` CLI.
+ */
+export default craftPlaywright.getWorkbenchConfig();

--- a/playwright.ddev.config.cjs
+++ b/playwright.ddev.config.cjs
@@ -1,0 +1,10 @@
+/* jshint esversion: 9, strict: false */
+/* globals module, require */
+const craftPlaywright = require('@craftcms/playwright');
+
+/**
+ * Config for the ddev-based harness (`npx craft-playwright test`), which
+ * boots a docker environment and loads Codeception fixtures. The default
+ * playwright.config.ts targets the Testbench workbench install instead.
+ */
+module.exports = craftPlaywright.getConfig();

--- a/resources/js/common/components/SecondaryNav.vue
+++ b/resources/js/common/components/SecondaryNav.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import {t} from '@craftcms/ui';
-  import CpLink from '@/common/components/CpLink.vue';
   import {computed, ref, watch} from 'vue';
   import {useMediaQuery} from '@vueuse/core';
 
@@ -64,33 +63,26 @@
               <span class="nav-heading-label">{{ item.label }}</span>
 
               <craft-nav-list>
-                <template
+                <craft-nav-item
                   v-for="(subitem, subindex) in item.subnav"
                   :key="subindex"
+                  :active="subitem.selected"
+                  :href="subitem.url"
+                  flush
                 >
-                  <CpLink
-                    as="craft-nav-item"
-                    :active="subitem.selected"
-                    :href="subitem.url"
-                    block
-                    flush
-                  >
-                    {{ subitem.label }}
-                  </CpLink>
-                </template>
+                  {{ subitem.label }}
+                </craft-nav-item>
               </craft-nav-list>
             </li>
 
-            <CpLink
+            <craft-nav-item
               v-else
-              as="craft-nav-item"
               :active="item.selected"
               :href="item.url"
-              block
               flush
             >
               {{ item.label }}
-            </CpLink>
+            </craft-nav-item>
           </template>
         </craft-nav-list>
       </slot>

--- a/resources/js/common/form/CraftCombobox.vue
+++ b/resources/js/common/form/CraftCombobox.vue
@@ -3,7 +3,7 @@
   import CraftComboboxControl from '@craftcms/ui/vue/CraftCombobox.vue';
   import type {SelectItem} from '@/common/types';
 
-  const modelValue = defineModel<string | number | boolean>();
+  const modelValue = defineModel<string>();
   defineProps<{
     label: string;
     id?: string;

--- a/resources/js/pages/settings/General.vue
+++ b/resources/js/pages/settings/General.vue
@@ -34,7 +34,7 @@
 
   const form = useForm({
     name: props.system.name ?? '',
-    live: props.system.live,
+    live: props.system.live ? 'true' : 'false',
     retryDuration: props.system.retryDuration,
     timeZone: props.system.timeZone,
   });

--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -55,15 +55,21 @@ readonly class LoginController extends AuthenticationController
             $oauth->getLoginButtons(),
         );
 
+        // `action([self::class, 'attemptLogin'])` is ambiguous here — the
+        // method is routed at the site login path, the CP login path, and
+        // `actions/users/login`, and Laravel resolves to whichever registered
+        // last. The CP page must post to the CP login path specifically, so
+        // the request counts as a CP request and the post-login redirect
+        // resolves to the CP dashboard rather than the site.
         return $this->renderViewWithFallback(
             inertiaComponent: 'auth/Login',
             inertiaProps: [
                 'username' => $generalConfig->rememberUsernameDuration ? $authMethods->getRememberedUsername() : '',
                 'oauthLoginButtons' => $oauthLoginButtons,
-                'action' => $request->isCpRequest() ? action([self::class, 'attemptLogin']) : action_url('users/login'),
+                'action' => $request->isCpRequest() ? cp_url(CpAuthPath::Login->value) : action_url('users/login'),
             ],
             data: [
-                'action' => action([self::class, 'attemptLogin']),
+                'action' => action_url('users/login'),
                 'oauthLoginButtons' => $oauthLoginButtons,
             ],
         );
@@ -98,7 +104,7 @@ readonly class LoginController extends AuthenticationController
         }
 
         $html = template('_special/login-modal', [
-            'action' => action([LoginController::class, 'attemptLogin']),
+            'action' => cp_url(CpAuthPath::Login->value),
             'staticEmail' => $staticEmail,
             'forElevatedSession' => $forElevatedSession,
         ], templateMode: TemplateMode::Cp);

--- a/src/Http/Controllers/Auth/SessionInfoController.php
+++ b/src/Http/Controllers/Auth/SessionInfoController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Http\Controllers\Auth;
 
 use CraftCms\Cms\Auth\Concerns\ConfirmsPasswords;
+use CraftCms\Cms\Auth\Enums\CpAuthPath;
 use CraftCms\Cms\Auth\Impersonation;
 use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\View\HtmlStack;
@@ -12,6 +13,8 @@ use CraftCms\Cms\View\TemplateGlobals;
 use CraftCms\Cms\View\TemplateHooks;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+
+use function CraftCms\Cms\cp_url;
 
 readonly class SessionInfoController
 {
@@ -83,7 +86,11 @@ readonly class SessionInfoController
         $loginName = (string) ($user->email ?? $user->username);
         $context = [
             ...$templateGlobals->resolve(),
-            'action' => action([LoginController::class, 'attemptLogin']),
+            // Deliberately the CP login path — `action()` is ambiguous for
+            // `attemptLogin` (also routed at the site login path and
+            // `actions/users/login`), and the CP path is what keeps the
+            // re-login counting as a CP request.
+            'action' => cp_url(CpAuthPath::Login->value),
             'forElevatedSession' => true,
             'generalConfig' => $generalConfig,
             'staticEmail' => $loginName,

--- a/src/Http/Mixins/RequestMixin.php
+++ b/src/Http/Mixins/RequestMixin.php
@@ -89,7 +89,7 @@ class RequestMixin
              *
              * @phpstan-ignore-next-line
              */
-            $userAgent = $this->userAgent();
+            $userAgent = $this->userAgent() ?? '';
 
             if (str_contains($userAgent, 'Linux')) {
                 return 'Linux';

--- a/tests-playwright/.gitignore
+++ b/tests-playwright/.gitignore
@@ -1,2 +1,4 @@
 /.env
 /.authentication.json
+/.auth/
+/test-results/

--- a/tests-playwright/README.md
+++ b/tests-playwright/README.md
@@ -55,16 +55,16 @@ The test suites under `tests/` were written for the ddev harness against the Cra
 CP. Suites not yet runnable in workbench mode are listed in `testIgnore` in
 `packages/craftcms-playwright/src/playwright/config/workbench.js`:
 
-| Suite            | Status in workbench mode                                          |
-| ---------------- | ----------------------------------------------------------------- |
-| `smoke.test.ts`  | ✅ runs                                                            |
-| `account/`       | ✅ runs (one `fixme`: user-menu items lack accessible roles)       |
-| `navigation/`    | ⛔ blocked: `/admin/dashboard` 500s (`Sites` twig global missing)  |
-| `settings/`      | ⛔ assumes an empty install; workbench seeds sections/entry types  |
-| `elementindex/`  | ⛔ needs Codeception fixtures (`testSorting` section)              |
-| `elements/`      | ⛔ needs Codeception fixtures                                      |
-| `matrix/`        | ⛔ needs Codeception fixtures (`testMatrix` section)               |
-| `pluginstore/`   | ⛔ needs installed plugins + external network                      |
+| Suite           | Status in workbench mode                                         |
+|-----------------|------------------------------------------------------------------|
+| `smoke.test.ts` | ✅ runs                                                           |
+| `account/`      | ✅ runs                                                           |
+| `navigation/`   | ⛔ blocked: `/admin/dashboard` 500s (`Sites` twig global missing) |
+| `settings/`     | ⛔ assumes an empty install; workbench seeds sections/entry types |
+| `elementindex/` | ⛔ needs Codeception fixtures (`testSorting` section)             |
+| `elements/`     | ⛔ needs Codeception fixtures                                     |
+| `matrix/`       | ⛔ needs Codeception fixtures (`testMatrix` section)              |
+| `pluginstore/`  | ⛔ needs installed plugins + external network                     |
 
 To migrate a suite: make the workbench seeder provide the content it needs (or create it
 in the test), update selectors for the redesigned CP, then remove it from `testIgnore`.

--- a/tests-playwright/README.md
+++ b/tests-playwright/README.md
@@ -1,0 +1,74 @@
+# Playwright tests
+
+Browser tests for the CP. There are two ways to run them:
+
+## Workbench mode (default)
+
+Runs against the Testbench workbench install — the same app you get from `composer serve`.
+No docker/ddev required.
+
+```bash
+npm run test:e2e                # boots workbench:serve itself (or reuses a running one)
+E2E_FRESH=1 npm run test:e2e    # rebuild + reseed the sqlite db first
+npx playwright test --ui        # interactive UI mode
+```
+
+If you already have `composer serve` running, the suite reuses it (outside CI). Otherwise
+Playwright starts `workbench:serve` on the same stable port and shuts it down afterwards.
+
+**Auth:** `workbench.setup.ts` hits the workbench's `/_workbench/login/1` route (user 1 is
+the admin the seeder creates), verifies it via `/_workbench/user`, and saves the session to
+`.auth/user.json`, which every test reuses. This requires persistent sessions —
+`SESSION_DRIVER=database` in `workbench/.env` (see `workbench/.env.example`).
+
+**Assets:** CP assets resolve through `cms-assets/resources/hot` when a Vite dev server is
+running, otherwise through the built manifest (`npm run build:all`). A stale hot file (dev
+server not actually running) fails the suite early with instructions.
+
+**Env vars:**
+
+- `E2E_PORT` — override the serve port (default: the stable port `workbench:serve` derives
+  from the repo path)
+- `E2E_BASE_URL` — point at an already-running install instead
+- `E2E_FRESH` — pass `--fresh` to `workbench:serve`
+- `CI` — never reuse a running server, retries, GitHub reporter
+
+Tests run sequentially against one shared sqlite install; write tests that tolerate the
+seeded content (see `workbench/database/seeders/DatabaseSeeder.php`) or create what they
+need.
+
+## ddev mode (legacy harness)
+
+The original harness boots a ddev docker environment, installs Craft in it, and loads
+Codeception fixtures (`tests/fixtures/*Fixture.php`). It uses
+`playwright.ddev.config.cjs`; see `packages/craftcms-playwright/README.md`.
+
+```bash
+npm run test:e2e:ddev                                    # full boot → test → teardown
+npx craft-playwright boot                                # just boot the env
+npx playwright test --config=playwright.ddev.config.cjs  # run against a booted env
+```
+
+## Suite migration status
+
+The test suites under `tests/` were written for the ddev harness against the Craft 5-era
+CP. Suites not yet runnable in workbench mode are listed in `testIgnore` in
+`packages/craftcms-playwright/src/playwright/config/workbench.js`:
+
+| Suite            | Status in workbench mode                                          |
+| ---------------- | ----------------------------------------------------------------- |
+| `smoke.test.ts`  | ✅ runs                                                            |
+| `account/`       | ✅ runs (one `fixme`: user-menu items lack accessible roles)       |
+| `navigation/`    | ⛔ blocked: `/admin/dashboard` 500s (`Sites` twig global missing)  |
+| `settings/`      | ⛔ assumes an empty install; workbench seeds sections/entry types  |
+| `elementindex/`  | ⛔ needs Codeception fixtures (`testSorting` section)              |
+| `elements/`      | ⛔ needs Codeception fixtures                                      |
+| `matrix/`        | ⛔ needs Codeception fixtures (`testMatrix` section)               |
+| `pluginstore/`   | ⛔ needs installed plugins + external network                      |
+
+To migrate a suite: make the workbench seeder provide the content it needs (or create it
+in the test), update selectors for the redesigned CP, then remove it from `testIgnore`.
+
+> [!TIP]
+> For tests on pages that use `ElementEditor`, use `.pressSequentially('text', {delay: 100})`
+> instead of `.fill('text')` — custom keyboard handling makes `fill` flaky.

--- a/tests-playwright/package.json
+++ b/tests-playwright/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "commonjs"
+}

--- a/tests-playwright/tests/account/index.test.js
+++ b/tests-playwright/tests/account/index.test.js
@@ -13,6 +13,14 @@ test('The My Account page exists', async ({page, baseURL}) => {
 });
 
 test('The active page has an accessible state', async ({page, baseURL}) => {
+  // In the redesigned CP the account sub-nav ("Profile", "Permissions", …)
+  // moved into the user-menu web component, and its items currently expose
+  // no link/menuitem roles for an aria-current assertion to attach to.
+  test.fixme(
+    true,
+    'Account sub-nav items are not exposed to the accessibility tree in the redesigned CP'
+  );
+
   const activeLink = page
     .getByRole('link')
     .filter({hasText: 'Profile', hasClass: 'sel'});

--- a/tests-playwright/tests/account/index.test.js
+++ b/tests-playwright/tests/account/index.test.js
@@ -13,16 +13,10 @@ test('The My Account page exists', async ({page, baseURL}) => {
 });
 
 test('The active page has an accessible state', async ({page, baseURL}) => {
-  // In the redesigned CP the account sub-nav ("Profile", "Permissions", …)
-  // moved into the user-menu web component, and its items currently expose
-  // no link/menuitem roles for an aria-current assertion to attach to.
-  test.fixme(
-    true,
-    'Account sub-nav items are not exposed to the accessibility tree in the redesigned CP'
-  );
-
+  // The nav items are `craft-nav-item` web components whose label is slotted;
+  // locate the link by its accessible name (which resolves through the slot).
   const activeLink = page
-    .getByRole('link')
-    .filter({hasText: 'Profile', hasClass: 'sel'});
+    .getByRole('navigation', {name: 'Secondary'})
+    .getByRole('link', {name: 'Profile'});
   await expect(activeLink).toHaveAttribute('aria-current', 'page');
 });

--- a/tests-playwright/tests/account/profile.test.js
+++ b/tests-playwright/tests/account/profile.test.js
@@ -1,0 +1,79 @@
+/* jshint esversion: 9, strict: false */
+/* globals module, require */
+const {test, expect} = require('../../index');
+
+// Field values asserted here come from the workbench seeder
+// (workbench/database/seeders/DatabaseSeeder.php), which installs Craft with
+// the `craftcms` admin (user 1).
+const username = 'craftcms';
+const email = 'support@craftcms.com';
+
+const saveButton = (page) => page.getByRole('button', {name: 'Save', exact: true});
+const statusNotice = (page, text) => page.getByRole('status').filter({hasText: text});
+
+test.beforeEach(async ({page}) => {
+  await page.goto('./myaccount');
+  // Wait for the form to hydrate before interacting with it
+  await page.locator('#username').waitFor();
+});
+
+test.describe('Profile form', () => {
+  test('shows the signed-in user’s identity', async ({page}) => {
+    await expect(page.locator('h1')).toHaveText('My Account');
+    await expect(page.locator('#username')).toHaveValue(username);
+    await expect(page.locator('#email')).toHaveValue(email);
+    await expect(saveButton(page)).toBeVisible();
+  });
+
+  test('saving an edited full name persists it', async ({page}) => {
+    const fullName = 'Playwright Full Name';
+
+    try {
+      // Clear first: pressSequentially appends, and an interrupted earlier
+      // run may have left a value behind
+      await page.locator('#fullName').fill('');
+      await page.locator('#fullName').pressSequentially(fullName, {delay: 50});
+      await saveButton(page).click();
+
+      // The result is announced accessibly
+      await expect(statusNotice(page, 'User saved.')).toBeVisible();
+
+      // The change survives a fresh page load
+      await page.reload();
+      await expect(page.locator('#fullName')).toHaveValue(fullName);
+    } finally {
+      // Restore the seeded state so other tests and reruns start clean
+      await page.locator('#fullName').fill('');
+      await saveButton(page).click();
+      await expect(statusNotice(page, 'User saved.')).toBeVisible();
+    }
+  });
+
+  test('rejects an empty username without applying it', async ({page}) => {
+    await page.locator('#username').fill('');
+    await saveButton(page).click();
+
+    // Curly apostrophe in “Couldn’t” — match loosely
+    await expect(statusNotice(page, /Couldn.t save user\./)).toBeVisible();
+
+    // The rejected change must not stick
+    await page.reload();
+    await expect(page.locator('#username')).toHaveValue(username);
+  });
+});
+
+test.describe('Account navigation', () => {
+  test('lists the account sections', async ({page}) => {
+    const nav = page.getByRole('navigation', {name: 'Secondary'});
+
+    for (const section of [
+      'Profile',
+      'Preferences',
+      'Addresses',
+      'Password & Verification',
+      'Passkeys',
+    ]) {
+      await expect(nav.getByRole('link', {name: section})).toBeVisible();
+    }
+  });
+});

--- a/tests-playwright/tests/smoke.test.ts
+++ b/tests-playwright/tests/smoke.test.ts
@@ -1,0 +1,15 @@
+import {expect, test} from '@playwright/test';
+
+test('entries index lists seeded posts', async ({page}) => {
+  await page.goto('/admin/entries');
+
+  await expect(page.getByRole('heading', {name: 'Entries'})).toBeVisible();
+  await expect(page.getByText('Welcome to Craft 6')).toBeVisible();
+});
+
+test('settings index renders', async ({page}) => {
+  await page.goto('/admin/settings');
+
+  await expect(page.getByRole('heading', {name: 'Settings'})).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Sections'})).toBeVisible();
+});

--- a/tests-playwright/workbench.setup.ts
+++ b/tests-playwright/workbench.setup.ts
@@ -1,0 +1,42 @@
+import {expect, test as setup} from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const authFile = path.join(__dirname, '.auth/user.json');
+const hotFile = path.join(__dirname, '../cms-assets/resources/hot');
+
+// CP assets are resolved through the Vite hot file when one exists. A stale
+// hot file (left behind by a killed `npm run dev`) makes every CP page load
+// with dead assets, so fail fast with a useful message instead.
+setup('vite assets are resolvable', async ({playwright}) => {
+  if (!fs.existsSync(hotFile)) {
+    return; // built manifest will be used
+  }
+
+  const devServer = fs.readFileSync(hotFile, 'utf8').trim();
+  const request = await playwright.request.newContext({ignoreHTTPSErrors: true});
+
+  try {
+    const response = await request.get(`${devServer}/@vite/client`, {timeout: 5_000});
+    expect(response.ok(), `Vite dev server at ${devServer} responded ${response.status()}`).toBe(true);
+  } catch {
+    throw new Error(
+      `A Vite hot file exists (${hotFile}) pointing at ${devServer}, but that dev server ` +
+        'is not reachable, so CP pages will render without assets. Either start `npm run dev` ' +
+        'or delete the stale hot file.'
+    );
+  } finally {
+    await request.dispose();
+  }
+});
+
+// The workbench exposes /_workbench/login/{userId} (session login, no
+// credentials needed). User 1 is the admin created by the workbench seeder.
+setup('authenticate', async ({page}) => {
+  await page.goto('/_workbench/login/1');
+
+  const response = await page.request.get('/_workbench/user');
+  expect(await response.json()).toMatchObject({id: 1});
+
+  await page.context().storageState({path: authFile});
+});

--- a/tests/Feature/Http/Controllers/Auth/LoginControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/LoginControllerTest.php
@@ -40,6 +40,18 @@ test('showLogin shows the login form for guests', function () {
         ->assertOk();
 });
 
+test('showLogin posts the CP login form to the CP login path', function () {
+    // `attemptLogin` is routed at the site login path, the CP login path, and
+    // `actions/users/login` — the CP page must target the CP path
+    // specifically, so the post-login redirect resolves to the CP dashboard
+    // (a CP request) rather than the site.
+    get(cp_url(CpAuthPath::Login->value))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('auth/Login')
+            ->where('action', cp_url(CpAuthPath::Login->value)));
+});
+
 test('showLogin includes configured OAuth buttons', function () {
     Edition::set(Edition::Pro);
 


### PR DESCRIPTION
@riasvdv has worked to give us a `composer serve` command that will spin up a working Craft install via [testbench](https://github.com/orchestral/testbench). This updates / adds some playwright tests that use that instead of the DDEV setup. 