### PR TITLE
[6.x] Render element editor meta fields as a Form

### DIFF
--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -20,10 +20,13 @@
     form,
     formPayload,
     onMutation,
+    onSidebarMutation,
     props: payload,
     renderer,
     save,
-    sidebarEl,
+    sidebarErrors,
+    sidebarPayload,
+    sidebarRenderer,
   } = useElementEditPage({saveData: props.saveData});
 
   useAppLayout(() => ({
@@ -55,17 +58,18 @@
     <slot :payload="payload" />
   </Pane>
 
-  <LayoutSlot v-if="payload.sidebarHtml || payload.metadataHtml" name="details">
+  <LayoutSlot v-if="sidebarPayload || payload.metadataHtml" name="details">
     <!--
-      The meta fields are still server-rendered; `useElementEditPage` reads
-      their inputs out of this container at submit time.
+      The meta fields render as their own Form, bridged into the same Inertia
+      form as the field layout above, so they submit as ordinary inputs.
     -->
-    <div ref="sidebarEl">
-      <DynamicHtmlRenderer
-        v-if="payload.sidebarHtml"
-        :html="payload.sidebarHtml"
-      />
-    </div>
+    <FormRenderer
+      v-if="sidebarPayload"
+      ref="sidebarRenderer"
+      :payload="sidebarPayload"
+      :errors="sidebarErrors"
+      @update:mutation="onSidebarMutation"
+    />
 
     <DynamicHtmlRenderer
       v-if="payload.metadataHtml"

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -1,8 +1,7 @@
 import {useEventListener} from '@vueuse/core';
 import {router, useForm, usePage} from '@inertiajs/vue3';
 import {t} from '@craftcms/ui';
-import {computed, onBeforeUnmount, ref} from 'vue';
-import {expandFormData} from '@/common/utils/forms';
+import {computed, onBeforeUnmount} from 'vue';
 import type {FormPayload} from '@/modules/forms/types';
 import {useInertiaFormRenderer} from '@/modules/forms/useInertiaFormRenderer';
 import {useSettingsSave} from '@/modules/settings/composables/useSettingsSave';
@@ -19,7 +18,7 @@ export interface ElementEditPayload {
   crumbs: Array<Record<string, any>>;
   readOnly: boolean;
   form: FormPayload | null;
-  sidebarHtml: string | null;
+  sidebarForm: FormPayload | null;
   metadataHtml: string | null;
   saveUrl: string;
   // Element-type view models add their own keys on top of the shared payload.
@@ -47,42 +46,21 @@ export function useElementEditPage({saveData}: Options = {}) {
   const props = page.props;
 
   const formPayload = computed(() => props.form);
+  const sidebarPayload = computed(() => props.sidebarForm);
   const form = useForm<Record<string, any>>({});
 
+  // Two bridges share one Inertia form. Each only ever deletes the root keys
+  // it wrote itself, and both are constructed here — before either receives a
+  // mutation — so neither can claim the other's keys.
   const {advanceBaseline, errors, onMutation, renderer, values} =
     useInertiaFormRenderer(form, formPayload);
 
-  // The meta fields (entry type, slug, parent, post date, …) are still
-  // server-rendered HTML, so their values are read out of the DOM at submit
-  // time rather than tracked as Inertia form state.
-  const sidebarEl = ref<HTMLElement | null>(null);
-
-  function sidebarData(): Record<string, unknown> {
-    const root = sidebarEl.value;
-
-    if (!root) {
-      return {};
-    }
-
-    const data = new FormData();
-
-    for (const input of root.querySelectorAll<
-      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
-    >('input[name], select[name], textarea[name]')) {
-      if (
-        (input instanceof HTMLInputElement &&
-          (input.type === 'checkbox' || input.type === 'radio') &&
-          !input.checked) ||
-        input.disabled
-      ) {
-        continue;
-      }
-
-      data.append(input.name, input.value);
-    }
-
-    return expandFormData(data);
-  }
+  const {
+    advanceBaseline: advanceSidebarBaseline,
+    errors: sidebarErrors,
+    onMutation: onSidebarMutation,
+    renderer: sidebarRenderer,
+  } = useInertiaFormRenderer(form, sidebarPayload);
 
   const {save} = useSettingsSave(
     form,
@@ -93,36 +71,20 @@ export function useElementEditPage({saveData}: Options = {}) {
     {
       transform: (data) => ({
         ...data,
-        ...sidebarData(),
         ...saveData?.(),
       }),
-      onSuccess: advanceBaseline,
+      onSuccess: () => {
+        advanceBaseline();
+        advanceSidebarBaseline();
+      },
     }
   );
 
-  // Unsaved-changes guard. The field layout is tracked by Inertia's own dirty
-  // state; the sidebar island is compared against a baseline captured on first
-  // interaction, since it injects asynchronously.
-  let sidebarBaseline: string | null = null;
-
-  function captureSidebarBaseline(): void {
-    sidebarBaseline ??= JSON.stringify(sidebarData());
-  }
-
+  // Both the field layout and the sidebar feed the same Inertia form, so its
+  // own dirty state covers the whole screen.
   function hasUnsavedChanges(): boolean {
-    if (form.processing) {
-      return false;
-    }
-
-    return (
-      form.isDirty ||
-      (sidebarBaseline !== null &&
-        JSON.stringify(sidebarData()) !== sidebarBaseline)
-    );
+    return !form.processing && form.isDirty;
   }
-
-  useEventListener(sidebarEl, 'focusin', captureSidebarBaseline);
-  useEventListener(sidebarEl, 'pointerdown', captureSidebarBaseline);
 
   useEventListener(window, 'beforeunload', (event) => {
     if (hasUnsavedChanges()) {
@@ -150,10 +112,13 @@ export function useElementEditPage({saveData}: Options = {}) {
     form,
     formPayload,
     onMutation,
+    onSidebarMutation,
     props,
     renderer,
     save,
-    sidebarEl,
+    sidebarErrors,
+    sidebarPayload,
+    sidebarRenderer,
     values,
   };
 }

--- a/resources/js/modules/forms/useInertiaFormRenderer.test.ts
+++ b/resources/js/modules/forms/useInertiaFormRenderer.test.ts
@@ -307,6 +307,68 @@ describe('useInertiaFormRenderer', () => {
     expect(form.isDirty).toBe(false);
   });
 
+  it('lets two root-scoped bridges share one form without clobbering each other', async () => {
+    const layoutPayload: FormPayload = {
+      scope: [],
+      refreshable: false,
+      nodes: [],
+      values: {title: 'Original', fields: {email: ''}},
+      errors: [],
+      globalErrors: [],
+    };
+    const sidebarPayload: FormPayload = {
+      scope: [],
+      refreshable: false,
+      nodes: [],
+      values: {slug: 'original-slug', enabled: true},
+      errors: [],
+      globalErrors: [],
+    };
+
+    let form!: ReturnType<typeof useForm<Record<string, any>>>;
+    let layout!: ReturnType<typeof useInertiaFormRenderer<Record<string, any>>>;
+    let sidebar!: ReturnType<
+      typeof useInertiaFormRenderer<Record<string, any>>
+    >;
+
+    mount(() => {
+      form = useForm<Record<string, any>>({});
+      layout = useInertiaFormRenderer(form, layoutPayload);
+      sidebar = useInertiaFormRenderer(form, sidebarPayload);
+    });
+
+    layout.onMutation({title: 'Changed', fields: {email: 'a@b.c'}});
+    sidebar.onMutation({slug: 'changed-slug', enabled: false});
+    await nextTick();
+
+    expect(form.data()).toEqual({
+      title: 'Changed',
+      fields: {email: 'a@b.c'},
+      slug: 'changed-slug',
+      enabled: false,
+    });
+
+    layout.onMutation({title: 'Changed again', fields: {email: 'a@b.c'}});
+    await nextTick();
+
+    expect(form.data()).toEqual({
+      title: 'Changed again',
+      fields: {email: 'a@b.c'},
+      slug: 'changed-slug',
+      enabled: false,
+    });
+
+    sidebar.onMutation({slug: 'final-slug', enabled: true});
+    await nextTick();
+
+    expect(form.data()).toEqual({
+      title: 'Changed again',
+      fields: {email: 'a@b.c'},
+      slug: 'final-slug',
+      enabled: true,
+    });
+  });
+
   function mount(setup: () => void): void {
     container = document.createElement('div');
     document.body.append(container);

--- a/src/Element/Concerns/HasControlPanelUI.php
+++ b/src/Element/Concerns/HasControlPanelUI.php
@@ -19,6 +19,13 @@ use CraftCms\Cms\Element\Events\ElementInlineAttributeInputHtmlResolving;
 use CraftCms\Cms\Element\Events\ElementMetadataResolving;
 use CraftCms\Cms\Element\Events\ElementMetaFieldsHtmlResolving;
 use CraftCms\Cms\Element\Events\ElementSidebarHtmlResolving;
+use CraftCms\Cms\Form\Contracts\Node;
+use CraftCms\Cms\Form\Controls\Lightswitch;
+use CraftCms\Cms\Form\Controls\Textarea;
+use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\Nodes\Field;
 use CraftCms\Cms\Http\Requests\ElementRequest;
 use CraftCms\Cms\Http\Responses\CpScreenResponse;
 use CraftCms\Cms\Shared\Enums\Color;
@@ -561,6 +568,47 @@ JS,
         event($event = new ElementSidebarHtmlResolving($this, $static, $html));
 
         return $event->html;
+    }
+
+    public function sidebarForm(FormContext $context = new FormContext): ?Form
+    {
+        $static = $context->mode === ControlMode::ReadOnly || $context->mode === ControlMode::Disabled;
+
+        $nodes = $this->metaFieldsNodes($static);
+
+        if (! $static && static::hasStatuses() && $this->showStatusField()) {
+            $nodes[] = Field::make(t('Status'))
+                ->control(
+                    Lightswitch::make('enabled')
+                        ->value((bool) $this->enabled)
+                        ->onLabel(t('Enabled'))
+                        ->offLabel(t('Disabled')),
+                );
+        }
+
+        if ($this->hasRevisions() && ! $this->getIsRevision()) {
+            $nodes[] = Field::make(t('Notes about your changes'))
+                ->control(
+                    Textarea::make('notes')
+                        ->rows(1)
+                        ->value($this->getIsDraft() ? $this->draftNotes : $this->revisionNotes),
+                );
+        }
+
+        return $nodes === [] ? null : Form::make($nodes);
+    }
+
+    /**
+     * Returns the editor sidebar's element-type-specific meta fields as Form
+     * Nodes. The Form-system counterpart to {@see metaFieldsHtml()}; element
+     * types override this alongside their HTML implementation until the legacy
+     * editor is retired.
+     *
+     * @return list<Node>
+     */
+    protected function metaFieldsNodes(bool $static): array
+    {
+        return [];
     }
 
     /**

--- a/src/Element/Contracts/ElementInterface.php
+++ b/src/Element/Contracts/ElementInterface.php
@@ -21,6 +21,8 @@ use CraftCms\Cms\Element\Enums\AttributeStatus;
 use CraftCms\Cms\Element\Queries\Contracts\ElementQueryInterface;
 use CraftCms\Cms\Field\Exceptions\InvalidFieldException;
 use CraftCms\Cms\FieldLayout\FieldLayout;
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\FormContext;
 use CraftCms\Cms\Http\Responses\CpScreenResponse;
 use CraftCms\Cms\Site\Data\Site;
 use CraftCms\Cms\Twig\Attributes\AllowedInSandbox;
@@ -1597,6 +1599,18 @@ interface ElementInterface extends Actionable, ArrayAccess, Chippable, Component
      * @param  bool  $static  Whether any fields within the sidebar should be static (non-interactive)
      */
     public function getSidebarHtml(bool $static): string|Stringable;
+
+    /**
+     * Returns the editor sidebar's meta fields as a Form.
+     *
+     * This is the Form-system replacement for {@see getSidebarHtml()}; the
+     * Inertia editor renders it through the Vue Form renderer, so the fields
+     * submit as ordinary nested inputs rather than scraped DOM values. The
+     * legacy editor and slideouts keep using `getSidebarHtml()`.
+     *
+     * Returns `null` when the element has no sidebar fields.
+     */
+    public function sidebarForm(FormContext $context = new FormContext): ?Form;
 
     /**
      * Returns element metadata that should be shown within the editor sidebar.

--- a/src/Entry/Elements/Entry.php
+++ b/src/Entry/Elements/Entry.php
@@ -54,6 +54,13 @@ use CraftCms\Cms\Field\Fields;
 use CraftCms\Cms\Field\Matrix;
 use CraftCms\Cms\FieldLayout\FieldLayout;
 use CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField;
+use CraftCms\Cms\Form\Contracts\Node;
+use CraftCms\Cms\Form\Controls\Choice;
+use CraftCms\Cms\Form\Controls\DateTime;
+use CraftCms\Cms\Form\Controls\ElementSelect;
+use CraftCms\Cms\Form\Controls\Text;
+use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Form\Nodes\Field;
 use CraftCms\Cms\Gql\Interfaces\Elements\Entry as EntryInterface;
 use CraftCms\Cms\Http\Requests\ElementRequest;
 use CraftCms\Cms\Section\Data\Section;
@@ -2039,6 +2046,139 @@ JS, [
         }
 
         return $user->can('move', $this);
+    }
+
+    /**
+     * The Form-system counterpart to {@see metaFieldsHtml()}. Mirrors the same
+     * visibility rules so the Inertia editor shows exactly the fields the
+     * legacy editor does.
+     *
+     * @return list<Node>
+     */
+    #[Override]
+    protected function metaFieldsNodes(bool $static): array
+    {
+        $nodes = [];
+        $section = $this->getSection();
+        $user = currentUserElement();
+
+        $entryTypes = $this->getAvailableEntryTypes();
+        if (collect($entryTypes)->doesntContain(fn (EntryType $entryType) => $entryType->id === $this->typeId)) {
+            $entryTypes[] = $this->getType();
+        }
+
+        if (count($entryTypes) > 1 || ! $this->isEntryTypeAllowed($entryTypes)) {
+            $nodes[] = Field::make(t('Entry Type'))
+                ->control(
+                    Choice::make('typeId')
+                        ->options(array_map(fn (EntryType $entryType) => [
+                            'label' => t($entryType->name, category: 'site'),
+                            'value' => $entryType->id,
+                        ], $entryTypes))
+                        ->value($this->getType()->id)
+                        ->mode($static ? ControlMode::Disabled : ControlMode::Editable),
+                );
+        }
+
+        if ($this->getType()->showSlugField) {
+            $nodes[] = Field::make(t('Slug'))
+                ->control(
+                    Text::make('slug')
+                        ->value(! ElementHelper::isTempSlug($this->slug) ? $this->slug : null)
+                        ->mode($static ? ControlMode::Disabled : ControlMode::Editable),
+                );
+        }
+
+        if ($section?->type === SectionType::Structure && $section->maxLevels !== 1) {
+            $nodes[] = Field::make(t('Parent'))
+                ->control(
+                    ElementSelect::make('parentId')
+                        ->elementType(self::class)
+                        ->sources(["section:$section->uid"])
+                        ->criteria($this->_parentOptionCriteria($section))
+                        ->selectionLabel(t('Choose'))
+                        ->showSiteMenu()
+                        ->limit(1)
+                        ->value(array_filter([$this->parentIdForForm()]))
+                        ->mode($static ? ControlMode::Disabled : ControlMode::Editable),
+                );
+        }
+
+        if ($section && $section->type !== SectionType::Single) {
+            if ($section->maxAuthors !== 0 && Edition::get() !== Edition::Solo) {
+                $nodes[] = Field::make(t('{max, plural, =1{Author} other {Authors}}', [
+                    'max' => $section->maxAuthors ?? PHP_INT_MAX,
+                ]))
+                    ->control(
+                        ElementSelect::make('authorIds')
+                            ->elementType(User::class)
+                            ->criteria(['can' => "viewEntries:$section->uid"])
+                            ->selectionLabel(t('Choose'))
+                            ->limit($section->maxAuthors)
+                            ->value($this->getAuthorIds())
+                            ->mode($static || ! $this->canChangeAuthor($user)
+                                ? ControlMode::Disabled
+                                : ControlMode::Editable),
+                    );
+            }
+
+            $nodes[] = Field::make(t('Post Date'))
+                ->control(
+                    DateTime::make('postDate')
+                        ->showTime()
+                        ->value(self::dateTimeControlValue($this->postDate))
+                        ->mode($static ? ControlMode::Disabled : ControlMode::Editable),
+                );
+
+            $nodes[] = Field::make(t('Expiry Date'))
+                ->control(
+                    DateTime::make('expiryDate')
+                        ->showTime()
+                        ->value(self::dateTimeControlValue($this->expiryDate))
+                        ->mode($static ? ControlMode::Disabled : ControlMode::Editable),
+                );
+        }
+
+        return $nodes;
+    }
+
+    /**
+     * The {@see DateTime} Control's value shape — an empty date still needs the
+     * date/time/timezone keys so the control renders.
+     *
+     * @return array{date: string, time: string, timezone: string}
+     */
+    private static function dateTimeControlValue(?DateTimeInterface $value): array
+    {
+        return [
+            'date' => $value?->format('Y-m-d') ?? '',
+            'time' => $value?->format('H:i') ?? '',
+            'timezone' => $value?->getTimezone()->getName() ?? Cms::timezone(),
+        ];
+    }
+
+    /**
+     * The entry's current parent id, resolved the same way the legacy Parent
+     * meta field resolves it.
+     */
+    private function parentIdForForm(): ?int
+    {
+        if ($parentId = $this->getParentId()) {
+            return $parentId;
+        }
+
+        /** @var self|null $parent */
+        $parent = self::find()
+            ->site('*')
+            ->preferSites([$this->siteId])
+            ->drafts(null)
+            ->draftOf(false)
+            ->status(null)
+            ->ancestorOf($this->lft ? $this : ($this->getIsCanonical() ? $this->id : $this->getCanonical(true)))
+            ->ancestorDist(1)
+            ->one();
+
+        return $parent?->id;
     }
 
     #[Override]

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\FieldLayout\FieldLayoutCompiler;
 use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\FormContext;
 use CraftCms\Cms\Form\FormPayload;
+use CraftCms\Cms\Form\FormResolver;
 use CraftCms\Cms\Http\Controllers\Elements\Concerns\EditsElement;
 use CraftCms\Cms\Http\Controllers\Elements\Concerns\ElementCrumbs;
 use CraftCms\Cms\Http\Requests\ElementRequest;
@@ -45,6 +46,10 @@ abstract class ElementEditViewModel extends ViewModel
     private ?FormPayload $form = null;
 
     private bool $formResolved = false;
+
+    private ?FormPayload $sidebarForm = null;
+
+    private bool $sidebarFormResolved = false;
 
     public function __construct(
         protected readonly ElementInterface $element,
@@ -146,17 +151,34 @@ abstract class ElementEditViewModel extends ViewModel
     }
 
     /**
-     * The element's meta fields (entry type, slug, parent, post date, …).
+     * The element's meta fields (entry type, slug, parent, post date, status,
+     * notes …) as a second Form, rendered into the editor sidebar.
      *
-     * These are still rendered by the legacy `metaFieldsHtml()` PHP surface, so
-     * the page mounts them as an HTML island and reads their inputs at submit
-     * time. Porting them onto Form Controls is a follow-up.
+     * Keeping it separate from {@see form()} lets the two render in different
+     * regions while both submit through the same Inertia form.
      */
-    public function sidebarHtml(): ?string
+    public function sidebarForm(): ?FormPayload
     {
-        $html = trim((string) $this->element->getSidebarHtml(! $this->canSave));
+        if ($this->sidebarFormResolved) {
+            return $this->sidebarForm;
+        }
 
-        return $html !== '' ? $html : null;
+        $this->sidebarFormResolved = true;
+        $context = $this->sidebarFormContext();
+        $form = $this->element->sidebarForm($context);
+
+        return $this->sidebarForm = $form === null
+            ? null
+            : app(FormResolver::class)->resolve($form, $context);
+    }
+
+    private function sidebarFormContext(): FormContext
+    {
+        return new FormContext(
+            namespace: [],
+            errors: $this->element->errors()->getMessages(),
+            mode: $this->canSave ? ControlMode::Editable : ControlMode::ReadOnly,
+        );
     }
 
     public function metadataHtml(): ?string

--- a/tests/Feature/Http/Controllers/Elements/EditElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/EditElementControllerTest.php
@@ -140,7 +140,7 @@ it('renders the current entry edit screen for each control panel route', functio
             ->where('readOnly', false)
             ->where('saveUrl', fn (string $url) => str_contains($url, 'entries/save-entry'))
             ->has('form.nodes')
-            ->has('sidebarHtml')
+            ->has('sidebarForm.nodes')
         );
 })->with('editElementEntryRoutes');
 

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -11,6 +11,7 @@ use CraftCms\Cms\FieldLayout\FieldLayout;
 use CraftCms\Cms\FieldLayout\FieldLayoutTab;
 use CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField;
 use CraftCms\Cms\FieldLayout\Models\FieldLayout as FieldLayoutModel;
+use CraftCms\Cms\Http\Controllers\Entries\StoreEntryController;
 use CraftCms\Cms\Section\Models\Section;
 use CraftCms\Cms\Support\Facades\Elements;
 use CraftCms\Cms\User\Elements\User;
@@ -20,6 +21,7 @@ use Inertia\Testing\AssertableInertia;
 use function CraftCms\Cms\cp_url;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
+use function Pest\Laravel\post;
 
 beforeEach(function () {
     actingAs(User::findOne());
@@ -79,14 +81,42 @@ it('points the form at the entry save action', function () {
         );
 });
 
-it('includes the meta fields and metadata as server-rendered islands', function () {
+it('compiles the meta fields into a sidebar form', function () {
     get($this->entry->getCpEditUrl())
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page
-            ->where('sidebarHtml', fn (?string $html) => is_string($html) && str_contains($html, 'name="slug"'))
+            ->where('sidebarForm.nodes', function (Collection $nodes) {
+                $paths = $nodes
+                    ->map(fn (array $node) => implode('.', $node['control']['path'] ?? []))
+                    ->all();
+
+                return in_array('slug', $paths, true)
+                    && in_array('postDate', $paths, true)
+                    && in_array('expiryDate', $paths, true)
+                    && in_array('enabled', $paths, true)
+                    && in_array('notes', $paths, true);
+            })
             ->where('metadataHtml', fn (?string $html) => is_string($html) && $html !== '')
             ->etc()
         );
+});
+
+it('saves the meta fields the sidebar form submits', function () {
+    post(action(StoreEntryController::class), [
+        'entryId' => $this->entry->id,
+        'siteId' => $this->entry->siteId,
+        'typeId' => $this->entry->typeId,
+        'title' => 'Retitled',
+        'slug' => 'retitled-slug',
+        'enabled' => '1',
+        'postDate' => ['date' => '2027-03-04', 'time' => '09:30'],
+    ])->assertRedirect();
+
+    $entry = Entry::find()->id($this->entry->id)->status(null)->one();
+
+    expect($entry->title)->toBe('Retitled')
+        ->and($entry->slug)->toBe('retitled-slug')
+        ->and($entry->postDate->format('Y-m-d'))->toBe('2027-03-04');
 });
 
 it('falls back to the legacy editor for drafts', function () {


### PR DESCRIPTION
### Description

Moves the editor sidebar's meta fields onto the Form system, so they submit as Inertia form state instead of being read out of the DOM at save time.

Adds `ElementInterface::sidebarForm()`, implemented on `HasControlPanelUI` with `metaFieldsNodes()` as the per-element-type extension point — the Form-system counterpart to `getSidebarHtml()` and `metaFieldsHtml()`, which stay in place for the legacy editor and slideouts. `Entry::metaFieldsNodes()` covers entry type, slug, parent, authors, post date, and expiry date under the same visibility rules as `metaFieldsHtml()`; the base implementation contributes the status and notes fields.

The sidebar renders as a second `FormRenderer` bridged into the same Inertia form as the field layout. Two root-scoped `useInertiaFormRenderer` bridges can share one form because each instance only clears the root keys it wrote itself, and both are constructed before either receives a mutation — `useInertiaFormRenderer.test.ts` pins that behavior. With every value now in Inertia state, the unsaved-changes guard reduces to `form.isDirty`.

Per-site statuses are not included. The expand control behind them is wired up by `Craft.ElementEditor`, which never ran on the Inertia screen, so it lands with the multi-site work later in the stack.
