### PR TITLE
[6.x] Render the element action menu in the Inertia editor

### DIFF
--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -8,6 +8,7 @@
   import {useAppLayout} from '@/common/composables/useAppLayout';
   import FormRenderer from '@/modules/forms/FormRenderer.vue';
   import {useElementEditPage} from '@/modules/elements/composables/useElementEditPage';
+  import {useElementActionMenu} from '@/modules/elements/composables/useElementActionMenu';
 
   const props = defineProps<{
     /**
@@ -50,6 +51,14 @@
     }))
   );
 
+  // The element's own actions (Validate, Copy, Delete, …). Behaviors are
+  // dispatched client-side rather than via registered jQuery handlers.
+  const actionMenuItems = useElementActionMenu(() => payload.actionMenu, {
+    // The entry type can be switched in the sidebar without saving, so the
+    // settings slideout should follow the field rather than the stored value.
+    currentEntryTypeId: () => form.typeId,
+  });
+
   const autosaveMessage = computed(() => {
     switch (autosave.status.value) {
       case 'saving':
@@ -75,6 +84,7 @@
     defaultFormActions: [],
     formActions: formActionItems.value,
     formAdditionalButtons: headerButtons.value,
+    formAdditionalActions: actionMenuItems.value,
   }));
 </script>
 

--- a/resources/js/modules/elements/composables/useElementActionMenu.ts
+++ b/resources/js/modules/elements/composables/useElementActionMenu.ts
@@ -1,0 +1,146 @@
+import {router} from '@inertiajs/vue3';
+import {computed, type ComputedRef} from 'vue';
+import type {ActionItem} from '@/common/types';
+import {ElementDeletionManager} from '@/modules/element-deletion-manager';
+
+/** Identifies an element for the CP clipboard. */
+interface ElementCopyRef {
+  type: string;
+  id: string | number;
+  siteId?: number | null;
+  draftId?: number | null;
+  revisionId?: number | null;
+}
+
+/**
+ * What an action menu item does, as described by the server. The element
+ * supplies behavior rather than markup plus an inline script, so the client
+ * dispatches these itself.
+ */
+export type ElementActionBehavior =
+  | {type: 'link'; href: string; newTab?: boolean}
+  | {
+      type: 'submit';
+      actionUrl: string;
+      params?: Record<string, unknown>;
+      /** Pre-encrypted by the server. */
+      redirect?: string;
+      confirm?: string;
+    }
+  | {type: 'copy'; elements: Array<ElementCopyRef>}
+  | {
+      type: 'delete';
+      elementType: string;
+      elementId: number;
+      siteId: number | null;
+      confirm: string;
+      redirect: string;
+    }
+  | {
+      type: 'slideout';
+      url?: string;
+      action?: string;
+      params?: Record<string, unknown>;
+      entryTypeFromField?: boolean;
+    };
+
+export interface ElementActionMenuItem {
+  label: string;
+  icon?: string;
+  color?: string;
+  destructive?: boolean;
+  behavior: ElementActionBehavior;
+}
+
+interface Options {
+  /**
+   * Resolves a live value the behavior depends on — currently the entry type,
+   * which the sidebar can change without saving.
+   */
+  currentEntryTypeId?: () => unknown;
+}
+
+/**
+ * Turns the element's action descriptors into menu items the CP action menu can
+ * render, dispatching each behavior directly rather than through registered
+ * jQuery handlers.
+ */
+export function useElementActionMenu(
+  items: () => Array<ElementActionMenuItem>,
+  {currentEntryTypeId}: Options = {}
+): ComputedRef<Array<ActionItem>> {
+  function dispatch(behavior: ElementActionBehavior): void {
+    switch (behavior.type) {
+      case 'link':
+        window.open(
+          behavior.href,
+          behavior.newTab ? '_blank' : '_self',
+          behavior.newTab ? 'noopener' : undefined
+        );
+
+        return;
+
+      case 'submit': {
+        if (behavior.confirm && !window.confirm(behavior.confirm)) {
+          return;
+        }
+
+        router.post(behavior.actionUrl, {
+          ...behavior.params,
+          ...(behavior.redirect ? {redirect: behavior.redirect} : {}),
+        });
+
+        return;
+      }
+
+      case 'copy':
+        // `Craft.cp` owns the clipboard, including its confirmation toast.
+        Craft.cp?.copyElements?.(behavior.elements);
+
+        return;
+
+      case 'delete':
+        // Routed through the deletion manager so blocking relations and
+        // references can be reassigned before the element goes.
+        new ElementDeletionManager(behavior.elementType, [behavior.elementId], {
+          siteId: behavior.siteId,
+          confirmationMessage: behavior.confirm,
+          onSuccess: () => router.visit(behavior.redirect),
+        });
+
+        return;
+
+      case 'slideout': {
+        const entryTypeId = currentEntryTypeId?.();
+        const url =
+          behavior.entryTypeFromField && entryTypeId
+            ? Craft.getCpUrl(`settings/entry-types/${entryTypeId}`)
+            : behavior.url;
+
+        if (url) {
+          new Craft.CpScreenSlideout(url);
+
+          return;
+        }
+
+        if (behavior.action) {
+          new Craft.CpScreenSlideout(behavior.action, {
+            params: behavior.params,
+          });
+        }
+      }
+    }
+  }
+
+  return computed(() =>
+    items().map(
+      (item): ActionItem => ({
+        label: item.label,
+        icon: item.icon,
+        iconColor: item.color,
+        destructive: item.destructive,
+        onClick: () => dispatch(item.behavior),
+      })
+    )
+  );
+}

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -3,6 +3,7 @@ import {router, useForm, usePage} from '@inertiajs/vue3';
 import {actionClient, t} from '@craftcms/ui';
 import {computed, nextTick, onBeforeUnmount, ref, watch} from 'vue';
 import type {FormPayload} from '@/modules/forms/types';
+import type {ElementActionMenuItem} from '@/modules/elements/composables/useElementActionMenu';
 import {useInertiaFormRenderer} from '@/modules/forms/useInertiaFormRenderer';
 import {useElementAutosave} from '@/modules/elements/composables/useElementAutosave';
 import {useSiteStatuses} from '@/modules/elements/composables/useSiteStatuses';
@@ -65,6 +66,7 @@ export interface ElementEditPayload {
   mergeNotice: string | null;
   canDiscardDraft: boolean;
   submitButtonLabel: string;
+  actionMenu: Array<ElementActionMenuItem>;
   contextMenu: {
     label: string;
     items: Array<ElementContextMenuItem>;

--- a/src/Element/Concerns/HasControlPanelUI.php
+++ b/src/Element/Concerns/HasControlPanelUI.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Element\Concerns;
 use CraftCms\Cms\Cp\FormFields;
 use CraftCms\Cms\Cp\Html\ElementHtml;
 use CraftCms\Cms\Cp\Html\MenuHtml;
+use CraftCms\Cms\Cp\Icons;
 use CraftCms\Cms\Element\Contracts\NestedElementInterface;
 use CraftCms\Cms\Element\ElementAttributeRenderer;
 use CraftCms\Cms\Element\ElementHelper;
@@ -37,7 +38,9 @@ use CraftCms\Cms\Support\Facades\InputNamespace;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\Support\Json;
+use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\Translation\Formatter;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Gate;
 use Stringable;
 use Symfony\Component\HttpFoundation\Response;
@@ -281,7 +284,7 @@ JS, [
                 $items[] = [
                     'id' => $copyId,
                     'color' => Color::Fuchsia,
-                    'icon' => 'clone-dashed',
+                    'icon' => self::actionMenuIcon('clone-dashed'),
                     'label' => mb_ucfirst(t('Copy {type}', [
                         'type' => static::lowerDisplayName(),
                     ])),
@@ -309,6 +312,146 @@ JS, [
         }
 
         return $items;
+    }
+
+    /**
+     * The element's action menu as behavior descriptors, for renderers that
+     * dispatch actions themselves rather than executing registered JavaScript.
+     *
+     * This is the counterpart to {@see getActionMenuItems()}: same actions, but
+     * each item names *what* it does (`behavior`) instead of pairing markup with
+     * an inline handler. The Inertia editor renders these; the legacy editor and
+     * slideouts keep using the HTML pairing.
+     *
+     * Element types extend this the way they extend the HTML items.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function actionMenuDescriptors(): array
+    {
+        $items = [];
+        $isDraft = $this->getIsDraft();
+        $isUnpublishedDraft = $this->getIsUnpublishedDraft();
+        $isCurrent = $this->getIsCanonical() || $this->isProvisionalDraft;
+        $canonical = $this->getCanonical(true);
+        $redirectUrl = ElementHelper::postEditUrl($this);
+        $sourceId = $this->isProvisionalDraft ? $this->getCanonicalId() : $this->id;
+
+        if (! $this->getIsRevision()) {
+            $items[] = [
+                'label' => t('Validate {type}', ['type' => static::lowerDisplayName()]),
+                'icon' => 'circle-check',
+                'behavior' => [
+                    'type' => 'submit',
+                    'actionUrl' => Url::actionUrl('elements/validate'),
+                    'params' => ['elementId' => $this->id],
+                ],
+            ];
+        }
+
+        if ($url = $this->getUrl()) {
+            $items[] = [
+                'label' => t('View in a new tab'),
+                'icon' => 'share',
+                'behavior' => ['type' => 'link', 'href' => $url, 'newTab' => true],
+            ];
+        }
+
+        if (! $this->getIsRevision() && Gate::check('copy', $this)) {
+            $items[] = [
+                'label' => mb_ucfirst(t('Copy {type}', ['type' => static::lowerDisplayName()])),
+                'icon' => self::actionMenuIcon('clone-dashed'),
+                'color' => Color::Fuchsia->value,
+                'behavior' => [
+                    'type' => 'copy',
+                    'elements' => [[
+                        'type' => static::class,
+                        'id' => $sourceId,
+                        'draftId' => $this->isProvisionalDraft ? null : $this->draftId,
+                        'revisionId' => $this->revisionId,
+                        'siteId' => $this->siteId,
+                    ]],
+                ],
+            ];
+        }
+
+        $items = [...$items, ...$this->extraActionMenuDescriptors()];
+
+        // Destructive items sort last and are flagged so the menu can style them.
+        $canDeleteForSite = (
+            ElementHelper::isMultiSite($this) &&
+            $isCurrent &&
+            Gate::check('deleteForSite', $canonical) &&
+            Gate::check('deleteForSite', $this)
+        );
+
+        if ($isCurrent && $canDeleteForSite) {
+            $type = $isUnpublishedDraft ? t('draft') : static::lowerDisplayName();
+
+            $items[] = [
+                'label' => mb_ucfirst(t('Delete {type} for this site', ['type' => $type])),
+                'icon' => 'remove',
+                'destructive' => true,
+                'behavior' => [
+                    'type' => 'submit',
+                    'actionUrl' => Url::actionUrl('elements/delete-for-site'),
+                    'params' => [
+                        'elementId' => $this->getCanonicalId(),
+                        'siteId' => $this->siteId,
+                    ],
+                    'redirect' => Crypt::encrypt("$redirectUrl#"),
+                    'confirm' => t('Are you sure you want to delete the {type} for this site?', ['type' => $type]),
+                ],
+            ];
+        }
+
+        if ($isCurrent && Gate::check('delete', $canonical)) {
+            $type = $isUnpublishedDraft ? t('draft') : static::lowerDisplayName();
+
+            $items[] = [
+                'label' => mb_ucfirst(t('Delete {type}', ['type' => $type])),
+                'icon' => 'trash',
+                'destructive' => true,
+                // Deletion runs through the deletion-blockers flow rather than a
+                // plain confirm, so relations and references can be reassigned.
+                'behavior' => [
+                    'type' => 'delete',
+                    'elementType' => static::class,
+                    'elementId' => $this->id,
+                    'siteId' => $this->siteId,
+                    'confirm' => t('Are you sure you want to delete this {type}?', [
+                        'type' => $isDraft ? t('draft') : static::lowerDisplayName(),
+                    ]),
+                    'redirect' => Url::cpUrl($redirectUrl),
+                ],
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Qualifies an icon with its family when it isn't in the default set.
+     *
+     * The action menu's icon renderer resolves a bare name against the default
+     * family, so custom icons have to arrive prefixed or they 404.
+     */
+    private static function actionMenuIcon(string $icon): string
+    {
+        $family = Icons::resolveIconFamily($icon);
+
+        return $family === 'solid' ? $icon : "$family/$icon";
+    }
+
+    /**
+     * Element-type additions to {@see actionMenuDescriptors()}, inserted before
+     * the destructive items.
+     *
+     * @return list<array<string, mixed>>
+     */
+    protected function extraActionMenuDescriptors(): array
+    {
+        return [];
     }
 
     /**

--- a/src/Entry/Elements/Entry.php
+++ b/src/Entry/Elements/Entry.php
@@ -1841,6 +1841,43 @@ class Entry extends Element implements Colorable, ExpirableElementInterface, Ico
         return sprintf('%s/revisions', $this->cpEditUrl());
     }
 
+    /**
+     * @return list<array<string, mixed>>
+     */
+    #[Override]
+    protected function extraActionMenuDescriptors(): array
+    {
+        if (! currentUser()?->isAdmin() || ! Cms::config()->allowAdminChanges) {
+            return [];
+        }
+
+        $items = [[
+            'label' => t('Entry type settings'),
+            'icon' => 'gear',
+            'behavior' => [
+                'type' => 'slideout',
+                'url' => Url::cpUrl("settings/entry-types/$this->typeId"),
+                // A non-nested entry can have its type switched in the sidebar,
+                // so the slideout follows the field rather than the saved value.
+                'entryTypeFromField' => ! isset($this->fieldId),
+            ],
+        ]];
+
+        if (! empty($this->sectionId)) {
+            $items[] = [
+                'label' => t('Section settings'),
+                'icon' => 'gear',
+                'behavior' => [
+                    'type' => 'slideout',
+                    'action' => 'sections/edit-section',
+                    'params' => ['sectionId' => $this->sectionId],
+                ],
+            ];
+        }
+
+        return $items;
+    }
+
     /** @return array<int, array<string, scalar|null>> */
     #[Override]
     protected function safeActionMenuItems(): array

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -235,6 +235,31 @@ abstract class ElementEditViewModel extends ViewModel
     }
 
     /**
+     * The element's action menu, as behavior descriptors the client dispatches.
+     *
+     * "View in a new tab" is dropped once preview targets exist, since the
+     * preview control already covers it, and "Edit" never appears — this screen
+     * is the edit screen.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function actionMenu(): array
+    {
+        if (! $this->element->id) {
+            return [];
+        }
+
+        $hidesView = $this->element->getPreviewTargets() !== [];
+
+        return array_values(array_filter(
+            $this->element->actionMenuDescriptors(),
+            fn (array $item): bool => ! (
+                $hidesView && ($item['behavior']['type'] ?? null) === 'link'
+            ),
+        ));
+    }
+
+    /**
      * The drafts-and-revisions switcher shown beside the breadcrumbs.
      *
      * Groups are flattened into a single item list — headings become `heading`

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -267,3 +267,70 @@ it('renders an unpublished draft as a create screen', function () {
             ->etc()
         );
 });
+
+it('exposes the action menu as behavior descriptors', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('actionMenu', function (Collection $items) {
+                $labels = $items->pluck('label');
+                $behaviors = $items->pluck('behavior.type');
+
+                return $labels->contains('Validate entry')
+                    && $labels->contains('Copy entry')
+                    && $labels->contains('Entry type settings')
+                    && $labels->contains('Section settings')
+                    && $behaviors->contains('submit')
+                    && $behaviors->contains('copy')
+                    && $behaviors->contains('slideout');
+            })
+            ->etc()
+        );
+});
+
+it('routes deletion through the deletion-blockers flow', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('actionMenu', function (Collection $items) {
+                $delete = $items->first(fn (array $item) => ($item['behavior']['type'] ?? null) === 'delete');
+
+                return $delete !== null
+                    && ($delete['destructive'] ?? false) === true
+                    && $delete['behavior']['elementId'] === $this->entry->id
+                    && is_string($delete['behavior']['confirm'])
+                    && is_string($delete['behavior']['redirect']);
+            })
+            ->etc()
+        );
+});
+
+it('omits the Edit action and never offers it on the edit screen', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('actionMenu', fn (Collection $items) => $items
+                ->pluck('label')
+                ->doesntContain(fn (string $label) => str_starts_with($label, 'Edit ')))
+            ->etc()
+        );
+});
+
+it('drops the View action for revisions, which have no editable URL context', function () {
+    $revision = Elements::getElementById(
+        app(Revisions::class)->createRevision($this->entry, auth()->id(), 'Revision notes'),
+    );
+
+    get(cp_url(sprintf(
+        'entries/news/%d-%s?revisionId=%d',
+        $this->entry->id,
+        $this->entry->slug,
+        $revision->revisionId,
+    )))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('actionMenu', fn (Collection $items) => $items
+                ->pluck('label')->doesntContain('Validate entry'))
+            ->etc()
+        );
+});


### PR DESCRIPTION
### Description

Brings the element action menu to the Inertia editor: Validate, Copy, the entry type and section settings slideouts, Delete for this site, and Delete.

`actionMenuDescriptors()` is the counterpart to `getActionMenuItems()` — the same actions, but each item names what it does rather than pairing markup with an inline script. The client dispatches those behaviors itself, so nothing depends on registered jQuery handlers. Element types extend it through `extraActionMenuDescriptors()` the way they extend the HTML items; entries add their settings slideouts there, and the entry type slideout still follows the sidebar's unsaved selection rather than the stored value.

Deletion continues to run through `ElementDeletionManager`, so blocking relations and references can be reassigned before the element goes. The manager was already ported to TypeScript, so the Vue handler constructs it directly.

"Edit" is never offered — this is the edit screen — and "View in a new tab" drops out once preview targets exist, matching the legacy rules.

Custom icons are qualified with their family. The action menu's icon renderer resolves a bare name against the default set, so `clone-dashed` was 404ing for the Copy item until its `custom-icons/` prefix was carried through.

Plugin-provided items still come through the HTML pairing and aren't rendered here yet; that contract is unchanged and needs its own decision.
