### PR TITLE
[6.x] Remove stray debug text from the Image Transforms index

### DIFF
--- a/resources/js/pages/settings/assets/transforms/Index.vue
+++ b/resources/js/pages/settings/assets/transforms/Index.vue
@@ -121,7 +121,6 @@
   </LayoutSlot>
 
   <Pane appearance="raised" :padding="0" class="@container">
-    hey hney
     <AdminTable :table="table">
       <template #empty-row>
         <Empty :label="t('No image transforms exist yet.')" icon="image">


### PR DESCRIPTION
### Description

`hey hney` was rendering as literal text above the transforms table on Settings → Assets → Image Transforms. Removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)