### PR TITLE
[6.x] Move more action routes

### DIFF
--- a/resources/js/modules/entry-types/components/EntryTypeSelect.vue
+++ b/resources/js/modules/entry-types/components/EntryTypeSelect.vue
@@ -367,7 +367,7 @@
     </craft-action-menu>
     <SlideoutButton
       v-if="!readOnly"
-      :url="create['/{cpTrigger?}/settings/entry-types/new']().url"
+      :url="create().url"
       @success="router.reload({only: ['entryTypes']})"
     >
       <craft-icon name="plus" slot="prefix"></craft-icon>

--- a/resources/js/modules/field-layout-designer/element.ts
+++ b/resources/js/modules/field-layout-designer/element.ts
@@ -321,12 +321,15 @@ export class Element extends Base {
   }
 
   async showFieldEditor(): Promise<void> {
-    const slideout = new Craft.CpScreenSlideout('fields/edit-field', {
-      params: {
-        fieldId: this.fieldId,
-        multiInstanceTypesOnly: this.isMultiInstance ? 1 : 0,
-      },
-    });
+    const slideout = new Craft.CpScreenSlideout(
+      Craft.getCpUrl('settings/fields/edit'),
+      {
+        params: {
+          fieldId: this.fieldId,
+          multiInstanceTypesOnly: this.isMultiInstance ? 1 : 0,
+        },
+      }
+    );
 
     slideout.on('submit', async ({response}: any) => {
       const designer = this.tab.designer;

--- a/resources/js/modules/field-layout-designer/field-layout-designer.ts
+++ b/resources/js/modules/field-layout-designer/field-layout-designer.ts
@@ -447,7 +447,9 @@ export class FieldLayoutDesigner extends Base<FieldLayoutDesignerSettings> {
   }
 
   createField(): void {
-    const slideout = new Craft.CpScreenSlideout('fields/edit-field');
+    const slideout = new Craft.CpScreenSlideout(
+      Craft.getCpUrl('settings/fields/edit')
+    );
 
     slideout.on('submit', async ({response}: any) => {
       // add the library selector

--- a/resources/js/modules/grouped-entry-type-manager/entry-type-override-settings.ts
+++ b/resources/js/modules/grouped-entry-type-manager/entry-type-override-settings.ts
@@ -16,7 +16,7 @@ declare const $: any;
  * `Craft.EntryTypeSelectInput.createSettings`/`applySettings` onto the
  * web-component `<craft-component-select>` path. POSTs the chip's current
  * `{id, group, name?, handle?, description?}` JSON to
- * the override-settings CP route, opens a `Craft.Slideout` with the
+ * the override-settings action route, opens a `Craft.Slideout` with the
  * returned settings form, and on submit applies the overrides back onto the
  * chip (label + indicators + hidden-input JSON) via {@link applyOverrides}.
  *

--- a/resources/js/modules/grouped-entry-type-manager/entry-type-override-settings.ts
+++ b/resources/js/modules/grouped-entry-type-manager/entry-type-override-settings.ts
@@ -1,3 +1,8 @@
+import {
+  applyOverrideSettings,
+  renderOverrideSettings,
+} from '@actions/Settings/EntryTypesController';
+
 // `Craft` and `$` (jQuery) remain page globals. The entry-type override editor
 // is a still-jQuery `Craft.Slideout` orchestrating server-rendered settings
 // HTML, so the same legacy seams the rest of the manager leans on survive here
@@ -11,7 +16,7 @@ declare const $: any;
  * `Craft.EntryTypeSelectInput.createSettings`/`applySettings` onto the
  * web-component `<craft-component-select>` path. POSTs the chip's current
  * `{id, group, name?, handle?, description?}` JSON to
- * `entry-types/render-override-settings`, opens a `Craft.Slideout` with the
+ * the override-settings CP route, opens a `Craft.Slideout` with the
  * returned settings form, and on submit applies the overrides back onto the
  * chip (label + indicators + hidden-input JSON) via {@link applyOverrides}.
  *
@@ -30,7 +35,7 @@ export async function editEntryTypeOverrides(chip: HTMLElement): Promise<void> {
   try {
     const response = await Craft.sendActionRequest(
       'POST',
-      'entry-types/render-override-settings',
+      renderOverrideSettings().url,
       {data: JSON.parse(input.value)}
     );
     data = response.data;
@@ -133,7 +138,7 @@ async function applyOverrides(
     try {
       const response = await Craft.sendActionRequest(
         'POST',
-        'entry-types/apply-override-settings',
+        applyOverrideSettings().url,
         {
           data: {
             id: chip.dataset.id,

--- a/resources/js/modules/matrix/matrix-entry.ts
+++ b/resources/js/modules/matrix/matrix-entry.ts
@@ -623,9 +623,11 @@ export class MatrixEntry extends Base {
       }
 
       case 'editEntryType': {
-        new Craft.CpScreenSlideout('entry-types/edit', {
-          params: {entryTypeId: this.container.dataset.typeId},
-        });
+        new Craft.CpScreenSlideout(
+          Craft.getCpUrl(
+            `settings/entry-types/${this.container.dataset.typeId}`
+          )
+        );
         break;
       }
 

--- a/resources/js/modules/slideout/cp-screen-slideout.ts
+++ b/resources/js/modules/slideout/cp-screen-slideout.ts
@@ -24,6 +24,8 @@
  */
 
 import {Garnish, ESC_KEY, S_KEY, isMobileBrowser} from '@craftcms/garnish';
+import {resolveInertiaPage} from '@/bootstrap/inertia-pages';
+import {createApp, type App} from 'vue';
 import {Slideout, uiLayerManager, type SlideoutSettings} from './slideout';
 
 declare const Craft: any;
@@ -86,6 +88,7 @@ export class CpScreenSlideout extends Slideout {
 
   action: string | null = null;
   namespace: string | null = null;
+  inertiaApp: App | null = null;
 
   showingLoadSpinner = false;
   hasTabs = false;
@@ -413,6 +416,8 @@ export class CpScreenSlideout extends Slideout {
         this.$body.addClass(data.bodyClass);
       }
 
+      this.inertiaApp?.unmount();
+      this.inertiaApp = null;
       this.$content.html(data.content);
       if (this.$actionBtn) {
         this.$actionBtn.data('disclosureMenu')?.destroy();
@@ -505,6 +510,19 @@ export class CpScreenSlideout extends Slideout {
         // get instantiated before field toggles
         await Craft.appendHeadHtml(data.headHtml);
         await Craft.appendBodyHtml(data.bodyHtml);
+
+        if (data.inertiaPage) {
+          const inertiaPage = await resolveInertiaPage(data.inertiaPage);
+
+          this.inertiaApp = createApp(inertiaPage, {
+            ...data.inertiaProps,
+            slideout: true,
+          });
+          this.inertiaApp.config.compilerOptions.isCustomElement = (tag) =>
+            tag.includes('-');
+          this.inertiaApp.mount(this.$content[0]);
+        }
+
         Craft.initUiElements(this.$content);
         Craft.cp.elementThumbLoader.load($(this.$content));
 
@@ -933,6 +951,9 @@ export class CpScreenSlideout extends Slideout {
   }
 
   override close(): void {
+    this.inertiaApp?.unmount();
+    this.inertiaApp = null;
+
     if (this.showingSidebar) {
       this.hideSidebar();
     }

--- a/resources/js/pages/settings/entry-types/Edit.vue
+++ b/resources/js/pages/settings/entry-types/Edit.vue
@@ -11,7 +11,6 @@
   import CraftSelectColor from '@craftcms/ui/vue/CraftSelectColor.vue';
   import {useInputGenerator} from '@/common/composables/useInputGenerator';
   import {useSettingsSave} from '@/modules/settings/composables/useSettingsSave';
-  import useCraftData from '@/common/composables/useCraftData';
   import Pane from '@/common/components/Pane.vue';
   import {store} from '@/actions/CraftCms/Cms/Http/Controllers/Settings/EntryTypesController';
   import type {SelectOption} from '@/common/types';
@@ -32,9 +31,11 @@
     errors: Record<any, any> | null;
     metadataHtml: string | null;
     formActions?: Array<any>;
+    slideout?: boolean;
+    readOnly: boolean;
   }>();
 
-  const {readOnly} = useCraftData();
+  const {readOnly} = props;
 
   const form = useForm({
     entryTypeId: props.entryType.id,
@@ -92,45 +93,47 @@
   // values back out of the self-booting custom elements at submit. `fieldLayout`
   // must stay a string (the server `JsonHelper::decode()`s it); `generatedFields`
   // is the ordered row list the server `array_values()`-es.
-  const {save} = useSettingsSave(form, store, {
-    transform: (data) => ({
-      ...data,
-      fieldLayout:
-        fldHost.value
-          ?.querySelector('craft-field-layout-designer')
-          ?.serialize() ?? '{}',
-      generatedFields:
-        fldHost.value
-          ?.querySelector('craft-generated-fields-table')
-          ?.serialize() ?? [],
-    }),
-  });
+  if (!props.slideout) {
+    const {save} = useSettingsSave(form, store, {
+      transform: (data) => ({
+        ...data,
+        fieldLayout:
+          fldHost.value
+            ?.querySelector('craft-field-layout-designer')
+            ?.serialize() ?? '{}',
+        generatedFields:
+          fldHost.value
+            ?.querySelector('craft-generated-fields-table')
+            ?.serialize() ?? [],
+      }),
+    });
 
-  // "Save as a new {type}" submits the current form (including the field layout)
-  // with a `saveAsNew` flag, so on-screen edits are carried into the duplicate —
-  // rather than a standalone request that would clone the last-saved version.
-  // Delete (and any other server-defined actions) come from `props.formActions`.
-  const formActionItems = computed(() => {
-    const actions = [...(props.formActions ?? [])];
+    // "Save as a new {type}" submits the current form (including the field layout)
+    // with a `saveAsNew` flag, so on-screen edits are carried into the duplicate —
+    // rather than a standalone request that would clone the last-saved version.
+    // Delete (and any other server-defined actions) come from `props.formActions`.
+    const formActionItems = computed(() => {
+      const actions = [...(props.formActions ?? [])];
 
-    if (!props.brandNew) {
-      actions.unshift({
-        label: t('Save as a new {type}', {type: props.lowerTypeName}),
-        // Don't preserve state — we navigate to the *new* type's edit screen, so
-        // the form must re-initialize from the new props (not keep this record's).
-        onClick: () => save({data: {saveAsNew: true}, preserveState: false}),
-      });
-    }
+      if (!props.brandNew) {
+        actions.unshift({
+          label: t('Save as a new {type}', {type: props.lowerTypeName}),
+          // Don't preserve state — we navigate to the *new* type's edit screen, so
+          // the form must re-initialize from the new props (not keep this record's).
+          onClick: () => save({data: {saveAsNew: true}, preserveState: false}),
+        });
+      }
 
-    return actions;
-  });
+      return actions;
+    });
 
-  useAppLayout(() => ({
-    title: props.title,
-    form,
-    onSave: save,
-    formActions: formActionItems.value,
-  }));
+    useAppLayout(() => ({
+      title: props.title,
+      form,
+      onSave: save,
+      formActions: formActionItems.value,
+    }));
+  }
 </script>
 
 <template>

--- a/resources/js/pages/settings/entry-types/Index.vue
+++ b/resources/js/pages/settings/entry-types/Index.vue
@@ -147,7 +147,7 @@
   <LayoutSlot name="actions">
     <CpLink
       appearance="button"
-      :href="create['/{cpTrigger?}/settings/entry-types/new']().url"
+      :href="create().url"
       variant="accent"
       :inertia="false"
       icon="plus"

--- a/resources/js/pages/settings/fields/Edit.vue
+++ b/resources/js/pages/settings/fields/Edit.vue
@@ -71,7 +71,7 @@
   }
 
   // The field type's own settings are a server-rendered legacy HTML island
-  // (each type's getSettingsHtml()), swapped out via `fields/render-settings`
+  // (each type's getSettingsHtml()), swapped out via `settings/fields/render-settings`
   // when the type changes. Its inputs — namespaced `types[<typeId>]` — aren't
   // part of the Inertia form, so they're serialized out of the DOM at submit.
   const settingsHost = ref<HTMLElement | null>(null);

--- a/resources/js/pages/settings/fields/Edit.vue
+++ b/resources/js/pages/settings/fields/Edit.vue
@@ -71,7 +71,7 @@
   }
 
   // The field type's own settings are a server-rendered legacy HTML island
-  // (each type's getSettingsHtml()), swapped out via `settings/fields/render-settings`
+  // (each type's getSettingsHtml()), swapped out via `fields/render-settings`
   // when the type changes. Its inputs — namespaced `types[<typeId>]` — aren't
   // part of the Inertia form, so they're serialized out of the DOM at submit.
   const settingsHost = ref<HTMLElement | null>(null);

--- a/resources/js/pages/settings/sections/Index.vue
+++ b/resources/js/pages/settings/sections/Index.vue
@@ -49,9 +49,7 @@
           'a',
           {
             class: 'font-bold',
-            href: edit['/{cpTrigger?}/settings/sections/{section}']({
-              section: row.original.id,
-            }).url,
+            href: edit({section: row.original.id}).url,
           },
           getValue()
         ),

--- a/resources/templates/_includes/forms/fieldSelect.twig
+++ b/resources/templates/_includes/forms/fieldSelect.twig
@@ -3,5 +3,5 @@
 {% include '_includes/forms/componentSelect.twig' with {
     options: options ?? Fields.getAllFields().all(),
     showHandles: true,
-    createAction: (create ?? false) ? 'fields/edit-field' : null,
+    createAction: (create ?? false) ? cpUrl('settings/fields/edit') : null,
 } %}

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -277,16 +277,11 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
 
         // Fields
         Route::middleware([RequireAdminChanges::class])->group(function () {
-            Route::get('fields/edit-field', [FieldsController::class, 'edit']);
             Route::post('fields/render-settings', [FieldsController::class, 'renderSettings']);
-            Route::post('fields/save-field', [FieldsController::class, 'store']);
             Route::post('fields/render-layout-component-settings', [FieldsController::class, 'renderLayoutComponentSettings']);
             Route::post('fields/apply-layout-tab-settings', [FieldsController::class, 'applyLayoutTabSettings']);
             Route::post('fields/apply-layout-element-settings', [FieldsController::class, 'applyLayoutElementSettings']);
             Route::post('fields/render-card-preview', [FieldsController::class, 'renderCardPreview']);
-        });
-        Route::middleware([RequireAdmin::class])->group(function () {
-            Route::get('fields/table-data', [FieldsController::class, 'tableData']);
         });
 
         // Entry types

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -69,7 +69,6 @@ use CraftCms\Cms\Http\Controllers\PreviewController;
 use CraftCms\Cms\Http\Controllers\QueueController;
 use CraftCms\Cms\Http\Controllers\RelationalFieldsController;
 use CraftCms\Cms\Http\Controllers\Settings\EntryTypesController;
-use CraftCms\Cms\Http\Controllers\Settings\SectionsController;
 use CraftCms\Cms\Http\Controllers\Settings\VolumesController;
 use CraftCms\Cms\Http\Controllers\StructuresController;
 use CraftCms\Cms\Http\Controllers\Updates\UpdatesController;
@@ -350,10 +349,6 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
         Route::post('dashboard/cache-feed-data', [FeedController::class, 'cacheData']);
         Route::post('dashboard/send-support-request', CraftSupportController::class);
         Route::post('charts/get-new-users-data', [NewUsersController::class, 'data']);
-
-        // Sections
-        Route::get('sections/table-data', [SectionsController::class, 'tableData']);
-        Route::get('sections/edit/{section}', [SectionsController::class, 'edit']);
 
         // Structures
         Route::post('structures/get-element-level-delta', [StructuresController::class, 'getElementLevelDelta']);

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -302,6 +302,9 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
             Route::get('fields/table-data', [FieldsController::class, 'tableData']);
         });
 
+        // Volumes
+        Route::middleware([RequireAdminChanges::class])->post('volumes/reorder-volumes', [VolumesController::class, 'reorder']);
+
         // Matrix
         Route::post('matrix/default-table-column-options', [MatrixController::class, 'defaultTableColumnOptions']);
         Route::post('matrix/create-entry', [MatrixController::class, 'createEntry']);
@@ -353,12 +356,6 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
         Route::post('dashboard/cache-feed-data', [FeedController::class, 'cacheData']);
         Route::post('dashboard/send-support-request', CraftSupportController::class);
         Route::post('charts/get-new-users-data', [NewUsersController::class, 'data']);
-
-        // Volumes
-        Route::middleware([RequireAdminChanges::class])->group(function () {
-            Route::post('volumes/save-volume', [VolumesController::class, 'save']);
-            Route::post('volumes/reorder-volumes', [VolumesController::class, 'reorder']);
-        });
 
         // Sections
         Route::get('sections/table-data', [SectionsController::class, 'tableData']);

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -276,18 +276,6 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
         Route::any('entries/reassign-modal', [ReassignEntriesModalController::class, 'show']);
         Route::any('entries/reassign', [ReassignEntriesModalController::class, 'store']);
 
-        // Entry Types
-        Route::get('entry-types/table-data', [EntryTypesController::class, 'tableData']);
-        Route::get('entry-types/edit/{entryType?}', [EntryTypesController::class, 'edit']);
-        Route::middleware([
-            RequireAdminChanges::class,
-        ])->group(function () {
-            Route::get('entry-types/new', [EntryTypesController::class, 'create']);
-            Route::post('entry-types/save', [EntryTypesController::class, 'store']);
-            Route::post('entry-types/render-override-settings', [EntryTypesController::class, 'renderOverrideSettings']);
-            Route::post('entry-types/apply-override-settings', [EntryTypesController::class, 'applyOverrideSettings']);
-        });
-
         // Fields
         Route::middleware([RequireAdminChanges::class])->group(function () {
             Route::get('fields/edit-field', [FieldsController::class, 'edit']);
@@ -300,6 +288,12 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
         });
         Route::middleware([RequireAdmin::class])->group(function () {
             Route::get('fields/table-data', [FieldsController::class, 'tableData']);
+        });
+
+        // Entry types
+        Route::middleware([RequireAdminChanges::class])->group(function () {
+            Route::post('entry-types/render-override-settings', [EntryTypesController::class, 'renderOverrideSettings']);
+            Route::post('entry-types/apply-override-settings', [EntryTypesController::class, 'applyOverrideSettings']);
         });
 
         // Volumes

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -275,6 +275,14 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
         Route::any('entries/reassign-modal', [ReassignEntriesModalController::class, 'show']);
         Route::any('entries/reassign', [ReassignEntriesModalController::class, 'store']);
 
+        // Entry Types
+        Route::middleware([
+            RequireAdminChanges::class,
+        ])->group(function () {
+            Route::post('entry-types/render-override-settings', [EntryTypesController::class, 'renderOverrideSettings']);
+            Route::post('entry-types/apply-override-settings', [EntryTypesController::class, 'applyOverrideSettings']);
+        });
+
         // Fields
         Route::middleware([RequireAdminChanges::class])->group(function () {
             Route::post('fields/render-settings', [FieldsController::class, 'renderSettings']);
@@ -283,15 +291,6 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
             Route::post('fields/apply-layout-element-settings', [FieldsController::class, 'applyLayoutElementSettings']);
             Route::post('fields/render-card-preview', [FieldsController::class, 'renderCardPreview']);
         });
-
-        // Entry types
-        Route::middleware([RequireAdminChanges::class])->group(function () {
-            Route::post('entry-types/render-override-settings', [EntryTypesController::class, 'renderOverrideSettings']);
-            Route::post('entry-types/apply-override-settings', [EntryTypesController::class, 'applyOverrideSettings']);
-        });
-
-        // Volumes
-        Route::middleware([RequireAdminChanges::class])->post('volumes/reorder-volumes', [VolumesController::class, 'reorder']);
 
         // Matrix
         Route::post('matrix/default-table-column-options', [MatrixController::class, 'defaultTableColumnOptions']);
@@ -344,6 +343,11 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
         Route::post('dashboard/cache-feed-data', [FeedController::class, 'cacheData']);
         Route::post('dashboard/send-support-request', CraftSupportController::class);
         Route::post('charts/get-new-users-data', [NewUsersController::class, 'data']);
+
+        // Volumes
+        Route::middleware([RequireAdminChanges::class])->group(function () {
+            Route::post('volumes/reorder-volumes', [VolumesController::class, 'reorder']);
+        });
 
         // Structures
         Route::post('structures/get-element-level-delta', [StructuresController::class, 'getElementLevelDelta']);

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -275,10 +275,17 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
         });
 
         // Fields
-        Route::get('settings/fields', [FieldsController::class, 'index']);
-        Route::middleware(RequireAdminChanges::class)->get('settings/fields/new', [FieldsController::class, 'create']);
-        Route::get('settings/fields/edit/{fieldId}', [FieldsController::class, 'edit']);
-        Route::middleware(RequireAdminChanges::class)->delete('settings/fields/{fieldId}', [FieldsController::class, 'destroy'])->whereNumber('fieldId');
+        Route::prefix('settings/fields')->group(function () {
+            Route::get('/', [FieldsController::class, 'index']);
+            Route::middleware(RequireAdminChanges::class)->get('edit', [FieldsController::class, 'edit']);
+            Route::get('edit/{fieldId}', [FieldsController::class, 'edit'])->whereNumber('fieldId');
+
+            Route::middleware(RequireAdminChanges::class)->group(function () {
+                Route::get('new', [FieldsController::class, 'create']);
+                Route::post('/', [FieldsController::class, 'store']);
+                Route::delete('{fieldId}', [FieldsController::class, 'destroy'])->whereNumber('fieldId');
+            });
+        });
 
         // General
         Route::get('settings/general', [GeneralSettingsController::class, 'index'])

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -262,10 +262,17 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
             ->name('settings.index');
 
         // Entry types
-        Route::get('settings/entry-types', [EntryTypesController::class, 'index']);
-        Route::middleware(RequireAdminChanges::class)->get('settings/entry-types/new', [EntryTypesController::class, 'create']);
-        Route::get('settings/entry-types/{entryType}', [EntryTypesController::class, 'edit']);
-        Route::middleware(RequireAdminChanges::class)->delete('settings/entry-types/{entryType}', [EntryTypesController::class, 'destroy']);
+        Route::prefix('settings/entry-types')->group(function () {
+            Route::get('/', [EntryTypesController::class, 'index']);
+
+            Route::middleware(RequireAdminChanges::class)->group(function () {
+                Route::get('new', [EntryTypesController::class, 'create']);
+                Route::post('/', [EntryTypesController::class, 'store']);
+                Route::delete('{entryType}', [EntryTypesController::class, 'destroy']);
+            });
+
+            Route::get('{entryType}', [EntryTypesController::class, 'edit']);
+        });
 
         // Fields
         Route::get('settings/fields', [FieldsController::class, 'index']);

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -374,10 +374,19 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
         Route::middleware(RequireAdminChanges::class)->post('sections/sections', [SectionsController::class, 'store']);
 
         // Volumes
-        Route::get('settings/assets', [VolumesController::class, 'index']);
-        Route::middleware(RequireAdminChanges::class)->get('settings/assets/volumes/new', [VolumesController::class, 'create']);
-        Route::get('settings/assets/volumes/{volumeId}', [VolumesController::class, 'edit'])->whereNumber('volumeId');
-        Route::middleware(RequireAdminChanges::class)->delete('settings/assets/volumes/{volumeId}', [VolumesController::class, 'destroy'])->whereNumber('volumeId');
+        Route::prefix('settings/assets')->group(function () {
+            Route::get('/', [VolumesController::class, 'index']);
+
+            Route::prefix('volumes')->group(function () {
+                Route::middleware(RequireAdminChanges::class)->get('new', [VolumesController::class, 'create']);
+                Route::get('{volumeId}', [VolumesController::class, 'edit'])->whereNumber('volumeId');
+
+                Route::middleware(RequireAdminChanges::class)->group(function () {
+                    Route::delete('{volumeId}', [VolumesController::class, 'destroy'])->whereNumber('volumeId');
+                    Route::post('/', [VolumesController::class, 'save']);
+                });
+            });
+        });
 
         // Transforms
         Route::prefix('settings/assets/transforms')->name('settings.assets.transforms.')->group(function () {

--- a/src/Address/Elements/Address.php
+++ b/src/Address/Elements/Address.php
@@ -377,7 +377,7 @@ class Address extends Element implements AddressInterface, NestedElementInterfac
             HtmlStack::jsWithVars(fn ($id, $params) => <<<JS
     (() => {
       $('#' + $id).on('activate', function() {
-        new Craft.CpScreenSlideout('fields/edit-field', {params: $params})
+        new Craft.CpScreenSlideout(Craft.getCpUrl('settings/fields/edit'), {params: $params})
       });
     })();
     JS, [

--- a/src/Entry/Data/EntryType.php
+++ b/src/Entry/Data/EntryType.php
@@ -186,15 +186,13 @@ class EntryType extends Component implements Actionable, Chippable, Colorable, C
             ],
         ];
 
-        HtmlStack::jsWithVars(fn ($id, $params) => <<<JS
+        HtmlStack::jsWithVars(fn ($id, $url) => <<<JS
 $(document).on('click', '#' + $id, () => {
-new Craft.CpScreenSlideout('entry-types/edit', {
-params: $params,
-})
+new Craft.CpScreenSlideout($url)
 });
 JS, [
             InputNamespace::namespaceId($editId),
-            ['entryTypeId' => $this->id],
+            Url::cpUrl("settings/entry-types/$this->id"),
         ]);
 
         return $items;

--- a/src/Entry/Elements/Entry.php
+++ b/src/Entry/Elements/Entry.php
@@ -1879,7 +1879,7 @@ JS, [
                 HtmlStack::jsWithVars(fn ($id, $params) => <<<JS
     (() => {
       $('#' + $id).on('activate', function() {
-        new Craft.CpScreenSlideout('fields/edit-field', {params: $params})
+        new Craft.CpScreenSlideout(Craft.getCpUrl('settings/fields/edit'), {params: $params})
       });
     })();
     JS, [

--- a/src/Entry/Elements/Entry.php
+++ b/src/Entry/Elements/Entry.php
@@ -1837,7 +1837,7 @@ class Entry extends Element implements Colorable, ExpirableElementInterface, Ico
           params.entryTypeId = input.val();
         }
     }
-    new Craft.CpScreenSlideout('entry-types/edit', {params});
+    new Craft.CpScreenSlideout(Craft.getCpUrl('settings/entry-types/' + params.entryTypeId));
   });
 })();
 JS, [

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -490,7 +490,7 @@ abstract class Field extends Component implements Actionable, FieldInterface, Ic
             HtmlStack::jsWithVars(fn ($id, $params) => <<<JS
 (() => {
 $('#' + $id).on('activate', () => {
-new Craft.CpScreenSlideout('fields/edit-field', {
+new Craft.CpScreenSlideout(Craft.getCpUrl('settings/fields/edit'), {
   params: $params,
 })
 });

--- a/src/Http/Controllers/FieldsController.php
+++ b/src/Http/Controllers/FieldsController.php
@@ -37,7 +37,6 @@ use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\View\HtmlStack;
 use CraftCms\Cms\View\LegacyAssets\FieldSettingsAsset;
 use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
-use Deprecated;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Crypt;
@@ -89,7 +88,7 @@ class FieldsController
 
     public function create(Request $request): CpScreenResponse
     {
-        // Slideouts (`new Craft.CpScreenSlideout('fields/edit-field')` with no
+        // Slideouts (`new Craft.CpScreenSlideout(Craft.getCpUrl('settings/fields/edit'))` with no
         // field ID, e.g. the field layout designer's "New field" button) still
         // consume the legacy Twig screen as JSON.
         if ($request->wantsJson()) {
@@ -400,23 +399,6 @@ class FieldsController
         ]);
     }
 
-    #[Deprecated(message: 'in 6.0. Use `settings/fields` instead.')]
-    public function tableData(TableRequest $request): Response
-    {
-        [$pagination, $tableData] = $this->fieldsService->getTableData(
-            page: $request->page(),
-            limit: $request->limit(),
-            searchTerm: $request->search(),
-            orderBy: $request->orderBy(),
-            sortDir: $request->sortDir(),
-        );
-
-        return $this->asSuccess(data: [
-            'pagination' => $pagination,
-            'data' => $tableData,
-        ]);
-    }
-
     private function fieldLayoutComponent(Request $request, ?array &$settings = null): FieldLayoutComponent
     {
         $request->validate([
@@ -596,7 +578,9 @@ class FieldsController
 
         if (! $this->readOnly) {
             $response
-                ->action('fields/save-field')
+                ->formAttributes([
+                    'action' => Url::cpUrl('settings/fields'),
+                ])
                 ->redirectUrl('settings/fields')
                 ->addAltAction(t('Save and continue editing'), [
                     'redirect' => 'settings/fields/edit/{id}',
@@ -631,9 +615,14 @@ JS, [
             if (! $this->readOnly) {
                 $response
                     ->addAltAction(t('Delete'), [
-                        'action' => 'fields/delete-field',
-                        'redirect' => 'settings/fields',
-                        'destructive' => true,
+                        'action' => [
+                            'type' => 'http',
+                            'method' => 'DELETE',
+                            'url' => Url::cpUrl("settings/fields/$field->id"),
+                            'body' => [
+                                'redirect' => Crypt::encrypt(Url::cpUrl('settings/fields')),
+                            ],
+                        ],
                         'confirm' => t('Are you sure you want to delete “{name}”?', [
                             'name' => $field->name,
                         ]),

--- a/src/Http/Controllers/Settings/EntryTypesController.php
+++ b/src/Http/Controllers/Settings/EntryTypesController.php
@@ -94,6 +94,9 @@ class EntryTypesController
             ->title(t('Create a new entry type'))
             ->addCrumb(t('Settings'), 'settings')
             ->addCrumb(t('Entry Types'), 'settings/entry-types')
+            ->formAttributes([
+                'action' => Url::cpUrl('settings/entry-types'),
+            ])
             ->redirectUrl('settings/entry-types')
             ->inertiaPage('settings/entry-types/Edit', $this->entryTypeProps($entryType, brandNew: true));
     }
@@ -118,6 +121,10 @@ class EntryTypesController
             ->inertiaPage('settings/entry-types/Edit', $this->entryTypeProps($entryTypeData, brandNew: false));
 
         if (! $this->readOnly) {
+            $response->formAttributes([
+                'action' => Url::cpUrl('settings/entry-types'),
+            ]);
+
             if ($entryTypeData->id) {
                 $response->addAltAction(t('Delete'), [
                     'variant' => 'danger',

--- a/src/Http/Controllers/Settings/EntryTypesController.php
+++ b/src/Http/Controllers/Settings/EntryTypesController.php
@@ -28,7 +28,6 @@ use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\View\HtmlStack;
-use Deprecated;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Crypt;
@@ -203,23 +202,6 @@ class EntryTypesController
             'isMultiSite' => Sites::isMultiSite(),
             'readOnly' => $this->readOnly,
         ];
-    }
-
-    #[Deprecated(message: 'in 6.0. Use `settings/entry-types` instead.')]
-    public function tableData(TableRequest $request): JsonResponse
-    {
-        [$pagination, $tableData] = $this->entryTypes->getTableData(
-            page: $request->page(),
-            limit: $request->limit(),
-            searchTerm: $request->search(),
-            orderBy: $request->orderBy(),
-            sortDir: $request->sortDir(),
-        );
-
-        return new JsonResponse([
-            'pagination' => $pagination,
-            'data' => $tableData,
-        ]);
     }
 
     public function store(Request $request): Response

--- a/src/Http/Controllers/Settings/SectionsController.php
+++ b/src/Http/Controllers/Settings/SectionsController.php
@@ -21,7 +21,6 @@ use CraftCms\Cms\Section\Resources\SectionResource;
 use CraftCms\Cms\Section\Sections;
 use CraftCms\Cms\Site\Sites;
 use CraftCms\Cms\Support\Url;
-use Deprecated;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
@@ -219,22 +218,5 @@ readonly class SectionsController
         return $this->asSuccess(t('Section “{name}” deleted.', [
             'name' => $name,
         ]));
-    }
-
-    #[Deprecated(message: 'in 6.0. Use `settings/sections` instead.')]
-    public function tableData(TableRequest $request, Sections $sections): Response
-    {
-        [$pagination, $tableData] = $sections->getSectionTableData(
-            page: $request->page(),
-            limit: $request->limit(),
-            searchTerm: $request->search(),
-            orderBy: $request->orderBy(),
-            sortDir: $request->sortDir(),
-        );
-
-        return $this->asSuccess(data: [
-            'pagination' => $pagination,
-            'data' => $tableData,
-        ]);
     }
 }

--- a/src/Http/Controllers/Settings/VolumesController.php
+++ b/src/Http/Controllers/Settings/VolumesController.php
@@ -139,7 +139,9 @@ class VolumesController
                 $this->readOnly,
                 function (CpScreenResponse $response) use ($volume) {
                     $response
-                        ->action('volumes/save-volume')
+                        ->formAttributes([
+                            'action' => Url::cpUrl('settings/assets/volumes'),
+                        ])
                         ->redirectUrl('settings/assets')
                         ->saveShortcutRedirectUrl('settings/assets/volumes/{id}')
                         ->addAltAction(t('Save and continue editing'), [

--- a/src/Http/Responses/CpScreenResponse.php
+++ b/src/Http/Responses/CpScreenResponse.php
@@ -799,6 +799,8 @@ class CpScreenResponse implements Responsable
                 'withButton' => false,
             ], namespace: $namespace),
             'content' => $content,
+            'inertiaPage' => $this->inertiaPage,
+            'inertiaProps' => $this->inertiaProps,
             'sidebar' => $sidebar,
             'errorSummary' => $errorSummary,
             'headHtml' => HtmlStack::headHtml(),

--- a/tests/Feature/Http/Controllers/FieldsControllerTest.php
+++ b/tests/Feature/Http/Controllers/FieldsControllerTest.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\Field\RadioButtons;
 use CraftCms\Cms\Http\Controllers\FieldsController;
 use CraftCms\Cms\Support\Facades\Fields;
 use CraftCms\Cms\Support\Str;
+use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Inertia\Testing\AssertableInertia;
@@ -47,7 +48,6 @@ it('needs authentication and admin changes for the routes', function (string $me
     ['postJson', [FieldsController::class, 'applyLayoutTabSettings'], true],
     ['postJson', [FieldsController::class, 'applyLayoutElementSettings'], true],
     ['postJson', [FieldsController::class, 'renderCardPreview'], true],
-    ['getJson', [FieldsController::class, 'tableData'], false],
 ]);
 
 it('needs authentication and admin changes to delete', function () {
@@ -154,7 +154,7 @@ it('serves the legacy screen to slideout requests', function (?callable $setUp) 
         ['X-Craft-Container-Id' => 'slideout'],
     )
         ->assertOk()
-        ->assertJsonPath('action', 'fields/save-field')
+        ->assertJsonPath('formAttributes.action', Url::cpUrl('settings/fields'))
         ->assertJson(fn (AssertableJson $json) => $json
             ->whereType('content', 'string')
             ->etc());

--- a/tests/Feature/Http/Controllers/Settings/EntryTypesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/EntryTypesControllerTest.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\Entry\Models\EntryType;
 use CraftCms\Cms\Http\Controllers\Settings\EntryTypesController;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
 use CraftCms\Cms\Support\Str;
+use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Testing\AssertableInertia;
@@ -68,6 +69,18 @@ test('create can be loaded', function () {
     get(action([EntryTypesController::class, 'create']))
         ->assertOk()
         ->assertSee(t('Create a new entry type'));
+});
+
+test('create returns the Inertia page for a slideout', function () {
+    get(action([EntryTypesController::class, 'create']), [
+        'Accept' => 'application/json',
+        'X-Craft-Container-Id' => 'entry-type-slideout',
+        'X-Requested-With' => 'XMLHttpRequest',
+    ])
+        ->assertOk()
+        ->assertJsonPath('inertiaPage', 'settings/entry-types/Edit')
+        ->assertJsonPath('inertiaProps.brandNew', true)
+        ->assertJsonPath('formAttributes.action', Url::cpUrl('settings/entry-types'));
 });
 
 test('it can edit an entry type', function () {

--- a/tests/Feature/Http/Controllers/Settings/EntryTypesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/EntryTypesControllerTest.php
@@ -17,7 +17,6 @@ use function CraftCms\Cms\t;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\deleteJson;
 use function Pest\Laravel\get;
-use function Pest\Laravel\getJson;
 use function Pest\Laravel\post;
 use function Pest\Laravel\postJson;
 use function Pest\Laravel\withSession;
@@ -36,7 +35,6 @@ it('requires authentication', function () {
     get(action([EntryTypesController::class, 'index']))->assertRedirect();
     get(action([EntryTypesController::class, 'create']))->assertRedirect();
     get(action([EntryTypesController::class, 'edit'], [EntryType::first()->id]))->assertRedirect();
-    get(action([EntryTypesController::class, 'tableData']))->assertRedirect();
     postJson(action([EntryTypesController::class, 'renderOverrideSettings']))->assertUnauthorized();
     postJson(action([EntryTypesController::class, 'applyOverrideSettings']))->assertUnauthorized();
     postJson(action([EntryTypesController::class, 'store']))->assertUnauthorized();
@@ -175,11 +173,6 @@ it('can delete an entry type', function () {
     deleteJson(action([EntryTypesController::class, 'destroy'], [$newEntryType->id]))->assertOk();
 
     expect(EntryType::count())->toBe(1);
-});
-
-it('can get table data', function () {
-    getJson(action([EntryTypesController::class, 'tableData']))
-        ->assertOk();
 });
 
 it('can render override settings', function () {

--- a/tests/Feature/Http/Controllers/Settings/SectionsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/SectionsControllerTest.php
@@ -25,7 +25,6 @@ use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\delete;
 use function Pest\Laravel\deleteJson;
 use function Pest\Laravel\get;
-use function Pest\Laravel\getJson;
 use function Pest\Laravel\post;
 use function Pest\Laravel\postJson;
 
@@ -43,7 +42,6 @@ it('requires authentication', function () {
     get(action([SectionsController::class, 'index']))->assertRedirect();
     get(action([SectionsController::class, 'create']))->assertRedirect();
     get(action([SectionsController::class, 'edit'], [Section::first()->id]))->assertRedirect();
-    get(action([SectionsController::class, 'tableData']))->assertRedirect();
     postJson(action([SectionsController::class, 'store']))->assertUnauthorized();
     deleteJson(action([SectionsController::class, 'destroy'], [Section::first()->id]))->assertUnauthorized();
 });
@@ -193,9 +191,4 @@ it('can delete a section', function () {
     assertSoftDeleted(Section::class, ['id' => $newSection->id]);
     expect(ProjectConfig::get(ProjectConfigPaths::PATH_SECTIONS.'.'.$newSection->uid))->toBeNull();
     expect(Section::count())->toBe(1);
-});
-
-it('can get table data', function () {
-    getJson(action([SectionsController::class, 'tableData']))
-        ->assertOk();
 });

--- a/tests/Feature/Http/Controllers/Settings/VolumesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/VolumesControllerTest.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\Asset\Volumes;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Http\Controllers\Settings\VolumesController;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
+use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Support\Facades\Auth;
@@ -101,6 +102,16 @@ describe('create / edit', function () {
         get(action([VolumesController::class, 'edit'], ['volumeId' => $volume->id]))
             ->assertOk()
             ->assertSee($volume->name);
+    });
+
+    test('slideout form targets the volume CP route', function () {
+        get(action([VolumesController::class, 'create']), [
+            'Accept' => 'application/json',
+            'X-Craft-Container-Id' => 'volume-slideout',
+            'X-Requested-With' => 'XMLHttpRequest',
+        ])
+            ->assertOk()
+            ->assertJsonPath('formAttributes.action', Url::cpUrl('settings/assets/volumes'));
     });
 
     test('edit returns 404 for non-existent volume', function () {


### PR DESCRIPTION
### Description

This is the last batch (for now). Inertia-ported controller methods aren't really "action" routes so porting them to the cp.php routes instead.