### PR TITLE
[6.x] Render named drafts and revisions in the Inertia editor

### DIFF
--- a/resources/js/common/components/FormActions.vue
+++ b/resources/js/common/components/FormActions.vue
@@ -11,6 +11,8 @@
     actionItems?: Array<ActionItem>;
     additionalActions?: Array<ActionItem>;
     additionalButtons?: Array<ActionItemButton>;
+    /** Overrides the submit button's text (e.g. "Save draft"). */
+    submitLabel?: string;
     readOnly?: boolean;
   }>();
 
@@ -82,7 +84,7 @@
           :loading="isButtonProcessing(primaryButton)"
           :disabled="form.processing"
         >
-          {{ t('Save') }}
+          {{ submitLabel ?? t('Save') }}
         </craft-button>
       </slot>
       <ActionMenu icon="chevron-down" :actions="actionItems">
@@ -106,7 +108,7 @@
         :loading="isButtonProcessing(primaryButton)"
         :disabled="form.processing"
       >
-        {{ t('Save') }}
+        {{ submitLabel ?? t('Save') }}
       </craft-button>
     </slot>
 

--- a/resources/js/common/layouts/screens/PageScreen.vue
+++ b/resources/js/common/layouts/screens/PageScreen.vue
@@ -247,6 +247,7 @@
                           :action-items="formActionItems"
                           :additional-actions="formAdditionalActions"
                           :additional-buttons="formAdditionalButtons"
+                          :submit-label="submitButtonLabel"
                           :read-only="readOnly"
                         >
                           <template

--- a/resources/js/common/layouts/screens/SlideoutScreen.vue
+++ b/resources/js/common/layouts/screens/SlideoutScreen.vue
@@ -109,7 +109,10 @@
   );
 
   const submitLabel = computed(
-    () => chrome.value.submitButtonLabel || t('Save')
+    () =>
+      props.value.submitButtonLabel ||
+      chrome.value.submitButtonLabel ||
+      t('Save')
   );
 
   /**

--- a/resources/js/common/layouts/screens/types.ts
+++ b/resources/js/common/layouts/screens/types.ts
@@ -24,6 +24,8 @@ export interface ScreenProps {
   formActions?: Array<ActionItem>;
   formAdditionalActions?: Array<ActionItem>;
   formAdditionalButtons?: Array<ActionItemButton>;
+  /** Overrides the submit button's text. Craft 5: `submitButtonLabel`. */
+  submitButtonLabel?: string;
   additionalSkipLinks?: Array<{label: string; url: string}>;
 }
 

--- a/resources/js/modules/elements/components/ElementContextMenu.vue
+++ b/resources/js/modules/elements/components/ElementContextMenu.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+  import {computed, h} from 'vue';
+  import ActionMenu from '@/common/components/ActionMenu.vue';
+  import type {ActionItem} from '@/common/types';
+  import type {ElementContextMenuItem} from '@/modules/elements/composables/useElementEditPage';
+
+  const props = defineProps<{
+    label: string;
+    items: Array<ElementContextMenuItem>;
+  }>();
+
+  /**
+   * The action menu's item contract has no nested-group shape, so group
+   * headings ride in as `display` items — the documented escape hatch for
+   * arbitrary content — while drafts and revisions stay ordinary links.
+   */
+  const actions = computed<Array<ActionItem>>(() =>
+    props.items.map((item): ActionItem => {
+      if (item.type === 'hr') {
+        return {type: 'hr'};
+      }
+
+      if (item.type === 'heading') {
+        return {
+          type: 'display',
+          is: () =>
+            h(
+              'h2',
+              {
+                class:
+                  'px-2 pt-2 pb-1 text-xs font-bold text-neutral-text-quiet',
+              },
+              item.label
+            ),
+        };
+      }
+
+      return {
+        type: 'link',
+        href: item.href!,
+        label: item.label!,
+        // Shown beneath the label — who saved it and when.
+        description: item.description,
+        selected: item.selected,
+      };
+    })
+  );
+</script>
+
+<template>
+  <ActionMenu :actions="actions" :label="label" icon="chevron-down" />
+</template>

