### PR TITLE
[6.x] Initial port of the entry edit page to Inertia

### DIFF
--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+  import {t} from '@craftcms/ui';
+  import DynamicHtmlRenderer from '@/common/components/DynamicHtmlRenderer.vue';
+  import LayoutSlot from '@/common/components/LayoutSlot.vue';
+  import Pane from '@/common/components/Pane.vue';
+  import {useAppLayout} from '@/common/composables/useAppLayout';
+  import FormRenderer from '@/modules/forms/FormRenderer.vue';
+  import {useElementEditPage} from '@/modules/elements/composables/useElementEditPage';
+
+  const props = defineProps<{
+    /**
+     * Identity attributes merged into every submission — the one per-type
+     * piece of the pipeline (e.g. an entry's `entryId`/`sectionId`).
+     */
+    saveData?: () => Record<string, unknown>;
+  }>();
+
+  const {
+    errors,
+    form,
+    formPayload,
+    onMutation,
+    props: payload,
+    renderer,
+    save,
+    sidebarEl,
+  } = useElementEditPage({saveData: props.saveData});
+
+  useAppLayout(() => ({
+    title: payload.title,
+    form,
+    onSave: save,
+  }));
+</script>
+
+<template>
+  <!--
+    Tabs are rendered by `FormNodeList` inside the form itself, and header
+    actions come through `useAppLayout`'s form-action props — filling the
+    `actions` layout slot here would replace the layout's own save button.
+  -->
+  <Pane appearance="raised">
+    <craft-callout v-if="payload.readOnly" variant="neutral" icon="lock">
+      {{ t('This is a read-only view.') }}
+    </craft-callout>
+
+    <FormRenderer
+      v-if="formPayload"
+      ref="renderer"
+      :payload="formPayload"
+      :errors="errors"
+      @update:mutation="onMutation"
+    />
+
+    <slot :payload="payload" />
+  </Pane>
+
+  <LayoutSlot v-if="payload.sidebarHtml || payload.metadataHtml" name="details">
+    <!--
+      The meta fields are still server-rendered; `useElementEditPage` reads
+      their inputs out of this container at submit time.
+    -->
+    <div ref="sidebarEl">
+      <DynamicHtmlRenderer
+        v-if="payload.sidebarHtml"
+        :html="payload.sidebarHtml"
+      />
+    </div>
+
+    <DynamicHtmlRenderer
+      v-if="payload.metadataHtml"
+      :html="payload.metadataHtml"
+    />
+  </LayoutSlot>
+</template>

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -1,0 +1,159 @@
+import {useEventListener} from '@vueuse/core';
+import {router, useForm, usePage} from '@inertiajs/vue3';
+import {t} from '@craftcms/ui';
+import {computed, onBeforeUnmount, ref} from 'vue';
+import {expandFormData} from '@/common/utils/forms';
+import type {FormPayload} from '@/modules/forms/types';
+import {useInertiaFormRenderer} from '@/modules/forms/useInertiaFormRenderer';
+import {useSettingsSave} from '@/modules/settings/composables/useSettingsSave';
+
+/** The shared payload every {@link ElementEditViewModel} emits. */
+export interface ElementEditPayload {
+  elementId: number | null;
+  canonicalId: number | null;
+  elementType: string;
+  siteId: number | null;
+  fieldLayoutId: number | null;
+  title: string;
+  docTitle: string;
+  crumbs: Array<Record<string, any>>;
+  readOnly: boolean;
+  form: FormPayload | null;
+  sidebarHtml: string | null;
+  metadataHtml: string | null;
+  saveUrl: string;
+  // Element-type view models add their own keys on top of the shared payload.
+  [key: string]: unknown;
+}
+
+interface Options {
+  /**
+   * Identity and element-type attributes merged into every submission —
+   * whatever the type's save action needs to resolve the element it's saving.
+   */
+  saveData?: () => Record<string, unknown>;
+}
+
+/**
+ * Drives an element edit screen: bridges the compiled field layout into an
+ * Inertia form, collects the still-server-rendered sidebar meta fields, and
+ * owns the unsaved-changes guard and saving. Tabs belong to `FormRenderer`.
+ *
+ * Element-type pages supply only what their save action needs via
+ * {@link Options.saveData}; everything else comes from the shared payload.
+ */
+export function useElementEditPage({saveData}: Options = {}) {
+  const page = usePage<ElementEditPayload>();
+  const props = page.props;
+
+  const formPayload = computed(() => props.form);
+  const form = useForm<Record<string, any>>({});
+
+  const {advanceBaseline, errors, onMutation, renderer, values} =
+    useInertiaFormRenderer(form, formPayload);
+
+  // The meta fields (entry type, slug, parent, post date, …) are still
+  // server-rendered HTML, so their values are read out of the DOM at submit
+  // time rather than tracked as Inertia form state.
+  const sidebarEl = ref<HTMLElement | null>(null);
+
+  function sidebarData(): Record<string, unknown> {
+    const root = sidebarEl.value;
+
+    if (!root) {
+      return {};
+    }
+
+    const data = new FormData();
+
+    for (const input of root.querySelectorAll<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >('input[name], select[name], textarea[name]')) {
+      if (
+        (input instanceof HTMLInputElement &&
+          (input.type === 'checkbox' || input.type === 'radio') &&
+          !input.checked) ||
+        input.disabled
+      ) {
+        continue;
+      }
+
+      data.append(input.name, input.value);
+    }
+
+    return expandFormData(data);
+  }
+
+  const {save} = useSettingsSave(
+    form,
+    () => ({
+      url: props.saveUrl,
+      method: 'post' as const,
+    }),
+    {
+      transform: (data) => ({
+        ...data,
+        ...sidebarData(),
+        ...saveData?.(),
+      }),
+      onSuccess: advanceBaseline,
+    }
+  );
+
+  // Unsaved-changes guard. The field layout is tracked by Inertia's own dirty
+  // state; the sidebar island is compared against a baseline captured on first
+  // interaction, since it injects asynchronously.
+  let sidebarBaseline: string | null = null;
+
+  function captureSidebarBaseline(): void {
+    sidebarBaseline ??= JSON.stringify(sidebarData());
+  }
+
+  function hasUnsavedChanges(): boolean {
+    if (form.processing) {
+      return false;
+    }
+
+    return (
+      form.isDirty ||
+      (sidebarBaseline !== null &&
+        JSON.stringify(sidebarData()) !== sidebarBaseline)
+    );
+  }
+
+  useEventListener(sidebarEl, 'focusin', captureSidebarBaseline);
+  useEventListener(sidebarEl, 'pointerdown', captureSidebarBaseline);
+
+  useEventListener(window, 'beforeunload', (event) => {
+    if (hasUnsavedChanges()) {
+      event.preventDefault();
+    }
+  });
+
+  const removeNavigationGuard = router.on('before', (event) => {
+    const visit = event.detail.visit;
+
+    if (
+      visit.method === 'get' &&
+      !visit.prefetch &&
+      hasUnsavedChanges() &&
+      !window.confirm(t('Any changes will be lost if you leave this page.'))
+    ) {
+      event.preventDefault();
+    }
+  });
+
+  onBeforeUnmount(removeNavigationGuard);
+
+  return {
+    errors,
+    form,
+    formPayload,
+    onMutation,
+    props,
+    renderer,
+    save,
+    sidebarEl,
+    values,
+  };
+}

