### PR TITLE
[6.x] Add dismissible tips and additional-site statuses to the Inertia editor

### DIFF
--- a/resources/js/modules/forms/CalloutNode.vue
+++ b/resources/js/modules/forms/CalloutNode.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
+  import {t} from '@craftcms/ui';
+  import {ref} from 'vue';
+  import {dismissTip, isTipDismissed} from './dismissedTips';
   import type {FormNodePayload} from './types';
 
-  defineProps<{
+  const props = defineProps<{
     node: FormNodePayload<{
       html: string;
       variant: string;
@@ -11,16 +14,42 @@
       width: number;
     }>;
   }>();
+
+  // A dismissed tip stays dismissed across loads, keyed by layout element UID.
+  const dismissed = ref(
+    props.node.props.dismissible && isTipDismissed(props.node.uid)
+  );
+
+  function dismiss(): void {
+    if (props.node.uid) {
+      dismissTip(props.node.uid);
+    }
+
+    dismissed.value = true;
+  }
 </script>
 
 <template>
   <craft-callout
+    v-if="!dismissed"
     :class="`width-${node.props.width}`"
     :data-form-node="node.uid"
     :variant="node.props.variant"
     v-bind="node.props.appearance ? {appearance: node.props.appearance} : {}"
     :icon="node.props.icon"
     :data-dismissible="node.props.dismissible || undefined"
-    v-html="node.props.html"
-  ></craft-callout>
+  >
+    <span v-html="node.props.html"></span>
+
+    <craft-button
+      v-if="node.props.dismissible"
+      slot="action"
+      type="button"
+      appearance="plain"
+      size="small"
+      icon="xmark"
+      :aria-label="t('Dismiss')"
+      @click="dismiss"
+    ></craft-button>
+  </craft-callout>
 </template>

--- a/resources/js/modules/forms/dismissedTips.test.ts
+++ b/resources/js/modules/forms/dismissedTips.test.ts
@@ -1,0 +1,59 @@
+import {beforeEach, describe, expect, it, vi} from 'vite-plus/test';
+import {dismissTip, dismissedTipUids, isTipDismissed} from './dismissedTips';
+
+describe('dismissedTips', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('reports nothing dismissed to begin with', () => {
+    expect(dismissedTipUids()).toEqual([]);
+    expect(isTipDismissed('abc')).toBe(false);
+  });
+
+  it('remembers a dismissed tip', () => {
+    dismissTip('abc');
+
+    expect(isTipDismissed('abc')).toBe(true);
+    expect(isTipDismissed('def')).toBe(false);
+  });
+
+  it('does not record the same tip twice', () => {
+    dismissTip('abc');
+    dismissTip('abc');
+
+    expect(dismissedTipUids()).toEqual(['abc']);
+  });
+
+  it('shares the legacy editor’s storage key', () => {
+    window.localStorage.setItem(
+      'dismissedTips',
+      JSON.stringify(['legacy-uid'])
+    );
+
+    expect(isTipDismissed('legacy-uid')).toBe(true);
+  });
+
+  it('treats a malformed value as nothing dismissed', () => {
+    window.localStorage.setItem('dismissedTips', 'not json');
+
+    expect(dismissedTipUids()).toEqual([]);
+  });
+
+  it('survives storage being unavailable', () => {
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+
+    expect(() => dismissTip('abc')).not.toThrow();
+
+    setItem.mockRestore();
+  });
+
+  it('ignores a tip with no uid', () => {
+    expect(isTipDismissed(null)).toBe(false);
+    expect(isTipDismissed(undefined)).toBe(false);
+  });
+});

--- a/resources/js/modules/forms/dismissedTips.ts
+++ b/resources/js/modules/forms/dismissedTips.ts
@@ -1,0 +1,39 @@
+const STORAGE_KEY = 'dismissedTips';
+
+/**
+ * Tips a user has dismissed, by layout element UID.
+ *
+ * Kept in local storage under the same key the legacy editor used, so a tip
+ * dismissed on either editor stays dismissed on both.
+ */
+export function dismissedTipUids(): Array<string> {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = stored ? JSON.parse(stored) : [];
+
+    return Array.isArray(parsed)
+      ? parsed.filter((uid) => typeof uid === 'string')
+      : [];
+  } catch {
+    // Private browsing, quota, or a malformed value — treat as nothing dismissed.
+    return [];
+  }
+}
+
+export function isTipDismissed(uid: string | null | undefined): boolean {
+  return uid ? dismissedTipUids().includes(uid) : false;
+}
+
+export function dismissTip(uid: string): void {
+  const uids = dismissedTipUids();
+
+  if (uids.includes(uid)) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...uids, uid]));
+  } catch {
+    // Dismissal is a convenience; failing to persist it isn't worth surfacing.
+  }
+}

