### PR TITLE
fix: avoid entry author deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a bug where entries could deadlock when saving their authors. ([#15768](https://github.com/craftcms/cms/issues/15768))
+
 ## 5.10.13.2 - 2026-08-05
 
 - Fixed a SQL error that could occur when viewing an element with an empty Categories field. ([#19372](https://github.com/craftcms/cms/issues/19372))

--- a/src/elements/Entry.php
+++ b/src/elements/Entry.php
@@ -3147,7 +3147,7 @@ JS;
             $this->_oldAuthorIds = array_map(fn($id) => (int)$id, $oldAuthorIds);
         }
 
-        Db::delete(Table::ENTRIES_AUTHORS, ['entryId' => $this->id]);
+        Db::deleteIfExists(Table::ENTRIES_AUTHORS, ['entryId' => $this->id]);
 
         if (!empty($this->_authorIds)) {
             $data = [];

--- a/tests/unit/services/EntriesTest.php
+++ b/tests/unit/services/EntriesTest.php
@@ -8,7 +8,6 @@
 namespace crafttests\unit\services;
 
 use Craft;
-use craft\db\Command;
 use craft\db\Query;
 use craft\db\Table;
 use craft\elements\Entry;
@@ -18,7 +17,6 @@ use craft\test\TestCase;
 use crafttests\fixtures\EntryFixture;
 use crafttests\fixtures\UserFixture;
 use UnitTester;
-use yii\base\Event;
 
 /**
  * Unit tests for the Entries service.
@@ -148,24 +146,27 @@ class EntriesTest extends TestCase
      */
     private function _captureAuthorWriteCommands(callable $callback): array
     {
+        $db = Craft::$app->getDb();
+        $oldCommandClass = $db->commandClass;
+        $db->commandClass = RecordingCommand::class;
+        RecordingCommand::startRecording();
+
+        try {
+            $callback();
+        } finally {
+            $db->commandClass = $oldCommandClass;
+        }
+
         $commands = [];
-        $handler = static function(Event $event) use (&$commands): void {
-            /** @var Command $command */
-            $command = $event->sender;
-            $sql = ltrim($command->getSql());
+
+        foreach (RecordingCommand::stopRecording() as $sql) {
+            $sql = ltrim($sql);
             if (
                 str_contains($sql, 'entries_authors') &&
                 preg_match('/^(DELETE|INSERT)\b/i', $sql, $matches)
             ) {
                 $commands[] = strtoupper($matches[1]);
             }
-        };
-
-        Event::on(Command::class, Command::EVENT_BEFORE_EXECUTE, $handler);
-        try {
-            $callback();
-        } finally {
-            Event::off(Command::class, Command::EVENT_BEFORE_EXECUTE, $handler);
         }
 
         return $commands;

--- a/tests/unit/services/EntriesTest.php
+++ b/tests/unit/services/EntriesTest.php
@@ -103,11 +103,13 @@ class EntriesTest extends TestCase
         ]);
 
         $commands = $this->_captureAuthorWriteCommands(fn() => $this->tester->saveElement($entry));
+        $entryId = $entry->id;
+        self::assertNotNull($entryId);
 
         self::assertSame(['INSERT'], $commands);
         self::assertSame([
             [$this->userA->id, 1],
-        ], $this->_savedAuthors($entry->id));
+        ], $this->_savedAuthors($entryId));
 
         $entry->authorId = $this->userB->id;
         $commands = $this->_captureAuthorWriteCommands(fn() => $this->tester->saveElement($entry));
@@ -115,7 +117,7 @@ class EntriesTest extends TestCase
         self::assertSame(['DELETE', 'INSERT'], $commands);
         self::assertSame([
             [$this->userB->id, 1],
-        ], $this->_savedAuthors($entry->id));
+        ], $this->_savedAuthors($entryId));
 
         $section = $entry->getSection();
         self::assertNotNull($section);
@@ -133,9 +135,11 @@ class EntriesTest extends TestCase
         } finally {
             $section->minAuthors = $oldMinAuthors;
         }
+        $authorlessEntryId = $authorlessEntry->id;
+        self::assertNotNull($authorlessEntryId);
 
         self::assertSame([], $commands);
