### PR TITLE
[6.x] Port the asset edit page to Inertia

### DIFF
--- a/resources/js/common/types/globals.d.ts
+++ b/resources/js/common/types/globals.d.ts
@@ -148,7 +148,12 @@ interface CraftStatic {
       message?: string | CpNotificationSettings,
       settings?: CpNotificationSettings
     ) => object;
+    displayNotice?: (
+      message?: string,
+      settings?: CpNotificationSettings
+    ) => object;
   };
+  broadcaster?: {postMessage(message: Record<string, unknown>): void};
   defaultIndexCriteria: Record<string, any>;
   systemUid?: string;
   canAccessQueueManager?: boolean;
@@ -190,6 +195,16 @@ interface CraftStatic {
       minSafeElevatedSessionTimeout?: number
     ): void | Promise<void>;
   };
+
+  // Asset editing, still served by the legacy bundle.
+  isImagick?: boolean;
+  PreviewFileModal: new (assetId: number, settings?: object) => unknown;
+  AssetImageEditor: new (assetId: number, settings?: object) => unknown;
+  createUploader(
+    fsType: string,
+    $element: unknown,
+    settings?: object
+  ): {setParams(params: Record<string, unknown>): void};
 }
 
 // oxlint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/resources/js/modules/elements/components/ElementEditPage.vue
+++ b/resources/js/modules/elements/components/ElementEditPage.vue
@@ -233,7 +233,14 @@
     <slot :payload="payload" />
   </Pane>
 
-  <LayoutSlot v-if="sidebarPayload || payload.metadataHtml" name="details">
+  <LayoutSlot
+    v-if="sidebarPayload || payload.metadataHtml || $slots['details-header']"
+    name="details"
+  >
+    <!-- Anything the element type shows above its meta fields, e.g. an
+      asset's file preview. -->
+    <slot name="details-header" :payload="payload" />
+
     <!--
       The meta fields render as their own Form, bridged into the same Inertia
       form as the field layout above, so they submit as ordinary inputs.

--- a/resources/js/modules/elements/composables/useElementActionMenu.ts
+++ b/resources/js/modules/elements/composables/useElementActionMenu.ts
@@ -1,4 +1,5 @@
 import {router} from '@inertiajs/vue3';
+import {t} from '@craftcms/ui';
 import {computed, type ComputedRef} from 'vue';
 import type {ActionItem} from '@/common/types';
 import {ElementDeletionManager} from '@/modules/element-deletion-manager';
@@ -42,7 +43,17 @@ export type ElementActionBehavior =
       action?: string;
       params?: Record<string, unknown>;
       entryTypeFromField?: boolean;
-    };
+    }
+  // The asset behaviors below all hand off to a legacy modal or uploader, and
+  // reload the page afterwards rather than patching the file's details into it.
+  | {
+      type: 'previewFile';
+      assetId: number;
+      settings?: Record<string, unknown>;
+    }
+  | {type: 'download'; actionUrl: string; params?: Record<string, unknown>}
+  | {type: 'replaceFile'; assetId: number; fsType: string}
+  | {type: 'editImage'; assetId: number};
 
 export interface ElementActionMenuItem {
   label: string;
@@ -128,8 +139,121 @@ export function useElementActionMenu(
             params: behavior.params,
           });
         }
+
+        return;
       }
+
+      case 'previewFile':
+        new Craft.PreviewFileModal(behavior.assetId, behavior.settings ?? {});
+
+        return;
+
+      case 'download':
+        // A real form post, not an Inertia visit: the response is the file.
+        submitNativeForm(behavior.actionUrl, behavior.params ?? {});
+
+        return;
+
+      case 'replaceFile':
+        replaceFile(behavior.assetId, behavior.fsType);
+
+        return;
+
+      case 'editImage':
+        new Craft.AssetImageEditor(behavior.assetId, {
+          allowDegreeFractions: Craft.isImagick,
+          // A new asset means a different element entirely, so only an in-place
+          // edit is worth refreshing this screen for.
+          onSave: (data: {newAssetId?: number}) => {
+            if (!data.newAssetId) {
+              router.reload();
+            }
+          },
+        });
     }
