### PR TITLE
[6.x] Add multi-site controls to the Inertia element editor

### DIFF
--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -4,6 +4,7 @@ import {t} from '@craftcms/ui';
 import {computed, onBeforeUnmount} from 'vue';
 import type {FormPayload} from '@/modules/forms/types';
 import {useInertiaFormRenderer} from '@/modules/forms/useInertiaFormRenderer';
+import {useSiteStatuses} from '@/modules/elements/composables/useSiteStatuses';
 import {useSettingsSave} from '@/modules/settings/composables/useSettingsSave';
 
 /** The shared payload every {@link ElementEditViewModel} emits. */
@@ -61,6 +62,8 @@ export function useElementEditPage({saveData}: Options = {}) {
     onMutation: onSidebarMutation,
     renderer: sidebarRenderer,
   } = useInertiaFormRenderer(form, sidebarPayload);
+
+  useSiteStatuses(form);
 
   const {save} = useSettingsSave(
     form,

--- a/resources/js/modules/elements/composables/useSiteStatuses.test.ts
+++ b/resources/js/modules/elements/composables/useSiteStatuses.test.ts
@@ -1,0 +1,106 @@
+import {useForm} from '@inertiajs/vue3';
+import {createApp, defineComponent, nextTick} from 'vue';
+import {afterEach, describe, expect, it} from 'vite-plus/test';
+import {useSiteStatuses} from './useSiteStatuses';
+
+describe('useSiteStatuses', () => {
+  let app: ReturnType<typeof createApp>;
+  let container: HTMLElement;
+
+  afterEach(() => {
+    app?.unmount();
+    container?.remove();
+  });
+
+  function mount(
+    initial: Record<string, any>
+  ): ReturnType<typeof useForm<Record<string, any>>> {
+    let form!: ReturnType<typeof useForm<Record<string, any>>>;
+
+    container = document.createElement('div');
+    document.body.append(container);
+    app = createApp(
+      defineComponent({
+        setup() {
+          form = useForm<Record<string, any>>(initial);
+          useSiteStatuses(form);
+
+          return () => null;
+        },
+      })
+    );
+    app.mount(container);
+
+    return form;
+  }
+
+  it('applies the global switch to every site', async () => {
+    const form = mount({
+      enabled: true,
+      enabledForSite: {'1': true, '2': true},
+    });
+
+    form.enabled = false;
+    await nextTick();
+
+    expect(form.enabledForSite).toEqual({'1': false, '2': false});
+  });
+
+  it('turns the global switch off when every site is off', async () => {
+    const form = mount({
+      enabled: true,
+      enabledForSite: {'1': true, '2': true},
+    });
+
+    form.enabledForSite['1'] = false;
+    form.enabledForSite['2'] = false;
+    await nextTick();
+
+    expect(form.enabled).toBe(false);
+  });
+
+  it('marks the global switch indeterminate when sites disagree', async () => {
+    const form = mount({
+      enabled: true,
+      enabledForSite: {'1': true, '2': true},
+    });
+
+    form.enabledForSite['2'] = false;
+    await nextTick();
+
+    expect(form.enabled).toBe('-');
+  });
+
+  it('turns the global switch on when every site is on', async () => {
+    const form = mount({
+      enabled: '-',
+      enabledForSite: {'1': true, '2': false},
+    });
+
+    form.enabledForSite['2'] = true;
+    await nextTick();
+
+    expect(form.enabled).toBe(true);
+  });
+
+  it('leaves the sites alone while the global switch is indeterminate', async () => {
+    const form = mount({
+      enabled: true,
+      enabledForSite: {'1': true, '2': false},
+    });
+
+    form.enabled = '-';
+    await nextTick();
+
+    expect(form.enabledForSite).toEqual({'1': true, '2': false});
+  });
+
+  it('does nothing without per-site switches', async () => {
+    const form = mount({enabled: true});
+
+    form.enabled = false;
+    await nextTick();
+
+    expect(form.enabled).toBe(false);
+  });
+});

--- a/resources/js/modules/elements/composables/useSiteStatuses.ts
+++ b/resources/js/modules/elements/composables/useSiteStatuses.ts
@@ -1,0 +1,81 @@
+import type {InertiaForm} from '@inertiajs/vue3';
+import {watch} from 'vue';
+
+/**
+ * Keeps the editor's "Enabled for all sites" switch in sync with the per-site
+ * switches beside it, mirroring the legacy element editor.
+ *
+ * Toggling the global switch applies its value to every site; toggling a site
+ * rolls back up into the global switch, which reads `true` when every site is
+ * on, `false` when none are, and indeterminate (`'-'`) when they disagree.
+ *
+ * Both switches are ordinary Form Controls writing into the shared Inertia
+ * form, so this only has to reconcile their values — no DOM involved.
+ */
+export function useSiteStatuses(form: InertiaForm<Record<string, any>>): void {
+  // Guards the two watchers below from re-entering each other: whichever
+  // direction fires first owns the reconciliation for that tick.
+  let syncing = false;
+
+  function siteIds(): string[] {
+    return Object.keys(form.enabledForSite ?? {});
+  }
+
+  function withSync(apply: () => void): void {
+    if (syncing) {
+      return;
+    }
+
+    syncing = true;
+    apply();
+    // Release only after the writes above have been observed, so the paired
+    // watcher doesn't immediately undo them.
+    void Promise.resolve().then(() => (syncing = false));
+  }
+
+  watch(
+    () => form.enabled,
+    (enabled) => {
+      // An indeterminate global switch describes the sites; it doesn't set them.
+      if (enabled === '-' || enabled === null || enabled === undefined) {
+        return;
+      }
+
+      withSync(() => {
+        const value = normalize(enabled);
+
+        for (const siteId of siteIds()) {
+          form.enabledForSite[siteId] = value;
+        }
+      });
+    }
+  );
+
+  watch(
+    () => (form.enabledForSite ? {...form.enabledForSite} : null),
+    (statuses) => {
+      if (!statuses) {
+        return;
+      }
+
+      const values = Object.values(statuses).map(normalize);
+
+      if (values.length === 0) {
+        return;
+      }
+
+      withSync(() => {
+        const allOn = values.every(Boolean);
+        const allOff = values.every((value) => !value);
+
+        form.enabled = allOn ? true : allOff ? false : '-';
+      });
+    },
+    {deep: true}
+  );
+}
+
+/** Lightswitch values arrive as booleans or their submitted string forms. */
+function normalize(value: unknown): boolean {
+  return value === true || value === '1' || value === 1;
+}

--- a/src/Element/Concerns/HasControlPanelUI.php
+++ b/src/Element/Concerns/HasControlPanelUI.php
@@ -26,6 +26,7 @@ use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\Form;
 use CraftCms\Cms\Form\FormContext;
 use CraftCms\Cms\Form\Nodes\Field;
+use CraftCms\Cms\Form\Nodes\Group;
 use CraftCms\Cms\Http\Requests\ElementRequest;
 use CraftCms\Cms\Http\Responses\CpScreenResponse;
 use CraftCms\Cms\Shared\Enums\Color;
@@ -577,13 +578,7 @@ JS,
         $nodes = $this->metaFieldsNodes($static);
 
         if (! $static && static::hasStatuses() && $this->showStatusField()) {
-            $nodes[] = Field::make(t('Status'))
-                ->control(
-                    Lightswitch::make('enabled')
-                        ->value((bool) $this->enabled)
-                        ->onLabel(t('Enabled'))
-                        ->offLabel(t('Disabled')),
-                );
+            $nodes = [...$nodes, ...$this->statusNodes()];
         }
 
         if ($this->hasRevisions() && ! $this->getIsRevision()) {
@@ -596,6 +591,104 @@ JS,
         }
 
         return $nodes === [] ? null : Form::make($nodes);
+    }
+
+    /**
+     * The status Node(s) for the sidebar Form.
+     *
+     * On a single-site install (or an element supported by one site) this is a
+     * lone `enabled` switch. Otherwise it mirrors the legacy editor: a global
+     * "Enabled for all sites" switch plus a per-site switch for every editable
+     * site the element propagates to, the latter collapsed behind a group. The
+     * global switch is indeterminate when the sites disagree, and the client
+     * keeps the two in sync.
+     *
+     * @return list<Node>
+     */
+    private function statusNodes(): array
+    {
+        $siteIds = $this->editableStatusSiteIds();
+
+        // One editable site (or a non-localized element) keeps the plain
+        // global switch the single-site editor has always shown.
+        if (count($siteIds) < 2) {
+            return [
+                Field::make(t('Status'))
+                    ->control(
+                        Lightswitch::make('enabled')
+                            ->value((bool) $this->enabled)
+                            ->onLabel(t('Enabled'))
+                            ->offLabel(t('Disabled')),
+                    ),
+            ];
+        }
+
+        // Sites the element hasn't propagated to yet are absent from the status
+        // map; the legacy editor defaults those to enabled, so match it.
+        $siteStatuses = ElementHelper::siteStatusesForElement($this, true);
+        $statuses = [];
+
+        foreach ($siteIds as $siteId) {
+            $statuses[$siteId] = (bool) ($siteStatuses[$siteId] ?? true);
+        }
+
+        $values = array_values($statuses);
+        $allEnabled = ! in_array(false, $values, true);
+        $allDisabled = ! in_array(true, $values, true);
+
+        $siteFields = [];
+
+        foreach ($statuses as $siteId => $enabled) {
+            $site = Sites::getSiteById($siteId);
+
+            if ($site === null) {
+                continue;
+            }
+
+            $siteFields[] = Field::make(t($site->getName(), category: 'site'))
+                ->control(
+                    Lightswitch::make(['enabledForSite', (string) $siteId])
+                        ->value($enabled),
+                );
+        }
+
+        return [
+            Field::make(t('Enabled for all sites'))
+                ->control(
+                    Lightswitch::make('enabled')
+                        ->value($allEnabled)
+                        ->indeterminate(! $allEnabled && ! $allDisabled)
+                        ->onLabel(t('Enabled'))
+                        ->offLabel(t('Disabled')),
+                ),
+            Group::make('site-statuses', $siteFields)
+                ->label(t('Update status for individual sites'))
+                ->collapsible(),
+        ];
+    }
+
+    /**
+     * The sites whose statuses the current user can edit from this screen —
+     * the element's propagating supported sites, limited to editable ones.
+     *
+     * @return list<int>
+     */
+    private function editableStatusSiteIds(): array
+    {
+        if (! static::isLocalized()) {
+            return [];
+        }
+
+        return array_values(array_intersect(
+            array_column(
+                array_filter(
+                    ElementHelper::supportedSitesForElement($this, true),
+                    fn (array $site): bool => $site['propagate'],
+                ),
+                'siteId',
+            ),
+            Sites::getEditableSiteIds()->all(),
+        ));
     }
 
     /**

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\Http\ViewModels;
 
 use CraftCms\Cms\Cp\Html\ContentHtml;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
+use CraftCms\Cms\Element\ElementHelper;
 use CraftCms\Cms\FieldLayout\FieldLayoutCompiler;
 use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\FormContext;
@@ -14,8 +15,12 @@ use CraftCms\Cms\Form\FormResolver;
 use CraftCms\Cms\Http\Controllers\Elements\Concerns\EditsElement;
 use CraftCms\Cms\Http\Controllers\Elements\Concerns\ElementCrumbs;
 use CraftCms\Cms\Http\Requests\ElementRequest;
+use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\DeltaRegistry;
+use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Url;
+
+use function CraftCms\Cms\t;
 
 /**
  * The shared Inertia payload for an element edit screen.
@@ -102,16 +107,84 @@ abstract class ElementEditViewModel extends ViewModel
         return $this->editElementTitles($this->element)[0];
     }
 
-    /** @return list<array<string, mixed>> */
+    /**
+     * The screen's breadcrumbs. On a multi-site install a localized element
+     * leads with a site crumb whose menu switches sites, mirroring the legacy
+     * editor.
+     *
+     * @return list<array<string, mixed>>
+     */
     public function crumbs(): array
     {
-        return array_map(function (array $crumb): array {
+        $crumbs = array_map(function (array $crumb): array {
             if (isset($crumb['url'])) {
                 $crumb['url'] = Url::cpUrl($crumb['url']);
             }
 
             return $crumb;
         }, $this->elementCrumbs($this->element));
+
+        $siteCrumb = $this->siteCrumb();
+
+        return $siteCrumb === null ? $crumbs : [$siteCrumb, ...$crumbs];
+    }
+
+    /**
+     * A crumb naming the site being edited, with a menu linking to the same
+     * element on every other editable site it propagates to.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function siteCrumb(): ?array
+    {
+        if (! $this->element::isLocalized() || ! Sites::isMultiSite()) {
+            return null;
+        }
+
+        $editableSiteIds = Sites::getEditableSiteIds()->all();
+        $siteIds = array_values(array_intersect(
+            array_column(
+                array_filter(
+                    ElementHelper::supportedSitesForElement($this->element, true),
+                    fn (array $site): bool => $site['propagate'],
+                ),
+                'siteId',
+            ),
+            $editableSiteIds,
+        ));
+
+        if (count($siteIds) < 2) {
+            return null;
+        }
+
+        $currentSite = $this->element->getSite();
+        // Keep every other query param so switching sites doesn't drop the
+        // draft, revision, or return URL the editor was opened with.
+        $params = Arr::except($this->request->query(), ['fresh', 'site']);
+        $path = $this->request->craftPath();
+
+        $items = [];
+
+        foreach ($siteIds as $siteId) {
+            $site = Sites::getSiteById($siteId);
+
+            if ($site === null) {
+                continue;
+            }
+
+            $items[] = [
+                'type' => 'link',
+                'label' => t($site->getName(), category: 'site'),
+                'href' => Url::cpUrl($path, ['site' => $site->handle] + $params),
+                'selected' => $site->id === $currentSite->id,
+            ];
+        }
+
+        return [
+            'icon' => 'earth',
+            'label' => t($currentSite->getName(), category: 'site'),
+            'actions' => $items,
+        ];
     }
 
     public function readOnly(): bool

--- a/tests/Feature/Http/Controllers/Entries/EditEntryMultiSiteTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryMultiSiteTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Entry\Elements\Entry;
+use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Entry\Models\EntryType;
+use CraftCms\Cms\FieldLayout\FieldLayout;
+use CraftCms\Cms\FieldLayout\FieldLayoutTab;
+use CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField;
+use CraftCms\Cms\FieldLayout\Models\FieldLayout as FieldLayoutModel;
+use CraftCms\Cms\Section\Models\Section;
+use CraftCms\Cms\Section\Models\SectionSiteSettings;
+use CraftCms\Cms\Site\Models\Site;
+use CraftCms\Cms\Support\Facades\Sections;
+use CraftCms\Cms\Support\Facades\Sites;
+use CraftCms\Cms\User\Elements\User;
+use Illuminate\Support\Collection;
+use Inertia\Testing\AssertableInertia;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    actingAs(User::findOne());
+
+    $layout = FieldLayout::make(Entry::class)
+        ->tab('Content', fn (FieldLayoutTab $tab) => $tab->add(new EntryTitleField(['uid' => 'entry-title'])));
+    $layoutModel = FieldLayoutModel::factory()->create([
+        'type' => Entry::class,
+        'config' => $layout->getConfig(),
+    ]);
+    $this->entryType = EntryType::factory()->create(['fieldLayoutId' => $layoutModel->id]);
+    $this->section = Section::factory()->withEntryTypes($this->entryType)->create(['handle' => 'news']);
+
+    $this->secondSite = Site::factory()->create();
+    Sites::refreshSites();
+    SectionSiteSettings::factory()->create([
+        'sectionId' => $this->section->id,
+        'siteId' => $this->secondSite->id,
+        'hasUrls' => true,
+        'dateCreated' => $this->section->dateCreated,
+        'dateUpdated' => $this->section->dateUpdated,
+    ]);
+    Sections::refreshSections();
+
+    $this->entry = EntryModel::factory()
+        ->forSection($this->section)
+        ->forEntryType($this->entryType)
+        ->createElement([
+            'title' => 'Current Title',
+            'slug' => 'current-title',
+        ]);
+});
+
+it('leads the breadcrumbs with a site switcher', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('crumbs', function (Collection $crumbs) {
+                $siteCrumb = $crumbs->first();
+
+                return ($siteCrumb['icon'] ?? null) === 'earth'
+                    && collect($siteCrumb['actions'] ?? [])
+                        ->pluck('label')
+                        ->contains($this->secondSite->name);
+            })
+            ->etc()
+        );
+});
+
+it('points each site switcher link at the same element on that site', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('crumbs', function (Collection $crumbs) {
+                $actions = collect($crumbs->first()['actions'] ?? []);
+
+                return $actions->every(fn (array $action) => str_contains(
+                    (string) $action['href'],
+                    (string) $this->entry->id,
+                ))
+                    && $actions->contains(fn (array $action) => str_contains(
+                        (string) $action['href'],
+                        "site={$this->secondSite->handle}",
+                    ));
+            })
+            ->etc()
+        );
+});
+
+it('renders a global status switch alongside per-site switches', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('sidebarForm.nodes', function (Collection $nodes) {
+                $paths = $nodes
+                    ->map(fn (array $node) => implode('.', $node['control']['path'] ?? []))
+                    ->all();
+
+                $group = $nodes->first(fn (array $node) => ($node['uid'] ?? null) === 'site-statuses');
+
+                $sitePaths = collect($group['children'] ?? [])
+                    ->map(fn (array $child) => implode('.', $child['control']['path'] ?? []))
+                    ->all();
+
+                return in_array('enabled', $paths, true)
+                    && in_array("enabledForSite.{$this->entry->siteId}", $sitePaths, true)
+                    && in_array("enabledForSite.{$this->secondSite->id}", $sitePaths, true);
+            })
+            ->etc()
+        );
+});
+
+it('omits the site switcher and per-site switches when the section is single-site', function () {
+    $section = Section::factory()->withEntryTypes($this->entryType)->create(['handle' => 'solo']);
+    Sections::refreshSections();
+
+    $entry = EntryModel::factory()
+        ->forSection($section)
+        ->forEntryType($this->entryType)
+        ->createElement(['title' => 'Solo', 'slug' => 'solo']);
+
+    get($entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('crumbs', fn (Collection $crumbs) => $crumbs->doesntContain(
+                fn (array $crumb) => ($crumb['icon'] ?? null) === 'earth',
+            ))
+            ->where('sidebarForm.nodes', fn (Collection $nodes) => $nodes->doesntContain(
+                fn (array $node) => ($node['uid'] ?? null) === 'site-statuses',
+            ))
+            ->etc()
+        );
+});


### PR DESCRIPTION
### Description

Restores the element editor's multi-site controls on the Inertia screen.

Breadcrumbs now lead with a site crumb whose menu links to the same element on every other editable site it propagates to, carrying the current query params across so switching sites doesn't drop the draft, revision, or return URL. The crumb is omitted for non-localized elements and anywhere fewer than two editable sites apply.

The sidebar's status control follows the legacy editor: with two or more editable sites it renders an "Enabled for all sites" switch plus a per-site switch for each of them, collapsed into a group. Sites the element hasn't propagated to yet are absent from `siteStatusesForElement()`, so they default to enabled the same way the legacy editor defaults them. A single editable site keeps the plain `enabled` switch.

`useSiteStatuses` reconciles the two directions: the global switch applies its value to every site, and per-site changes roll back up — `true` when all are on, `false` when none are, indeterminate when they disagree. Because both are ordinary Form Controls writing into the shared Inertia form, this is value reconciliation with no DOM involved, unlike the lightswitch bookkeeping the legacy editor needs.

Copying a field's value to other sites is not included; it hangs off per-field controls rather than the sidebar and is better handled with the field-level work.
