### PR TITLE
[6.x] Fix legacy asset bundle dependency order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a slideout system for the Inertia/Vue Control Panel, which renders any `CpScreenResponse`-based screen as an in-page panel from a normal Inertia response, alongside the existing legacy `Craft.CpScreenSlideout`. ([#19354](https://github.com/craftcms/cms/pull/19354))
 - Added `CraftCms\Cms\Http\Responses\CpScreenResponse::screenData()`. ([#19354](https://github.com/craftcms/cms/pull/19354))
 - Fixed a JavaScript error that occurred on non-Inertial pages that rendered field layout designers. ([#19380](https://github.com/craftcms/cms/discussions/19380))
+- Fixed a bug where legacy asset bundle dependencies could be rendered after their dependent resources when using `craftcms/yii2-adapter`. ([#19394](https://github.com/craftcms/cms/pull/19394))
 
 ## 6.0.0-alpha.16 - 2026-08-05
 

--- a/yii2-adapter/legacy/web/View.php
+++ b/yii2-adapter/legacy/web/View.php
@@ -36,6 +36,7 @@ use CraftCms\Cms\View\Events\TemplateRendered;
 use CraftCms\Cms\View\Events\TemplateRendering;
 use CraftCms\Cms\View\Events\ViewAssetsRendering;
 use CraftCms\Cms\View\HtmlStack;
+use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use CraftCms\Cms\View\PageLifecycle;
 use CraftCms\Cms\View\TemplateEngine;
 use CraftCms\Cms\View\TemplateHooks;
@@ -2147,6 +2148,7 @@ JS;
         }
         $this->_registeredAssetBundles[$hash] = true;
         parent::registerAssetFiles($name);
+        app(InternalAssetRegistry::class)->flush();
     }
 
     /**

--- a/yii2-adapter/tests-laravel/View/CpAssetOrderTest.php
+++ b/yii2-adapter/tests-laravel/View/CpAssetOrderTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use craft\web\assets\axios\AxiosAsset;
 use craft\web\assets\cp\CpAsset;
+use craft\web\assets\jquery\JqueryAsset;
 use CraftCms\Cms\Support\Facades\HtmlStack;
 use CraftCms\Cms\View\Enums\Position;
 use CraftCms\Cms\View\HtmlStack as HtmlStackService;
@@ -32,6 +34,32 @@ class YiiJqueryDependentAssetBundle extends AssetBundle
 
     public $js = [
         'depends-on-yii-jquery.js',
+    ];
+}
+
+class CraftJqueryDependentAssetBundle extends AssetBundle
+{
+    public $baseUrl = 'https://example.test/assets';
+
+    public $depends = [
+        JqueryAsset::class,
+    ];
+
+    public $js = [
+        'depends-on-craft-jquery.js',
+    ];
+}
+
+class CraftAxiosDependentAssetBundle extends AssetBundle
+{
+    public $baseUrl = 'https://example.test/assets';
+
+    public $depends = [
+        AxiosAsset::class,
+    ];
+
+    public $js = [
+        'depends-on-craft-axios.js',
     ];
 }
 
@@ -68,6 +96,30 @@ it('resolves Yii jQuery asset bundles to the internal jQuery asset', function() 
         ->and($html)->toContain('https://example.test/assets/depends-on-yii-jquery.js')
         ->and(strpos($html, 'legacy/jquery/dist/jquery.js'))->toBeLessThan(strpos($html, 'https://example.test/assets/depends-on-yii-jquery.js'))
         ->and($html)->not->toContain('cpresources');
+});
+
+it('renders the internal jQuery asset before Craft asset bundle dependents', function() {
+    $view = Craft::$app->getView();
+
+    $view->registerAssetBundle(CraftJqueryDependentAssetBundle::class);
+
+    $html = $view->placeholderHtml()['bodyEndHtml'];
+
+    expect($html)->toContain('legacy/jquery/dist/jquery.js')
+        ->and($html)->toContain('https://example.test/assets/depends-on-craft-jquery.js')
+        ->and(strpos($html, 'legacy/jquery/dist/jquery.js'))->toBeLessThan(strpos($html, 'https://example.test/assets/depends-on-craft-jquery.js'));
+});
+
+it('renders other internal assets before Craft asset bundle dependents', function() {
+    $view = Craft::$app->getView();
+
+    $view->registerAssetBundle(CraftAxiosDependentAssetBundle::class);
+
+    $html = $view->placeholderHtml()['bodyEndHtml'];
+
+    expect($html)->toContain('legacy/axios/dist/axios.js')
+        ->and($html)->toContain('https://example.test/assets/depends-on-craft-axios.js')
+        ->and(strpos($html, 'legacy/axios/dist/axios.js'))->toBeLessThan(strpos($html, 'https://example.test/assets/depends-on-craft-axios.js'));
 });
 
 it('uses the current scoped HtmlStack after scoped instances are flushed', function() {


### PR DESCRIPTION
### Description

Ensures internal legacy asset bundles are flushed while Yii processes each bundle so dependencies render before dependent resources.

### Related issues

Fixes #19382