+  }
+
+  /**
+   * Posts to an action the browser should handle itself — a file download,
+   * which can't come back through Inertia.
+   */
+  function submitNativeForm(
+    action: string,
+    params: Record<string, unknown>
+  ): void {
+    const form = document.createElement('form');
+    form.method = 'post';
+    form.action = action;
+    form.hidden = true;
+
+    const fields: Record<string, unknown> = {
+      ...(Craft.csrfTokenName
+        ? {[Craft.csrfTokenName]: Craft.csrfTokenValue}
+        : {}),
+      ...params,
+    };
+
+    for (const [name, value] of Object.entries(fields)) {
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = name;
+      input.value = String(value);
+      form.append(input);
+    }
+
+    document.body.append(form);
+    form.submit();
+    form.remove();
+  }
+
+  /**
+   * Swaps the asset's file for a newly uploaded one through the legacy
+   * uploader, then reloads so the filename, size, dimensions, and thumbnail all
+   * come back from the server together.
+   */
+  function replaceFile(assetId: number, fsType: string): void {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.name = 'replaceFile';
+    input.hidden = true;
+    document.body.append(input);
+
+    const uploader = Craft.createUploader(fsType, $(input), {
+      dropZone: null,
+      fileInput: $(input),
+      paramName: 'replaceFile',
+      replace: true,
+      events: {
+        fileuploaddone: (event: any, data: any) => {
+          const result =
+            event instanceof CustomEvent ? event.detail : data.result;
+
+          if (result?.error) {
+            Craft.cp?.displayError?.(result.error);
+
+            return;
+          }
+
+          Craft.cp?.displayNotice?.(t('New file uploaded.'));
+          Craft.broadcaster?.postMessage({event: 'saveElement', id: assetId});
+          router.reload();
+        },
+        fileuploadfail: (event: any, data: any) => {
+          const response =
+            event instanceof CustomEvent
+              ? event.detail
+              : data?.jqXHR?.responseJSON;
+
+          Craft.cp?.displayError?.(
+            response?.message ?? t('Replace file failed.')
+          );
+        },
+        fileuploadalways: () => input.remove(),
+      },
+    });
+
+    uploader.setParams({assetId});
+    input.click();
   }
 
   return computed(() =>

--- a/resources/js/modules/elements/composables/useElementActivity.ts
+++ b/resources/js/modules/elements/composables/useElementActivity.ts
@@ -39,6 +39,7 @@ export function useElementActivity(options: Options): {
   isStale: Readonly<Ref<boolean>>;
   staleType: Readonly<Ref<'element' | 'canonical' | null>>;
   poll: () => Promise<void>;
+  rebase: (timestamps: Options['updatedTimestamps']) => void;
 } {
   const activity = ref<Array<ElementActivityEntry>>([]);
   const isStale = ref(false);
@@ -84,6 +85,19 @@ export function useElementActivity(options: Options): {
     }
   }
 
+  /**
+   * Re-baselines against the stamps the screen has just re-rendered with.
+   *
+   * Saving in place bumps the element's `dateUpdated` without navigating away,
+   * which the next poll would otherwise report as someone else's change.
+   */
+  function rebase(timestamps: Options['updatedTimestamps']): void {
+    elementStamp = timestamps.element;
+    canonicalStamp = timestamps.canonical;
+    isStale.value = false;
+    staleType.value = null;
+  }
+
   const visibility = useDocumentVisibility();
 
   const {pause, resume} = useIntervalFn(
@@ -112,5 +126,6 @@ export function useElementActivity(options: Options): {
     isStale: readonly(isStale),
     staleType: readonly(staleType),
     poll,
+    rebase,
   };
 }

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -1,4 +1,4 @@
-import {useEventListener} from '@vueuse/core';
+import {toReactive, useEventListener} from '@vueuse/core';
 import {router, useForm, usePage} from '@inertiajs/vue3';
 import {actionClient, t} from '@craftcms/ui';
 import {computed, nextTick, onBeforeUnmount, ref, watch} from 'vue';
@@ -98,7 +98,13 @@ interface Options {
  */
 export function useElementEditPage({saveData}: Options = {}) {
   const page = usePage<ElementEditPayload>();
-  const props = page.props;
+
+  // `page.props` is a computed, so capturing it once would freeze the payload
+  // at the values the screen first rendered with. Saving in place — the normal
+  // path for an element with no drafts — replaces the props without remounting
+  // this component, so the title, notices, and timestamps below have to track
+  // the live page.
+  const props = toReactive(computed(() => page.props));
 
   const formPayload = computed(() => props.form);
   const sidebarPayload = computed(() => props.sidebarForm);
@@ -221,6 +227,10 @@ export function useElementEditPage({saveData}: Options = {}) {
           advanceBaseline();
           advanceSidebarBaseline();
         });
+
+        // The save itself moved the element's `dateUpdated`; without this the
+        // next poll would report our own write as someone else's change.
+        activity.rebase(props.updatedTimestamps);
       },
     }
   );

