### PR TITLE
[6.x] Render provisional drafts and autosave in the Inertia editor

### DIFF
--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import {t} from '@craftcms/ui';
+  import {computed} from 'vue';
   import DynamicHtmlRenderer from '@/common/components/DynamicHtmlRenderer.vue';
   import LayoutSlot from '@/common/components/LayoutSlot.vue';
   import Pane from '@/common/components/Pane.vue';
@@ -16,6 +17,8 @@
   }>();
 
   const {
+    autosave,
+    discardDraft,
     errors,
     form,
     formPayload,
@@ -28,6 +31,21 @@
     sidebarPayload,
     sidebarRenderer,
   } = useElementEditPage({saveData: props.saveData});
+
+  const autosaveMessage = computed(() => {
+    switch (autosave.status.value) {
+      case 'saving':
+        return t('Saving…');
+      case 'saved':
+        return autosave.savedAt.value
+          ? t('Saved {timestamp}', {timestamp: autosave.savedAt.value})
+          : t('Saved');
+      case 'failed':
+        return autosave.error.value ?? t('Couldn’t save draft.');
+      default:
+        return null;
+    }
+  });
 
   useAppLayout(() => ({
     title: payload.title,
@@ -42,9 +60,43 @@
     actions come through `useAppLayout`'s form-action props — filling the
     `actions` layout slot here would replace the layout's own save button.
   -->
+  <!--
+    Autosave state lives next to the save button, where the legacy editor puts
+    its spinner and checkmark.
+  -->
+  <LayoutSlot v-if="autosaveMessage" name="toolbar">
+    <span
+      class="text-sm text-neutral-text-quiet"
+      role="status"
+      aria-live="polite"
+      :class="{'text-danger-text': autosave.status.value === 'failed'}"
+    >
+      {{ autosaveMessage }}
+    </span>
+  </LayoutSlot>
+
   <Pane appearance="raised">
     <craft-callout v-if="payload.readOnly" variant="neutral" icon="lock">
       {{ t('This is a read-only view.') }}
+    </craft-callout>
+
+    <craft-callout
+      v-if="payload.notice"
+      variant="neutral"
+      icon="edit"
+      class="mb-4"
+    >
+      {{ payload.notice }}
+
+      <craft-button
+        slot="action"
+        type="button"
+        appearance="outline"
+        size="small"
+        @click="discardDraft"
+      >
+        {{ t('Discard changes') }}
+      </craft-button>
     </craft-callout>
 
     <FormRenderer

--- a/resources/js/modules/elements/composables/useElementAutosave.test.ts
+++ b/resources/js/modules/elements/composables/useElementAutosave.test.ts
@@ -1,0 +1,166 @@
+import {useForm} from '@inertiajs/vue3';
+import {createApp, defineComponent, nextTick} from 'vue';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vite-plus/test';
+import {useElementAutosave} from './useElementAutosave';
+
+const {postSpy} = vi.hoisted(() => ({postSpy: vi.fn()}));
+
+vi.mock('@craftcms/ui', () => ({
+  actionClient: {post: postSpy},
+}));
+
+describe('useElementAutosave', () => {
+  let app: ReturnType<typeof createApp>;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    postSpy.mockReset();
+    postSpy.mockResolvedValue({data: {draftId: 7, timestamp: 'at 9:00 AM'}});
+  });
+
+  afterEach(() => {
+    app?.unmount();
+    container?.remove();
+  });
+
+  function mount(overrides: Record<string, any> = {}) {
+    let autosave!: ReturnType<typeof useElementAutosave>;
+    let form!: ReturnType<typeof useForm<Record<string, any>>>;
+
+    container = document.createElement('div');
+    document.body.append(container);
+    app = createApp(
+      defineComponent({
+        setup() {
+          form = useForm<Record<string, any>>({title: 'Original'});
+          autosave = useElementAutosave(form, {
+            url: '/actions/elements/save-draft',
+            elementType: 'craft\\elements\\Entry',
+            elementId: 12,
+            siteId: 1,
+            draftId: null,
+            enabled: true,
+            ...overrides,
+          });
+
+          return () => null;
+        },
+      })
+    );
+    app.mount(container);
+
+    return {autosave, form};
+  }
+
+  it('creates the draft on the first save and targets it afterwards', async () => {
+    const {autosave} = mount();
+
+    await autosave.save();
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy.mock.calls[0]![1]).toMatchObject({
+      elementType: 'craft\\elements\\Entry',
+      elementId: 12,
+      siteId: 1,
+      provisional: 1,
+    });
+    expect(postSpy.mock.calls[0]![1].draftId).toBeUndefined();
+    expect(autosave.draftId.value).toBe(7);
+
+    await autosave.save();
+
+    expect(postSpy.mock.calls[1]![1]).toMatchObject({
+      draftId: 7,
+      provisional: 1,
+    });
+  });
+
+  it('reports status and the saved timestamp', async () => {
+    const {autosave} = mount();
+
+    expect(autosave.status.value).toBe('idle');
+
+    await autosave.save();
+
+    expect(autosave.status.value).toBe('saved');
+    expect(autosave.savedAt.value).toBe('at 9:00 AM');
+  });
+
+  it('records a failure without throwing', async () => {
+    postSpy.mockRejectedValue({response: {data: {message: 'Nope.'}}});
+
+    const {autosave} = mount();
+
+    await autosave.save();
+
+    expect(autosave.status.value).toBe('failed');
+    expect(autosave.error.value).toBe('Nope.');
+  });
+
+  it('does nothing when disabled', async () => {
+    const {autosave} = mount({enabled: false});
+
+    await autosave.save();
+
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('defers to a real submission in progress', async () => {
+    const {autosave, form} = mount();
+
+    form.processing = true;
+    await autosave.save();
+
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('coalesces saves requested while one is in flight', async () => {
+    const release: Array<() => void> = [];
+    postSpy.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release.push(() =>
+            resolve({data: {draftId: 7, timestamp: 'at 9:00 AM'}})
+          );
+        })
+    );
+
+    const {autosave} = mount();
+
+    const first = autosave.save();
+    void autosave.save();
+    void autosave.save();
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+
+    release[0]!();
+    await nextTick();
+    await nextTick();
+
+    // Both queued requests collapse into a single trailing save.
+    expect(postSpy).toHaveBeenCalledTimes(2);
+
+    release[1]!();
+    await first;
+
+    expect(postSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips scheduling while suspended', async () => {
+    const {autosave} = mount();
+
+    autosave.suspend(() => autosave.schedule());
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('adopts a draft id supplied by the server', async () => {
+    const {autosave} = mount();
+
+    autosave.setDraftId(99);
+    await autosave.save();
+
+    expect(postSpy.mock.calls[0]![1]).toMatchObject({draftId: 99});
+  });
+});

--- a/resources/js/modules/elements/composables/useElementAutosave.ts
+++ b/resources/js/modules/elements/composables/useElementAutosave.ts
@@ -1,0 +1,164 @@
+import {actionClient} from '@craftcms/ui';
+import {useDebounceFn} from '@vueuse/core';
+import type {InertiaForm} from '@inertiajs/vue3';
+import {readonly, ref, type Ref} from 'vue';
+
+export type AutosaveStatus = 'idle' | 'saving' | 'saved' | 'failed';
+
+interface Options {
+  /** The `elements/save-draft` endpoint. */
+  url: string;
+  /** The element class — the shared draft actions resolve the element by type. */
+  elementType: string;
+  /** The canonical element's id — what the draft is created against. */
+  elementId: number | null;
+  siteId: number | null;
+  /** The provisional draft's id, once one exists. */
+  draftId: number | null;
+  /** Autosave is skipped entirely when this is false (revisions, read-only). */
+  enabled: boolean;
+  /** How long to wait after the last edit before saving. */
+  debounceMs?: number;
+}
+
+/**
+ * Autosaves the editor's unsaved changes into a provisional draft, the way the
+ * legacy element editor does.
+ *
+ * The first save creates the draft; `draftId` then identifies it for every
+ * later save and is exposed so the host can submit it alongside the form. The
+ * canonical `elementId` is always sent, matching the hidden input the legacy
+ * editor posts.
+ *
+ * Saves are debounced and serialized — a save in flight defers the next one
+ * rather than racing it, so a burst of typing collapses into one trailing
+ * request per quiet period.
+ */
+export function useElementAutosave(
+  form: InertiaForm<Record<string, any>>,
+  options: Options
+): {
+  status: Readonly<Ref<AutosaveStatus>>;
+  draftId: Readonly<Ref<number | null>>;
+  savedAt: Readonly<Ref<string | null>>;
+  error: Readonly<Ref<string | null>>;
+  save: () => Promise<void>;
+  schedule: () => void;
+  suspend: (during: () => void) => void;
+  setDraftId: (value: number | null) => void;
+} {
+  const status = ref<AutosaveStatus>('idle');
+  const draftId = ref<number | null>(options.draftId);
+  const savedAt = ref<string | null>(null);
+  const error = ref<string | null>(null);
+
+  let inFlight: Promise<void> | null = null;
+  let pending = false;
+
+  async function send(): Promise<void> {
+    status.value = 'saving';
+    error.value = null;
+
+    const payload: Record<string, any> = {
+      ...form.data(),
+      elementType: options.elementType,
+      elementId: options.elementId,
+      siteId: options.siteId,
+    };
+
+    // No draft yet means this request creates one; an existing provisional
+    // draft is targeted by id and stays provisional.
+    if (draftId.value !== null) {
+      payload.draftId = draftId.value;
+    }
+
+    payload.provisional = 1;
+
+    try {
+      const {data} = await actionClient.post(options.url, payload);
+
+      draftId.value = data.draftId ?? draftId.value;
+      savedAt.value = data.timestamp ?? null;
+      status.value = 'saved';
+    } catch (e: any) {
+      status.value = 'failed';
+      error.value = e?.response?.data?.message ?? null;
+    }
+  }
+
+  async function save(): Promise<void> {
+    // A real submission is authoritative — don't race a draft write against it,
+    // and don't autosave the values it just wrote back.
+    if (!options.enabled || form.processing) {
+      return;
+    }
+
+    // Coalesce: whoever is already saving will pick up the newer values on its
+    // trailing run, so at most one extra request is ever queued.
+    if (inFlight) {
+      pending = true;
+
+      return inFlight;
+    }
+
+    inFlight = send().finally(async () => {
+      inFlight = null;
+
+      if (pending) {
+        pending = false;
+        await save();
+      }
+    });
+
+    return inFlight;
+  }
+
+  // Driven by the Form renderers' change callbacks rather than a deep watch on
+  // the form: the form is created empty and its keys are added dynamically, so
+  // watching `form.data()` doesn't reliably track them.
+  const debounced = useDebounceFn(
+    () => void save(),
+    options.debounceMs ?? 1500
+  );
+
+  let suspended = false;
+
+  function schedule(): void {
+    if (suspended) {
+      return;
+    }
+
+    void debounced();
+  }
+
+  /**
+   * Runs `during` without arming autosave. Re-baselining after a save emits
+   * mutations of its own, which would otherwise recreate the very draft the
+   * save just consumed.
+   */
+  function suspend(during: () => void): void {
+    suspended = true;
+
+    try {
+      during();
+    } finally {
+      // Released on a microtask so synchronously-emitted mutations are covered.
+      void Promise.resolve().then(() => (suspended = false));
+    }
+  }
+
+  function setDraftId(value: number | null): void {
+    draftId.value = value;
+  }
+
+  return {
+    status: readonly(status),
+    draftId: readonly(draftId),
+    savedAt: readonly(savedAt),
+    error: readonly(error),
+    save,
+    schedule,
+    suspend,
+    setDraftId,
+  };
+}

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -1,9 +1,10 @@
 import {useEventListener} from '@vueuse/core';
 import {router, useForm, usePage} from '@inertiajs/vue3';
-import {t} from '@craftcms/ui';
-import {computed, onBeforeUnmount} from 'vue';
+import {actionClient, t} from '@craftcms/ui';
+import {computed, onBeforeUnmount, watch} from 'vue';
 import type {FormPayload} from '@/modules/forms/types';
 import {useInertiaFormRenderer} from '@/modules/forms/useInertiaFormRenderer';
+import {useElementAutosave} from '@/modules/elements/composables/useElementAutosave';
 import {useSiteStatuses} from '@/modules/elements/composables/useSiteStatuses';
 import {useSettingsSave} from '@/modules/settings/composables/useSettingsSave';
 
@@ -22,6 +23,13 @@ export interface ElementEditPayload {
   sidebarForm: FormPayload | null;
   metadataHtml: string | null;
   saveUrl: string;
+  applyDraftUrl: string;
+  autosaveUrl: string;
+  discardDraftUrl: string;
+  isProvisionalDraft: boolean;
+  draftId: number | null;
+  canAutosave: boolean;
+  notice: string | null;
   // Element-type view models add their own keys on top of the shared payload.
   [key: string]: unknown;
 }
@@ -53,40 +61,119 @@ export function useElementEditPage({saveData}: Options = {}) {
   // Two bridges share one Inertia form. Each only ever deletes the root keys
   // it wrote itself, and both are constructed here — before either receives a
   // mutation — so neither can claim the other's keys.
-  const {advanceBaseline, errors, onMutation, renderer, values} =
-    useInertiaFormRenderer(form, formPayload);
+  const {
+    advanceBaseline,
+    errors,
+    onMutation: onLayoutMutation,
+    renderer,
+    values,
+  } = useInertiaFormRenderer(form, formPayload);
 
   const {
     advanceBaseline: advanceSidebarBaseline,
     errors: sidebarErrors,
-    onMutation: onSidebarMutation,
+    onMutation: onSidebarFormMutation,
     renderer: sidebarRenderer,
   } = useInertiaFormRenderer(form, sidebarPayload);
 
   useSiteStatuses(form);
 
+  const autosave = useElementAutosave(form, {
+    url: props.autosaveUrl,
+    elementType: props.elementType,
+    elementId: props.canonicalId,
+    siteId: props.siteId,
+    draftId: props.draftId,
+    enabled: props.canAutosave,
+  });
+
+  // Applying a draft consumes it, and Inertia preserves this component across
+  // the visit, so the server's view of the draft is authoritative afterwards.
+  watch(
+    () => props.draftId,
+    (draftId) => autosave.setDraftId(draftId)
+  );
+
+  // The renderers' change callbacks are the authoritative "content changed"
+  // signal, so autosave hangs off them rather than watching the form.
+  function onMutation(mutation: FormPayload['values']): void {
+    onLayoutMutation(mutation);
+    autosave.schedule();
+  }
+
+  function onSidebarMutation(mutation: FormPayload['values']): void {
+    onSidebarFormMutation(mutation);
+    autosave.schedule();
+  }
+
   const {save} = useSettingsSave(
     form,
+    // Applying a draft and saving the element are different endpoints, and
+    // which one applies depends on whether autosave has created a draft by the
+    // time the user submits — not on how the page was first rendered.
     () => ({
-      url: props.saveUrl,
+      url:
+        autosave.draftId.value !== null ? props.applyDraftUrl : props.saveUrl,
       method: 'post' as const,
     }),
     {
       transform: (data) => ({
         ...data,
         ...saveData?.(),
+        // Once autosave has created a provisional draft, the submission has to
+        // target it — otherwise applying would save the canonical element and
+        // strand the draft holding the newer values.
+        //
+        // This posts to a shared `elements/*` action rather than the element
+        // type's own, so it needs the generic identity params: the type-specific
+        // ones (an entry's `entryId`) mean nothing there.
+        ...(autosave.draftId.value !== null
+          ? {
+              elementType: props.elementType,
+              elementId: props.canonicalId,
+              draftId: autosave.draftId.value,
+              provisional: 1,
+            }
+          : {}),
       }),
       onSuccess: () => {
-        advanceBaseline();
-        advanceSidebarBaseline();
+        autosave.suspend(() => {
+          advanceBaseline();
+          advanceSidebarBaseline();
+        });
       },
     }
   );
 
+  /** Throws away the provisional draft, reverting to the canonical element. */
+  async function discardDraft(): Promise<void> {
+    if (autosave.draftId.value === null) {
+      return;
+    }
+
+    await actionClient.post(props.discardDraftUrl, {
+      elementType: props.elementType,
+      elementId: props.canonicalId,
+      siteId: props.siteId,
+      draftId: autosave.draftId.value,
+      provisional: 1,
+    });
+
+    // Re-render from the canonical element rather than patching state here.
+    router.reload();
+  }
+
   // Both the field layout and the sidebar feed the same Inertia form, so its
   // own dirty state covers the whole screen.
+  //
+  // When autosave is running, edits are already safe in a provisional draft, so
+  // only warn if it hasn't caught up — mid-save, or after a failed write.
   function hasUnsavedChanges(): boolean {
-    return !form.processing && form.isDirty;
+    if (form.processing || !form.isDirty) {
+      return false;
+    }
+
+    return !props.canAutosave || autosave.status.value !== 'saved';
   }
 
   useEventListener(window, 'beforeunload', (event) => {
@@ -111,6 +198,8 @@ export function useElementEditPage({saveData}: Options = {}) {
   onBeforeUnmount(removeNavigationGuard);
 
   return {
+    autosave,
+    discardDraft,
     errors,
     form,
     formPayload,

--- a/src/Entry/Elements/Entry.php
+++ b/src/Entry/Elements/Entry.php
@@ -2126,6 +2126,11 @@ JS, [
                 ->control(
                     DateTime::make('postDate')
                         ->showTime()
+                        // Stored times aren't constrained to a picker step, and
+                        // the screen submits natively — a coarser increment
+                        // would make any off-step value fail validation and
+                        // silently block saving.
+                        ->minuteIncrement(1)
                         ->value(self::dateTimeControlValue($this->postDate))
                         ->mode($static ? ControlMode::Disabled : ControlMode::Editable),
                 );
@@ -2134,6 +2139,11 @@ JS, [
                 ->control(
                     DateTime::make('expiryDate')
                         ->showTime()
+                        // Stored times aren't constrained to a picker step, and
+                        // the screen submits natively — a coarser increment
+                        // would make any off-step value fail validation and
+                        // silently block saving.
+                        ->minuteIncrement(1)
                         ->value(self::dateTimeControlValue($this->expiryDate))
                         ->mode($static ? ControlMode::Disabled : ControlMode::Editable),
                 );

--- a/src/Http/Controllers/Entries/EditEntryController.php
+++ b/src/Http/Controllers/Entries/EditEntryController.php
@@ -47,9 +47,10 @@ class EditEntryController
             abort(400, 'No entry was identified by the request.');
         }
 
-        // Visiting a canonical entry resolves to the author's provisional draft
-        // when one exists, so this covers provisional drafts too.
-        if ($element->getIsDraft() || $element->getIsRevision()) {
+        // Provisional drafts are the normal state of any entry someone has
+        // edited, so they render here. Named drafts and revisions still need
+        // the legacy editor's apply/revert controls.
+        if (($element->getIsDraft() && ! $element->isProvisionalDraft) || $element->getIsRevision()) {
             return app(EditElementController::class)->setElement($element)();
         }
 

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -65,11 +65,71 @@ abstract class ElementEditViewModel extends ViewModel
     }
 
     /**
-     * Where the edit form posts. Element types point this at their own store
-     * action — the Form payload submits ordinary nested input names, so the
-     * existing save controllers read it without a translation layer.
+     * The element type's own store action. The Form payload submits ordinary
+     * nested input names, so the existing save controllers read it without a
+     * translation layer.
      */
-    abstract public function saveUrl(): string;
+    abstract protected function elementSaveUrl(): string;
+
+    /** Where the edit form posts when there are no provisional changes to apply. */
+    public function saveUrl(): string
+    {
+        return $this->elementSaveUrl();
+    }
+
+    /**
+     * Where the edit form posts once provisional changes exist.
+     *
+     * The client picks between this and {@see saveUrl()} at submit time rather
+     * than relying on the state at page load: autosave can create a provisional
+     * draft partway through editing a canonical element, and from that point on
+     * saving means applying the draft, not saving the element under it.
+     */
+    public function applyDraftUrl(): string
+    {
+        return Url::actionUrl('elements/apply-draft');
+    }
+
+    /**
+     * Where unsaved changes are autosaved. Posting here with no draft yet
+     * creates the provisional draft; afterwards it updates it in place.
+     */
+    public function autosaveUrl(): string
+    {
+        return Url::actionUrl('elements/save-draft');
+    }
+
+    /** Where a provisional draft is discarded, reverting to the canonical element. */
+    public function discardDraftUrl(): string
+    {
+        return Url::actionUrl('elements/delete-draft');
+    }
+
+    public function isProvisionalDraft(): bool
+    {
+        return (bool) $this->element->isProvisionalDraft;
+    }
+
+    public function draftId(): ?int
+    {
+        return $this->element->draftId;
+    }
+
+    public function canAutosave(): bool
+    {
+        return $this->canSave && ! $this->element->getIsRevision();
+    }
+
+    /**
+     * The notice shown above the editor when the screen is showing unsaved
+     * provisional changes rather than the canonical element.
+     */
+    public function notice(): ?string
+    {
+        return $this->element->isProvisionalDraft
+            ? t('Showing your unsaved changes.')
+            : null;
+    }
 
     public function elementId(): ?int
     {

--- a/src/Http/ViewModels/EntryEditViewModel.php
+++ b/src/Http/ViewModels/EntryEditViewModel.php
@@ -23,7 +23,7 @@ class EntryEditViewModel extends ElementEditViewModel
     }
 
     #[Override]
-    public function saveUrl(): string
+    protected function elementSaveUrl(): string
     {
         return Url::actionUrl('entries/save-entry');
     }

--- a/tests/Feature/Http/Controllers/Elements/EditElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/EditElementControllerTest.php
@@ -330,28 +330,6 @@ it('renders revision notices and controls for revisions', function () {
         ->assertSee('elements/revert', false);
 });
 
-it('renders provisional draft notices when a provisional draft exists', function () {
-    $entry = EntryModel::factory()
-        ->forSection($this->section)
-        ->forEntryType($this->entryType)
-        ->createElement([
-            'title' => 'Canonical Title',
-            'slug' => 'canonical-title',
-        ]);
-
-    app(Drafts::class)->createDraft($entry, auth()->id(), provisional: true);
-
-    get(cp_url(sprintf(
-        'entries/%s/%d-%s',
-        $entry->getSection()->handle,
-        $entry->id,
-        $entry->slug,
-    )))
-        ->assertOk()
-        ->assertSeeText('Showing your unsaved changes.')
-        ->assertSee('elements/apply-draft', false);
-});
-
 it('renders unpublished draft controls', function () {
     /** @var Entry $draft */
     $draft = app(Entry::class);

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -147,10 +147,31 @@ it('falls back to the legacy editor for revisions', function () {
         ->assertSee('elements/revert', false);
 });
 
-it('falls back to the legacy editor when a provisional draft exists', function () {
-    app(Drafts::class)->createDraft($this->entry, auth()->id(), provisional: true);
+it('renders a provisional draft in the Inertia editor', function () {
+    $draft = app(Drafts::class)->createDraft($this->entry, auth()->id(), provisional: true);
 
     get($this->entry->getCpEditUrl())
         ->assertOk()
-        ->assertSee('elements/apply-draft', false);
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('content/Edit')
+            ->where('isProvisionalDraft', true)
+            ->where('draftId', $draft->draftId)
+            ->where('canonicalId', $this->entry->id)
+            ->where('notice', 'Showing your unsaved changes.')
+            ->where('applyDraftUrl', fn (string $url) => str_contains($url, 'elements/apply-draft'))
+            ->etc()
+        );
+});
+
+it('autosaves against the shared draft action', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('autosaveUrl', fn (string $url) => str_contains($url, 'elements/save-draft'))
+            ->where('discardDraftUrl', fn (string $url) => str_contains($url, 'elements/delete-draft'))
+            ->where('canAutosave', true)
+            ->where('isProvisionalDraft', false)
+            ->where('draftId', null)
+            ->etc()
+        );
 });


### PR DESCRIPTION
### Description

Renders provisional drafts in the Inertia editor and autosaves into them, which is what makes the port usable: the legacy editor creates a provisional draft the moment anyone types, so before this every previously-edited entry fell through to the old screen.

`EditEntryController` now only defers to `EditElementController` for named drafts and revisions. Provisional drafts render here, with a notice and a Discard control, and `saveUrl`/`applyDraftUrl` let the client pick its target at submit time — autosave can create a draft partway through editing a canonical element, and from that point saving means applying the draft rather than saving the element underneath it.

`useElementAutosave` posts to the shared `elements/save-draft` action, debounced and serialized so a burst of typing collapses into one trailing request. It is driven by the Form renderers' change callbacks rather than a watch on the Inertia form, because the form starts empty and gains its keys dynamically. Re-baselining after a save is suspended so it can't recreate the draft the save just consumed, and the draft id resyncs from the server after each visit. With edits safe in a draft, the unsaved-changes prompt now only fires when autosave hasn't caught up.

Also fixes a save-blocking bug from the meta-fields PR: the `DateTime` control defaults to a 30-minute increment, so an entry whose post time fell between steps failed native form validation and the Save button silently did nothing. The legacy editor never hit this because it submits through JS. Post and expiry dates now accept the stored precision.