--- a/resources/js/pages/content/Edit.vue
+++ b/resources/js/pages/content/Edit.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+  import ElementEditPage from '@/modules/elements/components/ElementEditPage.vue';
+
+  // The shared edit payload comes from the ElementEditPage pipeline; only the
+  // Entry-specific keys (EntryEditViewModel) remain props.
+  const props = defineProps<{
+    saveId: number | null;
+    siteId: number | null;
+    entryTypeId: number | null;
+    sectionHandle: string | null;
+  }>();
+
+  // What `entries/save-entry` needs to resolve the entry it's saving. The
+  // field layout and meta fields are collected by the pipeline itself.
+  const saveData = () => ({
+    entryId: props.saveId,
+    siteId: props.siteId,
+    typeId: props.entryTypeId,
+  });
+</script>
+
+<template>
+  <ElementEditPage :save-data="saveData" />
+</template>

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -19,6 +19,7 @@ use CraftCms\Cms\Http\Controllers\Elements\ElementRedirectController;
 use CraftCms\Cms\Http\Controllers\Elements\ElementRevisionsController;
 use CraftCms\Cms\Http\Controllers\Elements\PreviewElementController;
 use CraftCms\Cms\Http\Controllers\Entries\CreateEntryController;
+use CraftCms\Cms\Http\Controllers\Entries\EditEntryController;
 use CraftCms\Cms\Http\Controllers\Entries\EntriesIndexController;
 use CraftCms\Cms\Http\Controllers\FieldsController;
 use CraftCms\Cms\Http\Controllers\Gql\GraphiqlController;