--- a/resources/js/pages/assets/Edit.vue
+++ b/resources/js/pages/assets/Edit.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+  import ElementEditPage from '@/modules/elements/components/ElementEditPage.vue';
+  import HtmlFragmentRenderer from '@/common/components/HtmlFragmentRenderer.vue';
+
+  // The shared edit payload comes from the ElementEditPage pipeline; only the
+  // Asset-specific keys (AssetEditViewModel) remain props, alongside the
+  // identity the generic element save resolves the asset from.
+  const props = defineProps<{
+    elementType: string;
+    elementId: number | null;
+    siteId: number | null;
+    previewFragment: CraftCms.Cms.View.HtmlFragment | null;
+  }>();
+
+  // Assets have no store action of their own, so the generic element save
+  // reads the identity attributes every element carries.
+  const saveData = () => ({
+    elementType: props.elementType,
+    elementId: props.elementId,
+    siteId: props.siteId,
+  });
+</script>
+
+<template>
+  <ElementEditPage :save-data="saveData">
+    <!-- The file preview sits above the meta fields, as in the legacy
+      editor's sidebar. -->
+    <template v-if="previewFragment" #details-header>
+      <HtmlFragmentRenderer :fragment="previewFragment" class="mb-4" />
+    </template>
+  </ElementEditPage>
+</template>

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use CraftCms\Cms\Auth\Enums\CpAuthPath;
 use CraftCms\Cms\Auth\LoginRateLimiter;
 use CraftCms\Cms\Edition;
+use CraftCms\Cms\Http\Controllers\Assets\EditAssetController;
 use CraftCms\Cms\Http\Controllers\Assets\IndexController as AssetsIndexController;
 use CraftCms\Cms\Http\Controllers\Auth\LoginController;
 use CraftCms\Cms\Http\Controllers\Auth\SetPasswordController;
@@ -183,7 +184,7 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
         ...$idSlugParams,
         'page' => '[^\/]+',
     ]);