--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -2,6 +2,7 @@
   import {t} from '@craftcms/ui';
   import {computed} from 'vue';
   import DynamicHtmlRenderer from '@/common/components/DynamicHtmlRenderer.vue';
+  import ElementContextMenu from '@/modules/elements/components/ElementContextMenu.vue';
   import LayoutSlot from '@/common/components/LayoutSlot.vue';
   import Pane from '@/common/components/Pane.vue';
   import {useAppLayout} from '@/common/composables/useAppLayout';
@@ -68,6 +69,7 @@
     title: payload.title,
     form,
     onSave: save,
+    submitButtonLabel: payload.submitButtonLabel,
     // The element supplies its own full set of alternate saves — including its
     // own "Save and continue editing" — so the layout's default would duplicate.
     defaultFormActions: [],
@@ -77,6 +79,13 @@
 </script>
 
 <template>
+  <LayoutSlot v-if="payload.contextMenu" name="context-menu">
+    <ElementContextMenu
+      :label="payload.contextMenu.label"
+      :items="payload.contextMenu.items"
+    />
+  </LayoutSlot>
+
   <!--
     Tabs are rendered by `FormNodeList` inside the form itself, and header
     actions come through `useAppLayout`'s form-action props — filling the
@@ -111,6 +120,7 @@
       {{ payload.notice }}
 
       <craft-button
+        v-if="payload.canDiscardDraft"
         slot="action"
         type="button"
         appearance="outline"
@@ -119,6 +129,15 @@
       >
         {{ t('Discard changes') }}
       </craft-button>
+    </craft-callout>
+
+    <craft-callout
+      v-if="payload.mergeNotice"
+      variant="warning"
+      icon="triangle-exclamation"
+      class="mb-4"
+    >
+      {{ payload.mergeNotice }}
     </craft-callout>
 
     <FormRenderer

--- a/resources/js/modules/elements/composables/useElementAutosave.test.ts
+++ b/resources/js/modules/elements/composables/useElementAutosave.test.ts
@@ -39,6 +39,7 @@ describe('useElementAutosave', () => {
             elementId: 12,
             siteId: 1,
             draftId: null,
+            isProvisional: false,
             enabled: true,
             ...overrides,
           });
