### PR TITLE
Add missing WidgetInterface bridge methods to legacy Widget base class

### DIFF
--- a/yii2-adapter/legacy/base/Widget.php
+++ b/yii2-adapter/legacy/base/Widget.php
@@ -74,6 +74,38 @@ abstract class Widget extends SavableComponent implements \CraftCms\Cms\Dashboar
     /**
      * @inheritdoc
      */
+    public function getType(): string
+    {
+        return static::class;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getIcon(): ?string
+    {
+        return static::icon();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDisplayName(): string
+    {
+        return static::displayName();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMaxColspan(): ?int
+    {
+        return static::maxColspan();
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function defineRules(): array
     {
         $rules = parent::defineRules();


### PR DESCRIPTION
The legacy craft\base\Widget adapter implemented WidgetInterface but never got getType(), getIcon(), getDisplayName(), and getMaxColspan(), unlike the new native Widget base class. Any legacy-style widget errored on instantiation.

## Related issues

- Fixes #19369

