### PR TITLE
[6.x] Poll for element activity and upstream changes in the Inertia editor

### DIFF
--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import {t} from '@craftcms/ui';
   import {computed} from 'vue';
+  import {router} from '@inertiajs/vue3';
   import DynamicHtmlRenderer from '@/common/components/DynamicHtmlRenderer.vue';
   import ElementContextMenu from '@/modules/elements/components/ElementContextMenu.vue';
   import LayoutSlot from '@/common/components/LayoutSlot.vue';
@@ -19,6 +20,7 @@
   }>();
 
   const {
+    activity,
     autosave,
     discardDraft,
     errors,
@@ -74,6 +76,23 @@
       onClick: () => window.open(target.url, '_blank', 'noopener'),
     }))
   );
+
+  // Mirrors the legacy wording: a changed draft names the draft, anything else
+  // names the element type.
+  const staleMessage = computed(() =>
+    t('This {type} has been updated.', {
+      type:
+        activity.staleType.value === 'element' &&
+        payload.draftId !== null &&
+        !payload.isProvisionalDraft
+          ? t('draft')
+          : payload.elementDisplayName,
+    })
+  );
+
+  function reload(): void {
+    router.reload();
+  }
 
   const autosaveMessage = computed(() => {
     switch (autosave.status.value) {
@@ -132,7 +151,44 @@
     </span>
   </LayoutSlot>
 
+  <!-- Who else is working on this element, beside the save controls. -->
+  <LayoutSlot v-if="activity.activity.value.length" name="toolbar">
+    <div
+      role="region"
+      :aria-label="t('Recent Activity')"
+      class="flex items-center gap-1"
+    >
+      <span
+        v-for="entry in activity.activity.value"
+        :key="entry.userId"
+        :title="entry.message"
+        :aria-label="entry.message"
+        class="inline-flex"
+        v-html="entry.userThumb"
+      />
+    </div>
+  </LayoutSlot>
+
   <Pane appearance="raised">
+    <craft-callout
+      v-if="activity.isStale.value"
+      variant="warning"
+      icon="triangle-exclamation"
+      class="mb-4"
+    >
+      {{ staleMessage }}
+
+      <craft-button
+        slot="action"
+        type="button"
+        appearance="outline"
+        size="small"
+        @click="reload"
+      >
+        {{ t('Reload') }}
+      </craft-button>
+    </craft-callout>
+
     <craft-callout v-if="payload.readOnly" variant="neutral" icon="lock">
       {{ t('This is a read-only view.') }}
     </craft-callout>

--- a/resources/js/modules/elements/composables/useElementActivity.ts
+++ b/resources/js/modules/elements/composables/useElementActivity.ts
@@ -1,0 +1,116 @@
+import {actionClient} from '@craftcms/ui';
+import {useDocumentVisibility, useIntervalFn} from '@vueuse/core';
+import {readonly, ref, watch, type Ref} from 'vue';
+
+/** One person currently working on the element. */
+export interface ElementActivityEntry {
+  userId: number;
+  userName: string;
+  /** Server-rendered avatar. */
+  userThumb: string;
+  type: string;
+  message: string;
+}
+
+interface Options {
+  /** `elements/recent-activity`, or null when the screen shouldn't poll. */
+  url: string | null;
+  elementType: string;
+  /** The canonical element — activity is tracked against it, not the draft. */
+  elementId: number | null;
+  draftId: number | null;
+  siteId: number | null;
+  isProvisionalDraft: boolean;
+  /** Last-modified stamps as rendered, used to detect upstream changes. */
+  updatedTimestamps: {element: number | null; canonical: number | null};
+  intervalMs?: number;
+}
+
+/**
+ * Polls for other people editing this element, and notices when it changes
+ * underneath the person editing it.
+ *
+ * Polling pauses while the tab is hidden — the legacy editor keeps going, but
+ * a backgrounded tab has nobody to show the avatars to, and the timestamps are
+ * re-read on the first poll after it returns.
+ */
+export function useElementActivity(options: Options): {
+  activity: Readonly<Ref<Array<ElementActivityEntry>>>;
+  isStale: Readonly<Ref<boolean>>;
+  staleType: Readonly<Ref<'element' | 'canonical' | null>>;
+  poll: () => Promise<void>;
+} {
+  const activity = ref<Array<ElementActivityEntry>>([]);
+  const isStale = ref(false);
+  const staleType = ref<'element' | 'canonical' | null>(null);
+
+  // Advanced as the server reports them, so the notice fires once per change
+  // rather than on every poll after one.
+  let elementStamp = options.updatedTimestamps.element;
+  let canonicalStamp = options.updatedTimestamps.canonical;
+
+  async function poll(): Promise<void> {
+    if (!options.url) {
+      return;
+    }
+
+    try {
+      const {data} = await actionClient.post(options.url, {
+        elementType: options.elementType,
+        elementId: options.elementId,
+        draftId: options.draftId,
+        siteId: options.siteId,
+        provisional: options.isProvisionalDraft ? 1 : null,
+      });
+
+      activity.value = data.activity ?? [];
+
+      const elementChanged =
+        elementStamp !== null && data.updatedTimestamp !== elementStamp;
+      const canonicalChanged =
+        canonicalStamp !== null &&
+        data.canonicalUpdatedTimestamp !== canonicalStamp;
+
+      if (elementChanged || canonicalChanged) {
+        isStale.value = true;
+        staleType.value = elementChanged ? 'element' : 'canonical';
+      }
+
+      elementStamp = data.updatedTimestamp ?? elementStamp;
+      canonicalStamp = data.canonicalUpdatedTimestamp ?? canonicalStamp;
+    } catch {
+      // A failed poll is not worth surfacing — the next one may well succeed,
+      // and this is ambient information, not something the user asked for.
+    }
+  }
+
+  const visibility = useDocumentVisibility();
+
+  const {pause, resume} = useIntervalFn(
+    () => void poll(),
+    options.intervalMs ?? 15000,
+    {immediate: !!options.url, immediateCallback: !!options.url}
+  );
+
+  watch(visibility, (state, previous) => {
+    // Skip the ref's initial resolution, which would otherwise duplicate the
+    // poll `immediateCallback` already made.
+    if (!options.url || previous === undefined) {
+      return;
+    }
+
+    if (state === 'visible') {
+      resume();
+      void poll();
+    } else {
+      pause();
+    }
+  });
+
+  return {
+    activity: readonly(activity) as Readonly<Ref<Array<ElementActivityEntry>>>,
+    isStale: readonly(isStale),
+    staleType: readonly(staleType),
+    poll,
+  };
+}

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -6,6 +6,7 @@ import type {FormPayload} from '@/modules/forms/types';
 import type {ElementActionMenuItem} from '@/modules/elements/composables/useElementActionMenu';
 import {useInertiaFormRenderer} from '@/modules/forms/useInertiaFormRenderer';
 import {useElementAutosave} from '@/modules/elements/composables/useElementAutosave';
+import {useElementActivity} from '@/modules/elements/composables/useElementActivity';
 import {useSiteStatuses} from '@/modules/elements/composables/useSiteStatuses';
 import {useSettingsSave} from '@/modules/settings/composables/useSettingsSave';
 
@@ -68,6 +69,9 @@ export interface ElementEditPayload {
   submitButtonLabel: string;
   actionMenu: Array<ElementActionMenuItem>;
   previewTargets: Array<{label: string; url: string}>;
+  elementDisplayName: string;
+  activityUrl: string | null;
+  updatedTimestamps: {element: number | null; canonical: number | null};
   contextMenu: {
     label: string;
     items: Array<ElementContextMenuItem>;
@@ -128,6 +132,16 @@ export function useElementEditPage({saveData}: Options = {}) {
     draftId: props.draftId,
     isProvisional: props.isProvisionalDraft,
     enabled: props.canAutosave,
+  });
+
+  const activity = useElementActivity({
+    url: props.activityUrl,
+    elementType: props.elementType,
+    elementId: props.canonicalId,
+    draftId: props.draftId,
+    siteId: props.siteId,
+    isProvisionalDraft: props.isProvisionalDraft,
+    updatedTimestamps: props.updatedTimestamps,
   });
 
   /**
@@ -279,6 +293,7 @@ export function useElementEditPage({saveData}: Options = {}) {
   onBeforeUnmount(removeNavigationGuard);
 
   return {
+    activity,
     autosave,
     discardDraft,
     submitAction,

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -235,6 +235,39 @@ abstract class ElementEditViewModel extends ViewModel
         return $actions;
     }
 
+    /** The element type's lowercase display name, for user-facing messages. */
+    public function elementDisplayName(): string
+    {
+        return $this->element::lowerDisplayName();
+    }
+
+    /**
+     * Where the screen polls for other people working on this element.
+     *
+     * Revisions are read-only and can't be collaborated on, so they don't poll.
+     */
+    public function activityUrl(): ?string
+    {
+        return $this->element->id && ! $this->element->getIsRevision()
+            ? Url::actionUrl('elements/recent-activity', ['dontExtendSession' => 1])
+            : null;
+    }
+
+    /**
+     * The element's and its canonical's last-modified stamps at render time.
+     * Activity polling compares these against the server's to notice that
+     * something changed underneath the person editing.
+     *
+     * @return array{element: int|null, canonical: int|null}
+     */
+    public function updatedTimestamps(): array
+    {
+        return [
+            'element' => $this->element->dateUpdated?->getTimestamp(),
+            'canonical' => $this->element->getCanonical(true)->dateUpdated?->getTimestamp(),
+        ];
+    }
+
     /**
      * The element's preview targets as ready-to-open links.
      *

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -378,3 +378,35 @@ it('links preview targets through a token when the element is not public', funct
             ->etc()
         );
 });
+
+it('polls for activity against the canonical element', function () {
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('activityUrl', fn (?string $url) => is_string($url)
+                && str_contains($url, 'elements/recent-activity')
+                && str_contains($url, 'dontExtendSession'))
+            ->where('updatedTimestamps', fn (Collection $stamps) => $stamps->has('element')
+                && $stamps->has('canonical'))
+            ->where('elementDisplayName', 'entry')
+            ->etc()
+        );
+});
+
+it('does not poll for activity on a revision', function () {
+    $revision = Elements::getElementById(
+        app(Revisions::class)->createRevision($this->entry, auth()->id(), 'Revision notes'),
+    );
+
+    get(cp_url(sprintf(
+        'entries/news/%d-%s?revisionId=%d',
+        $this->entry->id,
+        $this->entry->slug,
+        $revision->revisionId,
+    )))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('activityUrl', null)
+            ->etc()
+        );
+});


### PR DESCRIPTION
### Description

Adds collaborative awareness to the Inertia editor: who else is working on the element, and whether it has changed underneath the person editing it.

`useElementActivity` polls `elements/recent-activity` on the same fifteen-second cadence the legacy editor uses, rendering each active user's avatar beside the save controls with their activity message. When the element's or its canonical's last-modified stamp comes back different from what the screen rendered with, a notice offers to reload — naming the draft when the draft itself moved, and the element type otherwise.

Polling pauses while the tab is hidden and re-reads on return. The legacy editor keeps polling regardless, but a backgrounded tab has nobody to show avatars to, and the timestamps are compared fresh on the next visible poll either way. A failed poll is swallowed: this is ambient information nobody asked for, and the next tick may well succeed.

Revisions don't poll. They're read-only, so there is nothing to collaborate on and nothing to go stale.