-    Route::get('assets/edit/{id}{slug}', EditElementController::class)->where($idSlugParams);
+    Route::get('assets/edit/{id}{slug}', EditAssetController::class)->where($idSlugParams);
     Route::get('entries/{section}/{id}{slug?}', EditEntryController::class)->where($idSlugParams);
     Route::get('content/{page}/{section}/{id}{slug?}', EditEntryController::class)->where([
         ...$idSlugParams,

--- a/src/Asset/Elements/Asset.php
+++ b/src/Asset/Elements/Asset.php
@@ -55,6 +55,10 @@ use CraftCms\Cms\Field\Enums\TranslationMethod;
 use CraftCms\Cms\FieldLayout\FieldLayout;
 use CraftCms\Cms\Filesystem\Exceptions\FilesystemException;
 use CraftCms\Cms\Filesystem\Filesystems\Filesystem;
+use CraftCms\Cms\Form\Contracts\Node;
+use CraftCms\Cms\Form\Controls\Text;
+use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Form\Nodes\Field;
 use CraftCms\Cms\Gql\Interfaces\Elements\Asset as AssetInterface;
 use CraftCms\Cms\Http\Requests\ElementRequest;
 use CraftCms\Cms\Image\Data\ImageTransform;
@@ -1311,6 +1315,113 @@ class Asset extends Element
     public function getPostEditUrl(): string
     {
         return Url::cpUrl('assets');
+    }
+
+    /**
+     * The asset's own action menu items for the Inertia editor — the Form-system
+     * counterpart to the items {@see safeActionMenuItems()} builds with inline
+     * jQuery. Everything that opens a legacy modal (the file preview, the image
+     * editor, the replace-file uploader) is described here and dispatched by the
+     * client, which reloads afterwards so the file's details come back from the
+     * server rather than being patched into the DOM.
+     *
+     * @return list<array<string, mixed>>
+     */
+    #[Override]
+    protected function extraActionMenuDescriptors(): array
+    {
+        $user = currentUserElement();
+        $items = [];
+
+        if (AssetsService::getAssetPreviewHandler($this) !== null) {
+            $items[] = [
+                'label' => t('Preview file'),
+                'icon' => 'view',
+                'behavior' => [
+                    'type' => 'previewFile',
+                    'assetId' => $this->id,
+                    'settings' => [
+                        'startingWidth' => $this->width,
+                        'startingHeight' => $this->height,
+                    ],
+                ],
+            ];
+        }
+
+        $items[] = [
+            'label' => t('Download'),
+            'icon' => 'download',
+            'behavior' => [
+                'type' => 'download',
+                'actionUrl' => Url::actionUrl('assets/download-asset'),
+                'params' => ['assetId' => $this->id],
+            ],
+        ];
+
+        if ($user && $this->volumeId && $this->canView($user)) {
+            $items[] = [
+                'label' => t('Show in folder'),
+                'icon' => 'magnifying-glass',
+                'behavior' => [
+                    'type' => 'link',
+                    'href' => Url::actionUrl('assets/show-in-folder', ['assetId' => $this->id]),
+                ],
+            ];
+        }
+
+        if ($user?->can('replaceFile', $this)) {
+            $items[] = [
+                'label' => t('Replace file'),
+                'icon' => 'upload',
+                'behavior' => [
+                    'type' => 'replaceFile',
+                    'assetId' => $this->id,
+                    'fsType' => $this->getVolume()->sourceFilesystemType(),
+                ],
+            ];
+        }
+
+        if ($this->getSupportsImageEditor() && $user?->can('editImage', $this)) {
+            $items[] = [
+                'label' => t('Open in Image Editor'),
+                'icon' => 'edit',
+                'behavior' => [
+                    'type' => 'editImage',
+                    'assetId' => $this->id,
+                ],
+            ];
+        }
+
+        if ($user?->isAdmin() && Cms::config()->allowAdminChanges) {
+            $items[] = [
+                'label' => t('Volume settings'),
+                'icon' => 'gear',
+                'behavior' => [
+                    'type' => 'slideout',
+                    'action' => 'volumes/edit-volume',
+                    'params' => ['volumeId' => $this->volumeId],
+                ],
+            ];
+
+            $fsHandle = $this->getVolume()->getFsHandle();
+
+            if (
+                is_string($fsHandle) &&
+                ! str_starts_with($fsHandle, Volume::STORAGE_DISK_PREFIX) &&
+                Filesystems::getFilesystemByHandle($fsHandle)
+            ) {
+                $items[] = [
+                    'label' => t('Filesystem settings'),
+                    'icon' => 'gear',
+                    'behavior' => [
+                        'type' => 'slideout',
+                        'url' => Url::cpUrl("settings/filesystems/$fsHandle/edit"),
+                    ],
+                ];
+            }
+        }
+
+        return $items;
     }
 
     /** @return list<array<string, bool|int|string|MenuItemType|list<array<string, bool|int|string|MenuItemType>>>> */
@@ -2735,6 +2846,47 @@ JS;
             ]),
             parent::metaFieldsHtml($static),
         ]);
