### PR TITLE
[6.x] Add header and alternate save actions to the Inertia editor

### DIFF
--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -30,7 +30,24 @@
     sidebarErrors,
     sidebarPayload,
     sidebarRenderer,
+    submitAction,
   } = useElementEditPage({saveData: props.saveData});
+
+  // Alternate saves in the Save button's menu, and the buttons beside it.
+  const formActionItems = computed(() =>
+    payload.formActions.map((action) => ({
+      label: action.label,
+      onClick: () => submitAction(action),
+    }))
+  );
+
+  const headerButtons = computed(() =>
+    payload.headerActions.map((action) => ({
+      label: action.label,
+      variant: action.variant,
+      onClick: () => submitAction(action),
+    }))
+  );
 
   const autosaveMessage = computed(() => {
     switch (autosave.status.value) {
@@ -51,6 +68,11 @@
     title: payload.title,
     form,
     onSave: save,
+    // The element supplies its own full set of alternate saves — including its
+    // own "Save and continue editing" — so the layout's default would duplicate.
+    defaultFormActions: [],
+    formActions: formActionItems.value,
+    formAdditionalButtons: headerButtons.value,
   }));
 </script>
 

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -1,12 +1,30 @@
 import {useEventListener} from '@vueuse/core';
 import {router, useForm, usePage} from '@inertiajs/vue3';
 import {actionClient, t} from '@craftcms/ui';
-import {computed, onBeforeUnmount, watch} from 'vue';
+import {computed, nextTick, onBeforeUnmount, ref, watch} from 'vue';
 import type {FormPayload} from '@/modules/forms/types';
 import {useInertiaFormRenderer} from '@/modules/forms/useInertiaFormRenderer';
 import {useElementAutosave} from '@/modules/elements/composables/useElementAutosave';
 import {useSiteStatuses} from '@/modules/elements/composables/useSiteStatuses';
 import {useSettingsSave} from '@/modules/settings/composables/useSettingsSave';
