### PR TITLE
[6.x] Preserve Yii asset bundles registered during plugin init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a slideout system for the Inertia/Vue Control Panel, which renders any `CpScreenResponse`-based screen as an in-page panel from a normal Inertia response, alongside the existing legacy `Craft.CpScreenSlideout`. ([#19354](https://github.com/craftcms/cms/pull/19354))
 - Added `CraftCms\Cms\Http\Responses\CpScreenResponse::screenData()`. ([#19354](https://github.com/craftcms/cms/pull/19354))
 - Fixed a JavaScript error that occurred on non-Inertial pages that rendered field layout designers. ([#19380](https://github.com/craftcms/cms/discussions/19380))
+- Fixed a bug where Yii asset bundles registered with `craft\web\View::registerAssetBundle()` during plugin initialization were not included in rendered pages. ([#19393](https://github.com/craftcms/cms/pull/19393))
 
 ## 6.0.0-alpha.16 - 2026-08-05
 

--- a/yii2-adapter/src/Http/PrepareLegacyCraftApp.php
+++ b/yii2-adapter/src/Http/PrepareLegacyCraftApp.php
@@ -47,7 +47,6 @@ readonly class PrepareLegacyCraftApp
         $yiiRequest->csrfCookie = Craft::cookieConfig([], $yiiRequest);
 
         Craft::$app->set('request', $yiiRequest);
-        Craft::$app->set('view', Craft::createObject(App::viewConfig()));
         Craft::$app->set('user', Craft::createObject(App::userConfig()));
     }
 }

--- a/yii2-adapter/tests-laravel/Http/PrepareLegacyCraftAppTest.php
+++ b/yii2-adapter/tests-laravel/Http/PrepareLegacyCraftAppTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Yii2Adapter\Http\PrepareLegacyCraftApp;
+use Illuminate\Http\Request;
+use yii\web\AssetBundle;
+
+it('preserves asset bundles registered before request middleware runs', function() {
+    Craft::$app->getView()->registerAssetBundle(InitRegisteredAsset::class);
+
+    $html = app(PrepareLegacyCraftApp::class)->handle(
+        Request::create('/'),
+        fn() => Craft::$app->getView()->placeholderHtml(),
+    );
+
+    expect($html['headHtml'])->toContain('/cms-2324.css')
+        ->and($html['bodyEndHtml'])->toContain('/cms-2324.js');
+});
+
+class InitRegisteredAsset extends AssetBundle
+{
+    public $baseUrl = '/';
+
+    public $css = ['cms-2324.css'];
+
+    public $js = ['cms-2324.js'];
+}


### PR DESCRIPTION
### Description

Preserves the initialized Yii view across request middleware so asset bundles registered by plugins during init are included in rendered pages.

### Related issues

Fixes #19381