+    }
+
+    /** @return list<Node> */
+    #[Override]
+    protected function metaFieldsNodes(bool $static): array
+    {
+        return [
+            Field::make(t('Filename'))
+                ->required()
+                ->control(
+                    Text::make('newFilename')
+                        ->value($this->_filename)
+                        ->mode($static ? ControlMode::Disabled : ControlMode::Editable),
+                ),
+            ...parent::metaFieldsNodes($static),
+        ];
+    }
+
+    /**
+     * Renaming validates the folder path and the filename together as
+     * `newLocation`, but the field that produced the error posts `newFilename`,
+     * so its messages move to the name the Control answers to. They're moved
+     * rather than copied so the error summary doesn't list each one twice.
+     *
+     * @return array<string, list<string>>
+     */
+    #[Override]
+    public function formErrors(): array
+    {
+        $errors = parent::formErrors();
+
+        if (isset($errors['newLocation'])) {
+            $errors['newFilename'] = [
+                ...($errors['newFilename'] ?? []),
+                ...$errors['newLocation'],
+            ];
+
+            unset($errors['newLocation']);
+        }
+
+        return $errors;
     }
 
     /** @return array<string, Closure(): bool|string> */

--- a/src/Element/Concerns/HasControlPanelUI.php
+++ b/src/Element/Concerns/HasControlPanelUI.php
@@ -881,6 +881,22 @@ JS,
     }
 
     /**
+     * Returns the element's validation errors keyed the way the editor's Forms
+     * address them.
+     *
+     * A Form matches errors to Controls by path, so an attribute validated
+     * under one name but posted under another — an asset's `newLocation` versus
+     * its `newFilename` field — needs remapping here, or its messages never
+     * reach the field that produced them.
+     *
+     * @return array<string, list<string>>
+     */
+    public function formErrors(): array
+    {
+        return $this->errors()->getMessages();
+    }
+
+    /**
      * Returns the HTML for any meta fields that should be shown within the editor sidebar.
      *
      * @param  bool  $static  Whether the fields should be static (non-interactive)

--- a/src/Element/Contracts/ElementInterface.php
+++ b/src/Element/Contracts/ElementInterface.php
@@ -1613,6 +1613,18 @@ interface ElementInterface extends Actionable, ArrayAccess, Chippable, Component
     public function sidebarForm(FormContext $context = new FormContext): ?Form;
 
     /**
+     * Returns the element's validation errors keyed the way the editor's Forms
+     * address them.
+     *
+     * A Form matches errors to Controls by path, so an attribute validated
+     * under one name but posted under another needs remapping here, or its
+     * messages never reach the field that produced them.
+     *
+     * @return array<string, list<string>>
+     */
+    public function formErrors(): array;
+
+    /**
      * Returns element metadata that should be shown within the editor sidebar.
      *
      * @return array<string,mixed> The data, with keys representing the labels. The values can either be strings or callables.

--- a/src/Http/Controllers/Assets/EditAssetController.php
+++ b/src/Http/Controllers/Assets/EditAssetController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http\Controllers\Assets;
+
+use CraftCms\Cms\Asset\Elements\Asset;
+use CraftCms\Cms\Http\Controllers\Elements\Concerns\SavesElement;
+use CraftCms\Cms\Http\Requests\ElementRequest;
+use CraftCms\Cms\Http\ViewModels\AssetEditViewModel;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Renders the Inertia asset edit screen.
+ *
+ * The legacy `EditElementController` still serves slideouts and the element
+ * types that haven't been ported.
+ */
+class EditAssetController
+{
+    use SavesElement;
+
+    public function __construct(
+        protected readonly ElementRequest $request,
+    ) {}
+
+    public function __invoke(): Response|InertiaResponse
+    {
+        $element = $this->request->element(
+            ['id' => $this->request->route('id') ?? $this->request->integer('elementId')],
+            strictSite: false,
+        );
+
+        if ($element instanceof Response) {
+            return $element;
+        }
+
+        if (! $element instanceof Asset) {
+            abort(400, 'No asset was identified by the request.');
+        }
+
+        $this->applyParamsToElement($element);
+
+        return Inertia::render('assets/Edit', new AssetEditViewModel(
+            asset: $element,
+            request: $this->request,
+            canSave: $this->canSave($element, $this->request->craftUser()),
+        ));
+    }
+}