@@ -69,10 +70,10 @@ describe('useElementAutosave', () => {
 
     await autosave.save();
 
-    expect(postSpy.mock.calls[1]![1]).toMatchObject({
-      draftId: 7,
-      provisional: 1,
-    });
+    // The second save targets the existing draft; `provisional` is dropped
+    // because sending it would narrow the server's lookup.
+    expect(postSpy.mock.calls[1]![1]).toMatchObject({draftId: 7});
+    expect(postSpy.mock.calls[1]![1].provisional).toBeUndefined();
   });
 
   it('reports status and the saved timestamp', async () => {
@@ -153,6 +154,17 @@ describe('useElementAutosave', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps sending provisional while editing a provisional draft', async () => {
+    const {autosave} = mount({draftId: 7, isProvisional: true});
+
+    await autosave.save();
+
+    expect(postSpy.mock.calls[0]![1]).toMatchObject({
+      draftId: 7,
+      provisional: 1,
+    });
   });
 
   it('adopts a draft id supplied by the server', async () => {

--- a/resources/js/modules/elements/composables/useElementAutosave.ts
+++ b/resources/js/modules/elements/composables/useElementAutosave.ts
@@ -15,6 +15,13 @@ interface Options {
   siteId: number | null;
   /** The provisional draft's id, once one exists. */
   draftId: number | null;
+  /**
+   * Whether the draft being edited is provisional. Sending `provisional` for a
+   * named draft narrows the server's lookup to provisional drafts and it stops
+   * resolving, so it's only ever sent when true — or when this request is the
+   * one creating the draft, which always creates a provisional one.
+   */
+  isProvisional: boolean;
   /** Autosave is skipped entirely when this is false (revisions, read-only). */
   enabled: boolean;
   /** How long to wait after the last edit before saving. */
@@ -72,7 +79,9 @@ export function useElementAutosave(
       payload.draftId = draftId.value;
     }
 
-    payload.provisional = 1;
+    if (options.isProvisional || draftId.value === null) {
+      payload.provisional = 1;
+    }
 
     try {
       const {data} = await actionClient.post(options.url, payload);

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -26,6 +26,18 @@ export interface ElementFormAction {
   shift?: boolean;
 }
 
+/**
+ * An entry in the drafts-and-revisions switcher. Groups arrive flattened, with
+ * `heading` rows standing in for the nesting the action menu has no shape for.
+ */
+export interface ElementContextMenuItem {
+  type: 'link' | 'heading' | 'hr';
+  label?: string;
+  description?: string;
+  href?: string;
+  selected?: boolean;
+}
+
 /** The shared payload every {@link ElementEditViewModel} emits. */
 export interface ElementEditPayload {
   elementId: number | null;
@@ -50,6 +62,13 @@ export interface ElementEditPayload {
   draftId: number | null;
   canAutosave: boolean;
   notice: string | null;
+  mergeNotice: string | null;
+  canDiscardDraft: boolean;
+  submitButtonLabel: string;
+  contextMenu: {
+    label: string;
+    items: Array<ElementContextMenuItem>;
+  } | null;
   // Element-type view models add their own keys on top of the shared payload.
   [key: string]: unknown;
 }
@@ -104,8 +123,20 @@ export function useElementEditPage({saveData}: Options = {}) {
     elementId: props.canonicalId,
     siteId: props.siteId,
     draftId: props.draftId,
+    isProvisional: props.isProvisionalDraft,
     enabled: props.canAutosave,
   });
+
+  /**
+   * Whether the draft the screen is working against is provisional — either it
+   * loaded that way, or autosave created one on a canonical element (autosave
+   * only ever creates provisional drafts).
+   */
+  const draftIsProvisional = computed(
+    () =>
+      props.isProvisionalDraft ||
+      (props.draftId === null && autosave.draftId.value !== null)
+  );
 
   // Applying a draft consumes it, and Inertia preserves this component across
   // the visit, so the server's view of the draft is authoritative afterwards.
@@ -158,7 +189,7 @@ export function useElementEditPage({saveData}: Options = {}) {
               elementType: props.elementType,
               elementId: props.canonicalId,
               draftId: autosave.draftId.value,
-              provisional: 1,
+              ...(draftIsProvisional.value ? {provisional: 1} : {}),
             }
           : {}),
         // An alternate action's own params win — "Create a draft" has to be

--- a/src/Http/Controllers/Entries/EditEntryController.php
+++ b/src/Http/Controllers/Entries/EditEntryController.php
@@ -4,24 +4,22 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http\Controllers\Entries;
 
+use CraftCms\Cms\Element\ElementHelper;
+use CraftCms\Cms\Element\Elements;
 use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Http\Controllers\Elements\Concerns\SavesElement;
-use CraftCms\Cms\Http\Controllers\Elements\EditElementController;
 use CraftCms\Cms\Http\Requests\ElementRequest;
-use CraftCms\Cms\Http\Responses\CpScreenResponse;
 use CraftCms\Cms\Http\ViewModels\EntryEditViewModel;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Renders the Inertia entry edit screen.
+ * Renders the Inertia entry edit screen for the canonical entry, its drafts,
+ * and its revisions.
  *
- * Drafts and revisions still fall through to the legacy
- * {@see EditElementController}, which keeps their notices, apply/revert
- * controls, and canonical-change merging intact until those screens are ported.
- * The legacy controller also continues to serve slideouts and the element types
- * that haven't been ported yet.
+ * The legacy `EditElementController` still serves slideouts and the element
+ * types that haven't been ported.
  */
 class EditEntryController
 {
@@ -29,9 +27,10 @@ class EditEntryController
 
     public function __construct(
         protected readonly ElementRequest $request,
+        private readonly Elements $elements,
     ) {}
 
-    public function __invoke(): Response|CpScreenResponse|InertiaResponse
+    public function __invoke(): Response|InertiaResponse
     {
         $element = $this->request->element(
             ['id' => $this->request->route('id') ?? $this->request->integer('elementId')],
@@ -47,11 +46,17 @@ class EditEntryController
             abort(400, 'No entry was identified by the request.');
         }
 
-        // Provisional drafts are the normal state of any entry someone has
-        // edited, so they render here. Named drafts and revisions still need
-        // the legacy editor's apply/revert controls.
-        if (($element->getIsDraft() && ! $element->isProvisionalDraft) || $element->getIsRevision()) {
-            return app(EditElementController::class)->setElement($element)();
+        // A draft that has fallen behind its canonical entry picks up the newer
+        // changes before rendering, and says so.
+        $mergedCanonicalChanges = (
+            $element::trackChanges() &&
+            $element->getIsDraft() &&
+            ! $element->getIsUnpublishedDraft() &&
+            ElementHelper::isOutdated($element)
+        );
+
+        if ($mergedCanonicalChanges) {
+            $this->elements->mergeCanonicalChanges($element);
         }
 
         $this->applyParamsToElement($element);
@@ -60,6 +65,7 @@ class EditEntryController
             entry: $element,
             request: $this->request,
             canSave: $this->canSave($element, $this->request->craftUser()),
+            mergedCanonicalChanges: $mergedCanonicalChanges,
         ));
     }
 }

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http\ViewModels;
 
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\Cp\Html\ContentHtml;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\ElementHelper;
+use CraftCms\Cms\Element\Queries\Contracts\ElementQueryInterface;
 use CraftCms\Cms\FieldLayout\FieldLayoutCompiler;
 use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\FormContext;
@@ -17,8 +19,11 @@ use CraftCms\Cms\Http\Controllers\Elements\Concerns\ElementCrumbs;
 use CraftCms\Cms\Http\Requests\ElementRequest;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\DeltaRegistry;
+use CraftCms\Cms\Support\Facades\I18N;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Url;
+use CraftCms\Cms\Translation\Locale;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Gate;
 
@@ -62,6 +67,7 @@ abstract class ElementEditViewModel extends ViewModel
         protected readonly ElementInterface $element,
         ElementRequest $request,
         protected readonly bool $canSave = true,
+        protected readonly bool $mergedCanonicalChanges = false,
     ) {
         $this->request = $request;
     }
@@ -169,6 +175,43 @@ abstract class ElementEditViewModel extends ViewModel
             ];
         }
 
