### PR TITLE
[6.x] Fix Yii-style migration resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 6
 
+## Unreleased
+
+- Fixed a bug where Yii-style migrations could be required twice. ([#19376](https://github.com/craftcms/cms/pull/19376))
+
 ## 6.0.0-alpha.15 - 2026-08-04
 
 - Added support for Markdown-based custom Dashboard widgets in the application's `resources/widgets/` directory. ([#19319](https://github.com/craftcms/cms/pull/19319))

--- a/yii2-adapter/src/Database/Migrator.php
+++ b/yii2-adapter/src/Database/Migrator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Yii2Adapter\Database;
+
+use CraftCms\Cms\Database\Migration;
+use CraftCms\Cms\Database\Migrator as CoreMigrator;
+use Override;
+use ReflectionClass;
+
+class Migrator extends CoreMigrator
+{
+    #[Override]
+    protected function resolvePath(string $path): object
+    {
+        $migrationName = $this->getMigrationName($path);
+        $realPath = realpath($path);
+
+        foreach (array_reverse(get_declared_classes()) as $class) {
+            if ($class !== $migrationName && !str_ends_with($class, "\\$migrationName")) {
+                continue;
+            }
+
+            if ($realPath !== new ReflectionClass($class)->getFileName()) {
+                continue;
+            }
+
+            return is_a($class, Migration::class, true)
+                ? app()->make($class)
+                : new MigrationWrapper($class);
+        }
+
+        return parent::resolvePath($path);
+    }
+}

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -13,6 +13,8 @@ use CraftCms\Cms\Asset\AssetFileKinds;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Cp\Settings;
 use CraftCms\Cms\Database\LaravelMigrations;
+use CraftCms\Cms\Database\MigrationRepository;
+use CraftCms\Cms\Database\Migrator as CoreMigrator;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Field\Events\FieldCachesInvalidated;
 use CraftCms\Cms\Gql\Gql;
@@ -42,6 +44,7 @@ use CraftCms\Yii2Adapter\Console\MigrateMigrationTableCommand;
 use CraftCms\Yii2Adapter\Console\MigrateSessionsTableCommand;
 use CraftCms\Yii2Adapter\Console\RepairCategoryGroupStructureCommand;
 use CraftCms\Yii2Adapter\Cp\LegacySettings;
+use CraftCms\Yii2Adapter\Database\Migrator;
 use CraftCms\Yii2Adapter\Filesystem\FilesystemCompatibility;
 use CraftCms\Yii2Adapter\Gql\LegacyGql;
 use CraftCms\Yii2Adapter\Gql\LegacyGqlArguments;
@@ -62,6 +65,7 @@ use CraftCms\Yii2Adapter\User\LegacyUserPermissions;
 use CraftCms\Yii2Adapter\Utility\LegacyUtilityTypes;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Artisan;
@@ -84,6 +88,12 @@ class Yii2ServiceProvider extends ServiceProvider
     #[Override]
     public function register(): void
     {
+        $this->app->bind(CoreMigrator::class, Migrator::class);
+        $this->app
+            ->when(Migrator::class)
+            ->needs(MigrationRepositoryInterface::class)
+            ->give(fn() => $this->app->make(MigrationRepository::class, ['table' => Table::MIGRATIONS]));
+
         new ClassAliases()->register();
         new MultiEnvironmentConfigCompatibility()->register($this->app);
 

--- a/yii2-adapter/tests-laravel/Legacy/Database/MigratorTest.php
+++ b/yii2-adapter/tests-laravel/Legacy/Database/MigratorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Database\MigrationRepository;
+use CraftCms\Cms\Database\Migrator as CoreMigrator;
+use CraftCms\Yii2Adapter\Database\MigrationWrapper;
+use CraftCms\Yii2Adapter\Database\Migrator;
+use Illuminate\Database\Migrations\Migrator as IlluminateMigrator;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+
+afterEach(function() {
+    File::delete(storage_path('m260226_120000_product_type_permissions.php'));
+});
+
+it('resolves a loaded Yii-style migration without requiring it again', function() {
+    $path = storage_path('m260226_120000_product_type_permissions.php');
+    File::put($path, <<<'PHP'
+        <?php
+
+        namespace CraftCms\Yii2Adapter\Tests\Fixtures;
+
+        class m260226_120000_product_type_permissions {}
+        PHP);
+
+    $filesystem = Mockery::mock(Filesystem::class)->makePartial();
+    $filesystem->shouldReceive('getRequire')->andReturn(new stdClass());
+
+    $migrator = app(CoreMigrator::class);
+    new ReflectionProperty(IlluminateMigrator::class, 'files')->setValue($migrator, $filesystem);
+
+    $migrator->requireFiles([$path]);
+
+    $resolvePath = new ReflectionMethod(Migrator::class, 'resolvePath');
+    $migration = $resolvePath->invoke($migrator, $path);
+
+    $filesystem->shouldNotHaveReceived('getRequire');
+
+    expect($migrator)->toBeInstanceOf(Migrator::class);
+    expect($migrator->getRepository())->toBeInstanceOf(MigrationRepository::class);
+    expect($migration)->toBeInstanceOf(MigrationWrapper::class);
+});


### PR DESCRIPTION
### Description

Fixes Yii-style migrations being required twice by resolving already-loaded migration classes through the Yii2 adapter migrator and wrapping legacy migrations with the existing compatibility wrapper.