@@ -183,8 +184,8 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
         'page' => '[^\/]+',
     ]);
     Route::get('assets/edit/{id}{slug}', EditElementController::class)->where($idSlugParams);
-    Route::get('entries/{section}/{id}{slug?}', EditElementController::class)->where($idSlugParams);
-    Route::get('content/{page}/{section}/{id}{slug?}', EditElementController::class)->where([
+    Route::get('entries/{section}/{id}{slug?}', EditEntryController::class)->where($idSlugParams);
+    Route::get('content/{page}/{section}/{id}{slug?}', EditEntryController::class)->where([
         ...$idSlugParams,
         'page' => '[^\/]+',
     ]);

--- a/src/Http/Controllers/Entries/EditEntryController.php
+++ b/src/Http/Controllers/Entries/EditEntryController.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http\Controllers\Entries;
+
+use CraftCms\Cms\Entry\Elements\Entry;
+use CraftCms\Cms\Http\Controllers\Elements\Concerns\SavesElement;
+use CraftCms\Cms\Http\Controllers\Elements\EditElementController;
+use CraftCms\Cms\Http\Requests\ElementRequest;
+use CraftCms\Cms\Http\Responses\CpScreenResponse;
+use CraftCms\Cms\Http\ViewModels\EntryEditViewModel;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Renders the Inertia entry edit screen.
+ *
+ * Drafts and revisions still fall through to the legacy
+ * {@see EditElementController}, which keeps their notices, apply/revert
+ * controls, and canonical-change merging intact until those screens are ported.
+ * The legacy controller also continues to serve slideouts and the element types
+ * that haven't been ported yet.
+ */
+class EditEntryController
+{
+    use SavesElement;
+
+    public function __construct(
+        protected readonly ElementRequest $request,
+    ) {}
+
+    public function __invoke(): Response|CpScreenResponse|InertiaResponse
+    {
+        $element = $this->request->element(
+            ['id' => $this->request->route('id') ?? $this->request->integer('elementId')],
+            checkForProvisionalDraft: true,
+            strictSite: false,
+        );
+
+        if ($element instanceof Response) {
+            return $element;
+        }
+
+        if (! $element instanceof Entry) {
+            abort(400, 'No entry was identified by the request.');
+        }
+
+        // Visiting a canonical entry resolves to the author's provisional draft
+        // when one exists, so this covers provisional drafts too.
+        if ($element->getIsDraft() || $element->getIsRevision()) {
+            return app(EditElementController::class)->setElement($element)();
+        }
+
+        $this->applyParamsToElement($element);
+
+        return Inertia::render('content/Edit', new EntryEditViewModel(
+            entry: $element,
+            request: $this->request,
+            canSave: $this->canSave($element, $this->request->craftUser()),
+        ));
+    }
+}

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http\ViewModels;
+
+use CraftCms\Cms\Cp\Html\ContentHtml;
+use CraftCms\Cms\Element\Contracts\ElementInterface;
+use CraftCms\Cms\FieldLayout\FieldLayoutCompiler;
+use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\FormPayload;
+use CraftCms\Cms\Http\Controllers\Elements\Concerns\EditsElement;
+use CraftCms\Cms\Http\Controllers\Elements\Concerns\ElementCrumbs;
+use CraftCms\Cms\Http\Requests\ElementRequest;
+use CraftCms\Cms\Support\Facades\DeltaRegistry;
+use CraftCms\Cms\Support\Url;
+
+/**
+ * The shared Inertia payload for an element edit screen.
+ *
+ * The element's field layout is compiled to a {@see FormPayload} through the
+ * same {@see FieldLayoutCompiler} the legacy editor and the slideouts use, so
+ * both renderers stay in sync; everything page-shaped (titles, crumbs, the save
+ * target, and the sidebar islands) lives here. Tabs belong to the Form renderer.
+ *
+ * Element-type view models extend this with their own payload keys (public
+ * methods) and supply their save route via {@see saveUrl()} — e.g. entries
+ * post to the entry store action, assets to their own.
+ *
+ * Public methods are payload keys (see {@see ViewModel}); shared intermediates
+ * (the compiled form) are memoized privately since payload methods may be
+ * invoked in any order.
+ */
+abstract class ElementEditViewModel extends ViewModel
+{
+    use EditsElement;
+
+    // Aliased so the payload key below can keep the `crumbs` name without
+    // shadowing the trait's element-crumb builder.
+    use ElementCrumbs {
+        crumbs as protected elementCrumbs;
+    }
+
+    private ?FormPayload $form = null;
+
+    private bool $formResolved = false;
+
+    public function __construct(
+        protected readonly ElementInterface $element,
+        ElementRequest $request,
+        protected readonly bool $canSave = true,
+    ) {
+        $this->request = $request;
+    }
+
+    /**
+     * Where the edit form posts. Element types point this at their own store
+     * action — the Form payload submits ordinary nested input names, so the
+     * existing save controllers read it without a translation layer.
+     */
+    abstract public function saveUrl(): string;
+
+    public function elementId(): ?int
+    {
+        return $this->element->id;
+    }
+
+    public function canonicalId(): ?int
+    {
+        return $this->element->getCanonical(true)->id;
+    }
+
+    /** @return class-string<ElementInterface> */
+    public function elementType(): string
+    {
+        return $this->element::class;
+    }
+
+    public function siteId(): ?int
+    {
+        return $this->element->siteId;
+    }
+
+    public function fieldLayoutId(): ?int
+    {
+        return $this->element->fieldLayoutId;
+    }
+
+    public function title(): string
+    {
+        return $this->editElementTitles($this->element)[1];
+    }
+
+    public function docTitle(): string
+    {
+        return $this->editElementTitles($this->element)[0];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function crumbs(): array
+    {
+        return array_map(function (array $crumb): array {
+            if (isset($crumb['url'])) {
+                $crumb['url'] = Url::cpUrl($crumb['url']);
+            }
+
+            return $crumb;
+        }, $this->elementCrumbs($this->element));
+    }
+
+    public function readOnly(): bool
+    {
+        return ! $this->canSave;
+    }
+
+    /**
+     * The compiled field layout. `null` when the element has no field layout —
+     * the page then renders its sidebar islands alone.
+     */
+    public function form(): ?FormPayload
+    {
+        if ($this->formResolved) {
+            return $this->form;
+        }
+
+        $this->formResolved = true;
+        $fieldLayout = $this->element->getFieldLayout();
+
+        if ($fieldLayout === null) {
+            return $this->form = null;
+        }
+
+        // Delta tracking stays active so the compiled payload carries the same
+        // initial values the autosave path compares against later in the stack.
+        return $this->form = DeltaRegistry::withActive(true, fn () => app(FieldLayoutCompiler::class)->compile(
+            $fieldLayout,
+            $this->element,
+            new FormContext(
+                namespace: [],
+                errors: $this->element->errors()->getMessages(),
+                mode: $this->canSave ? ControlMode::Editable : ControlMode::ReadOnly,
+                refreshable: true,
+            ),
+        ));
+    }
+
+    /**
+     * The element's meta fields (entry type, slug, parent, post date, …).
+     *
+     * These are still rendered by the legacy `metaFieldsHtml()` PHP surface, so
+     * the page mounts them as an HTML island and reads their inputs at submit
+     * time. Porting them onto Form Controls is a follow-up.
+     */
+    public function sidebarHtml(): ?string
+    {
+        $html = trim((string) $this->element->getSidebarHtml(! $this->canSave));
+
+        return $html !== '' ? $html : null;
+    }
+
+    public function metadataHtml(): ?string
+    {
+        return $this->element->id
+            ? app(ContentHtml::class)->metadataHtml($this->element->getMetadata())
+            : null;
+    }
+}

--- a/src/Http/ViewModels/EntryEditViewModel.php
+++ b/src/Http/ViewModels/EntryEditViewModel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http\ViewModels;
+
+use CraftCms\Cms\Entry\Elements\Entry;
+use CraftCms\Cms\Http\Requests\ElementRequest;
+use CraftCms\Cms\Support\Url;
+use Override;
+
+/**
+ * The Inertia payload for the entry edit screen (`content/Edit`).
+ */
+class EntryEditViewModel extends ElementEditViewModel
+{
+    public function __construct(
+        private readonly Entry $entry,
+        ElementRequest $request,
+        bool $canSave = true,
+    ) {
+        parent::__construct($entry, $request, $canSave);
+    }
+
+    #[Override]
+    public function saveUrl(): string
+    {
+        return Url::actionUrl('entries/save-entry');
+    }
+
+    public function sectionHandle(): ?string
+    {
+        return $this->entry->getSection()?->handle;
+    }
+
+    public function entryTypeId(): ?int
+    {
+        return $this->entry->typeId;
+    }
+
+    /**
+     * The canonical id the save action expects, so an edit of a draft or a
+     * revision posts against the entry it derives from rather than its own id.
+     */
+    public function saveId(): ?int
+    {
+        return $this->entry->getIsDraft() || $this->entry->getIsRevision()
+            ? $this->entry->getCanonicalId()
+            : $this->entry->id;
+    }
+}

--- a/tests/Feature/Http/Controllers/Elements/EditElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/EditElementControllerTest.php
@@ -22,6 +22,7 @@ use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use Illuminate\Testing\Fluent\AssertableJson;
+use Inertia\Testing\AssertableInertia;
 
 use function CraftCms\Cms\cp_url;
 use function CraftCms\Cms\t;
@@ -132,10 +133,15 @@ it('renders the current entry edit screen for each control panel route', functio
 
     get($route($entry))
         ->assertOk()
-        ->assertSeeText('Current Title')
-        ->assertSee('data-form-tab="entry-content"', false)
-        ->assertSeeText('Create a draft')
-        ->assertSee('elements/save', false);
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('content/Edit')
+            ->where('title', 'Current Title')
+            ->where('elementId', $entry->id)
+            ->where('readOnly', false)
+            ->where('saveUrl', fn (string $url) => str_contains($url, 'entries/save-entry'))
+            ->has('form.nodes')
+            ->has('sidebarHtml')
+        );
 })->with('editElementEntryRoutes');
 
 it('renders the asset edit screen', function () {

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Element\Drafts;
+use CraftCms\Cms\Element\Revisions;
+use CraftCms\Cms\Entry\Elements\Entry;
+use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Entry\Models\EntryType;
+use CraftCms\Cms\FieldLayout\FieldLayout;
+use CraftCms\Cms\FieldLayout\FieldLayoutTab;
+use CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField;
+use CraftCms\Cms\FieldLayout\Models\FieldLayout as FieldLayoutModel;
+use CraftCms\Cms\Section\Models\Section;
+use CraftCms\Cms\Support\Facades\Elements;
+use CraftCms\Cms\User\Elements\User;
+use Illuminate\Support\Collection;
+use Inertia\Testing\AssertableInertia;
+
+use function CraftCms\Cms\cp_url;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    actingAs(User::findOne());
+
+    $layout = FieldLayout::make(Entry::class)
+        ->tab('Content', fn (FieldLayoutTab $tab) => $tab->add(new EntryTitleField(['uid' => 'entry-title'])));
+    $config = $layout->getConfig();
+    $config['tabs'][0]['uid'] = 'entry-content';
+    $layout = FieldLayoutModel::factory()->create(['type' => Entry::class, 'config' => $config]);
+    $this->entryType = EntryType::factory()->create(['fieldLayoutId' => $layout->id]);
+    $this->section = Section::factory()->withEntryTypes($this->entryType)->create([
+        'handle' => 'news',
+        'enableVersioning' => true,
+    ]);
+    $this->entry = EntryModel::factory()
+        ->forSection($this->section)
+        ->forEntryType($this->entryType)
+        ->createElement([
+            'title' => 'Current Title',
+            'slug' => 'current-title',
+        ]);
+});
+
+it('renders the entry edit screen as an Inertia page', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('content/Edit')
+            ->where('elementId', $this->entry->id)
+            ->where('canonicalId', $this->entry->id)
+            ->where('elementType', Entry::class)
+            ->where('siteId', $this->entry->siteId)
+            ->where('title', 'Current Title')
+            ->where('sectionHandle', 'news')
+            ->where('saveId', $this->entry->id)
+            ->where('readOnly', false)
+        );
+});
+
+it('compiles the field layout into a form payload', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->has('form.nodes')
+            ->where('form.nodes', fn (Collection $nodes) => $nodes
+                ->contains(fn (array $node) => ($node['uid'] ?? null) === 'entry-content'))
+            ->etc()
+        );
+});
+
+it('points the form at the entry save action', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('saveUrl', fn (string $url) => str_contains($url, 'entries/save-entry'))
+            ->etc()
+        );
+});
+
+it('includes the meta fields and metadata as server-rendered islands', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('sidebarHtml', fn (?string $html) => is_string($html) && str_contains($html, 'name="slug"'))
+            ->where('metadataHtml', fn (?string $html) => is_string($html) && $html !== '')
+            ->etc()
+        );
+});
+
+it('falls back to the legacy editor for drafts', function () {
+    $draft = app(Drafts::class)->createDraft($this->entry, auth()->id(), name: 'Working Draft');
+
+    get(cp_url(sprintf(
+        'entries/news/%d-%s?draftId=%d',
+        $this->entry->id,
+        $this->entry->slug,
+        $draft->draftId,
+    )))
+        ->assertOk()
+        ->assertSee('elements/save-draft', false);
+});
+
+it('falls back to the legacy editor for revisions', function () {
+    $revision = Elements::getElementById(
+        app(Revisions::class)->createRevision($this->entry, auth()->id(), 'Revision notes'),
+    );
+
+    get(cp_url(sprintf(
+        'entries/news/%d-%s?revisionId=%d',
+        $this->entry->id,
+        $this->entry->slug,
+        $revision->revisionId,
+    )))
+        ->assertOk()
+        ->assertSee('elements/revert', false);
+});
+
+it('falls back to the legacy editor when a provisional draft exists', function () {
+    app(Drafts::class)->createDraft($this->entry, auth()->id(), provisional: true);
+
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertSee('elements/apply-draft', false);
+});


### PR DESCRIPTION
### Description

Ports the full-page entry edit screen to Inertia, rendering the field layout through the Form system.

`ElementEditViewModel` is the shared payload for element edit screens, mirroring `ContentIndexViewModel`: public methods are payload keys, and element types extend it with their own keys plus a `saveUrl()`. `EntryEditViewModel` and `content/Edit.vue` are the entry-specific pieces, while `useElementEditPage` and `ElementEditPage.vue` hold the shared client pipeline so the remaining element types only supply what their save action needs.

The field layout is compiled to a `FormPayload` through the same `FieldLayoutCompiler` the legacy editor and slideouts already use, and rendered by `FormRenderer`. Saving posts through Inertia to the existing `entries/save-entry` action — the Form payload submits ordinary nested input names, so the save controller reads it without a translation layer.

Drafts, revisions, and provisional drafts still fall through to `EditElementController`, keeping their notices and apply/revert controls intact until those screens are ported later in this stack. That controller also continues to serve slideouts and the element types that haven't been ported.

The sidebar meta fields remain a server-rendered island here and move onto the Form system in #19390.