+        // Applying a named draft writes it onto the canonical element. The
+        // provisional case isn't here: for those the Save button *is* apply.
+        if (
+            $element->getIsDraft() &&
+            ! $isCurrent &&
+            $this->canSave &&
+            Gate::check('saveCanonical', $element)
+        ) {
+            $actions[] = [
+                'label' => t('Apply draft'),
+                'actionUrl' => Url::actionUrl('elements/apply-draft'),
+                'params' => [
+                    ...$this->genericIdentityParams(),
+                    'draftId' => $element->draftId,
+                ],
+                'redirect' => Crypt::encrypt('{cpEditUrl}'),
+                'variant' => 'secondary',
+            ];
+        }
+
+        if (
+            $element->getIsRevision() &&
+            $element->hasRevisions() &&
+            Gate::check('saveCanonical', $element)
+        ) {
+            $actions[] = [
+                'label' => t('Revert content from this revision'),
+                'actionUrl' => Url::actionUrl('elements/revert'),
+                'params' => [
+                    ...$this->genericIdentityParams(),
+                    'revisionId' => $element->revisionId,
+                ],
+                'redirect' => Crypt::encrypt('{cpEditUrl}'),
+                'variant' => 'outline',
+            ];
+        }
+
         // Read-only users who may still branch the element get the duplicate
         // path instead, since they can't save over the canonical one.
         if (
@@ -189,6 +232,163 @@ abstract class ElementEditViewModel extends ViewModel
         }
 
         return $actions;
