### PR TITLE
[6.x] Add preview target links to the Inertia editor

### DIFF
--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -59,6 +59,22 @@
     currentEntryTypeId: () => form.typeId,
   });
 
+  // "View" opens the element on the front end. The hrefs arrive ready to
+  // follow — a live element points at its own URL, anything else at a
+  // token-minting redirect that lands on the tokenized preview.
+  //
+  // These ride in `formAdditionalButtons` because the layout's
+  // `additional-buttons` slot is a component slot, not a layout-slot outlet,
+  // so it can't be filled from a page using the ambient layout.
+  const viewButtons = computed(() =>
+    payload.previewTargets.map((target, index) => ({
+      label: payload.previewTargets.length === 1 ? t('View') : target.label,
+      variant: 'outline',
+      key: `view-${index}`,
+      onClick: () => window.open(target.url, '_blank', 'noopener'),
+    }))
+  );
+
   const autosaveMessage = computed(() => {
     switch (autosave.status.value) {
       case 'saving':
@@ -83,7 +99,7 @@
     // own "Save and continue editing" — so the layout's default would duplicate.
     defaultFormActions: [],
     formActions: formActionItems.value,
-    formAdditionalButtons: headerButtons.value,
+    formAdditionalButtons: [...viewButtons.value, ...headerButtons.value],
     formAdditionalActions: actionMenuItems.value,
   }));
 </script>

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -67,6 +67,7 @@ export interface ElementEditPayload {
   canDiscardDraft: boolean;
   submitButtonLabel: string;
   actionMenu: Array<ElementActionMenuItem>;
+  previewTargets: Array<{label: string; url: string}>;
   contextMenu: {
     label: string;
     items: Array<ElementContextMenuItem>;

--- a/src/Http/Controllers/Entries/EditEntryController.php
+++ b/src/Http/Controllers/Entries/EditEntryController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http\Controllers\Entries;
 
+use CraftCms\Cms\Auth\SessionAuth;
 use CraftCms\Cms\Element\ElementHelper;
 use CraftCms\Cms\Element\Elements;
 use CraftCms\Cms\Entry\Elements\Entry;
@@ -60,6 +61,16 @@ class EditEntryController
         }
 
         $this->applyParamsToElement($element);
+
+        // Minting a preview token later requires the session to be authorized
+        // for whatever is being previewed.
+        if ($element->id && $element->getPreviewTargets() !== []) {
+            match (true) {
+                $element->getIsDraft() && ! $element->isProvisionalDraft => SessionAuth::authorize("previewDraft:$element->draftId"),
+                $element->getIsRevision() => SessionAuth::authorize("previewRevision:$element->revisionId"),
+                default => SessionAuth::authorize('previewElement:'.$element->getCanonicalId()),
+            };
+        }
 
         return Inertia::render('content/Edit', new EntryEditViewModel(
             entry: $element,

--- a/src/Http/Controllers/PreviewController.php
+++ b/src/Http/Controllers/PreviewController.php
@@ -21,7 +21,20 @@ readonly class PreviewController
 
     public function createToken(Request $request, RouteTokens $tokens): JsonResponse|RedirectResponse
     {
-        $tokenData = new RouteToken($request->post());
+        // Craft 5 read these with `getParam()`, i.e. query *or* body: the View
+        // links in the element editor are plain GET hrefs that mint a token and
+        // redirect, so restricting this to POST left them with nothing to read.
+        // Only the token's own keys are taken — a CP URL carries others (`site`)
+        // that `RouteToken` rejects outright.
+        $tokenData = new RouteToken(array_filter([
+            'elementType' => $request->input('elementType'),
+            'canonicalId' => $request->input('canonicalId'),
+            'sourceId' => $request->input('sourceId'),
+            'siteId' => $request->input('siteId'),
+            'draftId' => $request->input('draftId'),
+            'revisionId' => $request->input('revisionId'),
+            'redirect' => $request->input('redirect'),
+        ], fn (mixed $value): bool => $value !== null));
 
         if ($token = $request->input('previewToken')) {
             $tokenData->previewToken = Crypt::decrypt($token);

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -21,6 +21,7 @@ use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\DeltaRegistry;
 use CraftCms\Cms\Support\Facades\I18N;
 use CraftCms\Cms\Support\Facades\Sites;
+use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\Translation\Locale;
 use Illuminate\Support\Collection;
@@ -232,6 +233,79 @@ abstract class ElementEditViewModel extends ViewModel
         }
 
         return $actions;
+    }
+
+    /**
+     * The element's preview targets as ready-to-open links.
+     *
+     * A live element links straight at its URL. Anything not publicly visible
+     * yet — a draft, a disabled entry, a future post date — links at
+     * `preview/create-token`, which mints a preview token and redirects to the
+     * tokenized URL. The legacy editor does that dance in JavaScript; every
+     * input is known here, so the link arrives ready to follow.
+     *
+     * @return list<array{label: string, url: string}>
+     */
+    public function previewTargets(): array
+    {
+        $element = $this->element;
+
+        if (! $element->id) {
+            return [];
+        }
+
+        $targets = $element->getPreviewTargets();
+
+        if ($targets === []) {
+            return [];
+        }
+
+        $isLive = (
+            ($element->getIsCanonical() || $element->isProvisionalDraft) &&
+            ! $element->getIsDraft() &&
+            $element->enabled &&
+            $element->getEnabledForSite() &&
+            $element->getRoute() !== null
+        );
+
+        $previewToken = Str::random(32, extendedChars: true);
+        $siteToken = (! app()->isLive() || ! $element->getSite()->getEnabled())
+            ? Crypt::encrypt((string) $element->siteId)
+            : null;
+
+        $tokenParams = array_filter([
+            'elementType' => $element::class,
+            'canonicalId' => $element->getCanonicalId(),
+            'siteId' => $element->siteId,
+            'revisionId' => $element->revisionId,
+            'draftId' => $element->isProvisionalDraft ? null : $element->draftId,
+            'previewToken' => Crypt::encrypt($previewToken),
+        ], fn (mixed $value): bool => $value !== null);
+
+        return array_values(array_map(function (array $target) use ($isLive, $previewToken, $siteToken, $tokenParams): array {
+            $params = array_filter([
+                // Randomized so CDNs don't serve a cached page.
+                'x-craft-preview' => $isLive ? null : Crypt::encrypt(Str::random(10)),
+                Cms::config()->siteToken => $siteToken,
+            ], fn (mixed $value): bool => $value !== null);
+
+            if ($isLive) {
+                return [
+                    'label' => (string) $target['label'],
+                    'url' => Url::url($target['url'], $params),
+                ];
+            }
+
+            $params[Cms::config()->tokenParam] = $previewToken;
+
+            return [
+                'label' => (string) $target['label'],
+                'url' => Url::actionUrl('preview/create-token', [
+                    ...$tokenParams,
+                    'redirect' => Url::url($target['url'], $params),
+                ]),
+            ];
+        }, $targets));
     }
 
     /**

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -13,7 +13,9 @@ use CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField;
 use CraftCms\Cms\FieldLayout\Models\FieldLayout as FieldLayoutModel;
 use CraftCms\Cms\Http\Controllers\Entries\StoreEntryController;
 use CraftCms\Cms\Section\Models\Section;
+use CraftCms\Cms\Section\Models\SectionSiteSettings;
 use CraftCms\Cms\Support\Facades\Elements;
+use CraftCms\Cms\Support\Facades\Sections;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Collection;
 use Inertia\Testing\AssertableInertia;
@@ -35,7 +37,21 @@ beforeEach(function () {
     $this->section = Section::factory()->withEntryTypes($this->entryType)->create([
         'handle' => 'news',
         'enableVersioning' => true,
+        'previewTargets' => [
+            ['label' => 'Primary entry page', 'urlFormat' => '{url}', 'refresh' => '1'],
+        ],
     ]);
+    // The site settings factory randomizes `hasUrls`, which would make preview
+    // targets come and go between runs.
+    SectionSiteSettings::query()
+        ->where('sectionId', $this->section->id)
+        ->update([
+            'hasUrls' => true,
+            'uriFormat' => 'news/{slug}',
+            'template' => 'news/_entry',
+        ]);
+    Sections::refreshSections();
+
     $this->entry = EntryModel::factory()
         ->forSection($this->section)
         ->forEntryType($this->entryType)
@@ -331,6 +347,34 @@ it('drops the View action for revisions, which have no editable URL context', fu
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->where('actionMenu', fn (Collection $items) => $items
                 ->pluck('label')->doesntContain('Validate entry'))
+            ->etc()
+        );
+});
+
+it('links preview targets straight at the element when it is live', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('previewTargets', fn (Collection $targets) => $targets->isNotEmpty()
+                && $targets->every(fn (array $target) => ! str_contains((string) $target['url'], 'preview/create-token')))
+            ->etc()
+        );
+});
+
+it('links preview targets through a token when the element is not public', function () {
+    $draft = app(Drafts::class)->createDraft($this->entry, auth()->id(), name: 'Working Draft');
+
+    get(cp_url(sprintf(
+        'entries/news/%d-%s?draftId=%d',
+        $this->entry->id,
+        $this->entry->slug,
+        $draft->draftId,
+    )))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('previewTargets', fn (Collection $targets) => $targets->isNotEmpty()
+                && $targets->every(fn (array $target) => str_contains((string) $target['url'], 'preview/create-token')
+                    && str_contains((string) $target['url'], 'redirect=')))
             ->etc()
         );
 });

--- a/tests/Feature/Http/Controllers/PreviewControllerTest.php
+++ b/tests/Feature/Http/Controllers/PreviewControllerTest.php
@@ -96,3 +96,23 @@ test('it can preview elements', function () {
         ->assertSee('previewing')
         ->assertDontSee('not previewing');
 });
+
+it('accepts token params from the query string', function () {
+    get(action([PreviewController::class, 'createToken'], [
+        'elementType' => CraftCms\Cms\Entry\Elements\Entry::class,
+        'siteId' => Site::firstOrFail()->id,
+        'canonicalId' => $this->entry->id,
+        'redirect' => 'https://example.com',
+    ]))->assertRedirect('https://example.com');
+});
+
+it('ignores params that are not part of the token', function () {
+    get(action([PreviewController::class, 'createToken'], [
+        'elementType' => CraftCms\Cms\Entry\Elements\Entry::class,
+        'siteId' => Site::firstOrFail()->id,
+        'canonicalId' => $this->entry->id,
+        'redirect' => 'https://example.com',
+        // Control panel URLs carry this; it isn't a token property.
+        'site' => 'default',
+    ]))->assertRedirect('https://example.com');
+});


### PR DESCRIPTION
### Description

Adds the View control to the Inertia editor, linking each of the element's preview targets at the front end.

The legacy editor mints preview tokens from JavaScript, juggling a token queue and rewriting hrefs once a token is live. Every input to that is known server-side, so the links arrive ready to follow instead: a live element points at its own URL, and anything not publicly visible — a draft, a disabled entry, a future post date — points at `preview/create-token`, which mints the token and redirects to the tokenized URL. The controller grants the matching session authorization, as the legacy screen did.

`PreviewController::createToken()` read its params from the request body only. Craft 5 read them with `getParam()`, i.e. query or body, which is what the View links depend on — they're plain GET hrefs. It now reads either, taking only the token's own keys, since a control panel URL carries others (`site`) that `RouteToken` rejects outright.

Live Preview itself is not included. `Craft.Preview` is built around a `Craft.ElementEditor` instance — it reads its settings, serializes its form, and asks it for tokenized URLs — and none of that exists on this screen. Wiring it up means writing an adapter that impersonates the legacy editor, which is worth doing deliberately rather than as a side effect of this change.
