### PR TITLE
[6.x] Fix cpcompat asset build

### DIFF
--- a/packages/craftcms-legacy/cpcompat/src/component-select-input.js
+++ b/packages/craftcms-legacy/cpcompat/src/component-select-input.js
@@ -23,7 +23,8 @@
  * jQuery via blocking scripts) is registered ahead of this file, so those
  * globals are present when this evaluates.
  *
- * Loaded CP-wide via CraftCms\Yii2Adapter\View\LegacyAssets\CpCompatAsset.
+ * Compiled into the legacy asset package and loaded CP-wide via
+ * CraftCms\Yii2Adapter\View\LegacyAssets\CpCompatAsset.
  */
 (function () {
   'use strict';
@@ -276,7 +277,9 @@
         }
 
         $components.on('keydown', (ev) => {
-          if ([Garnish.BACKSPACE_KEY, Garnish.DELETE_KEY].includes(ev.keyCode)) {
+          if (
+            [Garnish.BACKSPACE_KEY, Garnish.DELETE_KEY].includes(ev.keyCode)
+          ) {
             ev.stopPropagation();
             ev.preventDefault();
             const $selected = this.componentSelect.getSelectedItems();

--- a/packages/craftcms-legacy/cpcompat/src/cp-compat.js
+++ b/packages/craftcms-legacy/cpcompat/src/cp-compat.js
@@ -5,7 +5,8 @@
  * uses them; each shim below keeps third-party callers working while logging a
  * deprecation warning. Add future plugin shims to this file.
  *
- * Loaded CP-wide via CraftCms\Yii2Adapter\View\LegacyAssets\CpCompatAsset.
+ * Compiled into the legacy asset package and loaded CP-wide via
+ * CraftCms\Yii2Adapter\View\LegacyAssets\CpCompatAsset.
  */
 (function () {
   'use strict';

--- a/packages/craftcms-legacy/cpcompat/webpack.config.js
+++ b/packages/craftcms-legacy/cpcompat/webpack.config.js
@@ -1,0 +1,16 @@
+/* jshint esversion: 6 */
+/* globals module, require */
+const {getConfig} = require('@craftcms/webpack');
+
+module.exports = getConfig({
+  context: __dirname,
+  config: {
+    entry: {
+      'component-select-input': './component-select-input.js',
+      'cp-compat': './cp-compat.js',
+    },
+    output: {
+      path: __dirname + '/../../../cms-assets/resources/legacy/cpcompat/dist',
+    },
+  },
+});

--- a/resources/js/modules/component-select/README.md
+++ b/resources/js/modules/component-select/README.md
@@ -97,8 +97,8 @@ render `<craft-component-select>` instead of calling
 
 Core no longer instantiates `Craft.ComponentSelectInput` — every core CP
 surface renders `<craft-component-select>`. The legacy class no longer ships in
-the craftcms-legacy bundle either; it was relocated verbatim to
-`yii2-adapter/legacy/web/assets/cpcompat/component-select-input.js` (a real
+the main craftcms-legacy CP bundle either; it was relocated verbatim to
+`packages/craftcms-legacy/cpcompat/src/component-select-input.js` (a real
 implementation, not a warn stub) purely so the `componentSelect.twig` `jsClass`
 escape hatch keeps booting plugin subclasses. See that file and `CpCompatAsset`.
 

--- a/yii2-adapter/src/View/LegacyAssets/CpCompatAsset.php
+++ b/yii2-adapter/src/View/LegacyAssets/CpCompatAsset.php
@@ -16,14 +16,14 @@ use function CraftCms\Cms\craftAsset;
  *
  * Core no longer uses these plugins; the shims exist so third-party code that
  * still calls them keeps working, while logging a deprecation warning. The
- * shims live in legacy/web/assets/cpcompat/cp-compat.js (published to
- * public/vendor/craft/adapter/cpcompat). Loaded CP-wide via {@see RegisterLegacyCompatAssets}.
+ * shims live in the craftcms-legacy cpcompat bundle. Loaded CP-wide via
+ * {@see RegisterLegacyCompatAssets}.
  *
  * component-select-input.js is a related but distinct case: the real (not
- * stubbed) legacy `Craft.ComponentSelectInput` implementation, relocated here
- * so the core bundle can drop it while the `componentSelect.twig` `jsClass`
- * escape hatch keeps working for plugin subclasses. It defines its class at
- * top-level eval, so it is registered ahead of cp-compat.js.
+ * stubbed) legacy `Craft.ComponentSelectInput` implementation, relocated into
+ * that bundle so the core CP bundle can drop it while the `componentSelect.twig`
+ * `jsClass` escape hatch keeps working for plugin subclasses. It defines its
+ * class at top-level eval, so it is registered ahead of cp-compat.js.
  *
  * @internal
  */
@@ -33,7 +33,7 @@ class CpCompatAsset implements LegacyAssetInterface
 
     public function register(HtmlStack $htmlStack): void
     {
-        $htmlStack->jsFile(craftAsset('adapter/cpcompat/component-select-input.js'));
-        $htmlStack->jsFile(craftAsset('adapter/cpcompat/cp-compat.js'));
+        $htmlStack->jsFile(craftAsset('legacy/cpcompat/dist/component-select-input.js'));
+        $htmlStack->jsFile(craftAsset('legacy/cpcompat/dist/cp-compat.js'));
     }
 }

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -245,10 +245,6 @@ class Yii2ServiceProvider extends ServiceProvider
         $this->app->make(Router::class)->pushMiddlewareToGroup('craft.web', HandleYiiSiteRouteFallback::class);
         $this->app->make(Router::class)->pushMiddlewareToGroup('craft.cp', RegisterLegacyCompatAssets::class);
 
-        $this->publishes([
-            __DIR__ . '/../legacy/web/assets/cpcompat' => public_path('vendor/craft/adapter/cpcompat'),
-        ], ['craftcms', 'craftcms-assets']);
-
         $this->commands([
             AddCategoriesSupportCommand::class,
             AddGlobalSetsSupportCommand::class,


### PR DESCRIPTION
### Description

Moves the CP compatibility JavaScript sources into the legacy asset build and updates the adapter to load the compiled assets from `resources/legacy`.