+    }
+
+    /**
+     * The drafts-and-revisions switcher shown beside the breadcrumbs.
+     *
+     * Groups are flattened into a single item list — headings become `heading`
+     * entries the client renders as non-interactive rows — because the action
+     * menu's item contract has no nested-group shape.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function contextMenu(): ?array
+    {
+        $element = $this->element->isProvisionalDraft
+            ? $this->element->getCanonical(true)
+            : $this->element;
+
+        if (! $element->id || $element->getIsUnpublishedDraft()) {
+            return null;
+        }
+
+        $drafts = $element::find()
+            ->draftOf($element)
+            ->siteId($element->siteId)
+            ->status(null)
+            ->orderByDesc('dateUpdated')
+            ->with(['draftCreator'])
+            ->get()
+            ->filter(fn (ElementInterface $draft): bool => $this->request->craftUser()->can('view', $draft))
+            ->all();
+
+        $revisions = $this->recentRevisions($element);
+
+        if ($drafts === [] && $revisions->isEmpty()) {
+            return null;
+        }
+
+        $formatter = I18N::getFormatter();
+        $baseParams = Arr::except($this->request->query(), ['draftId', 'revisionId', 'siteId', 'fresh']);
+        $cpEditUrl = Url::cpUrl($element->getCpEditUrl(), ['draftId' => null, 'revisionId' => null]);
+        $isDraft = $this->element->getIsDraft() && ! $this->element->isProvisionalDraft;
+        $isRevision = $this->element->getIsRevision();
+
+        $currentRevision = $element->getCurrentRevision();
+        $currentCreator = $currentRevision?->getRevisionCreator();
+        $currentTimestamp = $formatter->asTimestamp(
+            $currentRevision->dateCreated ?? $element->dateUpdated,
+            Locale::LENGTH_SHORT,
+            true,
+        );
+
+        $items = [[
+            'type' => 'link',
+            'label' => t('Current'),
+            'description' => $currentCreator
+                ? t('Saved {timestamp} by {creator}', ['timestamp' => $currentTimestamp, 'creator' => $currentCreator->name])
+                : t('Last saved {timestamp}', ['timestamp' => $currentTimestamp]),
+            'href' => $cpEditUrl,
+            'selected' => ! $isDraft && ! $isRevision,
+        ]];
+
+        if ($drafts !== []) {
+            $items[] = ['type' => 'heading', 'label' => t('Drafts')];
+
+            foreach ($drafts as $draft) {
+                $creator = $draft->getDraftCreator();
+                $timestamp = $formatter->asTimestamp($draft->dateUpdated, Locale::LENGTH_SHORT, true);
+
+                $items[] = [
+                    'type' => 'link',
+                    'label' => (string) $draft->draftName,
+                    'description' => $creator
+                        ? t('Saved {timestamp} by {creator}', ['timestamp' => $timestamp, 'creator' => $creator->name])
+                        : t('Last saved {timestamp}', ['timestamp' => $timestamp]),
+                    'href' => Url::urlWithParams($cpEditUrl, [...$baseParams, 'draftId' => $draft->draftId]),
+                    'selected' => $draft->id === $this->element->id,
+                ];
+            }
+        }
+
+        if ($revisions->isNotEmpty()) {
+            $items[] = ['type' => 'heading', 'label' => t('Recent Revisions')];
+
+            foreach ($revisions as $revision) {
+                $creator = $revision->getRevisionCreator();
+                $timestamp = $formatter->asTimestamp($revision->dateCreated, Locale::LENGTH_SHORT, true);
+
+                $items[] = [
+                    'type' => 'link',
+                    'label' => (string) $revision->getRevisionLabel(),
+                    'description' => $creator
+                        ? t('Saved {timestamp} by {creator}', ['timestamp' => $timestamp, 'creator' => $creator->name])
+                        : t('Saved {timestamp}', ['timestamp' => $timestamp]),
+                    'href' => Url::urlWithParams($cpEditUrl, [...$baseParams, 'revisionId' => $revision->revisionId]),
+                    'selected' => $revision->id === $this->element->id,
+                ];
+            }
+        }
+
+        if (($revisionsUrl = $element->getCpRevisionsUrl()) !== null && $this->hasMoreRevisions($element)) {
+            $items[] = ['type' => 'hr'];
+            $items[] = [
+                'type' => 'link',
+                'label' => t('View all revisions'),
+                'href' => Url::cpUrl($revisionsUrl),
+                'selected' => false,
+            ];
+        }
+
+        return [
+            'label' => $this->editElementTitles($this->element)[1],
+            'items' => $items,
+        ];
+    }
+
+    /** @return Collection<int, ElementInterface> */
+    private function recentRevisions(ElementInterface $element): Collection
+    {
+        if (! $element->hasRevisions() || Cms::config()->maxRevisions === 1) {
+            return collect();
+        }
+
+        $revisions = $this->revisionQuery($element)->get();
+
+        // A revision being viewed is always listed, even when it has aged out
+        // of the recent window.
+        if (
+            $this->element->getIsRevision() &&
+            $revisions->doesntContain(fn (ElementInterface $revision): bool => $revision->id === $this->element->id)
+        ) {
+            $revisions->push($this->element);
+        }
+
+        return $revisions;
+    }
+
+    private function hasMoreRevisions(ElementInterface $element): bool
+    {
+        if (! $element->hasRevisions() || Cms::config()->maxRevisions === 1) {
+            return false;
+        }
+
+        return ($this->revisionQuery($element)->getCountForPagination() - 1) > 0;
+    }
+
+    private function revisionQuery(ElementInterface $element): ElementQueryInterface
+    {
+        $maxRevisions = Cms::config()->maxRevisions;
+
+        return $element::find()
+            ->revisionOf($element)
+            ->siteId($element->siteId)
+            ->status(null)
+            ->offset(1)
+            ->limit($maxRevisions ? min($maxRevisions - 1, 10) : 10)
+            ->orderByDesc('dateCreated')
+            ->with(['revisionCreator']);
     }
 
     /**
@@ -223,14 +423,56 @@ abstract class ElementEditViewModel extends ViewModel
     }
 
     /**
-     * The notice shown above the editor when the screen is showing unsaved
-     * provisional changes rather than the canonical element.
+     * The notice shown above the editor when the screen isn't showing the
+     * canonical element as it stands.
      */
     public function notice(): ?string
     {
-        return $this->element->isProvisionalDraft
-            ? t('Showing your unsaved changes.')
+        return match (true) {
+            $this->element->isProvisionalDraft => t('Showing your unsaved changes.'),
+            $this->element->getIsRevision() => t('You’re viewing a revision. None of the {type}’s fields are editable.', [
+                'type' => $this->element::lowerDisplayName(),
+            ]),
+            default => null,
+        };
+    }
+
+    /**
+     * Shown when an outdated draft picked up newer canonical changes on the way
+     * in, so the author knows the content shifted under them.
+     */
+    public function mergeNotice(): ?string
+    {
+        return $this->mergedCanonicalChanges
+            ? t('Recent changes to the Current revision have been merged into this draft.')
             : null;
+    }
+
+    /** Whether the notice offers to throw the provisional changes away. */
+    public function canDiscardDraft(): bool
+    {
+        return (bool) $this->element->isProvisionalDraft;
+    }
+
+    /**
+     * The Save button's label. Saving a named draft saves the draft rather than
+     * the element, and an unpublished draft creates the element outright.
+     */
+    public function submitButtonLabel(): string
+    {
+        $element = $this->element;
+
+        if ($element->getIsUnpublishedDraft()) {
+            return Gate::check('saveCanonical', $element)
+                ? mb_ucfirst(t('Create {type}', ['type' => $element::lowerDisplayName()]))
+                : mb_ucfirst(t('Save {type}', ['type' => t('draft')]));
+        }
+
+        if ($element->getIsDraft() && ! $element->isProvisionalDraft) {
+            return mb_ucfirst(t('Save {type}', ['type' => t('draft')]));
+        }
+
+        return t('Save');
     }
 
     public function elementId(): ?int