+
+/**
+ * A save the screen can perform besides the plain Save button — an alternate
+ * save action, or a header button like "Create a draft".
+ *
+ * `actionUrl` of `null` means "the screen's ordinary save target", which
+ * depends on whether a provisional draft exists by the time it's submitted.
+ */
+export interface ElementFormAction {
+  label: string;
+  actionUrl: string | null;
+  params: Record<string, unknown>;
+  /** Pre-encrypted by the server; the save controllers decrypt it. */
+  redirect: string | null;
+  variant?: string;
+  shortcut?: boolean;
+  shift?: boolean;
+}
 
 /** The shared payload every {@link ElementEditViewModel} emits. */
 export interface ElementEditPayload {
@@ -24,6 +42,8 @@ export interface ElementEditPayload {
   metadataHtml: string | null;
   saveUrl: string;
   applyDraftUrl: string;
+  formActions: Array<ElementFormAction>;
+  headerActions: Array<ElementFormAction>;
   autosaveUrl: string;
   discardDraftUrl: string;
   isProvisionalDraft: boolean;
@@ -106,6 +126,11 @@ export function useElementEditPage({saveData}: Options = {}) {
     autosave.schedule();
   }
 
+  // Set for the duration of one submission when an alternate action owns it,
+  // so the shared save pipeline (elevated sessions, error handling, the
+  // processing flag) is reused rather than reimplemented per action.
+  const pendingAction = ref<ElementFormAction | null>(null);
+
   const {save} = useSettingsSave(
     form,
     // Applying a draft and saving the element are different endpoints, and
@@ -113,7 +138,8 @@ export function useElementEditPage({saveData}: Options = {}) {
     // time the user submits — not on how the page was first rendered.
     () => ({
       url:
-        autosave.draftId.value !== null ? props.applyDraftUrl : props.saveUrl,
+        pendingAction.value?.actionUrl ??
+        (autosave.draftId.value !== null ? props.applyDraftUrl : props.saveUrl),
       method: 'post' as const,
     }),
     {
@@ -135,6 +161,12 @@ export function useElementEditPage({saveData}: Options = {}) {
               provisional: 1,
             }
           : {}),
+        // An alternate action's own params win — "Create a draft" has to be
+        // able to override the provisional targeting above.
+        ...pendingAction.value?.params,
+        ...(pendingAction.value?.redirect
+          ? {redirect: pendingAction.value.redirect}
+          : {}),
       }),
       onSuccess: () => {
         autosave.suspend(() => {
@@ -144,6 +176,21 @@ export function useElementEditPage({saveData}: Options = {}) {
       },
     }
   );
+
+  /**
+   * Submits the edit form under an alternate action — a Save-menu entry or a
+   * header button. The action owns the request only until it settles, so the
+   * plain Save button reverts to the normal target afterwards.
+   */
+  function submitAction(action: ElementFormAction): void {
+    pendingAction.value = action;
+
+    // `redirect: false` keeps `useSettingsSave` from layering the screen's own
+    // redirect on top of the one this action carries.
+    save({redirect: false});
+
+    void nextTick(() => (pendingAction.value = null));
+  }
 
   /** Throws away the provisional draft, reverting to the canonical element. */
   async function discardDraft(): Promise<void> {
@@ -200,6 +247,7 @@ export function useElementEditPage({saveData}: Options = {}) {
   return {
     autosave,
     discardDraft,
+    submitAction,
     errors,
     form,
     formPayload,

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -19,6 +19,8 @@ use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\DeltaRegistry;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Url;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Gate;
 
 use function CraftCms\Cms\t;
 
@@ -103,6 +105,106 @@ abstract class ElementEditViewModel extends ViewModel
     public function discardDraftUrl(): string
     {
         return Url::actionUrl('elements/delete-draft');
+    }
+
+    /**
+     * The alternate save actions offered beside the Save button — "Save and
+     * continue editing", "Save as a new …", and friends.
+     *
+     * Each entry submits the edit form as it stands, optionally to a different
+     * action and with extra params. `actionUrl` is null when the item posts to
+     * the screen's ordinary save target, which the client resolves at submit
+     * time (see {@see applyDraftUrl()}).
+     *
+     * @return list<array{label: string, actionUrl: string|null, params: array<string, mixed>, redirect: string|null, shortcut: bool, shift: bool}>
+     */
+    public function formActions(): array
+    {
+        if (! $this->canSave) {
+            return [];
+        }
+
+        return array_map(fn (array $action): array => [
+            'label' => (string) $action['label'],
+            'actionUrl' => isset($action['action']) ? Url::actionUrl($action['action']) : null,
+            'params' => isset($action['action'])
+                ? [...$this->genericIdentityParams(), ...($action['params'] ?? [])]
+                : ($action['params'] ?? []),
+            // Redirects cross the wire encrypted; the save controllers decrypt
+            // them and render `{cpEditUrl}` against the saved element.
+            'redirect' => isset($action['redirect']) ? Crypt::encrypt($action['redirect']) : null,
+            'shortcut' => (bool) ($action['shortcut'] ?? false),
+            'shift' => (bool) ($action['shift'] ?? false),
+        ], $this->element->getAltActions());
+    }
+
+    /**
+     * Buttons shown beside Save.
+     *
+     * Applying a named draft and reverting a revision belong here too, but
+     * those screens still render through the legacy editor, so they arrive with
+     * the draft/revision work rather than as unreachable buttons.
+     *
+     * @return list<array{label: string, actionUrl: string, params: array<string, mixed>, redirect: string|null, variant: string}>
+     */
+    public function headerActions(): array
+    {
+        $element = $this->element;
+        $canonical = $element->getCanonical(true);
+        $isCurrent = $element->getIsCanonical() || $element->isProvisionalDraft;
+        $actions = [];
+
+        if ($isCurrent && ! $element->getIsUnpublishedDraft() && Gate::check('createDrafts', $canonical)) {
+            $actions[] = [
+                'label' => t('Create a draft'),
+                'actionUrl' => Url::actionUrl('elements/save-draft'),
+                'params' => [
+                    ...$this->genericIdentityParams(),
+                    // Without this the provisional draft is promoted in place
+                    // rather than a separate named draft being created.
+                    'dropProvisional' => 1,
+                ],
+                'redirect' => Crypt::encrypt('{cpEditUrl}'),
+                'variant' => 'outline',
+            ];
+        }
+
+        // Read-only users who may still branch the element get the duplicate
+        // path instead, since they can't save over the canonical one.
+        if (
+            ! $this->canSave &&
+            ! $element->getIsRevision() &&
+            Gate::check('duplicateAsDraft', $element)
+        ) {
+            $actions[] = [
+                'label' => t('Save as a new {type}', ['type' => $element::lowerDisplayName()]),
+                'actionUrl' => Url::actionUrl('elements/duplicate'),
+                'params' => [
+                    ...$this->genericIdentityParams(),
+                    'asUnpublishedDraft' => 1,
+                ],
+                'redirect' => Crypt::encrypt('{cpEditUrl}'),
+                'variant' => 'outline',
+            ];
+        }
+
+        return $actions;
+    }
+
+    /**
+     * Identity params the shared `elements/*` actions need to resolve the
+     * element. The type-specific save controllers key off their own params
+     * (an entry's `entryId`), so these only apply to the generic endpoints.
+     *
+     * @return array{elementType: class-string<ElementInterface>, elementId: int|null, siteId: int|null}
+     */
+    private function genericIdentityParams(): array
+    {
+        return [
+            'elementType' => $this->element::class,
+            'elementId' => $this->element->getCanonical(true)->id,
+            'siteId' => $this->element->siteId,
+        ];
     }
 
     public function isProvisionalDraft(): bool

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -119,6 +119,40 @@ it('saves the meta fields the sidebar form submits', function () {
         ->and($entry->postDate->format('Y-m-d'))->toBe('2027-03-04');
 });
 
+it('offers a Create a draft button on a canonical entry', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('headerActions', function (Collection $actions) {
+                $create = $actions->firstWhere('label', 'Create a draft');
+
+                return $create !== null
+                    && str_contains((string) $create['actionUrl'], 'elements/save-draft')
+                    && ($create['params']['dropProvisional'] ?? null) === 1
+                    && is_string($create['redirect']);
+            })
+            ->etc()
+        );
+});
+
+it('offers the alternate save actions beside Save', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('formActions', function (Collection $actions) {
+                $labels = $actions->pluck('label');
+
+                return $labels->contains('Save and continue editing')
+                    && $labels->contains('Save and add another')
+                    && $actions->contains(fn (array $action) => str_contains(
+                        (string) ($action['actionUrl'] ?? ''),
+                        'elements/duplicate',
+                    ));
+            })
+            ->etc()
+        );
+});
+
 it('falls back to the legacy editor for drafts', function () {
     $draft = app(Drafts::class)->createDraft($this->entry, auth()->id(), name: 'Working Draft');
 


### PR DESCRIPTION
### Description

Adds the header buttons and the alternate save actions beside the Save button.

`headerActions()` covers "Create a draft" (a canonical element the user may branch, posting to `elements/save-draft` with `dropProvisional` so a named draft is created rather than the provisional one being promoted) and "Save as a new …" for users who can't save the element but may duplicate it. `formActions()` serializes `getAltActions()` into the Save button's menu — Save and continue editing, Save and add another, Save as a new … — with redirects encrypted the way the save controllers expect to decrypt them.

Both render through `FormActions`, which already supported additional buttons and action items. The layout's own default action is switched off for this screen, since the element supplies its own "Save and continue editing" and the two would otherwise both appear.

`submitAction()` routes every one of these through the existing save pipeline rather than reimplementing submission per action: a pending-action reference overrides the target URL and merges the action's params for exactly one submission, so they inherit the elevated-session handling, error plumbing, and processing state already in place. Action params take precedence over the provisional-draft targeting, which is what lets "Create a draft" opt out of it.

Actions posting to a shared `elements/*` endpoint now carry the generic identity params those endpoints resolve by. The type-specific save controllers key off their own params, so a request built for one is not understood by the other — this previously surfaced as a 400 when applying a draft, and again here.

Applying a named draft and reverting a revision belong beside these buttons, but those screens still render through the legacy editor, so they arrive with the draft and revision work rather than as buttons nothing can reach.
