### PR TITLE
[6.x] Hide the site group ID input

### DIFF
--- a/resources/js/pages/settings/sites/Index.vue
+++ b/resources/js/pages/settings/sites/Index.vue
@@ -299,12 +299,7 @@
     @submit="saveGroup"
     :loading="form.processing"
   >
-    <craft-input
-      name="id"
-      id="id"
-      v-model="form.id"
-      type="hidden"
-    ></craft-input>
+    <craft-input name="id" id="id" v-model="form.id" hidden-input></craft-input>
     <Deferred data="nameSuggestions">
       <template #fallback>
         <craft-input


### PR DESCRIPTION
### Description

The site group modal's ID field passed `type="hidden"`, which `craft-input` doesn't support — it exposes a `hidden-input` boolean instead. The field rendered as an empty, unlabeled text input above the Group Name field in the New Group / Rename Group modal.

Switches to `hidden-input`, which hides the control while keeping it form-bound, and is the pattern `IconPicker` already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)