--- a/src/Http/ViewModels/EntryEditViewModel.php
+++ b/src/Http/ViewModels/EntryEditViewModel.php
@@ -18,8 +18,9 @@ class EntryEditViewModel extends ElementEditViewModel
         private readonly Entry $entry,
         ElementRequest $request,
         bool $canSave = true,
+        bool $mergedCanonicalChanges = false,
     ) {
-        parent::__construct($entry, $request, $canSave);
+        parent::__construct($entry, $request, $canSave, $mergedCanonicalChanges);
     }
 
     #[Override]

--- a/tests/Feature/Http/Controllers/Elements/EditElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/EditElementControllerTest.php
@@ -6,7 +6,6 @@ use CraftCms\Cms\Asset\Models\Asset as AssetModel;
 use CraftCms\Cms\Asset\Models\Volume;
 use CraftCms\Cms\Asset\Models\VolumeFolder as VolumeFolderModel;
 use CraftCms\Cms\Element\Drafts;
-use CraftCms\Cms\Element\Revisions;
 use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Entry\Models\Entry as EntryModel;
 use CraftCms\Cms\Entry\Models\EntryType;
@@ -20,12 +19,10 @@ use CraftCms\Cms\Support\Facades\Elements;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Str;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Inertia\Testing\AssertableInertia;
 
 use function CraftCms\Cms\cp_url;
