### PR TITLE
Group the Matrix block action menu’s “Add … above” items by entry type group

### DIFF
--- a/src/templates/_components/fieldtypes/Matrix/block.twig
+++ b/src/templates/_components/fieldtypes/Matrix/block.twig
@@ -143,19 +143,34 @@
   }) %}
 {% endif %}
 
-{% set actionMenuItems = actionMenuItems|push({hr: true}) %}
-
 {% if not staticEntries %}
-  {% for entryType in entryTypes %}
-    {% set actionMenuItems = actionMenuItems|push({
+  {% set groupedEntryTypes = collect(entryTypes).groupBy(et => (et.group ?? 'General'|t('app'))) %}
+  {% if groupedEntryTypes.count() > 1 %}
+    {% set actionMenuItems = actionMenuItems|merge(groupedEntryTypes.map((entryTypes, group) => [
+      {hr: true, padded: false},
+      {
+        heading: group|t('site'),
+        padded: false,
+        items: entryTypes|map(entryType => {
+          icon: entryType.icon ?? 'plus',
+          color: entryType.color,
+          label: 'Add {type} above'|t('app', {type: entryType.name|t('site')}),
+          attributes: {
+            data: {action: 'add', type: entryType.handle},
+          },
+        }),
+      },
+    ]).flatten(1).all()) %}
+  {% else %}
+    {% set actionMenuItems = actionMenuItems|push({hr: true})|merge(entryTypes|map(entryType => {
       icon: entryType.icon ?? 'plus',
       color: entryType.color,
       label: 'Add {type} above'|t('app', {type: entryType.name|t('site')}),
       attributes: {
         data: {action: 'add', type: entryType.handle},
       },
-    }) %}
-  {% endfor %}
+    })) %}
+  {% endif %}
 {% endif %}
 
 {% namespace baseInputName %}

--- a/src/templates/_components/fieldtypes/Matrix/block.twig
+++ b/src/templates/_components/fieldtypes/Matrix/block.twig
@@ -273,6 +273,7 @@
       <div class="checkbox" title="{{ 'Select'|t('app') }}" aria-label="{{ 'Select'|t('app') }}" tabindex="0" role="checkbox" aria-checked="false"></div>
       {{ disclosureMenu(actionMenuItems, {
         hiddenLabel: 'Actions'|t('app'),
+        withSearchInput: not staticEntries and entryTypes|length > 5,
         buttonAttributes: {
           class: ['action-btn', 'small'],
           title: 'Actions'|t('app'),


### PR DESCRIPTION
### Description

Fixes #17594.

In the `blocks` view mode, each Matrix block’s action menu appends one “Add {type} above” item per entry type, in one flat list — also reported in #17594. We have Matrix fields with 35+ entry types, and the menu becomes a long scrolling list where the only way to find a type is to read every row.

The field’s “+” button already solves this: `create-button.twig` groups the same entry types by their entry type group and shows a search input above five types. This PR brings the block action menu in line with it:

1. **Group the “Add {type} above” items by entry type group** — same `collect().groupBy()` and `{hr, padded: false}` / `{heading, padded: false, items}` structure as `create-button.twig`. Fields with a single group (or no groups set) render exactly as before.
2. **Show a search input above five entry types** (`withSearchInput: not staticEntries and entryTypes|length > 5`), same threshold as the create button. The search filters *all* menu items (Collapse, Delete, …), like other searchable disclosure menus — it’s a separate commit so it can be dropped if that’s not wanted.

Drive-by: the trailing `{hr: true}` is now only added when add items follow, removing a dangling separator at the end of the menu for static blocks (e.g. revision view).

### Testing

- 20 entry types across 6 groups: headings and separators render in field-settings order; activating a grouped item still inserts the block above it; arrow-key navigation skips headings.
- Searching narrows the menu and hides emptied group headings; activating a filtered item works.
- Single group / no groups set: unchanged flat menu.
- Revision view (`staticEntries`): no add items, no search input, no trailing separator.
- `maxEntries` reached: `DisclosureMenu.updateVisibility()` hides the emptied groups including their headings.