--- a/src/Http/Responses/ElementResponse.php
+++ b/src/Http/Responses/ElementResponse.php
@@ -84,10 +84,18 @@ class ElementResponse
         $data = [
             'modelName' => 'element',
             'element' => $element->toArray($element->attributes()),
+            // The legacy editor and the slideouts apply errors by the raw
+            // attribute name, so the JSON branch keeps them as validated.
             'errors' => $element->errors()->getMessages(),
             'errorSummary' => $this->errorSummary($element),
             'invalidNestedElementIds' => $element->getInvalidNestedElementIds(),
         ];
+
+        // The Inertia editor matches errors to Form Controls by path, which is
+        // the posted input name rather than the validated attribute.
+        if (! request()->expectsJson()) {
+            $data['errors'] = $element->formErrors();
+        }
 
         return $this->asFailure($message, $data);
     }

--- a/src/Http/ViewModels/AssetEditViewModel.php
+++ b/src/Http/ViewModels/AssetEditViewModel.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http\ViewModels;
+
+use CraftCms\Cms\Asset\Elements\Asset;
+use CraftCms\Cms\Http\Requests\ElementRequest;
+use CraftCms\Cms\Support\Facades\HtmlStack;
+use CraftCms\Cms\Support\Url;
+use CraftCms\Cms\View\HtmlFragment;
+use Override;
+
+/**
+ * The Inertia payload for the asset edit screen (`assets/Edit`).
+ *
+ * Assets have no drafts, revisions, or statuses, so most of the shared
+ * editor's machinery stays dormant here; what's left is the field layout, the
+ * filename meta field, and the file preview.
+ */
+class AssetEditViewModel extends ElementEditViewModel
+{
+    public function __construct(
+        private readonly Asset $asset,
+        ElementRequest $request,
+        bool $canSave = true,
+    ) {
+        parent::__construct($asset, $request, $canSave);
+    }
+
+    /**
+     * Assets have no store action of their own — the generic element save
+     * reads the identity params every element edit screen submits.
+     */
+    #[Override]
+    protected function elementSaveUrl(): string
+    {
+        return Url::actionUrl('elements/save');
+    }
+
+    public function volumeId(): ?int
+    {
+        return $this->asset->getVolumeId();
+    }
+
+    public function folderId(): ?int
+    {
+        return $this->asset->folderId;
+    }
+
+    /**
+     * The file preview — a thumbnail, or a player for audio and video — shown
+     * above the meta fields.
+     *
+     * Still server-rendered HTML: previewing and image editing both open
+     * legacy modals, and the markup carries the JS that wires them up, so it
+     * arrives as a fragment rather than a payload the Vue side rebuilds.
+     */
+    public function previewFragment(): ?HtmlFragment
+    {
+        if (! $this->asset->id) {
+            return null;
+        }
+
+        $fragment = HtmlStack::capture(fn (): string => $this->asset->getPreviewHtml());
+
+        return $fragment->isEmpty() ? null : $fragment;
+    }
+}

--- a/src/Http/ViewModels/ElementEditViewModel.php
+++ b/src/Http/ViewModels/ElementEditViewModel.php
@@ -549,9 +549,15 @@ abstract class ElementEditViewModel extends ViewModel
         return $this->element->draftId;
     }
 