-use function CraftCms\Cms\t;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 use function Pest\Laravel\getJson;
@@ -280,72 +277,6 @@ it('prevalidates enabled live elements and returns an error summary', function (
                 && str_contains($summary, 'field-error-key'))
             ->etc()
         );
-});
-
-it('renders draft editing controls for saved drafts', function () {
-    $entry = EntryModel::factory()
-        ->forSection($this->section)
-        ->forEntryType($this->entryType)
-        ->createElement([
-            'title' => 'Canonical Title',
-            'slug' => 'canonical-title',
-        ]);
-    /** @var Entry $draft */
-    $draft = app(Drafts::class)->createDraft($entry, auth()->id(), name: 'Working Draft');
-
-    get(cp_url(sprintf(
-        'entries/%s/%d-%s?draftId=%d',
-        $entry->getSection()->handle,
-        $entry->id,
-        $entry->slug,
-        $draft->draftId,
-    )))
-        ->assertOk()
-        ->assertSeeText('Apply draft')
-        ->assertSeeText(mb_ucfirst(t('Save {type}', ['type' => t('draft')])))
-        ->assertSee('elements/save-draft', false);
-});
-
-it('renders revision notices and controls for revisions', function () {
-    $entry = EntryModel::factory()
-        ->forSection($this->section)
-        ->forEntryType($this->entryType)
-        ->createElement([
-            'title' => 'Canonical Title',
-            'slug' => 'canonical-title',
-        ]);
-    /** @var Entry $revision */
-    $revision = Elements::getElementById(app(Revisions::class)->createRevision($entry, auth()->id(), 'Revision notes'));
-
-    get(cp_url(sprintf(
-        'entries/%s/%d-%s?revisionId=%d',
-        $entry->getSection()->handle,
-        $entry->id,
-        $entry->slug,
-        $revision->revisionId,
-    )))
-        ->assertOk()
-        ->assertSeeText('viewing a revision')
-        ->assertSeeText('Revert content from this revision')
-        ->assertSee('elements/revert', false);
-});
-
-it('renders unpublished draft controls', function () {
-    /** @var Entry $draft */
-    $draft = app(Entry::class);
-    $draft->siteId = Sites::getPrimarySite()->id;
-    $draft->sectionId = $this->section->id;
-    $draft->typeId = $this->entryType->id;
-    $draft->title = 'Unpublished Draft';
-    $draft->slug = Str::slug($draft->title);
-    $draft->setAuthorIds([auth()->id()]);
-
-    app(Drafts::class)->saveElementAsDraft($draft, auth()->id(), markAsSaved: false);
-
-    get($draft->getCpEditUrl())
-        ->assertOk()
-        ->assertSeeText(mb_ucfirst(t('Create {type}', ['type' => Entry::lowerDisplayName()])))
-        ->assertSee('elements/apply-draft', false);
 });
 
 it('merges canonical changes into outdated drafts before rendering', function () {

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -153,7 +153,7 @@ it('offers the alternate save actions beside Save', function () {
         );
 });
 
-it('falls back to the legacy editor for drafts', function () {
+it('renders a named draft in the Inertia editor', function () {
     $draft = app(Drafts::class)->createDraft($this->entry, auth()->id(), name: 'Working Draft');
 
     get(cp_url(sprintf(
@@ -163,10 +163,19 @@ it('falls back to the legacy editor for drafts', function () {
         $draft->draftId,
     )))
         ->assertOk()
-        ->assertSee('elements/save-draft', false);
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('content/Edit')
+            ->where('draftId', $draft->draftId)
+            ->where('isProvisionalDraft', false)
+            ->where('readOnly', false)
+            ->where('submitButtonLabel', 'Save draft')
+            ->where('headerActions', fn (Collection $actions) => $actions
+                ->pluck('label')->contains('Apply draft'))
+            ->etc()
+        );
 });
 
-it('falls back to the legacy editor for revisions', function () {
+it('renders a revision read-only in the Inertia editor', function () {
     $revision = Elements::getElementById(
         app(Revisions::class)->createRevision($this->entry, auth()->id(), 'Revision notes'),
     );
@@ -178,7 +187,35 @@ it('falls back to the legacy editor for revisions', function () {
         $revision->revisionId,
     )))
         ->assertOk()
-        ->assertSee('elements/revert', false);
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('content/Edit')
+            ->where('readOnly', true)
+            ->where('canAutosave', false)
+            ->where('notice', fn (?string $notice) => is_string($notice)
+                && str_contains($notice, 'viewing a revision'))
+            ->where('headerActions', fn (Collection $actions) => $actions
+                ->pluck('label')->contains('Revert content from this revision'))
+            ->etc()
+        );
+});
+
+it('lists drafts and revisions in the context menu', function () {
+    app(Drafts::class)->createDraft($this->entry, auth()->id(), name: 'Working Draft');
+    app(Revisions::class)->createRevision($this->entry, auth()->id(), 'Revision notes');
+
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('contextMenu.items', function (Collection $items) {
+                $labels = $items->pluck('label');
+
+                return $labels->contains('Current')
+                    && $labels->contains('Drafts')
+                    && $labels->contains('Working Draft')
+                    && $items->contains(fn (array $item) => ($item['selected'] ?? false) === true);
+            })
+            ->etc()
+        );
 });
 
 it('renders a provisional draft in the Inertia editor', function () {
@@ -206,6 +243,27 @@ it('autosaves against the shared draft action', function () {
             ->where('canAutosave', true)
             ->where('isProvisionalDraft', false)
             ->where('draftId', null)
+            ->etc()
+        );
+});
+
+it('renders an unpublished draft as a create screen', function () {
+    $draft = app(Entry::class);
+    $draft->siteId = $this->entry->siteId;
+    $draft->sectionId = $this->section->id;
+    $draft->typeId = $this->entryType->id;
+    $draft->title = 'Unpublished Draft';
+    $draft->slug = 'unpublished-draft';
+    $draft->setAuthorIds([auth()->id()]);
+
+    app(Drafts::class)->saveElementAsDraft($draft, auth()->id(), markAsSaved: false);
+
+    get($draft->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('content/Edit')
+            ->where('submitButtonLabel', 'Create entry')
+            ->where('contextMenu', null)
             ->etc()
         );
 });


### PR DESCRIPTION
### Description

Renders named drafts and revisions in the Inertia editor, removing the last fallback to the legacy `EditElementController` for entries.

Revisions render read-only with the notice explaining why, and offer "Revert content from this revision". Named drafts get "Apply draft" and a Save button labelled for what it saves — "Save draft" for a draft, "Create entry" for an unpublished one — which required a `submitButtonLabel` pass-through on the layout and form actions. An outdated draft still merges the canonical element's newer changes on the way in, and now says so above the editor; that logic moved back out of the legacy controller along with everything else.

The drafts-and-revisions switcher returns beside the breadcrumbs. Its groups arrive flattened, with headings carried as `display` items, because the action menu's item contract has no nested-group shape.

Also fixes a bug that predates this PR: `provisional` was sent on every draft-targeted request once a draft existed. The server narrows its draft lookup when that param is present, so a named draft stopped resolving — applying one appeared to succeed and silently did nothing. It's now sent only when the draft really is provisional, or when the request is the one creating it, matching what the legacy editor does.
