### PR TITLE
Add support for `.well-known/passkey-endpoints`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added support for `.well-known/passkey-endpoints` requests. ([#19364](https://github.com/craftcms/cms/pull/19364))
 - Fixed a bug where image transforms could be generated from a stale locally-cached copy of an asset’s source file, after the file was replaced on a non-local filesystem. ([#19328](https://github.com/craftcms/cms/issues/19328))
 - Fixed a bug where warnings were getting logged for SSO attributes that mapped to native user properties. ([#19294](https://github.com/craftcms/cms/pull/19294))
 - Fixed an error that could occur when applying a draft. ([#19277](https://github.com/craftcms/cms/issues/19277))

--- a/src/controllers/WellKnownController.php
+++ b/src/controllers/WellKnownController.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\controllers;
+
+use craft\web\Controller;
+use yii\web\Response;
+
+/**
+ * Class WellKnownController
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.11.0
+ */
+class WellKnownController extends Controller
+{
+    protected array|bool|int $allowAnonymous = self::ALLOW_ANONYMOUS_LIVE;
+
+    public function actionPasskeyEndpoints(): Response
+    {
+        // Just return an empty object to signal support for passkeys, w/o leaking the CP URL.
+        $this->response->format = Response::FORMAT_JSON;
+        $this->response->content = '{}';
+        return $this->response;
+    }
+}

--- a/src/web/UrlManager.php
+++ b/src/web/UrlManager.php
@@ -470,9 +470,23 @@ class UrlManager extends \yii\web\UrlManager
      */
     private function _getMatchedDiscoverableUrlRoute(Request $request): array|false
     {
-        $redirectUri = $request->getPathInfo() === '.well-known/change-password'
-            ? Craft::$app->getConfig()->getGeneral()->getSetPasswordRequestPath(Craft::$app->getSites()->getCurrentSite()->handle)
-            : null;
+        return match ($request->getPathInfo()) {
+            '.well-known/change-password' => $this->_changePasswordRoute(),
+            '.well-known/passkey-endpoints' => $this->_passkeyEndpointsRoute(),
+            default => false,
+        };
+    }
+
+    /**
+     * Returns the route for `.well-known/change-password` requests, per
+     * https://w3c.github.io/webappsec-change-password-url/.
+     *
+     * @return array|false
+     */
+    private function _changePasswordRoute(): array|false
+    {
+        $redirectUri = Craft::$app->getConfig()->getGeneral()
+            ->getSetPasswordRequestPath(Craft::$app->getSites()->getCurrentSite()->handle);
 
         if (App::devMode()) {
             Craft::debug([
@@ -493,6 +507,25 @@ class UrlManager extends \yii\web\UrlManager
                 'statusCode' => 302,
             ],
         ];
+    }
+
+    /**
+     * Returns the route for `.well-known/passkey-endpoints` requests, per
+     * https://www.w3.org/TR/passkey-endpoints/.
+     *
+     * @return array
+     */
+    private function _passkeyEndpointsRoute(): array
+    {
+        if (App::devMode()) {
+            Craft::debug([
+                'rule' => 'Discoverable passkey endpoints',
+                'match' => true,
+                'parent' => null,
+            ], __METHOD__);
+        }
+
+        return ['well-known/passkey-endpoints'];
     }
 
     /**

--- a/tests/functional/WellKnownCest.php
+++ b/tests/functional/WellKnownCest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace crafttests\functional;
+
+use FunctionalTester;
+
+/**
+ * Tests `.well-known/*` discoverable URLs.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.11.0
+ */
+class WellKnownCest
+{
+    /**
+     * @param FunctionalTester $I
+     */
+    public function testPasskeyEndpoints(FunctionalTester $I)
+    {
+        $I->amOnPage('/.well-known/passkey-endpoints');
+        $I->seeResponseCodeIs(200);
+        $I->assertSame('{}', $I->grabPageSource());
+    }
+}


### PR DESCRIPTION
### Description

Adds basic support for the [`.well-known/passkey-endpoints`](https://www.w3.org/TR/passkey-endpoints/) well-known URL, to advertise that Craft supports passkeys.

The endpoint only returns `{}`, as passkey enrollment/management happens in the control panel, and we don’t want to publicly reveal the control panel URL.

### Related issues

- Resolves #19344