### PR TITLE
only order by fixed order if we have any ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 5
 
+## Unreleased
+
+- Fixed a SQL error that could occur when viewing an element with an empty Categories field. ([#19372](https://github.com/craftcms/cms/issues/19372))
+
 ## 5.10.13.1 - 2026-08-04
 
 - Fixed a bug where sanitized SVGs wouldn’t render. ([#19368](https://github.com/craftcms/cms/issues/19368))

--- a/src/fields/Categories.php
+++ b/src/fields/Categories.php
@@ -133,7 +133,9 @@ class Categories extends BaseRelationField
 
                     $finalIds = array_map(fn(Category $category) => $category->id, $categories);
                     $query->where(['elements.id' => $finalIds]);
-                    $query->orderBy([new FixedOrderExpression('elements.id', $finalIds, Craft::$app->getDb())]);
+                    if (!empty($finalIds)) {
+                        $query->orderBy([new FixedOrderExpression('elements.id', $finalIds, Craft::$app->getDb())]);
+                    }
                 },
             ]));
         }


### PR DESCRIPTION
### Description
When normalising the Categories field, we only want to order by fixed order if we have any IDs to order by in the first place.

(The `BaseRelationField` already has this check in place: https://github.com/craftcms/cms/blob/5.10.13.1/src/fields/BaseRelationField.php#L785-L787)

### Related issues
#19372 
