### PR TITLE
[6.x] Fix cache command registration timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added a slideout system for the Inertia/Vue Control Panel, which renders any `CpScreenResponse`-based screen as an in-page panel from a normal Inertia response, alongside the existing legacy `Craft.CpScreenSlideout`. ([#19354](https://github.com/craftcms/cms/pull/19354))
 - Added `CraftCms\Cms\Http\Responses\CpScreenResponse::screenData()`. ([#19354](https://github.com/craftcms/cms/pull/19354))
+- Fixed a bug where cache options and tags registered via `CraftCms\Cms\Utility\Utilities\ClearCaches::add()` and `addTag()` were unavailable as Artisan commands.
 - Fixed a JavaScript error that occurred on non-Inertial pages that rendered field layout designers. ([#19380](https://github.com/craftcms/cms/discussions/19380))
 
 ## 6.0.0-alpha.16 - 2026-08-05

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -95,21 +95,23 @@ class ConsoleServiceProvider extends ServiceProvider
 
         $this->commands($this->commands);
 
-        foreach (ClearCachesCommand::signatures() as $signature) {
-            $this->commands(new ClearCachesCommand(
-                signature: $signature['signature'],
-                description: $signature['description'],
-                aliases: $signature['aliases'] ?? [],
-            ));
-        }
+        $this->app->booted(function () {
+            foreach (ClearCachesCommand::signatures() as $signature) {
+                $this->commands(new ClearCachesCommand(
+                    signature: $signature['signature'],
+                    description: $signature['description'],
+                    aliases: $signature['aliases'] ?? [],
+                ));
+            }
 
-        foreach (InvalidateTagsCommand::signatures() as $signature) {
-            $this->commands(new InvalidateTagsCommand(
-                signature: $signature['signature'],
-                description: $signature['description'],
-                aliases: $signature['aliases'] ?? [],
-            ));
-        }
+            foreach (InvalidateTagsCommand::signatures() as $signature) {
+                $this->commands(new InvalidateTagsCommand(
+                    signature: $signature['signature'],
+                    description: $signature['description'],
+                    aliases: $signature['aliases'] ?? [],
+                ));
+            }
+        });
 
         $this->optimizes(
             optimize: 'craft:twig:cache',

--- a/tests/Unit/Console/ConsoleServiceProviderTest.php
+++ b/tests/Unit/Console/ConsoleServiceProviderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Console\ConsoleServiceProvider;
+use CraftCms\Cms\Utility\Utilities\ClearCaches;
+use Illuminate\Console\Command;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
+use Override;
+
+afterEach(function () {
+    ClearCaches::flushState();
+});
+
+it('registers cache commands after all service providers have booted', function () {
+    $container = Container::getInstance();
+
+    try {
+        $application = new class extends Application
+        {
+            public ?Closure $capturedBootedCallback = null;
+
+            public function booted($callback)
+            {
+                $this->capturedBootedCallback = $callback;
+            }
+        };
+    } finally {
+        Container::setInstance($container);
+    }
+
+    $provider = new class($application) extends ConsoleServiceProvider
+    {
+        public bool $registeredCacheCommand = false;
+
+        public bool $registeredTagCommand = false;
+
+        #[Override]
+        public function commands($commands): void
+        {
+            foreach (is_array($commands) ? $commands : [$commands] as $command) {
+                if (! $command instanceof Command) {
+                    continue;
+                }
+
+                $this->registeredCacheCommand = $this->registeredCacheCommand || $command->getName() === 'craft:clear-caches:plugin';
+                $this->registeredTagCommand = $this->registeredTagCommand || $command->getName() === 'craft:invalidate-tags:plugin';
+            }
+        }
+    };
+
+    $provider->boot();
+
+    ClearCaches::add('plugin', [
+        'label' => 'Plugin caches',
+        'action' => fn () => null,
+    ]);
+    ClearCaches::addTag('plugin', 'Plugin caches');
+
+    $application->capturedBootedCallback?->__invoke();
+
+    expect($provider->registeredCacheCommand)->toBeTrue()
+        ->and($provider->registeredTagCommand)->toBeTrue();
+});


### PR DESCRIPTION
### Description

Defers cache-clearing and tag-invalidation command registration until all service providers have booted, so plugins and application service providers can register their cache options and tags during boot.