### PR TITLE
Fix `@property` annotation for `VolumeFolder::$parentId`

### DIFF
--- a/src/records/VolumeFolder.php
+++ b/src/records/VolumeFolder.php
@@ -15,7 +15,7 @@ use yii\db\ActiveQueryInterface;
  * Class VolumeFolder record.
  *
  * @property int $id ID
- * @property int $parentId Parent ID
+ * @property int|null $parentId Parent ID
  * @property int $volumeId Volume ID
  * @property string $name Name
  * @property string $path Path


### PR DESCRIPTION
### Description

I was testing the new version of [yii2-phpstan-rules](https://github.com/mspirkov/yii2-phpstan-rules) and found this errors:

<img width="1277" height="293" alt="image" src="https://github.com/user-attachments/assets/a065824c-78ce-4fc4-af6b-195798647270" />