+    /**
+     * Autosaving means writing a provisional draft, so an element type without
+     * drafts — an asset, a user — saves only when the Save button is pressed.
+     */
     public function canAutosave(): bool
     {
-        return $this->canSave && ! $this->element->getIsRevision();
+        return $this->canSave
+            && $this->element::hasDrafts()
+            && ! $this->element->getIsRevision();
     }
 
     /**
@@ -752,7 +758,7 @@ abstract class ElementEditViewModel extends ViewModel
             $this->element,
             new FormContext(
                 namespace: [],
-                errors: $this->element->errors()->getMessages(),
+                errors: $this->element->formErrors(),
                 mode: $this->canSave ? ControlMode::Editable : ControlMode::ReadOnly,
                 refreshable: true,
             ),
@@ -785,7 +791,7 @@ abstract class ElementEditViewModel extends ViewModel
     {
         return new FormContext(
             namespace: [],
-            errors: $this->element->errors()->getMessages(),
+            errors: $this->element->formErrors(),
             mode: $this->canSave ? ControlMode::Editable : ControlMode::ReadOnly,
         );
     }

--- a/tests/Feature/Http/Controllers/Assets/EditAssetControllerTest.php
+++ b/tests/Feature/Http/Controllers/Assets/EditAssetControllerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Asset\Elements\Asset;
+use CraftCms\Cms\Asset\Models\Asset as AssetModel;
+use CraftCms\Cms\Asset\Models\Volume;
+use CraftCms\Cms\Asset\Models\VolumeFolder as VolumeFolderModel;
+use CraftCms\Cms\FieldLayout\FieldLayout;
+use CraftCms\Cms\FieldLayout\FieldLayoutTab;
+use CraftCms\Cms\FieldLayout\LayoutElements\Assets\AltField;
+use CraftCms\Cms\FieldLayout\Models\FieldLayout as FieldLayoutModel;
+use CraftCms\Cms\Support\Facades\Elements;
+use CraftCms\Cms\User\Elements\User;
+use Illuminate\Support\Collection;
+use Inertia\Testing\AssertableInertia;
+
+use function CraftCms\Cms\cp_url;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    actingAs(User::findOne());
+
+    config()->set('filesystems.disks.edit-asset-test', [
+        'driver' => 'local',
+        'root' => storage_path('framework/testing/edit-asset-controller-test'),
+    ]);
+
+    $layout = FieldLayout::make(Asset::class)
+        // The Title field is mandatory, so the layout supplies it itself.
+        ->tab('Content', fn (FieldLayoutTab $tab) => $tab
+            ->add(new AltField(['uid' => 'asset-alt'])));
+    $config = $layout->getConfig();
+    $config['tabs'][0]['uid'] = 'asset-content';
+    $layout = FieldLayoutModel::factory()->create(['type' => Asset::class, 'config' => $config]);
+
+    $this->volume = Volume::factory()->create([
+        'fs' => 'disk:edit-asset-test',
+        'fieldLayoutId' => $layout->id,
+    ]);
+    $this->folder = VolumeFolderModel::factory()->create(['volumeId' => $this->volume->id]);
+
+    $this->asset = AssetModel::factory()->createElement([
+        'volumeId' => $this->volume->id,
+        'folderId' => $this->folder->id,
+        'filename' => 'current-file.png',
+        'kind' => 'image',
+    ]);
+
+    // The title lives on `elements_sites`, not the `assets` row the factory
+    // writes, so it's set through the element.
+    $this->asset->title = 'Current Title';
+    Elements::saveElement($this->asset);
+});
+
+it('renders the asset edit screen as an Inertia page', function () {
+    get($this->asset->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->component('assets/Edit')
+            ->where('elementId', $this->asset->id)
+            ->where('canonicalId', $this->asset->id)
+            ->where('elementType', Asset::class)
+            ->where('siteId', $this->asset->siteId)
+            ->where('volumeId', $this->volume->id)
+            ->where('folderId', $this->folder->id)
+            ->where('title', 'Current Title')
+            ->where('readOnly', false)
+        );
+});
+
+it('compiles the field layout into a form payload', function () {
+    get($this->asset->getCpEditUrl())
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->has('form.nodes')
+            ->where('form.values.title', 'Current Title')
+        );
+});
+
+it('renders the filename as a sidebar meta field', function () {
+    get($this->asset->getCpEditUrl())
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('sidebarForm.values.newFilename', 'current-file.png')
+        );
+});
+
+it('posts to the generic element save action', function () {
+    get($this->asset->getCpEditUrl())
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('saveUrl', fn (string $url): bool => str_contains($url, 'elements/save'))
+        );
+});
+
+it('does not autosave, since assets have no drafts', function () {
+    get($this->asset->getCpEditUrl())
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('canAutosave', false)
+            ->where('draftId', null)
+            ->where('isProvisionalDraft', false)
+            ->where('contextMenu', null)
+        );
+});
+
+it('offers the asset’s own actions in the action menu', function () {
+    get($this->asset->getCpEditUrl())
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('actionMenu', function (Collection $items): bool {
+                $types = $items->pluck('behavior.type')->all();
+
+                return in_array('download', $types, true)
+                    && in_array('replaceFile', $types, true);
+            })
+        );
+});
+
+it('re-keys rename errors onto the field that posts them', function () {
+    $asset = Asset::find()->id($this->asset->id)->one();
+    $asset->errors()->add('newLocation', '“exe” is not an allowed file extension.');
+
+    expect($asset->formErrors())
+        ->not->toHaveKey('newLocation')
+        ->toHaveKey('newFilename');
+});
+
+it('rejects an id that doesn’t resolve to an asset', function () {
+    get(cp_url('assets/edit/999999999-nope'))->assertStatus(400);
+});


### PR DESCRIPTION
### Description

Ports the asset edit screen onto the shared Inertia element editor, replacing the `CpScreenResponse` the generic `EditElementController` produced for it. `assets/edit/{id}{slug}` now routes to `EditAssetController`, which renders `assets/Edit` from an `AssetEditViewModel`.

Assets have no drafts, revisions, or editable status, so most of the editor's machinery stays dormant here. What's left is the compiled field layout (title, alt text, custom fields), the Filename meta field, the file preview, and the asset's own actions. Saving posts to the generic `elements/save` — assets have no store action of their own — resolved from the identity attributes every element edit screen already submits.

`Asset::metaFieldsNodes()` renders Filename as a Form Control alongside the existing `metaFieldsHtml()`. Renaming validates the folder path and the filename together as `newLocation`, but the field posts `newFilename`, so the messages have to move to the name the Control answers to or they never reach the field that produced them. That remapping is a new `ElementInterface::formErrors()` hook, defaulting to the raw error bag; `ElementResponse::failure()` uses it for the Inertia branch only, since the legacy editor and the slideouts still apply errors by the validated attribute.

The asset's own actions — preview, download, show in folder, replace file, image editor, volume and filesystem settings — arrive as behavior descriptors rather than markup plus an inline script. The three that hand off to a legacy modal or uploader reload the screen afterwards rather than patching the file's details into the DOM, which is both shorter and more correct than the legacy JS that hand-edits the filename input, file size, dimensions, and thumbnail.

Two fixes to shared editor code, both surfaced by this screen because an in-place save with no redirect is the normal path for an element with no drafts:

- `useElementEditPage` captured `page.props` once. It's a computed, so the payload froze at whatever the screen first rendered with — the title, notices, and timestamps never updated after saving in place. Now read through `toReactive`.
- The activity poller compared against the timestamps it was constructed with, so a successful save reported our own write as someone else's change. It re-baselines on save.

`canAutosave` now also requires the element type to have drafts. Autosaving means writing a provisional draft; without one there's nothing to write to.

The file preview is still server-rendered HTML. Previewing and image editing both open legacy modals and the markup carries the JS that wires them up, so it arrives as a fragment rather than something the Vue side rebuilds.