--- a/src/Element/Concerns/HasControlPanelUI.php
+++ b/src/Element/Concerns/HasControlPanelUI.php
@@ -751,10 +751,11 @@ JS,
     private function statusNodes(): array
     {
         $siteIds = $this->editableStatusSiteIds();
+        $additionalSiteIds = $this->additionalStatusSiteIds();
 
-        // One editable site (or a non-localized element) keeps the plain
-        // global switch the single-site editor has always shown.
-        if (count($siteIds) < 2) {
+        // One editable site in total (or a non-localized element) keeps the
+        // plain global switch the single-site editor has always shown.
+        if (count($siteIds) + count($additionalSiteIds) < 2) {
             return [
                 Field::make(t('Status'))
                     ->control(
@@ -773,6 +774,14 @@ JS,
 
         foreach ($siteIds as $siteId) {
             $statuses[$siteId] = (bool) ($siteStatuses[$siteId] ?? true);
+        }
+
+        // Supported sites the element doesn't propagate to are offered here too,
+        // switched off. The legacy editor hides these behind an "Add a site…"
+        // select; turning one on has the same effect — the element is saved for
+        // that site — without the dynamic field building.
+        foreach ($additionalSiteIds as $siteId) {
+            $statuses[$siteId] ??= false;
         }
 
         $values = array_values($statuses);
@@ -808,6 +817,30 @@ JS,
                 ->label(t('Update status for individual sites'))
                 ->collapsible(),
         ];
+    }
+
+    /**
+     * Supported sites the element does *not* propagate to, limited to editable
+     * ones — the sites it could be added to.
+     *
+     * @return list<int>
+     */
+    private function additionalStatusSiteIds(): array
+    {
+        if (! static::isLocalized()) {
+            return [];
+        }
+
+        return array_values(array_intersect(
+            array_column(
+                array_filter(
+                    ElementHelper::supportedSitesForElement($this, true),
+                    fn (array $site): bool => ! $site['propagate'],
+                ),
+                'siteId',
+            ),
+            Sites::getEditableSiteIds()->all(),
+        ));
     }
 
     /**

--- a/tests/Feature/Http/Controllers/Entries/EditEntryMultiSiteTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryMultiSiteTest.php
@@ -133,3 +133,29 @@ it('omits the site switcher and per-site switches when the section is single-sit
             ->etc()
         );
 });
+
+it('offers a switch for every site the section is enabled for', function () {
+    $extraSite = Site::factory()->create();
+    Sites::refreshSites();
+    SectionSiteSettings::factory()->create([
+        'sectionId' => $this->section->id,
+        'siteId' => $extraSite->id,
+        'hasUrls' => true,
+        'dateCreated' => $this->section->dateCreated,
+        'dateUpdated' => $this->section->dateUpdated,
+    ]);
+    Sections::refreshSections();
+
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('sidebarForm.nodes', function (Collection $nodes) use ($extraSite) {
+                $group = $nodes->first(fn (array $node) => ($node['uid'] ?? null) === 'site-statuses');
+
+                return collect($group['children'] ?? [])
+                    ->map(fn (array $child) => implode('.', $child['control']['path'] ?? []))
+                    ->contains("enabledForSite.{$extraSite->id}");
+            })
+            ->etc()
+        );
+});


### PR DESCRIPTION
### Description

Two remaining pieces of the element editor.

Dismissible tips now dismiss. `CalloutNode` renders a dismiss control for tips marked dismissible and remembers them by layout element UID, under the same local storage key the legacy editor uses, so a tip dismissed on either editor stays dismissed on both. Storage failures are swallowed — dismissal is a convenience, not something worth interrupting anyone over. The payload already carried `dismissible`; nothing acted on it.

The sidebar's site statuses now also cover supported sites the element does not propagate to, switched off, so the element can be added to them. The legacy editor hides these behind an "Add a site…" select that builds fields on demand; listing them reaches the same outcome without the dynamic DOM work.

Note that entries don't currently produce non-propagating supported sites — a section site either propagates or isn't supported at all — so that path is dormant for them and matters only for element types whose `getSupportedSites()` marks a site as non-propagating. The accompanying test covers the ordinary multi-site case rather than claiming to exercise it.

Copying a field's value from another site is not included, and isn't a gap in this editor: Craft 5 renders a "Copy value from site…" item into each translatable field's action menu, and the Craft 6 port never carried it over, so the feature is unreachable on the legacy editor too. `elements/copy-values-from-site` still exists and still works. Restoring it means giving Form-rendered fields an action menu, which is a Form system decision rather than an element editor one.