-        self::assertSame([], $this->_savedAuthors($authorlessEntry->id));
+        self::assertSame([], $this->_savedAuthors($authorlessEntryId));
     }
 
     /**

--- a/tests/unit/services/EntriesTest.php
+++ b/tests/unit/services/EntriesTest.php
@@ -8,6 +8,9 @@
 namespace crafttests\unit\services;
 
 use Craft;
+use craft\db\Command;
+use craft\db\Query;
+use craft\db\Table;
 use craft\elements\Entry;
 use craft\elements\User;
 use craft\services\Entries;
@@ -15,6 +18,7 @@ use craft\test\TestCase;
 use crafttests\fixtures\EntryFixture;
 use crafttests\fixtures\UserFixture;
 use UnitTester;
+use yii\base\Event;
 
 /**
  * Unit tests for the Entries service.
@@ -84,6 +88,101 @@ class EntriesTest extends TestCase
         /** @var Entry $untouchedEntry */
         $untouchedEntry = Entry::find()->id($this->entryB->id)->one();
         self::assertSame($this->userB->id, $untouchedEntry->getAuthorId());
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function testSaveAuthorsAvoidsDeletingMissingRows(): void
+    {
+        $entry = new Entry([
+            'sectionId' => 1000,
+            'typeId' => 1000,
+            'title' => 'Save Authors Test',
+            'authorId' => $this->userA->id,
+        ]);
+
+        $commands = $this->_captureAuthorWriteCommands(fn() => $this->tester->saveElement($entry));
+
+        self::assertSame(['INSERT'], $commands);
+        self::assertSame([
+            [$this->userA->id, 1],
+        ], $this->_savedAuthors($entry->id));
+
+        $entry->authorId = $this->userB->id;
+        $commands = $this->_captureAuthorWriteCommands(fn() => $this->tester->saveElement($entry));
+
+        self::assertSame(['DELETE', 'INSERT'], $commands);
+        self::assertSame([
+            [$this->userB->id, 1],
+        ], $this->_savedAuthors($entry->id));
+
+        $section = $entry->getSection();
+        self::assertNotNull($section);
+        $oldMinAuthors = $section->minAuthors;
+        $section->minAuthors = 0;
+        $authorlessEntry = new Entry([
+            'sectionId' => 1000,
+            'typeId' => 1000,
+            'title' => 'Save Without Authors Test',
+            'authorIds' => [],
+        ]);
+
+        try {
+            $commands = $this->_captureAuthorWriteCommands(fn() => $this->tester->saveElement($authorlessEntry));
+        } finally {
+            $section->minAuthors = $oldMinAuthors;
+        }
+
+        self::assertSame([], $commands);
+        self::assertSame([], $this->_savedAuthors($authorlessEntry->id));
+    }
+
+    /**
+     * @param callable(): mixed $callback
+     * @return string[]
+     */
+    private function _captureAuthorWriteCommands(callable $callback): array
+    {
+        $commands = [];
+        $handler = static function(Event $event) use (&$commands): void {
+            /** @var Command $command */
+            $command = $event->sender;
+            $sql = ltrim($command->getSql());
+            if (
+                str_contains($sql, 'entries_authors') &&
+                preg_match('/^(DELETE|INSERT)\b/i', $sql, $matches)
+            ) {
+                $commands[] = strtoupper($matches[1]);
+            }
+        };
+
+        Event::on(Command::class, Command::EVENT_BEFORE_EXECUTE, $handler);
+        try {
+            $callback();
+        } finally {
+            Event::off(Command::class, Command::EVENT_BEFORE_EXECUTE, $handler);
+        }
+
+        return $commands;
+    }
+
+    /**
+     * @return int[][]
+     */
+    private function _savedAuthors(int $entryId): array
+    {
+        $rows = (new Query())
+            ->select(['authorId', 'sortOrder'])
+            ->from(Table::ENTRIES_AUTHORS)
+            ->where(['entryId' => $entryId])
+            ->orderBy(['sortOrder' => SORT_ASC])
+            ->all();
+
+        return array_map(
+            fn(array $row) => [(int)$row['authorId'], (int)$row['sortOrder']],
+            $rows,
+        );
     }
 
     /**

--- a/tests/unit/services/RecordingCommand.php
+++ b/tests/unit/services/RecordingCommand.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace crafttests\unit\services;
+
+use craft\db\Command;
+
+/**
+ * A [[Command]] that records the SQL of every statement it executes.
+ *
+ * Tests swap this in via [[\yii\db\Connection::$commandClass]] when they need to
+ * assert on the statements a save issued. The query log isn’t an option here:
+ * Codeception replaces the Yii logger with one that explicitly drops
+ * `yii\db\Command` categories.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ */
+class RecordingCommand extends Command
+{
+    /**
+     * @var string[] The SQL of each statement executed since recording began.
+     */
+    private static array $executed = [];
+
+    /**
+     * Discards anything recorded so far.
+     */
+    public static function startRecording(): void
+    {
+        self::$executed = [];
+    }
+
+    /**
+     * Returns the SQL of each statement executed since [[startRecording()]], and resets.
+     *
+     * @return string[]
+     */
+    public static function stopRecording(): array
+    {
+        $executed = self::$executed;
+        self::$executed = [];
+        return $executed;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        self::$executed[] = $this->getSql();
+        return parent::execute();
+    }
+}


### PR DESCRIPTION
### Description

Change `Entry::_saveAuthors()` to use the existing `Db::deleteIfExists()` helper for `entries_authors`, which performs the delete only when matching rows exist and was designed to avoid deadlocks caused by deleting absent rows. Keep the existing author lookup and batch insert behavior intact so author replacement on established entries and initial author persistence continue to work across supported databases. Add a focused regression in `EntriesTest` that observes the database commands for an initial authored-entry save versus an author update: the initial save must not execute a delete for its absent author rows, while the update must still remove the existing rows and persist the replacement author.

Concurrent entry creation can intermittently deadlock on MySQL or MariaDB while `Entry::_saveAuthors()` writes to `entries_authors`. The thread includes reproductions from queue jobs, load-balanced installations, Craft Cloud, and a core-only control-panel flow, with InnoDB diagnostics showing distinct new entry IDs contending on the primary-index supremum. The save path currently issues an unconditional delete for an entry ID before inserting its authors, even when a newly-created entry cannot have author rows yet. That empty-range delete can take a gap lock that conflicts with another transaction following the same delete-then-insert sequence.

Fixes #15768

### Related issues

Not applicable to this change.
