### PR TITLE
Mockery to Double Converter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,235 +1,236 @@
 {
-  "name": "craftcms/cms",
-  "description": "Craft CMS",
-  "keywords": [
-    "cms",
-    "craftcms",
-    "laravel"
-  ],
-  "homepage": "https://craftcms.com",
-  "license": "proprietary",
-  "authors": [
-    {
-      "name": "Pixel & Tonic",
-      "homepage": "https://pixelandtonic.com/"
-    }
-  ],
-  "support": {
-    "email": "support@craftcms.com",
-    "issues": "https://github.com/craftcms/cms/issues?state=open",
-    "forum": "https://craftcms.stackexchange.com/",
-    "source": "https://github.com/craftcms/cms",
-    "docs": "https://craftcms.com/docs/5.x/",
-    "rss": "https://github.com/craftcms/cms/releases.atom"
-  },
-  "require": {
-    "php": "^8.5",
-    "ext-bcmath": "*",
-    "ext-curl": "*",
-    "ext-dom": "*",
-    "ext-intl": "*",
-    "ext-json": "*",
-    "ext-mbstring": "*",
-    "ext-openssl": "*",
-    "ext-pcre": "*",
-    "ext-pdo": "*",
-    "ext-zip": "*",
-    "bacon/bacon-qr-code": "^3.0",
-    "commerceguys/addressing": "^2.1.1",
-    "composer/semver": "^3.3.2",
-    "craftcms/cms-assets": "self.version",
-    "craftcms/laravel-aliases": "^2.0",
-    "craftcms/laravel-dependency-aware-cache": "^1.2.3",
-    "craftcms/laravel-ruleset-validation": "^1.1",
-    "craftcms/plugin-installer": "~1.6.0",
-    "craftcms/server-check": "~6.0.0",
-    "craftcms/url-validator": "^1.0",
-    "elvanto/litemoji": "^5.2.0",
-    "enshrined/svg-sanitize": "~0.22.0",
-    "guzzlehttp/guzzle": "^7.2.0",
-    "inertiajs/inertia-laravel": "^3.0",
-    "intervention/image": "^4.2",
-    "laravel/framework": "^13.0.0",
-    "laravel/wayfinder": "^0.1.12",
-    "league/commonmark": "^2.8",
-    "league/flysystem-path-prefixing": "^3.31",
-    "league/uri": "^7.0",
-    "moneyphp/money": "^4.0",
-    "phpoffice/phpspreadsheet": "^5.3",
-    "pragmarx/google2fa": "^9.0",
-    "pragmarx/recovery": "^0.2.1",
-    "symfony/css-selector": "^7.0|^8.0",
-    "symfony/dom-crawler": "^7.0|^8.0",
-    "symfony/filesystem": "^7.0|^8.0",
-    "symfony/html-sanitizer": "^7.0|^8.0",
-    "symfony/serializer": "^6.4|^7.0|^8.0",
-    "symfony/yaml": "^7.0|^8.0",
-    "theiconic/name-parser": "^1.2",
-    "tpetry/laravel-query-expressions": "^1.5",
-    "twig/twig": "~3.27.0",
-    "voku/portable-ascii": "^2.0",
-    "web-auth/webauthn-lib": "~5.3.5",
-    "webonyx/graphql-php": "~15.33.1",
-    "yiisoft/arrays": "^3.2",
-    "yiisoft/html": "^4.1",
-    "yiisoft/translator": "^3.2",
-    "yiisoft/translator-message-php": "^1.1"
-  },
-  "require-dev": {
-    "barryvdh/laravel-debugbar": "^4.2",
-    "dg/bypass-finals": "^1.9",
-    "driftingly/rector-laravel": "^2.1",
-    "fakerphp/faker": "^1.19.0",
-    "intervention/image-driver-vips": "^4.1",
-    "larastan/larastan": "^3.4",
-    "laravel/pao": "^1.0",
-    "laravel/pint": "^1.22",
-    "laravel/socialite": "^5.23",
-    "orchestra/testbench": "^11.0",
-    "pestphp/pest": "^5.0",
-    "pestphp/pest-plugin-arch": "^5.0",
-    "pestphp/pest-plugin-laravel": "^5.0",
-    "phpstan/phpstan": "^2.1",
-    "rector/rector": "^2.3",
-    "spatie/laravel-typescript-transformer": "^3.2"
-  },
-  "repositories": [
-    {
-      "type": "path",
-      "url": "./yii2-adapter"
+    "name": "craftcms/cms",
+    "description": "Craft CMS",
+    "keywords": [
+        "cms",
+        "craftcms",
+        "laravel"
+    ],
+    "homepage": "https://craftcms.com",
+    "license": "proprietary",
+    "authors": [
+        {
+            "name": "Pixel & Tonic",
+            "homepage": "https://pixelandtonic.com/"
+        }
+    ],
+    "support": {
+        "email": "support@craftcms.com",
+        "issues": "https://github.com/craftcms/cms/issues?state=open",
+        "forum": "https://craftcms.stackexchange.com/",
+        "source": "https://github.com/craftcms/cms",
+        "docs": "https://craftcms.com/docs/5.x/",
+        "rss": "https://github.com/craftcms/cms/releases.atom"
     },
-    {
-      "type": "path",
-      "url": "./cms-assets"
-    }
-  ],
-  "suggest": {
-    "ext-exif": "Adds support for parsing image EXIF data.",
-    "ext-imagick": "Adds support for more image processing formats and options.",
-    "intervention/image-driver-vips": "Adds support for image processing with libvips (requires ext-ffi and libvips).",
-    "ext-iconv": "Adds support for more character encodings than PHP\u2019s built-in mb_convert_encoding() function, which Craft will take advantage of when converting strings to UTF-8.",
-    "laravel/socialite": "Adds OAuth login support for providers configured with `GeneralConfig::oauthProviders()`."
-  },
-  "autoload": {
-    "psr-4": {
-      "CraftCms\\Cms\\": "src/"
+    "require": {
+        "php": "^8.5",
+        "ext-bcmath": "*",
+        "ext-curl": "*",
+        "ext-dom": "*",
+        "ext-intl": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-openssl": "*",
+        "ext-pcre": "*",
+        "ext-pdo": "*",
+        "ext-zip": "*",
+        "bacon/bacon-qr-code": "^3.0",
+        "commerceguys/addressing": "^2.1.1",
+        "composer/semver": "^3.3.2",
+        "craftcms/cms-assets": "self.version",
+        "craftcms/laravel-aliases": "^2.0",
+        "craftcms/laravel-dependency-aware-cache": "^1.2.3",
+        "craftcms/laravel-ruleset-validation": "^1.1",
+        "craftcms/plugin-installer": "~1.6.0",
+        "craftcms/server-check": "~6.0.0",
+        "craftcms/url-validator": "^1.0",
+        "elvanto/litemoji": "^5.2.0",
+        "enshrined/svg-sanitize": "~0.22.0",
+        "guzzlehttp/guzzle": "^7.2.0",
+        "inertiajs/inertia-laravel": "^3.0",
+        "intervention/image": "^4.2",
+        "laravel/framework": "^13.0.0",
+        "laravel/wayfinder": "^0.1.12",
+        "league/commonmark": "^2.8",
+        "league/flysystem-path-prefixing": "^3.31",
+        "league/uri": "^7.0",
+        "moneyphp/money": "^4.0",
+        "phpoffice/phpspreadsheet": "^5.3",
+        "pragmarx/google2fa": "^9.0",
+        "pragmarx/recovery": "^0.2.1",
+        "symfony/css-selector": "^7.0|^8.0",
+        "symfony/dom-crawler": "^7.0|^8.0",
+        "symfony/filesystem": "^7.0|^8.0",
+        "symfony/html-sanitizer": "^7.0|^8.0",
+        "symfony/serializer": "^6.4|^7.0|^8.0",
+        "symfony/yaml": "^7.0|^8.0",
+        "theiconic/name-parser": "^1.2",
+        "tpetry/laravel-query-expressions": "^1.5",
+        "twig/twig": "~3.27.0",
+        "voku/portable-ascii": "^2.0",
+        "web-auth/webauthn-lib": "~5.3.5",
+        "webonyx/graphql-php": "~15.33.1",
+        "yiisoft/arrays": "^3.2",
+        "yiisoft/html": "^4.1",
+        "yiisoft/translator": "^3.2",
+        "yiisoft/translator-message-php": "^1.1"
     },
-    "files": [
-      "src/helpers.php"
-    ]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "CraftCms\\Cms\\Tests\\": "tests/",
-      "CraftCms\\Cms\\Database\\": "database/",
-      "CraftCms\\Yii2Adapter\\Tests\\": "yii2-adapter/tests-laravel/",
-      "Workbench\\App\\": "workbench/app/",
-      "Workbench\\Database\\Factories\\": "workbench/database/factories/",
-      "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
-    }
-  },
-  "scripts": {
-    "copy-icons": "php ./scripts/copyicons.php",
-    "fix-cs": "npx concurrently -c 'rector' 'pint src --parallel' './yii2-adapter/vendor/bin/ecs check --config ./yii2-adapter/ecs.php --ansi --fix' --names=rector,pint,ecs",
-    "phpstan": "phpstan --memory-limit=1G",
-    "rector": "rector",
-    "tests": [
-      "Composer\\Config::disableProcessTimeout",
-      "./vendor/bin/pest --compact"
-    ],
-    "tests-adapter": "./yii2-adapter/vendor/bin/pest --configuration ./yii2-adapter/phpunit.xml.dist --test-directory ./tests-laravel",
-    "post-autoload-dump": [
-      "@clear",
-      "@prepare"
-    ],
-    "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
-    "prepare": "@php vendor/bin/testbench package:discover --ansi",
-    "build": [
-      "@php vendor/bin/testbench package:create-sqlite-db --ansi",
-      "@php vendor/bin/testbench workbench:build --ansi"
-    ],
-    "serve": [
-      "Composer\\Config::disableProcessTimeout",
-      "@php vendor/bin/testbench workbench:serve --ansi"
-    ],
-    "ci": [
-      "@php pint --parallel",
-      "@rector",
-      "@phpstan",
-      "@tests",
-      "@tests-adapter"
-    ]
-  },
-  "config": {
-    "sort-packages": true,
-    "platform": {
-      "php": "8.5"
+    "require-dev": {
+        "barryvdh/laravel-debugbar": "^4.2",
+        "dg/bypass-finals": "^1.9",
+        "driftingly/rector-laravel": "^2.1",
+        "fakerphp/faker": "^1.19.0",
+        "intervention/image-driver-vips": "^4.1",
+        "larastan/larastan": "^3.4",
+        "laravel/pao": "^1.0",
+        "laravel/pint": "^1.22",
+        "laravel/socialite": "^5.23",
+        "orchestra/testbench": "^11.0",
+        "pestphp/pest": "^5.0",
+        "pestphp/pest-plugin-arch": "^5.0",
+        "pestphp/pest-plugin-laravel": "^5.0",
+        "phpstan/phpstan": "^2.1",
+        "rector/rector": "^2.3",
+        "spatie/laravel-typescript-transformer": "^3.2",
+        "jasonmccreary/double": "^0.3"
     },
-    "platform-check": false,
-    "allow-plugins": {
-      "craftcms/plugin-installer": true,
-      "pestphp/pest-plugin": true,
-      "yiisoft/yii2-composer": true
-    }
-  },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "CraftCms\\Cms\\Providers\\CraftServiceProvider"
-      ],
-      "aliases": {
-        "Addresses": "CraftCms\\Cms\\Support\\Facades\\Addresses",
-        "Announcements": "CraftCms\\Cms\\Support\\Facades\\Announcements",
-        "AssetIndexer": "CraftCms\\Cms\\Support\\Facades\\AssetIndexer",
-        "Assets": "CraftCms\\Cms\\Support\\Facades\\Assets",
-        "AuthMethods": "CraftCms\\Cms\\Support\\Facades\\AuthMethods",
-        "BulkOps": "CraftCms\\Cms\\Support\\Facades\\BulkOps",
-        "Conditions": "CraftCms\\Cms\\Support\\Facades\\Conditions",
-        "DeltaRegistry": "CraftCms\\Cms\\Support\\Facades\\DeltaRegistry",
-        "Deprecator": "CraftCms\\Cms\\Support\\Facades\\Deprecator",
-        "Drafts": "CraftCms\\Cms\\Support\\Facades\\Drafts",
-        "ElementActions": "CraftCms\\Cms\\Support\\Facades\\ElementActions",
-        "ElementActivity": "CraftCms\\Cms\\Support\\Facades\\ElementActivity",
-        "ElementCaches": "CraftCms\\Cms\\Support\\Facades\\ElementCaches",
-        "ElementExporters": "CraftCms\\Cms\\Support\\Facades\\ElementExporters",
-        "ElementSources": "CraftCms\\Cms\\Support\\Facades\\ElementSources",
-        "Elements": "CraftCms\\Cms\\Support\\Facades\\Elements",
-        "Entries": "CraftCms\\Cms\\Support\\Facades\\Entries",
-        "EntryTypes": "CraftCms\\Cms\\Support\\Facades\\EntryTypes",
-        "Fields": "CraftCms\\Cms\\Support\\Facades\\Fields",
-        "Filesystems": "CraftCms\\Cms\\Support\\Facades\\Filesystems",
-        "Folders": "CraftCms\\Cms\\Support\\Facades\\Folders",
-        "Gql": "CraftCms\\Cms\\Support\\Facades\\Gql",
-        "HtmlSanitizers": "CraftCms\\Cms\\Support\\Facades\\HtmlSanitizers",
-        "HtmlStack": "CraftCms\\Cms\\Support\\Facades\\HtmlStack",
-        "I18N": "CraftCms\\Cms\\Support\\Facades\\I18N",
-        "ImageTransforms": "CraftCms\\Cms\\Support\\Facades\\ImageTransforms",
-        "Images": "CraftCms\\Cms\\Support\\Facades\\Images",
-        "InputNamespace": "CraftCms\\Cms\\Support\\Facades\\InputNamespace",
-        "JobProgress": "CraftCms\\Cms\\Support\\Facades\\JobProgress",
-        "Markdown": "CraftCms\\Cms\\Support\\Facades\\Markdown",
-        "OAuth": "CraftCms\\Cms\\Support\\Facades\\OAuth",
-        "Path": "CraftCms\\Cms\\Support\\Facades\\Path",
-        "Plugins": "CraftCms\\Cms\\Support\\Facades\\Plugins",
-        "ProjectConfig": "CraftCms\\Cms\\Support\\Facades\\ProjectConfig",
-        "Revisions": "CraftCms\\Cms\\Support\\Facades\\Revisions",
-        "Search": "CraftCms\\Cms\\Support\\Facades\\Search",
-        "Sections": "CraftCms\\Cms\\Support\\Facades\\Sections",
-        "Security": "CraftCms\\Cms\\Support\\Facades\\Security",
-        "SiteGroups": "CraftCms\\Cms\\Support\\Facades\\SiteGroups",
-        "Sites": "CraftCms\\Cms\\Support\\Facades\\Sites",
-        "Structures": "CraftCms\\Cms\\Support\\Facades\\Structures",
-        "Template": "CraftCms\\Cms\\Support\\Facades\\Template",
-        "TemplateHooks": "CraftCms\\Cms\\Support\\Facades\\TemplateHooks",
-        "Twig": "CraftCms\\Cms\\Support\\Facades\\Twig",
-        "Updates": "CraftCms\\Cms\\Support\\Facades\\Updates",
-        "UserGroups": "CraftCms\\Cms\\Support\\Facades\\UserGroups",
-        "UserPermissions": "CraftCms\\Cms\\Support\\Facades\\UserPermissions",
-        "Users": "CraftCms\\Cms\\Support\\Facades\\Users",
-        "Volumes": "CraftCms\\Cms\\Support\\Facades\\Volumes"
-      }
-    }
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true
+    "repositories": [
+        {
+            "type": "path",
+            "url": "./yii2-adapter"
+        },
+        {
+            "type": "path",
+            "url": "./cms-assets"
+        }
+    ],
+    "suggest": {
+        "ext-exif": "Adds support for parsing image EXIF data.",
+        "ext-imagick": "Adds support for more image processing formats and options.",
+        "intervention/image-driver-vips": "Adds support for image processing with libvips (requires ext-ffi and libvips).",
+        "ext-iconv": "Adds support for more character encodings than PHP’s built-in mb_convert_encoding() function, which Craft will take advantage of when converting strings to UTF-8.",
+        "laravel/socialite": "Adds OAuth login support for providers configured with `GeneralConfig::oauthProviders()`."
+    },
+    "autoload": {
+        "psr-4": {
+            "CraftCms\\Cms\\": "src/"
+        },
+        "files": [
+            "src/helpers.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "CraftCms\\Cms\\Tests\\": "tests/",
+            "CraftCms\\Cms\\Database\\": "database/",
+            "CraftCms\\Yii2Adapter\\Tests\\": "yii2-adapter/tests-laravel/",
+            "Workbench\\App\\": "workbench/app/",
+            "Workbench\\Database\\Factories\\": "workbench/database/factories/",
+            "Workbench\\Database\\Seeders\\": "workbench/database/seeders/"
+        }
+    },
+    "scripts": {
+        "copy-icons": "php ./scripts/copyicons.php",
+        "fix-cs": "npx concurrently -c 'rector' 'pint src --parallel' './yii2-adapter/vendor/bin/ecs check --config ./yii2-adapter/ecs.php --ansi --fix' --names=rector,pint,ecs",
+        "phpstan": "phpstan --memory-limit=1G",
+        "rector": "rector",
+        "tests": [
+            "Composer\\Config::disableProcessTimeout",
+            "./vendor/bin/pest --compact"
+        ],
+        "tests-adapter": "./yii2-adapter/vendor/bin/pest --configuration ./yii2-adapter/phpunit.xml.dist --test-directory ./tests-laravel",
+        "post-autoload-dump": [
+            "@clear",
+            "@prepare"
+        ],
+        "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
+        "prepare": "@php vendor/bin/testbench package:discover --ansi",
+        "build": [
+            "@php vendor/bin/testbench package:create-sqlite-db --ansi",
+            "@php vendor/bin/testbench workbench:build --ansi"
+        ],
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php vendor/bin/testbench workbench:serve --ansi"
+        ],
+        "ci": [
+            "@php pint --parallel",
+            "@rector",
+            "@phpstan",
+            "@tests",
+            "@tests-adapter"
+        ]
+    },
+    "config": {
+        "sort-packages": true,
+        "platform": {
+            "php": "8.5"
+        },
+        "platform-check": false,
+        "allow-plugins": {
+            "craftcms/plugin-installer": true,
+            "pestphp/pest-plugin": true,
+            "yiisoft/yii2-composer": true
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "CraftCms\\Cms\\Providers\\CraftServiceProvider"
+            ],
+            "aliases": {
+                "Addresses": "CraftCms\\Cms\\Support\\Facades\\Addresses",
+                "Announcements": "CraftCms\\Cms\\Support\\Facades\\Announcements",
+                "AssetIndexer": "CraftCms\\Cms\\Support\\Facades\\AssetIndexer",
+                "Assets": "CraftCms\\Cms\\Support\\Facades\\Assets",
+                "AuthMethods": "CraftCms\\Cms\\Support\\Facades\\AuthMethods",
+                "BulkOps": "CraftCms\\Cms\\Support\\Facades\\BulkOps",
+                "Conditions": "CraftCms\\Cms\\Support\\Facades\\Conditions",
+                "DeltaRegistry": "CraftCms\\Cms\\Support\\Facades\\DeltaRegistry",
+                "Deprecator": "CraftCms\\Cms\\Support\\Facades\\Deprecator",
+                "Drafts": "CraftCms\\Cms\\Support\\Facades\\Drafts",
+                "ElementActions": "CraftCms\\Cms\\Support\\Facades\\ElementActions",
+                "ElementActivity": "CraftCms\\Cms\\Support\\Facades\\ElementActivity",
+                "ElementCaches": "CraftCms\\Cms\\Support\\Facades\\ElementCaches",
+                "ElementExporters": "CraftCms\\Cms\\Support\\Facades\\ElementExporters",
+                "ElementSources": "CraftCms\\Cms\\Support\\Facades\\ElementSources",
+                "Elements": "CraftCms\\Cms\\Support\\Facades\\Elements",
+                "Entries": "CraftCms\\Cms\\Support\\Facades\\Entries",
+                "EntryTypes": "CraftCms\\Cms\\Support\\Facades\\EntryTypes",
+                "Fields": "CraftCms\\Cms\\Support\\Facades\\Fields",
+                "Filesystems": "CraftCms\\Cms\\Support\\Facades\\Filesystems",
+                "Folders": "CraftCms\\Cms\\Support\\Facades\\Folders",
+                "Gql": "CraftCms\\Cms\\Support\\Facades\\Gql",
+                "HtmlSanitizers": "CraftCms\\Cms\\Support\\Facades\\HtmlSanitizers",
+                "HtmlStack": "CraftCms\\Cms\\Support\\Facades\\HtmlStack",
+                "I18N": "CraftCms\\Cms\\Support\\Facades\\I18N",
+                "ImageTransforms": "CraftCms\\Cms\\Support\\Facades\\ImageTransforms",
+                "Images": "CraftCms\\Cms\\Support\\Facades\\Images",
+                "InputNamespace": "CraftCms\\Cms\\Support\\Facades\\InputNamespace",
+                "JobProgress": "CraftCms\\Cms\\Support\\Facades\\JobProgress",
+                "Markdown": "CraftCms\\Cms\\Support\\Facades\\Markdown",
+                "OAuth": "CraftCms\\Cms\\Support\\Facades\\OAuth",
+                "Path": "CraftCms\\Cms\\Support\\Facades\\Path",
+                "Plugins": "CraftCms\\Cms\\Support\\Facades\\Plugins",
+                "ProjectConfig": "CraftCms\\Cms\\Support\\Facades\\ProjectConfig",
+                "Revisions": "CraftCms\\Cms\\Support\\Facades\\Revisions",
+                "Search": "CraftCms\\Cms\\Support\\Facades\\Search",
+                "Sections": "CraftCms\\Cms\\Support\\Facades\\Sections",
+                "Security": "CraftCms\\Cms\\Support\\Facades\\Security",
+                "SiteGroups": "CraftCms\\Cms\\Support\\Facades\\SiteGroups",
+                "Sites": "CraftCms\\Cms\\Support\\Facades\\Sites",
+                "Structures": "CraftCms\\Cms\\Support\\Facades\\Structures",
+                "Template": "CraftCms\\Cms\\Support\\Facades\\Template",
+                "TemplateHooks": "CraftCms\\Cms\\Support\\Facades\\TemplateHooks",
+                "Twig": "CraftCms\\Cms\\Support\\Facades\\Twig",
+                "Updates": "CraftCms\\Cms\\Support\\Facades\\Updates",
+                "UserGroups": "CraftCms\\Cms\\Support\\Facades\\UserGroups",
+                "UserPermissions": "CraftCms\\Cms\\Support\\Facades\\UserPermissions",
+                "Users": "CraftCms\\Cms\\Support\\Facades\\Users",
+                "Volumes": "CraftCms\\Cms\\Support\\Facades\\Volumes"
+            }
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/tests/Feature/Auth/Auth/AuthPasskeyTest.php
+++ b/tests/Feature/Auth/Auth/AuthPasskeyTest.php
@@ -48,26 +48,13 @@ test('authenticateWithPasskey enforces user status after a valid response', func
     Session::put($passkeys->passkeyCredSourceParam, $updatedCredentialSource);
 
     $credentialRepository = Double::for(CredentialRepository::class);
-    $credentialRepository
-        ->shouldReceive('saveCredentialSource')
-        ->once()
-        ->with($updatedCredentialSource);
+    $credentialRepository->expects('saveCredentialSource')->with($updatedCredentialSource);
 
     $webauthnServer = Double::for(WebauthnServer::class);
-    $webauthnServer
-        ->shouldReceive('getCredentialRepository')
-        ->once()
-        ->andReturn($credentialRepository);
+    $webauthnServer->expects('getCredentialRepository')->returns($credentialRepository);
 
-    $passkeys
-        ->shouldReceive('verifyPasskey')
-        ->once()
-        ->with(Mockery::type(UserElement::class), $requestOptions, $response)
-        ->andReturn(true);
-    $passkeys
-        ->shouldReceive('webauthnServer')
-        ->once()
-        ->andReturn($webauthnServer);
+    $passkeys->expects('verifyPasskey')->with(Mockery::type(UserElement::class), $requestOptions, $response)->returns(true);
+    $passkeys->expects('webauthnServer')->returns($webauthnServer);
 
     $result = app(AuthMethods::class)->authenticateWithPasskey($user, $requestOptions, $response);
 
@@ -102,11 +89,8 @@ test('authenticateWithPasskey with invalid response', function () {
     $passkeys = mockAuthPasskeys();
     Session::put($passkeys->passkeyCredSourceParam, $updatedCredentialSource);
 
-    $passkeys
-        ->shouldReceive('verifyPasskey')
-        ->once()
-        ->andReturn(false);
-    $passkeys->shouldNotReceive('webauthnServer');
+    $passkeys->expects('verifyPasskey')->returns(false);
+    $passkeys->expects('webauthnServer')->never();
 
     $result = app(AuthMethods::class)->authenticateWithPasskey($user, $requestOptions, $response);
 

--- a/tests/Feature/Auth/Auth/AuthPasskeyTest.php
+++ b/tests/Feature/Auth/Auth/AuthPasskeyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Matching\Argument;
 use JMac\Testing\Double;
 use CraftCms\Cms\Auth\AuthMethods;
 use CraftCms\Cms\Auth\Enums\AuthError;
@@ -53,7 +54,7 @@ test('authenticateWithPasskey enforces user status after a valid response', func
     $webauthnServer = Double::for(WebauthnServer::class);
     $webauthnServer->expects('getCredentialRepository')->returns($credentialRepository);
 
-    $passkeys->expects('verifyPasskey')->with(Mockery::type(UserElement::class), $requestOptions, $response)->returns(true);
+    $passkeys->expects('verifyPasskey')->with(Argument::type(UserElement::class), $requestOptions, $response)->returns(true);
     $passkeys->expects('webauthnServer')->returns($webauthnServer);
 
     $result = app(AuthMethods::class)->authenticateWithPasskey($user, $requestOptions, $response);

--- a/tests/Feature/Auth/Auth/AuthPasskeyTest.php
+++ b/tests/Feature/Auth/Auth/AuthPasskeyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Auth\AuthMethods;
 use CraftCms\Cms\Auth\Enums\AuthError;
 use CraftCms\Cms\Auth\Events\UserAuthenticating;
@@ -46,13 +47,13 @@ test('authenticateWithPasskey enforces user status after a valid response', func
     $passkeys = mockAuthPasskeys();
     Session::put($passkeys->passkeyCredSourceParam, $updatedCredentialSource);
 
-    $credentialRepository = Mockery::mock(CredentialRepository::class);
+    $credentialRepository = Double::for(CredentialRepository::class);
     $credentialRepository
         ->shouldReceive('saveCredentialSource')
         ->once()
         ->with($updatedCredentialSource);
 
-    $webauthnServer = Mockery::mock(WebauthnServer::class);
+    $webauthnServer = Double::for(WebauthnServer::class);
     $webauthnServer
         ->shouldReceive('getCredentialRepository')
         ->once()
@@ -158,7 +159,7 @@ test('authenticateWithPasskey event can skip verification', function () {
 
 function mockAuthPasskeys(): Passkeys
 {
-    $passkeys = Mockery::mock(Passkeys::class, ['pkCredCreationOptions', 'pkReqOptions', 'pkCredSource'])->makePartial();
+    $passkeys = Double::for(Passkeys::class)->passthru(new Passkeys('pkCredCreationOptions', 'pkReqOptions', 'pkCredSource'));
 
     app()->instance(Passkeys::class, $passkeys);
     app()->forgetInstance(AuthMethods::class);

--- a/tests/Feature/Auth/Auth/AuthVerifyMethodLockingTest.php
+++ b/tests/Feature/Auth/Auth/AuthVerifyMethodLockingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Auth\AuthMethods;
 use CraftCms\Cms\Auth\Methods\TOTP;
 use CraftCms\Cms\Auth\Models\Authenticator;
@@ -34,7 +35,7 @@ test('verifyMethod returns false without verifying when the per-user lock cannot
     Cache::shouldReceive('lock')
         ->with("auth-verify:{$userModel->id}", 10)
         ->andReturn(
-            Mockery::mock(Lock::class)
+            Double::for(Lock::class)
                 ->shouldReceive('block')
                 ->andThrow(LockTimeoutException::class)
                 ->getMock()

--- a/tests/Feature/Auth/PasskeysTest.php
+++ b/tests/Feature/Auth/PasskeysTest.php
@@ -132,39 +132,20 @@ test('verifyPasskey persists the validated credential source', function () {
     );
 
     $serializer = Double::for(SerializerInterface::class);
-    $serializer
-        ->shouldReceive('deserialize')
-        ->once()
-        ->with($requestOptionsJson, PublicKeyCredentialRequestOptions::class, 'json')
-        ->andReturn($requestOptions);
-    $serializer
-        ->shouldReceive('deserialize')
-        ->once()
-        ->with($responseJson, PublicKeyCredential::class, 'json')
-        ->andReturn($publicKeyCredential);
+    $serializer->expects('deserialize')->with($requestOptionsJson, PublicKeyCredentialRequestOptions::class, 'json')->returns($requestOptions);
+    $serializer->expects('deserialize')->with($responseJson, PublicKeyCredential::class, 'json')->returns($publicKeyCredential);
 
     $credentialRepository = Double::for(CredentialRepository::class);
-    $credentialRepository
-        ->shouldReceive('findOneByCredentialId')
-        ->once()
-        ->with('test-credential-id', false)
-        ->andReturn($credentialRecord);
-    $credentialRepository
-        ->shouldReceive('saveCredentialSource')
-        ->once()
-        ->with($credentialRecord);
+    $credentialRepository->expects('findOneByCredentialId')->with('test-credential-id', false)->returns($credentialRecord);
+    $credentialRepository->expects('saveCredentialSource')->with($credentialRecord);
 
     $assertionResponseValidator = Double::for(AuthenticatorAssertionResponseValidator::class);
-    $assertionResponseValidator
-        ->shouldReceive('check')
-        ->once()
-        ->with($credentialRecord, $authenticatorAssertionResponse, $requestOptions, 'localhost', $this->passkeys->passkeyUserEntity($this->user)->id)
-        ->andReturn($credentialRecord);
+    $assertionResponseValidator->expects('check')->with($credentialRecord, $authenticatorAssertionResponse, $requestOptions, 'localhost', $this->passkeys->passkeyUserEntity($this->user)->id)->returns($credentialRecord);
 
     $webauthnServer = Double::for(WebauthnServer::class);
-    $webauthnServer->shouldReceive('getSerializer')->andReturn($serializer);
-    $webauthnServer->shouldReceive('getCredentialRepository')->andReturn($credentialRepository);
-    $webauthnServer->shouldReceive('getAuthenticatorAssertionResponseValidator')->andReturn($assertionResponseValidator);
+    $webauthnServer->allows('getSerializer')->returns($serializer);
+    $webauthnServer->allows('getCredentialRepository')->returns($credentialRepository);
+    $webauthnServer->allows('getAuthenticatorAssertionResponseValidator')->returns($assertionResponseValidator);
 
     $property = new ReflectionProperty($this->passkeys, 'webauthnServer');
     $property->setValue($this->passkeys, $webauthnServer);

--- a/tests/Feature/Auth/PasskeysTest.php
+++ b/tests/Feature/Auth/PasskeysTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Auth\Models\WebAuthn;
 use CraftCms\Cms\Auth\Passkeys\CredentialRepository;
 use CraftCms\Cms\Auth\Passkeys\Passkeys;
@@ -112,7 +113,7 @@ test('verifyPasskey persists the validated credential source', function () {
     $requestOptionsJson = '{"challenge":"test-challenge"}';
     $responseJson = '{"id":"test-credential-id"}';
     $requestOptions = PublicKeyCredentialRequestOptions::create(challenge: 'test-challenge');
-    $authenticatorAssertionResponse = Mockery::mock(AuthenticatorAssertionResponse::class);
+    $authenticatorAssertionResponse = Double::for(AuthenticatorAssertionResponse::class);
     $publicKeyCredential = PublicKeyCredential::create(
         type: 'public-key',
         rawId: 'test-credential-id',
@@ -130,7 +131,7 @@ test('verifyPasskey persists the validated credential source', function () {
         counter: 1,
     );
 
-    $serializer = Mockery::mock(SerializerInterface::class);
+    $serializer = Double::for(SerializerInterface::class);
     $serializer
         ->shouldReceive('deserialize')
         ->once()
@@ -142,7 +143,7 @@ test('verifyPasskey persists the validated credential source', function () {
         ->with($responseJson, PublicKeyCredential::class, 'json')
         ->andReturn($publicKeyCredential);
 
-    $credentialRepository = Mockery::mock(CredentialRepository::class);
+    $credentialRepository = Double::for(CredentialRepository::class);
     $credentialRepository
         ->shouldReceive('findOneByCredentialId')
         ->once()
@@ -153,14 +154,14 @@ test('verifyPasskey persists the validated credential source', function () {
         ->once()
         ->with($credentialRecord);
 
-    $assertionResponseValidator = Mockery::mock(AuthenticatorAssertionResponseValidator::class);
+    $assertionResponseValidator = Double::for(AuthenticatorAssertionResponseValidator::class);
     $assertionResponseValidator
         ->shouldReceive('check')
         ->once()
         ->with($credentialRecord, $authenticatorAssertionResponse, $requestOptions, 'localhost', $this->passkeys->passkeyUserEntity($this->user)->id)
         ->andReturn($credentialRecord);
 
-    $webauthnServer = Mockery::mock(WebauthnServer::class);
+    $webauthnServer = Double::for(WebauthnServer::class);
     $webauthnServer->shouldReceive('getSerializer')->andReturn($serializer);
     $webauthnServer->shouldReceive('getCredentialRepository')->andReturn($credentialRepository);
     $webauthnServer->shouldReceive('getAuthenticatorAssertionResponseValidator')->andReturn($assertionResponseValidator);

--- a/tests/Feature/Console/Commands/User/Remove2faCommandTest.php
+++ b/tests/Feature/Console/Commands/User/Remove2faCommandTest.php
@@ -46,10 +46,7 @@ test('removes all methods when all is passed', function () {
         activeMethods: collect([$sms, $email]),
         activeMethodsAfterRemoval: fn () => TestRemove2faEmailMethod::$removeCount === 0 ? collect([$email]) : collect(),
     );
-    $auth->shouldReceive('getMethod')
-        ->once()
-        ->with(RecoveryCodes::class, Mockery::type(UserElement::class))
-        ->andReturn(tap(new RecoveryCodes, fn (RecoveryCodes $method) => $method->setUser($user)));
+    $auth->expects('getMethod')->with(RecoveryCodes::class, Mockery::type(UserElement::class))->returns(tap(new RecoveryCodes, fn (RecoveryCodes $method) => $method->setUser($user)));
 
     app()->instance(AuthMethods::class, $auth);
 
@@ -92,16 +89,10 @@ function mockRemove2faAuthMethods(
     bool $expectAfterRemovalCheck = true,
 ): AuthMethods {
     $auth = Double::for(AuthMethods::class);
-    $auth->shouldReceive('getActiveMethods')
-        ->once()
-        ->with(Mockery::type(UserElement::class))
-        ->andReturn($activeMethods);
+    $auth->expects('getActiveMethods')->with(Mockery::type(UserElement::class))->returns($activeMethods);
 
     if ($expectAfterRemovalCheck) {
-        $auth->shouldReceive('getActiveMethods')
-            ->zeroOrMoreTimes()
-            ->with(Mockery::type(UserElement::class))
-            ->andReturnUsing($activeMethodsAfterRemoval);
+        $auth->allows('getActiveMethods')->with(Mockery::type(UserElement::class))->resolves($activeMethodsAfterRemoval);
     }
 
     return $auth;

--- a/tests/Feature/Console/Commands/User/Remove2faCommandTest.php
+++ b/tests/Feature/Console/Commands/User/Remove2faCommandTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Matching\Argument;
 use JMac\Testing\Double;
 use CraftCms\Cms\Auth\AuthMethods;
 use CraftCms\Cms\Auth\Methods\BaseAuthMethod;
@@ -46,7 +47,7 @@ test('removes all methods when all is passed', function () {
         activeMethods: collect([$sms, $email]),
         activeMethodsAfterRemoval: fn () => TestRemove2faEmailMethod::$removeCount === 0 ? collect([$email]) : collect(),
     );
-    $auth->expects('getMethod')->with(RecoveryCodes::class, Mockery::type(UserElement::class))->returns(tap(new RecoveryCodes, fn (RecoveryCodes $method) => $method->setUser($user)));
+    $auth->expects('getMethod')->with(RecoveryCodes::class, Argument::type(UserElement::class))->returns(tap(new RecoveryCodes, fn (RecoveryCodes $method) => $method->setUser($user)));
 
     app()->instance(AuthMethods::class, $auth);
 
@@ -89,10 +90,10 @@ function mockRemove2faAuthMethods(
     bool $expectAfterRemovalCheck = true,
 ): AuthMethods {
     $auth = Double::for(AuthMethods::class);
-    $auth->expects('getActiveMethods')->with(Mockery::type(UserElement::class))->returns($activeMethods);
+    $auth->expects('getActiveMethods')->with(Argument::type(UserElement::class))->returns($activeMethods);
 
     if ($expectAfterRemovalCheck) {
-        $auth->allows('getActiveMethods')->with(Mockery::type(UserElement::class))->resolves($activeMethodsAfterRemoval);
+        $auth->allows('getActiveMethods')->with(Argument::type(UserElement::class))->resolves($activeMethodsAfterRemoval);
     }
 
     return $auth;

--- a/tests/Feature/Console/Commands/User/Remove2faCommandTest.php
+++ b/tests/Feature/Console/Commands/User/Remove2faCommandTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Auth\AuthMethods;
 use CraftCms\Cms\Auth\Methods\BaseAuthMethod;
 use CraftCms\Cms\Auth\Methods\RecoveryCodes;
@@ -90,7 +91,7 @@ function mockRemove2faAuthMethods(
     Closure $activeMethodsAfterRemoval,
     bool $expectAfterRemovalCheck = true,
 ): AuthMethods {
-    $auth = Mockery::mock(AuthMethods::class);
+    $auth = Double::for(AuthMethods::class);
     $auth->shouldReceive('getActiveMethods')
         ->once()
         ->with(Mockery::type(UserElement::class))

--- a/tests/Feature/Database/Commands/MigrateCommandTest.php
+++ b/tests/Feature/Database/Commands/MigrateCommandTest.php
@@ -54,11 +54,11 @@ it('adds the migration track column before checking pending migrations', functio
 
 it('runs additional migrators', function () {
     $migrator = Double::for(Migrator::class);
-    $migrator->expects('getTrack')->andReturn('custom');
-    $migrator->expects('getPendingMigrations')->andReturn(['2026_01_01_000000_custom']);
-    $migrator->allows('setOutput')->andReturnSelf();
-    $migrator->allows('getMigrationName')->andReturn('Custom migration');
-    $migrator->expects('run')->once()->andReturn([]);
+    $migrator->expects('getTrack')->returns('custom');
+    $migrator->expects('getPendingMigrations')->returns(['2026_01_01_000000_custom']);
+    $migrator->allows('setOutput')->returns($migrator);
+    $migrator->allows('getMigrationName')->returns('Custom migration');
+    $migrator->expects('run')->returns([]);
 
     MigrateCommand::registerMigrator(fn () => $migrator);
 
@@ -72,7 +72,7 @@ it('runs additional migrators', function () {
 
 it('skips additional migrators without a track', function () {
     $migrator = Double::for(Migrator::class);
-    $migrator->expects('getTrack')->andReturnNull();
+    $migrator->expects('getTrack')->returns(null);
 
     MigrateCommand::registerMigrator(fn () => $migrator);
 

--- a/tests/Feature/Database/Commands/MigrateCommandTest.php
+++ b/tests/Feature/Database/Commands/MigrateCommandTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Database\Commands\MigrateCommand;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Database\Table;
@@ -52,7 +53,7 @@ it('adds the migration track column before checking pending migrations', functio
 });
 
 it('runs additional migrators', function () {
-    $migrator = Mockery::mock(Migrator::class);
+    $migrator = Double::for(Migrator::class);
     $migrator->expects('getTrack')->andReturn('custom');
     $migrator->expects('getPendingMigrations')->andReturn(['2026_01_01_000000_custom']);
     $migrator->allows('setOutput')->andReturnSelf();
@@ -70,7 +71,7 @@ it('runs additional migrators', function () {
 });
 
 it('skips additional migrators without a track', function () {
-    $migrator = Mockery::mock(Migrator::class);
+    $migrator = Double::for(Migrator::class);
     $migrator->expects('getTrack')->andReturnNull();
 
     MigrateCommand::registerMigrator(fn () => $migrator);

--- a/tests/Feature/Database/Migrations/MigrateFieldTypesTest.php
+++ b/tests/Feature/Database/Migrations/MigrateFieldTypesTest.php
@@ -11,13 +11,10 @@ test('restores project config event muting when migration fails', function () {
     /** @var ProjectConfig&MockInterface $projectConfig */
     $projectConfig = Double::for(app(ProjectConfig::class))->passthru();
     $projectConfig->muteEvents = false;
-    $projectConfig->shouldReceive('find')->once()->andReturn([
+    $projectConfig->expects('find')->returns([
         'fields.test' => ['type' => 'craft\fields\PlainText'],
     ]);
-    $projectConfig->shouldReceive('set')
-        ->once()
-        ->with('fields.test.type', PlainText::class)
-        ->andThrow(new RuntimeException('Failed to update project config'));
+    $projectConfig->expects('set')->with('fields.test.type', PlainText::class)->throws(new RuntimeException('Failed to update project config'));
     app()->instance(ProjectConfig::class, $projectConfig);
 
     $migration = require dirname(__DIR__, 4).'/src/Database/Migrations/0000_00_00_000004_migrate_field_types.php';

--- a/tests/Feature/Database/Migrations/MigrateFieldTypesTest.php
+++ b/tests/Feature/Database/Migrations/MigrateFieldTypesTest.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Field\PlainText;
 use CraftCms\Cms\ProjectConfig\ProjectConfig;
 use Mockery\MockInterface;
 
 test('restores project config event muting when migration fails', function () {
     /** @var ProjectConfig&MockInterface $projectConfig */
-    $projectConfig = Mockery::mock(app(ProjectConfig::class))->makePartial();
+    $projectConfig = Double::for(app(ProjectConfig::class))->passthru();
     $projectConfig->muteEvents = false;
     $projectConfig->shouldReceive('find')->once()->andReturn([
         'fields.test' => ['type' => 'craft\fields\PlainText'],

--- a/tests/Feature/Element/Concerns/HasCanonicalTest.php
+++ b/tests/Feature/Element/Concerns/HasCanonicalTest.php
@@ -149,21 +149,16 @@ describe('mergeCanonicalChanges', function () {
         $derivative->testAttr = 'Old Value';
 
         // Mock getOutdatedAttributes to return our test attribute
-        $derivative->shouldReceive('getOutdatedAttributes')
-            ->andReturn(['testAttr']);
+        $derivative->allows('getOutdatedAttributes')->returns(['testAttr']);
 
         // Mock isAttributeModified to return false (not modified)
-        $derivative->shouldReceive('isAttributeModified')
-            ->with('testAttr')
-            ->andReturn(false);
+        $derivative->allows('isAttributeModified')->with('testAttr')->returns(false);
 
         // Mock getOutdatedFields to return empty array
-        $derivative->shouldReceive('getOutdatedFields')
-            ->andReturn([]);
+        $derivative->allows('getOutdatedFields')->returns([]);
 
         // Mock getCanonical to return our canonical element
-        $derivative->shouldReceive('getCanonical')
-            ->andReturn($canonical);
+        $derivative->allows('getCanonical')->returns($canonical);
 
         // Run merge
         $derivative->mergeCanonicalChanges();
@@ -184,21 +179,16 @@ describe('mergeCanonicalChanges', function () {
         $derivative->testAttr = 'My Custom Value';
 
         // Mock getOutdatedAttributes to return our test attribute
-        $derivative->shouldReceive('getOutdatedAttributes')
-            ->andReturn(['testAttr']);
+        $derivative->allows('getOutdatedAttributes')->returns(['testAttr']);
 
         // Mock isAttributeModified to return true (modified)
-        $derivative->shouldReceive('isAttributeModified')
-            ->with('testAttr')
-            ->andReturn(true);
+        $derivative->allows('isAttributeModified')->with('testAttr')->returns(true);
 
         // Mock getOutdatedFields to return empty array
-        $derivative->shouldReceive('getOutdatedFields')
-            ->andReturn([]);
+        $derivative->allows('getOutdatedFields')->returns([]);
 
         // Mock getCanonical to return our canonical element
-        $derivative->shouldReceive('getCanonical')
-            ->andReturn($canonical);
+        $derivative->allows('getCanonical')->returns($canonical);
 
         // Run merge
         $derivative->mergeCanonicalChanges();

--- a/tests/Feature/Element/Concerns/HasCanonicalTest.php
+++ b/tests/Feature/Element/Concerns/HasCanonicalTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Element\Element;
 use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Entry\Models\Entry as EntryModel;
@@ -142,7 +143,7 @@ describe('mergeCanonicalChanges', function () {
         $canonical->testAttr = 'Canonical Value';
 
         // Create a derivative with a mock for getOutdatedAttributes and isAttributeModified
-        $derivative = Mockery::mock(TestHasCanonicalElement::class)->makePartial();
+        $derivative = Double::for(TestHasCanonicalElement::class)->passthru();
         $derivative->id = 200;
         $derivative->setCanonicalId($canonical->id);
         $derivative->testAttr = 'Old Value';
@@ -177,7 +178,7 @@ describe('mergeCanonicalChanges', function () {
         $canonical->testAttr = 'Canonical Value';
 
         // Create a derivative
-        $derivative = Mockery::mock(TestHasCanonicalElement::class)->makePartial();
+        $derivative = Double::for(TestHasCanonicalElement::class)->passthru();
         $derivative->id = 200;
         $derivative->setCanonicalId($canonical->id);
         $derivative->testAttr = 'My Custom Value';

--- a/tests/Feature/Element/DeletionBlockersTest.php
+++ b/tests/Feature/Element/DeletionBlockersTest.php
@@ -66,16 +66,12 @@ it('reports entry author blockers with details and actions', function () {
         ->create();
 
     $this->mock(ElementIndexHtml::class, function (MockInterface $mock) use ($author) {
-        $mock
-            ->shouldReceive('html')
-            ->once()
-            ->with(Entry::class, Mockery::on(fn (array $config) => $config['context'] === 'pane' &&
+        $mock->expects('html')->with(Entry::class, Mockery::on(fn (array $config) => $config['context'] === 'pane' &&
                 $config['sources'] === false &&
                 $config['defaultTableColumns'] === [['authors'], ['section']] &&
                 $config['defaultSort'] === ['section', 'asc'] &&
                 $config['jsSettings']['criteria']['authorId'] === [$author->id] &&
-                $config['jsSettings']['criteria']['status'] === null))
-            ->andReturn('<div>author details</div>');
+                $config['jsSettings']['criteria']['status'] === null))->returns('<div>author details</div>');
     });
 
     $blocker = new EntryAuthorsBlocker(ElementCollection::make([$author]), false);
@@ -149,10 +145,7 @@ it('reports relation blockers with details and actions', function () {
     ]);
 
     $this->mock(ElementIndexHtml::class, function (MockInterface $mock) {
-        $mock
-            ->shouldReceive('html')
-            ->once()
-            ->andReturn('<div>relation details</div>');
+        $mock->expects('html')->returns('<div>relation details</div>');
     });
 
     $blocker = new RelationDeletionBlocker(Entry::class, ElementCollection::make([$target]), true, [

--- a/tests/Feature/Element/DeletionBlockersTest.php
+++ b/tests/Feature/Element/DeletionBlockersTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Matching\Argument;
 use CraftCms\Cms\Cp\Html\ElementIndexHtml;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\DeletionBlockers\BaseDeletionBlocker;
@@ -66,7 +67,7 @@ it('reports entry author blockers with details and actions', function () {
         ->create();
 
     $this->mock(ElementIndexHtml::class, function (MockInterface $mock) use ($author) {
-        $mock->expects('html')->with(Entry::class, Mockery::on(fn (array $config) => $config['context'] === 'pane' &&
+        $mock->expects('html')->with(Entry::class, Argument::satisfies(fn (array $config) => $config['context'] === 'pane' &&
                 $config['sources'] === false &&
                 $config['defaultTableColumns'] === [['authors'], ['section']] &&
                 $config['defaultSort'] === ['section', 'asc'] &&

--- a/tests/Feature/Element/ElementCanonicalChanges/MergeCanonicalChangesTest.php
+++ b/tests/Feature/Element/ElementCanonicalChanges/MergeCanonicalChangesTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Element\BulkOp\BulkOps;
 use CraftCms\Cms\Element\Drafts;
 use CraftCms\Cms\Element\Element;
@@ -200,7 +201,7 @@ it('merges and saves localized derivatives before the requested site', function 
     Elements::saveElement($secondaryDraft, false, false);
 
     $saveCalls = [];
-    $writes = Mockery::mock(ElementWrites::class);
+    $writes = Double::for(ElementWrites::class);
     $writes->shouldReceive('save')
         ->twice()
         ->andReturnUsing(function (Entry $element, bool $runValidation, bool $propagate, ?bool $updateSearchIndex = null, ?array $supportedSites = null) use (&$saveCalls) {
@@ -218,7 +219,7 @@ it('merges and saves localized derivatives before the requested site', function 
             return true;
         });
 
-    $service = new ElementCanonicalChanges(app(BulkOps::class), $writes, Mockery::mock(ElementDuplicates::class));
+    $service = new ElementCanonicalChanges(app(BulkOps::class), $writes, Double::for(ElementDuplicates::class));
 
     $originalDuplicate = new Entry;
     $draft->duplicateOf = $originalDuplicate;
@@ -277,12 +278,12 @@ it('merges localized elements, sets dateLastMerged, and resets the merging flag'
 
     $currentSiteElement->localizedQuery = new TestMergeCanonicalChangesQuery([$otherSiteElement]);
 
-    $writes = Mockery::mock(ElementWrites::class);
+    $writes = Double::for(ElementWrites::class);
     $writes->shouldReceive('save')
         ->twice()
         ->andReturnUsing(fn () => true);
 
-    $service = new ElementCanonicalChanges(app(BulkOps::class), $writes, Mockery::mock(ElementDuplicates::class));
+    $service = new ElementCanonicalChanges(app(BulkOps::class), $writes, Double::for(ElementDuplicates::class));
 
     $service->mergeCanonicalChanges($currentSiteElement);
 

--- a/tests/Feature/Element/ElementCanonicalChanges/MergeCanonicalChangesTest.php
+++ b/tests/Feature/Element/ElementCanonicalChanges/MergeCanonicalChangesTest.php
@@ -202,9 +202,7 @@ it('merges and saves localized derivatives before the requested site', function 
 
     $saveCalls = [];
     $writes = Double::for(ElementWrites::class);
-    $writes->shouldReceive('save')
-        ->twice()
-        ->andReturnUsing(function (Entry $element, bool $runValidation, bool $propagate, ?bool $updateSearchIndex = null, ?array $supportedSites = null) use (&$saveCalls) {
+    $writes->expects('save')->times(2)->resolves(function (Entry $element, bool $runValidation, bool $propagate, ?bool $updateSearchIndex = null, ?array $supportedSites = null) use (&$saveCalls) {
             $saveCalls[] = [
                 'id' => $element->id,
                 'siteId' => $element->siteId,
@@ -279,9 +277,7 @@ it('merges localized elements, sets dateLastMerged, and resets the merging flag'
     $currentSiteElement->localizedQuery = new TestMergeCanonicalChangesQuery([$otherSiteElement]);
 
     $writes = Double::for(ElementWrites::class);
-    $writes->shouldReceive('save')
-        ->twice()
-        ->andReturnUsing(fn () => true);
+    $writes->expects('save')->times(2)->resolves(fn () => true);
 
     $service = new ElementCanonicalChanges(app(BulkOps::class), $writes, Double::for(ElementDuplicates::class));
 

--- a/tests/Feature/Element/ElementCanonicalChanges/UpdateCanonicalElementTest.php
+++ b/tests/Feature/Element/ElementCanonicalChanges/UpdateCanonicalElementTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\BulkOp\BulkOps;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
@@ -250,7 +251,7 @@ function createActionSpy(?ElementInterface $duplicateResult = null): array
         public ?array $duplicateCall = null;
     };
 
-    $duplicates = Mockery::mock(ElementDuplicates::class);
+    $duplicates = Double::for(ElementDuplicates::class);
     $duplicates->shouldReceive('duplicateElement')
         ->andReturnUsing(function (
             ElementInterface $element,
@@ -272,5 +273,5 @@ function createActionSpy(?ElementInterface $duplicateResult = null): array
             return $duplicateResult ?? $element;
         });
 
-    return [new ElementCanonicalChanges(Mockery::mock(BulkOps::class), Mockery::mock(ElementWrites::class), $duplicates), $state];
+    return [new ElementCanonicalChanges(Double::for(BulkOps::class), Double::for(ElementWrites::class), $duplicates), $state];
 }

--- a/tests/Feature/Element/ElementCanonicalChanges/UpdateCanonicalElementTest.php
+++ b/tests/Feature/Element/ElementCanonicalChanges/UpdateCanonicalElementTest.php
@@ -252,8 +252,7 @@ function createActionSpy(?ElementInterface $duplicateResult = null): array
     };
 
     $duplicates = Double::for(ElementDuplicates::class);
-    $duplicates->shouldReceive('duplicateElement')
-        ->andReturnUsing(function (
+    $duplicates->allows('duplicateElement')->resolves(function (
             ElementInterface $element,
             array $newAttributes = [],
             bool $placeInStructure = true,

--- a/tests/Feature/Element/ElementDeletions/RestoreElementsTest.php
+++ b/tests/Feature/Element/ElementDeletions/RestoreElementsTest.php
@@ -106,10 +106,10 @@ it('throws and rolls back when another supported site fails essential validation
     $siteElement->siteId = $otherSite->id;
 
     $query = Double::for(ElementQueryInterface::class);
-    $query->shouldReceive('siteId')->once()->andReturnSelf();
-    $query->shouldReceive('status')->once()->andReturnSelf();
-    $query->shouldReceive('trashed')->once()->andReturnSelf();
-    $query->shouldReceive('all')->once()->andReturn([$siteElement]);
+    $query->expects('siteId')->returns($query);
+    $query->expects('status')->returns($query);
+    $query->expects('trashed')->returns($query);
+    $query->expects('all')->returns([$siteElement]);
 
     $action = restoreElementsService();
     $element = new TestRestoreElement(localizedQuery: $query, supportedSites: [
@@ -164,27 +164,23 @@ it('restores drafts and revisions, reindexes supported sites, and invalidates ca
     $siteElement->siteId = $otherSite->id;
 
     $query = Double::for(ElementQueryInterface::class);
-    $query->shouldReceive('siteId')->once()->andReturnSelf();
-    $query->shouldReceive('status')->once()->andReturnSelf();
-    $query->shouldReceive('trashed')->once()->andReturnSelf();
-    $query->shouldReceive('all')->once()->andReturn([$siteElement]);
+    $query->expects('siteId')->returns($query);
+    $query->expects('status')->returns($query);
+    $query->expects('trashed')->returns($query);
+    $query->expects('all')->returns([$siteElement]);
 
     $indexed = [];
     $invalidated = [];
 
     $search = Double::for(Search::class);
-    $search->shouldReceive('indexElementAttributes')
-        ->twice()
-        ->andReturnUsing(function (ElementInterface $element, ?array $fieldHandles = null) use (&$indexed): bool {
+    $search->expects('indexElementAttributes')->times(2)->resolves(function (ElementInterface $element, ?array $fieldHandles = null) use (&$indexed): bool {
             $indexed[] = [$element->id, $element->siteId];
 
             return true;
         });
 
     $elementCaches = Double::for(ElementCaches::class);
-    $elementCaches->shouldReceive('invalidateForElement')
-        ->once()
-        ->andReturnUsing(function (ElementInterface $element) use (&$invalidated): array {
+    $elementCaches->expects('invalidateForElement')->resolves(function (ElementInterface $element) use (&$invalidated): array {
             $invalidated[] = [$element->id, $element->siteId];
 
             return [];
@@ -222,10 +218,10 @@ it('restores drafts and revisions, reindexes supported sites, and invalidates ca
 function restoreElementsService(): ElementDeletions
 {
     $search = Double::for(Search::class);
-    $search->shouldReceive('indexElementAttributes')->andReturn(true);
+    $search->allows('indexElementAttributes')->returns(true);
 
     $elementCaches = Double::for(ElementCaches::class);
-    $elementCaches->shouldReceive('invalidateForElement')->andReturn([]);
+    $elementCaches->allows('invalidateForElement')->returns([]);
 
     return new ElementDeletions(
         Double::for(Elements::class),
@@ -289,10 +285,10 @@ class TestRestoreElement extends Element
         }
 
         $query = Double::for(ElementQueryInterface::class);
-        $query->shouldReceive('siteId')->andReturnSelf();
-        $query->shouldReceive('status')->andReturnSelf();
-        $query->shouldReceive('trashed')->andReturnSelf();
-        $query->shouldReceive('all')->andReturn([]);
+        $query->allows('siteId')->returns($query);
+        $query->allows('status')->returns($query);
+        $query->allows('trashed')->returns($query);
+        $query->allows('all')->returns([]);
 
         return $query;
     }

--- a/tests/Feature/Element/ElementDeletions/RestoreElementsTest.php
+++ b/tests/Feature/Element/ElementDeletions/RestoreElementsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\Element;
@@ -104,7 +105,7 @@ it('throws and rolls back when another supported site fails essential validation
     $siteElement->id = $elementRecord->id;
     $siteElement->siteId = $otherSite->id;
 
-    $query = Mockery::mock(ElementQueryInterface::class);
+    $query = Double::for(ElementQueryInterface::class);
     $query->shouldReceive('siteId')->once()->andReturnSelf();
     $query->shouldReceive('status')->once()->andReturnSelf();
     $query->shouldReceive('trashed')->once()->andReturnSelf();
@@ -162,7 +163,7 @@ it('restores drafts and revisions, reindexes supported sites, and invalidates ca
     $siteElement->id = $elementRecord->id;
     $siteElement->siteId = $otherSite->id;
 
-    $query = Mockery::mock(ElementQueryInterface::class);
+    $query = Double::for(ElementQueryInterface::class);
     $query->shouldReceive('siteId')->once()->andReturnSelf();
     $query->shouldReceive('status')->once()->andReturnSelf();
     $query->shouldReceive('trashed')->once()->andReturnSelf();
@@ -171,7 +172,7 @@ it('restores drafts and revisions, reindexes supported sites, and invalidates ca
     $indexed = [];
     $invalidated = [];
 
-    $search = Mockery::mock(Search::class);
+    $search = Double::for(Search::class);
     $search->shouldReceive('indexElementAttributes')
         ->twice()
         ->andReturnUsing(function (ElementInterface $element, ?array $fieldHandles = null) use (&$indexed): bool {
@@ -180,7 +181,7 @@ it('restores drafts and revisions, reindexes supported sites, and invalidates ca
             return true;
         });
 
-    $elementCaches = Mockery::mock(ElementCaches::class);
+    $elementCaches = Double::for(ElementCaches::class);
     $elementCaches->shouldReceive('invalidateForElement')
         ->once()
         ->andReturnUsing(function (ElementInterface $element) use (&$invalidated): array {
@@ -190,8 +191,8 @@ it('restores drafts and revisions, reindexes supported sites, and invalidates ca
         });
 
     $deletions = new ElementDeletions(
-        Mockery::mock(Elements::class),
-        Mockery::mock(ElementWrites::class),
+        Double::for(Elements::class),
+        Double::for(ElementWrites::class),
         $elementCaches,
         $search,
     );
@@ -220,15 +221,15 @@ it('restores drafts and revisions, reindexes supported sites, and invalidates ca
 
 function restoreElementsService(): ElementDeletions
 {
-    $search = Mockery::mock(Search::class);
+    $search = Double::for(Search::class);
     $search->shouldReceive('indexElementAttributes')->andReturn(true);
 
-    $elementCaches = Mockery::mock(ElementCaches::class);
+    $elementCaches = Double::for(ElementCaches::class);
     $elementCaches->shouldReceive('invalidateForElement')->andReturn([]);
 
     return new ElementDeletions(
-        Mockery::mock(Elements::class),
-        Mockery::mock(ElementWrites::class),
+        Double::for(Elements::class),
+        Double::for(ElementWrites::class),
         $elementCaches,
         $search,
     );
@@ -287,7 +288,7 @@ class TestRestoreElement extends Element
             return $this->localizedQuery;
         }
 
-        $query = Mockery::mock(ElementQueryInterface::class);
+        $query = Double::for(ElementQueryInterface::class);
         $query->shouldReceive('siteId')->andReturnSelf();
         $query->shouldReceive('status')->andReturnSelf();
         $query->shouldReceive('trashed')->andReturnSelf();

--- a/tests/Feature/Element/ElementDuplicates/DuplicateElementTest.php
+++ b/tests/Feature/Element/ElementDuplicates/DuplicateElementTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\Drafts;
@@ -103,7 +104,7 @@ test('creates an unpublished draft and deletes provisional source draft', functi
     $deletedElements = [];
     $saveCalls = [];
 
-    $deletions = Mockery::mock(ElementDeletions::class);
+    $deletions = Double::for(ElementDeletions::class);
     $deletions->shouldReceive('deleteElementById')
         ->once()
         ->andReturnUsing(function (
@@ -121,7 +122,7 @@ test('creates an unpublished draft and deletes provisional source draft', functi
             return true;
         });
 
-    $drafts = Mockery::mock(Drafts::class);
+    $drafts = Double::for(Drafts::class);
     $drafts->shouldReceive('insertDraftRow')
         ->once()
         ->andReturnUsing(function (
@@ -274,7 +275,7 @@ test('uses auto mode when forcing an id in new attributes for structure placemen
 
     $structureCalls = [];
 
-    $mockStructures = Mockery::mock(Structures::class);
+    $mockStructures = Double::for(Structures::class);
     $mockStructures->shouldReceive('moveAfter')
         ->once()
         ->andReturnUsing(function (int $structureId, ElementInterface $element, ElementInterface|int $prevElement, Mode $mode = Mode::Auto) use (&$structureCalls): bool {
@@ -287,9 +288,9 @@ test('uses auto mode when forcing an id in new attributes for structure placemen
 
     $action = new ElementDuplicates(
         $writes,
-        Mockery::mock(ElementUris::class),
-        Mockery::mock(ElementDeletions::class),
-        drafts: Mockery::mock(Drafts::class),
+        Double::for(ElementUris::class),
+        Double::for(ElementDeletions::class),
+        drafts: Double::for(Drafts::class),
         structures: $mockStructures,
     );
 
@@ -329,7 +330,7 @@ test('throws when a localized site clone has an invalid slug', function () {
 test('continues when setting uri for a localized clone is aborted', function () {
     $saveCalls = [];
 
-    $uris = Mockery::mock(ElementUris::class);
+    $uris = Double::for(ElementUris::class);
     $uris->shouldReceive('setElementUri')
         ->once()
         ->andReturnUsing(function (ElementInterface $element): void {
@@ -451,17 +452,17 @@ function duplicateAction(
     ?Structures $structures = null,
 ): ElementDuplicates {
     return new ElementDuplicates(
-        $writes ?? Mockery::mock(ElementWrites::class),
-        $uris ?? Mockery::mock(ElementUris::class),
-        $deletions ?? Mockery::mock(ElementDeletions::class),
-        $drafts ?? Mockery::mock(Drafts::class),
-        $structures ?? Mockery::mock(Structures::class),
+        $writes ?? Double::for(ElementWrites::class),
+        $uris ?? Double::for(ElementUris::class),
+        $deletions ?? Double::for(ElementDeletions::class),
+        $drafts ?? Double::for(Drafts::class),
+        $structures ?? Double::for(Structures::class),
     );
 }
 
 function successfulElementWrites(array &$calls, array $idsToAssign = [], int $expectedSaveCalls = 1): ElementWrites
 {
-    $writes = Mockery::mock(ElementWrites::class);
+    $writes = Double::for(ElementWrites::class);
     $writes->shouldReceive('save')
         ->times($expectedSaveCalls)
         ->andReturnUsing(function (

--- a/tests/Feature/Element/ElementDuplicates/DuplicateElementTest.php
+++ b/tests/Feature/Element/ElementDuplicates/DuplicateElementTest.php
@@ -105,9 +105,7 @@ test('creates an unpublished draft and deletes provisional source draft', functi
     $saveCalls = [];
 
     $deletions = Double::for(ElementDeletions::class);
-    $deletions->shouldReceive('deleteElementById')
-        ->once()
-        ->andReturnUsing(function (
+    $deletions->expects('deleteElementById')->resolves(function (
             int $elementId,
             ?string $elementType = null,
             ?int $siteId = null,
@@ -123,9 +121,7 @@ test('creates an unpublished draft and deletes provisional source draft', functi
         });
 
     $drafts = Double::for(Drafts::class);
-    $drafts->shouldReceive('insertDraftRow')
-        ->once()
-        ->andReturnUsing(function (
+    $drafts->expects('insertDraftRow')->resolves(function (
             ?string $name,
             ?string $notes = null,
             ?int $creatorId = null,
@@ -276,9 +272,7 @@ test('uses auto mode when forcing an id in new attributes for structure placemen
     $structureCalls = [];
 
     $mockStructures = Double::for(Structures::class);
-    $mockStructures->shouldReceive('moveAfter')
-        ->once()
-        ->andReturnUsing(function (int $structureId, ElementInterface $element, ElementInterface|int $prevElement, Mode $mode = Mode::Auto) use (&$structureCalls): bool {
+    $mockStructures->expects('moveAfter')->resolves(function (int $structureId, ElementInterface $element, ElementInterface|int $prevElement, Mode $mode = Mode::Auto) use (&$structureCalls): bool {
             $structureCalls[] = compact('structureId', 'mode');
             $element->structureId = $structureId;
             $element->root = 1;
@@ -331,9 +325,7 @@ test('continues when setting uri for a localized clone is aborted', function () 
     $saveCalls = [];
 
     $uris = Double::for(ElementUris::class);
-    $uris->shouldReceive('setElementUri')
-        ->once()
-        ->andReturnUsing(function (ElementInterface $element): void {
+    $uris->expects('setElementUri')->resolves(function (ElementInterface $element): void {
             throw new OperationAbortedException('URI aborted.');
         });
 
@@ -463,9 +455,7 @@ function duplicateAction(
 function successfulElementWrites(array &$calls, array $idsToAssign = [], int $expectedSaveCalls = 1): ElementWrites
 {
     $writes = Double::for(ElementWrites::class);
-    $writes->shouldReceive('save')
-        ->times($expectedSaveCalls)
-        ->andReturnUsing(function (
+    $writes->expects('save')->times($expectedSaveCalls)->resolves(function (
             ElementInterface $element,
             bool $runValidation = true,
             bool $propagate = true,
@@ -497,9 +487,7 @@ function successfulElementWrites(array &$calls, array $idsToAssign = [], int $ex
 function elementWritesForMissingSitePropagation(array &$saveCalls, array &$propagateCalls, bool $result = true): ElementWrites
 {
     $writes = successfulElementWrites($saveCalls);
-    $writes->shouldReceive('propagate')
-        ->once()
-        ->andReturnUsing(function (
+    $writes->expects('propagate')->resolves(function (
             ElementInterface $element,
             array $supportedSites,
             int $siteId,

--- a/tests/Feature/Element/Jobs/ReplaceReferencesTest.php
+++ b/tests/Feature/Element/Jobs/ReplaceReferencesTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\Elements as ElementsService;
@@ -168,7 +169,7 @@ it('continues when saving a changed element fails', function () {
     $source = $result->element;
 
     $realElements = app(ElementsService::class);
-    $elements = Mockery::mock($realElements)->makePartial();
+    $elements = Double::for($realElements)->passthru();
     $elements->shouldReceive('saveElement')
         ->once()
         ->andThrow(new RuntimeException('Save failed'));

--- a/tests/Feature/Element/Jobs/ReplaceReferencesTest.php
+++ b/tests/Feature/Element/Jobs/ReplaceReferencesTest.php
@@ -170,9 +170,7 @@ it('continues when saving a changed element fails', function () {
 
     $realElements = app(ElementsService::class);
     $elements = Double::for($realElements)->passthru();
-    $elements->shouldReceive('saveElement')
-        ->once()
-        ->andThrow(new RuntimeException('Save failed'));
+    $elements->expects('saveElement')->throws(new RuntimeException('Save failed'));
     Elements::swap($elements);
 
     $job = new TestReplaceReferences(

--- a/tests/Feature/Element/NestedElementManagerTest.php
+++ b/tests/Feature/Element/NestedElementManagerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Address\Elements\Address as AddressElement;
 use CraftCms\Cms\Address\Models\Address as AddressModel;
 use CraftCms\Cms\Database\Table;
@@ -642,7 +643,7 @@ it('creates eager-loaded field addresses with the requested source owner', funct
             'addressLine1' => '123 Main St',
         ]);
     $map = $field->getEagerLoadingMap([$firstEntry]);
-    $query = Mockery::mock(AddressQuery::class);
+    $query = Double::for(AddressQuery::class);
     $result = [
         'id' => $address->id,
         'siteId' => $firstEntry->siteId,

--- a/tests/Feature/Element/NestedElementManagerTest.php
+++ b/tests/Feature/Element/NestedElementManagerTest.php
@@ -649,14 +649,8 @@ it('creates eager-loaded field addresses with the requested source owner', funct
         'siteId' => $firstEntry->siteId,
     ];
 
-    $query->shouldReceive('owner')
-        ->once()
-        ->with($firstEntry)
-        ->andReturnSelf();
-    $query->shouldReceive('createElement')
-        ->once()
-        ->with($result)
-        ->andReturn($address);
+    $query->expects('owner')->with($firstEntry)->returns($query);
+    $query->expects('createElement')->with($result)->returns($address);
 
     $created = $map['createElement']($query, $result, $firstEntry);
 

--- a/tests/Feature/FieldLayout/FieldLayoutCompilerTest.php
+++ b/tests/Feature/FieldLayout/FieldLayoutCompilerTest.php
@@ -217,22 +217,18 @@ it('preserves missing persisted form providers without submitting their values',
     $missingControlType = 'Acme\\Forms\\MissingField';
     actingAs(User::find()->one());
     app()->instance(Plugins::class, Mockery::mock(Plugins::class, function ($plugins) use ($missingNodeType, $missingControlType) {
-        $plugins->shouldReceive('getPluginHandleByClass')->andReturn(null)->byDefault();
-        $plugins->shouldReceive('getPluginHandleByClass')->with($missingNodeType)->andReturnUsing(
-            fn () => class_exists($missingNodeType, false) ? null : 'missing-node-plugin',
-        );
-        $plugins->shouldReceive('getPluginHandleByClass')->with($missingControlType)->andReturnUsing(
-            fn () => class_exists($missingControlType, false) ? null : 'missing-control-plugin',
-        );
-        $plugins->shouldReceive('getPluginInfo')->with('missing-node-plugin')->andReturn([
+        $plugins->allows('getPluginHandleByClass')->returns(null);
+        $plugins->allows('getPluginHandleByClass')->with($missingNodeType)->resolves(fn () => class_exists($missingNodeType, false) ? null : 'missing-node-plugin');
+        $plugins->allows('getPluginHandleByClass')->with($missingControlType)->resolves(fn () => class_exists($missingControlType, false) ? null : 'missing-control-plugin');
+        $plugins->allows('getPluginInfo')->with('missing-node-plugin')->returns([
             'isInstalled' => true,
             'name' => 'Missing Node Plugin',
         ]);
-        $plugins->shouldReceive('getPluginInfo')->with('missing-control-plugin')->andReturn([
+        $plugins->allows('getPluginInfo')->with('missing-control-plugin')->returns([
             'isInstalled' => false,
             'name' => 'Missing Control Plugin',
         ]);
-        $plugins->shouldReceive('getPluginIconSvg')->andReturn('<svg></svg>');
+        $plugins->allows('getPluginIconSvg')->returns('<svg></svg>');
     }));
     $layout = FieldLayout::make(CraftCms\Cms\Entry\Elements\Entry::class)
         ->tab('Content', fn (FieldLayoutTab $tab) => $tab->add(

--- a/tests/Feature/GarbageCollection/Jobs/RunGarbageCollectionTest.php
+++ b/tests/Feature/GarbageCollection/Jobs/RunGarbageCollectionTest.php
@@ -13,7 +13,7 @@ it('is unique while queued or running', function () {
 
 it('forces garbage collection when handled', function () {
     $garbageCollection = Double::for(GarbageCollection::class);
-    $garbageCollection->shouldReceive('run')->once()->with(true);
+    $garbageCollection->expects('run')->with(true);
 
     new RunGarbageCollection()->handle($garbageCollection);
 });

--- a/tests/Feature/GarbageCollection/Jobs/RunGarbageCollectionTest.php
+++ b/tests/Feature/GarbageCollection/Jobs/RunGarbageCollectionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\GarbageCollection\GarbageCollection;
 use CraftCms\Cms\GarbageCollection\Jobs\RunGarbageCollection;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -11,7 +12,7 @@ it('is unique while queued or running', function () {
 });
 
 it('forces garbage collection when handled', function () {
-    $garbageCollection = Mockery::mock(GarbageCollection::class);
+    $garbageCollection = Double::for(GarbageCollection::class);
     $garbageCollection->shouldReceive('run')->once()->with(true);
 
     new RunGarbageCollection()->handle($garbageCollection);

--- a/tests/Feature/Gql/GqlTest.php
+++ b/tests/Feature/Gql/GqlTest.php
@@ -246,13 +246,9 @@ it('generates the expected permission list through the new service', function ()
         'entryTypes' => [$typeB],
     ]);
 
-    Sections::partialMock()
-        ->shouldReceive('getAllSections')
-        ->andReturn(collect([$sectionA, $sectionB]));
+    Sections::partialMock()->allows('getAllSections')->returns(collect([$sectionA, $sectionB]));
 
-    Volumes::partialMock()
-        ->shouldReceive('getAllVolumes')
-        ->andReturn(collect([
+    Volumes::partialMock()->allows('getAllVolumes')->returns(collect([
             new Local([
                 'id' => 1,
                 'name' => 'Test volume',

--- a/tests/Feature/Http/Controllers/App/PluginsControllerTest.php
+++ b/tests/Feature/Http/Controllers/App/PluginsControllerTest.php
@@ -20,10 +20,7 @@ beforeEach(function () {
 
 test('get plugin license info validates and sorts plugin results', function () {
     $api = Double::for(Api::class);
-    $api->shouldReceive('getLicenseInfo')
-        ->once()
-        ->with(['plugins'])
-        ->andReturn([
+    $api->expects('getLicenseInfo')->with(['plugins'])->returns([
             'pluginLicenses' => [
                 [
                     'key' => 'ABC123ABC123ABC123ABC123',

--- a/tests/Feature/Http/Controllers/App/PluginsControllerTest.php
+++ b/tests/Feature/Http/Controllers/App/PluginsControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Http\Controllers\App\PluginsController;
 use CraftCms\Cms\Plugin\Plugins;
 use CraftCms\Cms\Shared\Enums\LicenseKeyStatus;
@@ -18,7 +19,7 @@ beforeEach(function () {
 });
 
 test('get plugin license info validates and sorts plugin results', function () {
-    $api = Mockery::mock(Api::class);
+    $api = Double::for(Api::class);
     $api->shouldReceive('getLicenseInfo')
         ->once()
         ->with(['plugins'])

--- a/tests/Feature/Http/Controllers/Elements/DuplicateElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/DuplicateElementControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Element\Drafts;
 use CraftCms\Cms\Element\Elements as ElementsService;
 use CraftCms\Cms\Element\Exceptions\InvalidElementException;
@@ -104,7 +105,7 @@ describe('duplicate', function () {
             ]);
         $entry->errors()->add('title', 'Title is invalid.');
 
-        $elements = Mockery::mock(ElementsService::class);
+        $elements = Double::for(ElementsService::class);
         $elements->shouldReceive('duplicateElement')
             ->once()
             ->andThrow(new InvalidElementException($entry));
@@ -316,7 +317,7 @@ describe('bulkDuplicate', function () {
             ]);
         $entry->errors()->add('title', 'Title is invalid.');
 
-        $elements = Mockery::mock(ElementsService::class);
+        $elements = Double::for(ElementsService::class);
         $elements->shouldReceive('duplicateElement')
             ->once()
             ->andThrow(new InvalidElementException($entry));

--- a/tests/Feature/Http/Controllers/Elements/DuplicateElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/DuplicateElementControllerTest.php
@@ -106,9 +106,7 @@ describe('duplicate', function () {
         $entry->errors()->add('title', 'Title is invalid.');
 
         $elements = Double::for(ElementsService::class);
-        $elements->shouldReceive('duplicateElement')
-            ->once()
-            ->andThrow(new InvalidElementException($entry));
+        $elements->expects('duplicateElement')->throws(new InvalidElementException($entry));
 
         app()->instance(ElementsService::class, $elements);
 
@@ -318,9 +316,7 @@ describe('bulkDuplicate', function () {
         $entry->errors()->add('title', 'Title is invalid.');
 
         $elements = Double::for(ElementsService::class);
-        $elements->shouldReceive('duplicateElement')
-            ->once()
-            ->andThrow(new InvalidElementException($entry));
+        $elements->expects('duplicateElement')->throws(new InvalidElementException($entry));
 
         app()->instance(ElementsService::class, $elements);
 

--- a/tests/Feature/Http/Controllers/Elements/ElementDraftsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/ElementDraftsControllerTest.php
@@ -123,13 +123,8 @@ describe('ensure', function () {
         $draft = app(Drafts::class)->createDraft($entry, auth()->id(), provisional: true);
 
         $request = Double::for(ElementRequest::class);
-        $request->shouldReceive('element')
-            ->once()
-            ->with([], true)
-            ->andReturn($entry);
-        $request->shouldReceive('craftUser')
-            ->once()
-            ->andReturn(currentUser());
+        $request->expects('element')->with([], true)->returns($entry);
+        $request->expects('craftUser')->returns(currentUser());
 
         app()->instance('request', Request::create('/actions/elements/ensure-draft', 'POST', [], [], [], [
             'HTTP_ACCEPT' => 'application/json',

--- a/tests/Feature/Http/Controllers/Elements/ElementDraftsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/ElementDraftsControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Auth\SessionAuth;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
@@ -121,7 +122,7 @@ describe('ensure', function () {
         /** @var Entry $draft */
         $draft = app(Drafts::class)->createDraft($entry, auth()->id(), provisional: true);
 
-        $request = Mockery::mock(ElementRequest::class);
+        $request = Double::for(ElementRequest::class);
         $request->shouldReceive('element')
             ->once()
             ->with([], true)

--- a/tests/Feature/Http/Controllers/Elements/PreviewElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/PreviewElementControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Element\Drafts;
 use CraftCms\Cms\Element\ElementHelper;
 use CraftCms\Cms\Element\Revisions;
@@ -30,7 +31,7 @@ it('renders preview pages for saved drafts and honors signed return urls', funct
     $draft->title = 'Draft Title';
     Elements::saveElement($draft);
 
-    $request = Mockery::mock(ElementRequest::class);
+    $request = Double::for(ElementRequest::class);
     $request->shouldReceive('element')
         ->once()
         ->with(['id' => $entry->id], true)
@@ -64,7 +65,7 @@ it('renders preview pages for provisional drafts using canonical ids in the prev
     $draft->title = 'Edited Title';
     Elements::saveElement($draft);
 
-    $request = Mockery::mock(ElementRequest::class);
+    $request = Double::for(ElementRequest::class);
     $request->shouldReceive('element')
         ->once()
         ->with(['id' => $entry->id], true)
@@ -97,7 +98,7 @@ it('renders preview pages for revisions', function () {
     $revisionElementId = app(Revisions::class)->createRevision($entry, auth()->id());
     $revision = Elements::getElementById($revisionElementId, Entry::class, $entry->siteId);
 
-    $request = Mockery::mock(ElementRequest::class);
+    $request = Double::for(ElementRequest::class);
     $request->shouldReceive('element')
         ->once()
         ->with(['id' => $entry->id], true)
@@ -127,7 +128,7 @@ it('redirects to the canonical edit url when the requested draft is invalid', fu
 
     $redirect = redirect($entry->getCpEditUrl());
 
-    $request = Mockery::mock(ElementRequest::class);
+    $request = Double::for(ElementRequest::class);
     $request->shouldReceive('element')
         ->once()
         ->with(['id' => $entry->id], true)

--- a/tests/Feature/Http/Controllers/Elements/PreviewElementControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/PreviewElementControllerTest.php
@@ -32,14 +32,8 @@ it('renders preview pages for saved drafts and honors signed return urls', funct
     Elements::saveElement($draft);
 
     $request = Double::for(ElementRequest::class);
-    $request->shouldReceive('element')
-        ->once()
-        ->with(['id' => $entry->id], true)
-        ->andReturn($draft);
-    $request->shouldReceive('getSigned')
-        ->once()
-        ->with('returnUrl', ElementHelper::postEditUrl($draft))
-        ->andReturn('entries');
+    $request->expects('element')->with(['id' => $entry->id], true)->returns($draft);
+    $request->expects('getSigned')->with('returnUrl', ElementHelper::postEditUrl($draft))->returns('entries');
 
     HtmlStack::clear();
 
@@ -66,14 +60,8 @@ it('renders preview pages for provisional drafts using canonical ids in the prev
     Elements::saveElement($draft);
 
     $request = Double::for(ElementRequest::class);
-    $request->shouldReceive('element')
-        ->once()
-        ->with(['id' => $entry->id], true)
-        ->andReturn($draft);
-    $request->shouldReceive('getSigned')
-        ->once()
-        ->with('returnUrl', ElementHelper::postEditUrl($draft))
-        ->andReturn(ElementHelper::postEditUrl($draft));
+    $request->expects('element')->with(['id' => $entry->id], true)->returns($draft);
+    $request->expects('getSigned')->with('returnUrl', ElementHelper::postEditUrl($draft))->returns(ElementHelper::postEditUrl($draft));
 
     HtmlStack::clear();
 
@@ -99,14 +87,8 @@ it('renders preview pages for revisions', function () {
     $revision = Elements::getElementById($revisionElementId, Entry::class, $entry->siteId);
 
     $request = Double::for(ElementRequest::class);
-    $request->shouldReceive('element')
-        ->once()
-        ->with(['id' => $entry->id], true)
-        ->andReturn($revision);
-    $request->shouldReceive('getSigned')
-        ->once()
-        ->with('returnUrl', ElementHelper::postEditUrl($revision))
-        ->andReturn(ElementHelper::postEditUrl($revision));
+    $request->expects('element')->with(['id' => $entry->id], true)->returns($revision);
+    $request->expects('getSigned')->with('returnUrl', ElementHelper::postEditUrl($revision))->returns(ElementHelper::postEditUrl($revision));
 
     HtmlStack::clear();
 
@@ -129,10 +111,7 @@ it('redirects to the canonical edit url when the requested draft is invalid', fu
     $redirect = redirect($entry->getCpEditUrl());
 
     $request = Double::for(ElementRequest::class);
-    $request->shouldReceive('element')
-        ->once()
-        ->with(['id' => $entry->id], true)
-        ->andReturn($redirect);
+    $request->expects('element')->with(['id' => $entry->id], true)->returns($redirect);
 
     $response = new PreviewElementController($request)->__invoke($entry->id, "-$entry->slug");
 

--- a/tests/Feature/Http/Controllers/Entries/ReassignEntriesModalControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/ReassignEntriesModalControllerTest.php
@@ -96,10 +96,7 @@ it('fails when no new author is selected', function () {
 
 it('reassigns entries to the selected author', function (int $count, string $message) {
     $entries = Double::for(Entries::class);
-    $entries->shouldReceive('reassignEntries')
-        ->once()
-        ->with([1, 2], 3)
-        ->andReturn($count);
+    $entries->expects('reassignEntries')->with([1, 2], 3)->returns($count);
 
     app()->instance(Entries::class, $entries);
 

--- a/tests/Feature/Http/Controllers/Entries/ReassignEntriesModalControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/ReassignEntriesModalControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Entry\Entries;
 use CraftCms\Cms\Http\Controllers\Entries\ReassignEntriesModalController;
 use CraftCms\Cms\User\Elements\User;
@@ -94,7 +95,7 @@ it('fails when no new author is selected', function () {
 });
 
 it('reassigns entries to the selected author', function (int $count, string $message) {
-    $entries = Mockery::mock(Entries::class);
+    $entries = Double::for(Entries::class);
     $entries->shouldReceive('reassignEntries')
         ->once()
         ->with([1, 2], 3)

--- a/tests/Feature/Http/Controllers/Entries/StoreEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/StoreEntryControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Asset\Models\Asset as AssetModel;
 use CraftCms\Cms\Element\Drafts;
 use CraftCms\Cms\Entry\Elements\Entry;
@@ -301,7 +302,7 @@ it('throws exception when entry is locked', function () {
     Cache::shouldReceive('lock')
         ->with("entry:{$entryModel->id}", 15)
         ->andReturn(
-            Mockery::mock(Lock::class)
+            Double::for(Lock::class)
                 ->shouldReceive('get')
                 ->andReturn(false)
                 ->getMock()

--- a/tests/Feature/Http/Controllers/QueueControllerTest.php
+++ b/tests/Feature/Http/Controllers/QueueControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Http\Controllers\QueueController;
 use CraftCms\Cms\Queue\JobProgress;
@@ -131,7 +132,7 @@ it('returns total jobs and job info without a limit', function () {
 });
 
 it('does not require Queue Manager utility access for job info', function () {
-    $utilities = Mockery::mock(Utilities::class);
+    $utilities = Double::for(Utilities::class);
     $utilities->shouldNotReceive('checkAuthorization');
     app()->instance(Utilities::class, $utilities);
 

--- a/tests/Feature/Http/Controllers/QueueControllerTest.php
+++ b/tests/Feature/Http/Controllers/QueueControllerTest.php
@@ -133,7 +133,7 @@ it('returns total jobs and job info without a limit', function () {
 
 it('does not require Queue Manager utility access for job info', function () {
     $utilities = Double::for(Utilities::class);
-    $utilities->shouldNotReceive('checkAuthorization');
+    $utilities->expects('checkAuthorization')->never();
     app()->instance(Utilities::class, $utilities);
 
     getJson(action([QueueController::class, 'jobInfo']))->assertOk();

--- a/tests/Feature/Http/Controllers/RelationalFieldsControllerTest.php
+++ b/tests/Feature/Http/Controllers/RelationalFieldsControllerTest.php
@@ -82,17 +82,11 @@ it('renders an empty structured input', function () {
 it('fills structure gaps and loads provisional changes', function () {
     ['siteId' => $siteId, 'root' => $root, 'child' => $child] = createRelationalFieldEntries();
 
-    StructuresFacade::partialMock()
-        ->shouldReceive('fillGapsInElements')
-        ->once()
-        ->andReturnUsing(function (array &$elements) use ($root, $child) {
+    StructuresFacade::partialMock()->expects('fillGapsInElements')->resolves(function (array &$elements) use ($root, $child) {
             $elements = [$root, $child];
         });
 
-    DraftsFacade::partialMock()
-        ->shouldReceive('loadProvisionalChanges')
-        ->once()
-        ->andReturnUsing(function (array $elements) {
+    DraftsFacade::partialMock()->expects('loadProvisionalChanges')->resolves(function (array $elements) {
             $elements[0]->title = 'Draft Root';
         });
 
@@ -118,10 +112,7 @@ it('fills structure gaps and loads provisional changes', function () {
 it('applies the branch limit to structured elements', function () {
     ['siteId' => $siteId, 'root' => $root, 'child' => $child, 'secondRoot' => $secondRoot] = createRelationalFieldEntries();
 
-    StructuresFacade::partialMock()
-        ->shouldReceive('fillGapsInElements')
-        ->once()
-        ->andReturnUsing(function (array &$elements) use ($root, $child, $secondRoot) {
+    StructuresFacade::partialMock()->expects('fillGapsInElements')->resolves(function (array &$elements) use ($root, $child, $secondRoot) {
             $elements = [$root, $child, $secondRoot];
         });
 

--- a/tests/Feature/Http/Middleware/CheckForUpdatesTest.php
+++ b/tests/Feature/Http/Middleware/CheckForUpdatesTest.php
@@ -14,19 +14,19 @@ use function CraftCms\Cms\cp_url;
 
 beforeEach(function () {
     $this->updates = $this->mock(Updates::class);
-    $this->updates->shouldReceive('isCraftSchemaVersionCompatible')->andReturn(true)->byDefault();
+    $this->updates->allows('isCraftSchemaVersionCompatible')->returns(true);
 
     TemplateMode::set(TemplateMode::Cp);
 });
 
 it('aborts 503 for site requests when the schema version is incompatible', function () {
-    $this->updates->shouldReceive('isCraftSchemaVersionCompatible')->andReturn(false);
+    $this->updates->allows('isCraftSchemaVersionCompatible')->returns(false);
 
     app(CheckForUpdates::class)->handle(Request::create('/site-page'), fn () => 'passed');
 })->throws(HttpException::class);
 
 it('throws for CP requests when the schema version is incompatible', function () {
-    $this->updates->shouldReceive('isCraftSchemaVersionCompatible')->andReturn(false);
+    $this->updates->allows('isCraftSchemaVersionCompatible')->returns(false);
 
     app(CheckForUpdates::class)->handle(
         Request::create('/'.Cms::config()->cpTrigger.'/dashboard'),
@@ -35,9 +35,9 @@ it('throws for CP requests when the schema version is incompatible', function ()
 })->throws(RuntimeException::class);
 
 it('passes through when no updates pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(false);
-    $this->updates->shouldReceive('hasCraftVersionChanged')->andReturn(false);
-    $this->updates->shouldReceive('isPluginUpdatePending')->andReturn(false);
+    $this->updates->allows('isCraftUpdatePending')->returns(false);
+    $this->updates->allows('hasCraftVersionChanged')->returns(false);
+    $this->updates->allows('isPluginUpdatePending')->returns(false);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('foo');
@@ -48,9 +48,9 @@ it('passes through when no updates pending', function () {
 });
 
 it('passes through for regular site request when no updates pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(false);
-    $this->updates->shouldReceive('hasCraftVersionChanged')->andReturn(false);
-    $this->updates->shouldReceive('isPluginUpdatePending')->andReturn(false);
+    $this->updates->allows('isCraftUpdatePending')->returns(false);
+    $this->updates->allows('hasCraftVersionChanged')->returns(false);
+    $this->updates->allows('isPluginUpdatePending')->returns(false);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/site-page');
@@ -61,9 +61,9 @@ it('passes through for regular site request when no updates pending', function (
 });
 
 it('passes through for action request when no updates pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(false);
-    $this->updates->shouldReceive('hasCraftVersionChanged')->andReturn(false);
-    $this->updates->shouldReceive('isPluginUpdatePending')->andReturn(false);
+    $this->updates->allows('isCraftUpdatePending')->returns(false);
+    $this->updates->allows('hasCraftVersionChanged')->returns(false);
+    $this->updates->allows('isPluginUpdatePending')->returns(false);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/actions/app/health-check');
@@ -74,10 +74,10 @@ it('passes through for action request when no updates pending', function () {
 });
 
 it('cleans compiled templates when craft version changed', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(false);
-    $this->updates->shouldReceive('hasCraftVersionChanged')->andReturn(true);
-    $this->updates->shouldReceive('updateCraftVersionInfo')->once();
-    $this->updates->shouldReceive('isPluginUpdatePending')->andReturn(false);
+    $this->updates->allows('isCraftUpdatePending')->returns(false);
+    $this->updates->allows('hasCraftVersionChanged')->returns(true);
+    $this->updates->expects('updateCraftVersionInfo');
+    $this->updates->allows('isPluginUpdatePending')->returns(false);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/site-page');
@@ -88,10 +88,10 @@ it('cleans compiled templates when craft version changed', function () {
 });
 
 it('renders db update page for cp request when craft update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
-    $this->updates->shouldReceive('wasCraftBreakpointSkipped')->andReturn(false);
-    $this->updates->shouldReceive('isUpdateInfoCached')->andReturn(false);
-    $this->updates->shouldReceive('areMigrationsPending')->andReturn(false);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
+    $this->updates->allows('wasCraftBreakpointSkipped')->returns(false);
+    $this->updates->allows('isUpdateInfoCached')->returns(false);
+    $this->updates->allows('areMigrationsPending')->returns(false);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create(Cms::config()->cpTrigger);
@@ -105,12 +105,12 @@ it('renders db update page for cp request when craft update pending', function (
 });
 
 it('renders db update page for cp request when plugin update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(false);
-    $this->updates->shouldReceive('hasCraftVersionChanged')->andReturn(false);
-    $this->updates->shouldReceive('isPluginUpdatePending')->andReturn(true);
-    $this->updates->shouldReceive('wasCraftBreakpointSkipped')->andReturn(false);
-    $this->updates->shouldReceive('isUpdateInfoCached')->andReturn(false);
-    $this->updates->shouldReceive('areMigrationsPending')->andReturn(false);
+    $this->updates->allows('isCraftUpdatePending')->returns(false);
+    $this->updates->allows('hasCraftVersionChanged')->returns(false);
+    $this->updates->allows('isPluginUpdatePending')->returns(true);
+    $this->updates->allows('wasCraftBreakpointSkipped')->returns(false);
+    $this->updates->allows('isUpdateInfoCached')->returns(false);
+    $this->updates->allows('areMigrationsPending')->returns(false);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create(Cms::config()->cpTrigger);
@@ -121,7 +121,7 @@ it('renders db update page for cp request when plugin update pending', function 
 });
 
 it('aborts 503 for site request when craft update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/site-page');
@@ -130,9 +130,9 @@ it('aborts 503 for site request when craft update pending', function () {
 })->throws(HttpException::class);
 
 it('aborts 503 for site request when plugin update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(false);
-    $this->updates->shouldReceive('hasCraftVersionChanged')->andReturn(false);
-    $this->updates->shouldReceive('isPluginUpdatePending')->andReturn(true);
+    $this->updates->allows('isCraftUpdatePending')->returns(false);
+    $this->updates->allows('hasCraftVersionChanged')->returns(false);
+    $this->updates->allows('isPluginUpdatePending')->returns(true);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/site-page');
@@ -141,7 +141,7 @@ it('aborts 503 for site request when plugin update pending', function () {
 })->throws(HttpException::class);
 
 it('allows updater CP routes when update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/'.Cms::config()->cpTrigger.'/updates/migrate');
@@ -153,7 +153,7 @@ it('allows updater CP routes when update pending', function () {
 });
 
 it('allows health check action when update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/actions/app/health-check');
@@ -164,7 +164,7 @@ it('allows health check action when update pending', function () {
 });
 
 it('allows migrate action when update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/actions/app/migrate');
@@ -175,7 +175,7 @@ it('allows migrate action when update pending', function () {
 });
 
 it('allows pluginstore install migrate action when update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/actions/pluginstore/install/migrate');
@@ -186,10 +186,10 @@ it('allows pluginstore install migrate action when update pending', function () 
 });
 
 it('allows users login action when update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
-    $this->updates->shouldReceive('wasCraftBreakpointSkipped')->andReturn(false);
-    $this->updates->shouldReceive('isUpdateInfoCached')->andReturn(false);
-    $this->updates->shouldReceive('areMigrationsPending')->andReturn(false);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
+    $this->updates->allows('wasCraftBreakpointSkipped')->returns(false);
+    $this->updates->allows('isUpdateInfoCached')->returns(false);
+    $this->updates->allows('areMigrationsPending')->returns(false);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create(Cms::config()->cpTrigger.'/actions/users/login');
@@ -200,7 +200,7 @@ it('allows users login action when update pending', function () {
 });
 
 it('aborts 503 for disallowed action when update pending', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create('/actions/entries/save');
@@ -209,8 +209,8 @@ it('aborts 503 for disallowed action when update pending', function () {
 })->throws(HttpException::class);
 
 it('throws exception when craft breakpoint was skipped', function () {
-    $this->updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
-    $this->updates->shouldReceive('wasCraftBreakpointSkipped')->andReturn(true);
+    $this->updates->allows('isCraftUpdatePending')->returns(true);
+    $this->updates->allows('wasCraftBreakpointSkipped')->returns(true);
 
     $middleware = app(CheckForUpdates::class);
     $request = Request::create(Cms::config()->cpTrigger);

--- a/tests/Feature/Http/Middleware/Enforce2faTest.php
+++ b/tests/Feature/Http/Middleware/Enforce2faTest.php
@@ -61,7 +61,7 @@ test('allows user through when 2fa is required and active', function () {
 
     // Mock active method
     $auth = Double::for(app(AuthMethods::class))->passthru();
-    $auth->shouldReceive('hasActiveMethod')->andReturn(true);
+    $auth->allows('hasActiveMethod')->returns(true);
 
     $this->actingAs($user)
         ->get('/test-2fa')

--- a/tests/Feature/Http/Middleware/Enforce2faTest.php
+++ b/tests/Feature/Http/Middleware/Enforce2faTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Auth\AuthMethods;
 use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\Http\Middleware\Enforce2fa;
@@ -59,7 +60,7 @@ test('allows user through when 2fa is required and active', function () {
     ProjectConfig::set('users.require2fa', 'all');
 
     // Mock active method
-    $auth = Mockery::mock(app(AuthMethods::class))->makePartial();
+    $auth = Double::for(app(AuthMethods::class))->passthru();
     $auth->shouldReceive('hasActiveMethod')->andReturn(true);
 
     $this->actingAs($user)

--- a/tests/Feature/Http/Middleware/EnforceLicensesTest.php
+++ b/tests/Feature/Http/Middleware/EnforceLicensesTest.php
@@ -38,7 +38,7 @@ it('passes through if no license issues', function () {
     putenv('CRAFT_NO_TRIALS=true');
 
     $mockLicense = Double::for(License::class)->passthru();
-    $mockLicense->shouldReceive('issues')->with(false)->andReturn([]);
+    $mockLicense->allows('issues')->with(false)->returns([]);
     $middleware = new EnforceLicenses($mockLicense);
 
     $request = Request::create('foo');
@@ -58,9 +58,9 @@ it('shows licensing screen when license issues exist', function () {
     $hash = 'abc123';
 
     $mockLicense = Double::for(License::class)->passthru();
-    $mockLicense->shouldReceive('issues')->andReturn($licenseIssues);
-    $mockLicense->shouldReceive('issuesHash')->with($licenseIssues)->andReturn($hash);
-    $mockLicense->shouldReceive('shunCookieName')->andReturn('craft_license_shun');
+    $mockLicense->allows('issues')->returns($licenseIssues);
+    $mockLicense->allows('issuesHash')->with($licenseIssues)->returns($hash);
+    $mockLicense->allows('shunCookieName')->returns('craft_license_shun');
     $middleware = new EnforceLicenses($mockLicense);
 
     $request = Request::create('foo');

--- a/tests/Feature/Http/Middleware/EnforceLicensesTest.php
+++ b/tests/Feature/Http/Middleware/EnforceLicensesTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Http\Middleware\EnforceLicenses;
 use CraftCms\Cms\License\License;
 use CraftCms\Cms\User\Contracts\CraftUser;
@@ -26,7 +27,7 @@ it('passes through if no user is authenticated', function () {
 
 it('passes through if edition can test', function () {
     $request = Request::create('foo');
-    $request->setUserResolver(fn () => Mockery::mock(CraftUser::class));
+    $request->setUserResolver(fn () => Double::for(CraftUser::class));
 
     $result = $this->middleware->handle($request, fn () => 'bar');
 
@@ -36,12 +37,12 @@ it('passes through if edition can test', function () {
 it('passes through if no license issues', function () {
     putenv('CRAFT_NO_TRIALS=true');
 
-    $mockLicense = Mockery::mock(License::class)->makePartial();
+    $mockLicense = Double::for(License::class)->passthru();
     $mockLicense->shouldReceive('issues')->with(false)->andReturn([]);
     $middleware = new EnforceLicenses($mockLicense);
 
     $request = Request::create('foo');
-    $request->setUserResolver(fn () => Mockery::mock(CraftUser::class));
+    $request->setUserResolver(fn () => Double::for(CraftUser::class));
 
     $result = $middleware->handle($request, fn () => 'bar');
 
@@ -56,14 +57,14 @@ it('shows licensing screen when license issues exist', function () {
     $licenseIssues = [['Issue 1', 'Description 1', 'sku1']];
     $hash = 'abc123';
 
-    $mockLicense = Mockery::mock(License::class)->makePartial();
+    $mockLicense = Double::for(License::class)->passthru();
     $mockLicense->shouldReceive('issues')->andReturn($licenseIssues);
     $mockLicense->shouldReceive('issuesHash')->with($licenseIssues)->andReturn($hash);
     $mockLicense->shouldReceive('shunCookieName')->andReturn('craft_license_shun');
     $middleware = new EnforceLicenses($mockLicense);
 
     $request = Request::create('foo');
-    $request->setUserResolver(fn () => Mockery::mock(CraftUser::class));
+    $request->setUserResolver(fn () => Double::for(CraftUser::class));
 
     $result = $middleware->handle($request, fn () => new Response);
 

--- a/tests/Feature/Image/ImageTransformerTest.php
+++ b/tests/Feature/Image/ImageTransformerTest.php
@@ -222,7 +222,7 @@ it('uses the provided asset when immediately generating transforms', function ()
         'filename' => 'transform-test.txt',
     ]);
     $assets = Double::for(Assets::class);
-    $assets->shouldNotReceive('getAssetById');
+    $assets->expects('getAssetById')->never();
     app()->instance(Assets::class, $assets);
 
     $transform = new ImageTransform([

--- a/tests/Feature/Image/ImageTransformerTest.php
+++ b/tests/Feature/Image/ImageTransformerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Asset\Assets;
 use CraftCms\Cms\Asset\Exceptions\ImageTransformException;
 use CraftCms\Cms\Asset\Models\Asset as AssetModel;
@@ -220,7 +221,7 @@ it('uses the provided asset when immediately generating transforms', function ()
     $asset = ($this->createImageAsset)([
         'filename' => 'transform-test.txt',
     ]);
-    $assets = Mockery::mock(Assets::class);
+    $assets = Double::for(Assets::class);
     $assets->shouldNotReceive('getAssetById');
     app()->instance(Assets::class, $assets);
 

--- a/tests/Feature/Plugin/PluginLifecycleTest.php
+++ b/tests/Feature/Plugin/PluginLifecycleTest.php
@@ -97,7 +97,7 @@ it('rejects plugin classes discovered as Laravel providers', function () {
     app()->forgetInstance(Plugins::class);
 
     $manifest = Double::for(PackageManifest::class);
-    $manifest->shouldReceive('providers')->andReturn([FirstLifecycleTestPlugin::class]);
+    $manifest->allows('providers')->returns([FirstLifecycleTestPlugin::class]);
     app()->instance(PackageManifest::class, $manifest);
 
     $plugins = app(Plugins::class);

--- a/tests/Feature/Plugin/PluginLifecycleTest.php
+++ b/tests/Feature/Plugin/PluginLifecycleTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Plugin\Exceptions\InvalidPluginException;
 use CraftCms\Cms\Plugin\Plugins;
@@ -95,7 +96,7 @@ it('returns null for plugin classes that do not implement the plugin interface',
 it('rejects plugin classes discovered as Laravel providers', function () {
     app()->forgetInstance(Plugins::class);
 
-    $manifest = Mockery::mock(PackageManifest::class);
+    $manifest = Double::for(PackageManifest::class);
     $manifest->shouldReceive('providers')->andReturn([FirstLifecycleTestPlugin::class]);
     app()->instance(PackageManifest::class, $manifest);
 

--- a/tests/Feature/Plugin/PluginsTest.php
+++ b/tests/Feature/Plugin/PluginsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Plugin\Events\PluginSettingsSaved;
 use CraftCms\Cms\Plugin\Events\PluginsLoading;
 use CraftCms\Cms\Plugin\Events\PluginsRegistered;
@@ -209,7 +210,7 @@ it('ignores missing transaction exceptions during uninstall commits', function (
     $manager = DB::getFacadeRoot();
     $connectionName = DB::getDefaultConnection();
     $connection = DB::connection();
-    $connectionMock = Mockery::mock($connection)->makePartial();
+    $connectionMock = Double::for($connection)->passthru();
 
     $connections = new ReflectionProperty($manager, 'connections');
     $resolvedConnections = $connections->getValue($manager);

--- a/tests/Feature/Plugin/PluginsTest.php
+++ b/tests/Feature/Plugin/PluginsTest.php
@@ -217,10 +217,7 @@ it('ignores missing transaction exceptions during uninstall commits', function (
     $resolvedConnections[$connectionName] = $connectionMock;
     $connections->setValue($manager, $resolvedConnections);
 
-    $connectionMock
-        ->shouldReceive('commit')
-        ->once()
-        ->andThrow(new PDOException('There is no active transaction'));
+    $connectionMock->expects('commit')->throws(new PDOException('There is no active transaction'));
 
     try {
         $this->plugins->uninstallPlugin('test-plugin');

--- a/tests/Feature/Queue/JobProgressServiceTest.php
+++ b/tests/Feature/Queue/JobProgressServiceTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Queue\Enums\JobStatus;
@@ -104,7 +105,7 @@ it('clears the Laravel queue when clearing all job progress', function () {
     Cms::config()->lowPriorityQueueName = 'test-low-prio-queue';
 
     // Create a mock queue connection that implements ClearableQueue
-    $queueConnection = Mockery::mock(QueueContract::class, ClearableQueue::class);
+    $queueConnection = Double::for(QueueContract::class, ClearableQueue::class);
 
     $queueConnection->shouldReceive('clear')->once()->with('test-queue');
     $queueConnection->shouldReceive('clear')->once()->with('test-low-prio-queue');

--- a/tests/Feature/Queue/JobProgressServiceTest.php
+++ b/tests/Feature/Queue/JobProgressServiceTest.php
@@ -107,8 +107,8 @@ it('clears the Laravel queue when clearing all job progress', function () {
     // Create a mock queue connection that implements ClearableQueue
     $queueConnection = Double::for(QueueContract::class, ClearableQueue::class);
 
-    $queueConnection->shouldReceive('clear')->once()->with('test-queue');
-    $queueConnection->shouldReceive('clear')->once()->with('test-low-prio-queue');
+    $queueConnection->expects('clear')->with('test-queue');
+    $queueConnection->expects('clear')->with('test-low-prio-queue');
 
     Queue::shouldReceive('connection')->once()->andReturn($queueConnection);
 

--- a/tests/Feature/Queue/Middleware/RunQueueMiddlewareTest.php
+++ b/tests/Feature/Queue/Middleware/RunQueueMiddlewareTest.php
@@ -45,8 +45,8 @@ it('does not inject script for ajax requests', function () {
 
 it('does not inject script for non-HTML responses', function () {
     $this->generalConfig->runQueueAutomatically(true);
-    $this->progressService->allows('getActive')->andReturn(collect());
-    $this->queue->allows('size')->andReturn(1);
+    $this->progressService->allows('getActive')->returns(collect());
+    $this->queue->allows('size')->returns(1);
 
     $request = Request::create('/');
     $response = new Response('{"data": "json"}');
@@ -59,7 +59,7 @@ it('does not inject script for non-HTML responses', function () {
 
 it('does not inject script when jobs are already running', function () {
     $this->generalConfig->runQueueAutomatically(true);
-    $this->progressService->allows('getActive')->andReturn(collect([
+    $this->progressService->allows('getActive')->returns(collect([
         ['uid' => 'test-123', 'description' => 'Test job', 'progress' => 50, 'progressLabel' => null],
     ]));
 
@@ -74,8 +74,8 @@ it('does not inject script when jobs are already running', function () {
 
 it('does not inject script when queue is empty', function () {
     $this->generalConfig->runQueueAutomatically(true);
-    $this->progressService->allows('getActive')->andReturn(collect());
-    $this->queue->allows('size')->andReturn(0);
+    $this->progressService->allows('getActive')->returns(collect());
+    $this->queue->allows('size')->returns(0);
 
     $request = Request::create('/');
     $response = new Response('<html><body>Test</body></html>');
@@ -88,8 +88,8 @@ it('does not inject script when queue is empty', function () {
 
 it('injects queue runner script for HTML responses with waiting jobs', function () {
     $this->generalConfig->runQueueAutomatically(true);
-    $this->progressService->allows('getActive')->andReturn(collect());
-    $this->queue->allows('size')->andReturn(5);
+    $this->progressService->allows('getActive')->returns(collect());
+    $this->queue->allows('size')->returns(5);
 
     $request = Request::create('/');
     $response = new Response('<html><body>Test</body></html>');
@@ -105,8 +105,8 @@ it('injects queue runner script for HTML responses with waiting jobs', function 
 
 it('injects script before closing body tag', function () {
     $this->generalConfig->runQueueAutomatically(true);
-    $this->progressService->allows('getActive')->andReturn(collect());
-    $this->queue->allows('size')->andReturn(1);
+    $this->progressService->allows('getActive')->returns(collect());
+    $this->queue->allows('size')->returns(1);
 
     $request = Request::create('/');
     $response = new Response('<html><body><p>Content</p></body></html>');
@@ -123,8 +123,8 @@ it('injects script before closing body tag', function () {
 
 it('appends script if no closing body tag exists', function () {
     $this->generalConfig->runQueueAutomatically(true);
-    $this->progressService->allows('getActive')->andReturn(collect());
-    $this->queue->allows('size')->andReturn(1);
+    $this->progressService->allows('getActive')->returns(collect());
+    $this->queue->allows('size')->returns(1);
 
     $request = Request::create('/');
     $response = new Response('<html><div>Content</div></html>');
@@ -139,8 +139,8 @@ it('appends script if no closing body tag exists', function () {
 
 it('handles xhtml content type', function () {
     $this->generalConfig->runQueueAutomatically(true);
-    $this->progressService->allows('getActive')->andReturn(collect());
-    $this->queue->allows('size')->andReturn(1);
+    $this->progressService->allows('getActive')->returns(collect());
+    $this->queue->allows('size')->returns(1);
 
     $request = Request::create('/');
     $response = new Response('<html><body>Test</body></html>');

--- a/tests/Feature/Queue/Middleware/RunQueueMiddlewareTest.php
+++ b/tests/Feature/Queue/Middleware/RunQueueMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Http\Middleware\RunQueue;
 use CraftCms\Cms\Queue\JobProgress;
@@ -10,8 +11,8 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
 beforeEach(function () {
-    $this->queue = Mockery::mock(Queue::class);
-    $this->progressService = Mockery::mock(JobProgress::class);
+    $this->queue = Double::for(Queue::class);
+    $this->progressService = Double::for(JobProgress::class);
     $this->middleware = new RunQueue($this->queue, $this->progressService);
     $this->generalConfig = Cms::config();
 });

--- a/tests/Feature/Route/RoutesTest.php
+++ b/tests/Feature/Route/RoutesTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\ProjectConfig\ProjectConfig;
 use CraftCms\Cms\Route\Data\Route;
 use CraftCms\Cms\Route\Routes;
@@ -118,7 +119,7 @@ it('can delete a route by uid', function () {
 });
 
 it('returns no project config routes when no current site exists yet', function () {
-    $sites = mock(Sites::class);
+    $sites = Double::for(Sites::class);
     $sites->shouldReceive('getCurrentSite')->andThrow(new SiteNotFoundException('No primary site exists'));
 
     $routes = new Routes($this->projectConfig, $sites);

--- a/tests/Feature/Route/RoutesTest.php
+++ b/tests/Feature/Route/RoutesTest.php
@@ -120,7 +120,7 @@ it('can delete a route by uid', function () {
 
 it('returns no project config routes when no current site exists yet', function () {
     $sites = Double::for(Sites::class);
-    $sites->shouldReceive('getCurrentSite')->andThrow(new SiteNotFoundException('No primary site exists'));
+    $sites->allows('getCurrentSite')->throws(new SiteNotFoundException('No primary site exists'));
 
     $routes = new Routes($this->projectConfig, $sites);
 

--- a/tests/Feature/User/Elements/UserValidationTest.php
+++ b/tests/Feature/User/Elements/UserValidationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\FieldLayout\FieldLayout;
@@ -498,10 +499,10 @@ describe('Name field validation with field layout', function () {
     test('firstName and lastName are required when showFirstAndLastNameFields is true and FullNameField is required in SCENARIO_LIVE', function () {
         Cms::config()->showFirstAndLastNameFields = true;
 
-        $fullNameField = Mockery::mock(FullNameField::class);
+        $fullNameField = Double::for(FullNameField::class);
         $fullNameField->required = true;
 
-        $fieldLayout = Mockery::mock(FieldLayout::class);
+        $fieldLayout = Double::for(FieldLayout::class);
         $fieldLayout->shouldReceive('getFirstVisibleElementByType')
             ->with(FullNameField::class, Mockery::any())
             ->andReturn($fullNameField);
@@ -526,10 +527,10 @@ describe('Name field validation with field layout', function () {
     test('firstName and lastName are not required when showFirstAndLastNameFields is true but FullNameField is not required in SCENARIO_LIVE', function () {
         Cms::config()->showFirstAndLastNameFields = true;
 
-        $fullNameField = Mockery::mock(FullNameField::class);
+        $fullNameField = Double::for(FullNameField::class);
         $fullNameField->required = false;
 
-        $fieldLayout = Mockery::mock(FieldLayout::class);
+        $fieldLayout = Double::for(FieldLayout::class);
         $fieldLayout->shouldReceive('getFirstVisibleElementByType')
             ->with(FullNameField::class, Mockery::any())
             ->andReturn($fullNameField);
@@ -551,10 +552,10 @@ describe('Name field validation with field layout', function () {
     test('fullName is required when showFirstAndLastNameFields is false and FullNameField is required in SCENARIO_LIVE', function () {
         Cms::config()->showFirstAndLastNameFields = false;
 
-        $fullNameField = Mockery::mock(FullNameField::class);
+        $fullNameField = Double::for(FullNameField::class);
         $fullNameField->required = true;
 
-        $fieldLayout = Mockery::mock(FieldLayout::class);
+        $fieldLayout = Double::for(FieldLayout::class);
         $fieldLayout->shouldReceive('getFirstVisibleElementByType')
             ->with(FullNameField::class, Mockery::any())
             ->andReturn($fullNameField);
@@ -575,10 +576,10 @@ describe('Name field validation with field layout', function () {
     test('fullName is not required when showFirstAndLastNameFields is false but FullNameField is not required in SCENARIO_LIVE', function () {
         Cms::config()->showFirstAndLastNameFields = false;
 
-        $fullNameField = Mockery::mock(FullNameField::class);
+        $fullNameField = Double::for(FullNameField::class);
         $fullNameField->required = false;
 
-        $fieldLayout = Mockery::mock(FieldLayout::class);
+        $fieldLayout = Double::for(FieldLayout::class);
         $fieldLayout->shouldReceive('getFirstVisibleElementByType')
             ->with(FullNameField::class, Mockery::any())
             ->andReturn($fullNameField);
@@ -598,10 +599,10 @@ describe('Name field validation with field layout', function () {
     test('name field required validation does not apply outside SCENARIO_LIVE', function () {
         Cms::config()->showFirstAndLastNameFields = true;
 
-        $fullNameField = Mockery::mock(FullNameField::class);
+        $fullNameField = Double::for(FullNameField::class);
         $fullNameField->required = true;
 
-        $fieldLayout = Mockery::mock(FieldLayout::class);
+        $fieldLayout = Double::for(FieldLayout::class);
         $fieldLayout->shouldReceive('getFirstVisibleElementByType')
             ->with(FullNameField::class, Mockery::any())
             ->andReturn($fullNameField);
@@ -623,7 +624,7 @@ describe('Name field validation with field layout', function () {
     test('handles missing FullNameField gracefully using null coalescing', function () {
         Cms::config()->showFirstAndLastNameFields = true;
 
-        $fieldLayout = Mockery::mock(FieldLayout::class);
+        $fieldLayout = Double::for(FieldLayout::class);
         $fieldLayout->shouldReceive('getFirstVisibleElementByType')
             ->with(FullNameField::class, Mockery::any())
             ->andReturn(null);

--- a/tests/Feature/User/Elements/UserValidationTest.php
+++ b/tests/Feature/User/Elements/UserValidationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Matching\Argument;
 use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Edition;
@@ -503,7 +504,7 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = true;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Argument::any())->returns($fullNameField);
         $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
         $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
         $fieldLayout->allows('getTabs')->returns([]);
@@ -529,7 +530,7 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = false;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Argument::any())->returns($fullNameField);
         $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
         $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
         $fieldLayout->allows('getTabs')->returns([]);
@@ -552,7 +553,7 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = true;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Argument::any())->returns($fullNameField);
         $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
         $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
         $fieldLayout->allows('getTabs')->returns([]);
@@ -574,7 +575,7 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = false;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Argument::any())->returns($fullNameField);
         $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
         $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
         $fieldLayout->allows('getTabs')->returns([]);
@@ -595,7 +596,7 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = true;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Argument::any())->returns($fullNameField);
         $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
         $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
         $fieldLayout->allows('getTabs')->returns([]);
@@ -615,7 +616,7 @@ describe('Name field validation with field layout', function () {
         Cms::config()->showFirstAndLastNameFields = true;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns(null);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Argument::any())->returns(null);
         $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
         $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
         $fieldLayout->allows('getTabs')->returns([]);

--- a/tests/Feature/User/Elements/UserValidationTest.php
+++ b/tests/Feature/User/Elements/UserValidationTest.php
@@ -503,12 +503,10 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = true;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->shouldReceive('getFirstVisibleElementByType')
-            ->with(FullNameField::class, Mockery::any())
-            ->andReturn($fullNameField);
-        $fieldLayout->shouldReceive('getVisibleCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getEditableCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getTabs')->andReturn([]);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getTabs')->returns([]);
 
         $user = new TestUserWithFieldLayout;
         $user->setMockFieldLayout($fieldLayout);
@@ -531,12 +529,10 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = false;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->shouldReceive('getFirstVisibleElementByType')
-            ->with(FullNameField::class, Mockery::any())
-            ->andReturn($fullNameField);
-        $fieldLayout->shouldReceive('getVisibleCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getEditableCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getTabs')->andReturn([]);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getTabs')->returns([]);
 
         $user = new TestUserWithFieldLayout;
         $user->setMockFieldLayout($fieldLayout);
@@ -556,12 +552,10 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = true;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->shouldReceive('getFirstVisibleElementByType')
-            ->with(FullNameField::class, Mockery::any())
-            ->andReturn($fullNameField);
-        $fieldLayout->shouldReceive('getVisibleCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getEditableCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getTabs')->andReturn([]);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getTabs')->returns([]);
 
         $user = new TestUserWithFieldLayout;
         $user->setMockFieldLayout($fieldLayout);
@@ -580,12 +574,10 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = false;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->shouldReceive('getFirstVisibleElementByType')
-            ->with(FullNameField::class, Mockery::any())
-            ->andReturn($fullNameField);
-        $fieldLayout->shouldReceive('getVisibleCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getEditableCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getTabs')->andReturn([]);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getTabs')->returns([]);
 
         $user = new TestUserWithFieldLayout;
         $user->setMockFieldLayout($fieldLayout);
@@ -603,12 +595,10 @@ describe('Name field validation with field layout', function () {
         $fullNameField->required = true;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->shouldReceive('getFirstVisibleElementByType')
-            ->with(FullNameField::class, Mockery::any())
-            ->andReturn($fullNameField);
-        $fieldLayout->shouldReceive('getVisibleCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getEditableCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getTabs')->andReturn([]);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns($fullNameField);
+        $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getTabs')->returns([]);
 
         $user = new TestUserWithFieldLayout;
         $user->setMockFieldLayout($fieldLayout);
@@ -625,12 +615,10 @@ describe('Name field validation with field layout', function () {
         Cms::config()->showFirstAndLastNameFields = true;
 
         $fieldLayout = Double::for(FieldLayout::class);
-        $fieldLayout->shouldReceive('getFirstVisibleElementByType')
-            ->with(FullNameField::class, Mockery::any())
-            ->andReturn(null);
-        $fieldLayout->shouldReceive('getVisibleCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getEditableCustomFieldElements')->andReturn([]);
-        $fieldLayout->shouldReceive('getTabs')->andReturn([]);
+        $fieldLayout->allows('getFirstVisibleElementByType')->with(FullNameField::class, Mockery::any())->returns(null);
+        $fieldLayout->allows('getVisibleCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getEditableCustomFieldElements')->returns([]);
+        $fieldLayout->allows('getTabs')->returns([]);
 
         $user = new TestUserWithFieldLayout;
         $user->setMockFieldLayout($fieldLayout);

--- a/tests/Unit/CmsTest.php
+++ b/tests/Unit/CmsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\Database\Table;
@@ -172,7 +173,7 @@ it('uses a valid CP user language preference', function () {
     Cms::setIsInstalled();
     Cms::config()->cpTrigger = 'admin';
     Updates::shouldReceive('isCraftUpdatePending')->once()->andReturn(false);
-    $user = Mockery::mock(CraftUser::class);
+    $user = Double::for(CraftUser::class);
     $user->shouldReceive('getAuthIdentifier')->once()->andReturn(42);
     Auth::shouldReceive('user')->once()->andReturn($user);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'language')->andReturn('pt-BR');
@@ -196,7 +197,7 @@ it('falls back to the accepted language when the CP user preference is invalid a
     Cms::config()->cpTrigger = 'admin';
     Cms::config()->defaultCpLanguage = null;
     Updates::shouldReceive('isCraftUpdatePending')->once()->andReturn(false);
-    $user = Mockery::mock(CraftUser::class);
+    $user = Double::for(CraftUser::class);
     $user->shouldReceive('getAuthIdentifier')->once()->andReturn(42);
     Auth::shouldReceive('user')->once()->andReturn($user);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'language')->andReturn('not-real');

--- a/tests/Unit/CmsTest.php
+++ b/tests/Unit/CmsTest.php
@@ -73,8 +73,7 @@ it('uses the logged-in CP user timezone preference first', function () {
     Cms::config()->cpTrigger = 'admin';
     app()->instance('request', Request::create('/admin'));
 
-    Auth::shouldReceive('hasUser')->andReturnTrue()
-        ->shouldReceive('id')->once()->andReturn(42);
+    Auth::shouldReceive('hasUser')->andReturnTrue()->expects('id')->returns(42);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'timeZone')->andReturn('Europe/Brussels');
 
     expect(Cms::timezone())->toBe('Europe/Brussels');
@@ -174,7 +173,7 @@ it('uses a valid CP user language preference', function () {
     Cms::config()->cpTrigger = 'admin';
     Updates::shouldReceive('isCraftUpdatePending')->once()->andReturn(false);
     $user = Double::for(CraftUser::class);
-    $user->shouldReceive('getAuthIdentifier')->once()->andReturn(42);
+    $user->expects('getAuthIdentifier')->returns(42);
     Auth::shouldReceive('user')->once()->andReturn($user);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'language')->andReturn('pt-BR');
     I18N::shouldReceive('validateAppLocaleId')->once()->with('pt-BR')->andReturn(true);
@@ -198,7 +197,7 @@ it('falls back to the accepted language when the CP user preference is invalid a
     Cms::config()->defaultCpLanguage = null;
     Updates::shouldReceive('isCraftUpdatePending')->once()->andReturn(false);
     $user = Double::for(CraftUser::class);
-    $user->shouldReceive('getAuthIdentifier')->once()->andReturn(42);
+    $user->expects('getAuthIdentifier')->returns(42);
     Auth::shouldReceive('user')->once()->andReturn($user);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'language')->andReturn('not-real');
     I18N::shouldReceive('validateAppLocaleId')->once()->with('not-real')->andReturn(false);

--- a/tests/Unit/Component/ComponentHelperTest.php
+++ b/tests/Unit/Component/ComponentHelperTest.php
@@ -123,8 +123,8 @@ describe('validateComponentClass', function () {
 
     test('returns false when class belongs to a disabled plugin', function () {
         $pluginsMock = Double::for(Plugins::class);
-        $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
-        $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(false);
+        $pluginsMock->allows('getPluginHandleByClass')->returns('my-plugin');
+        $pluginsMock->allows('isPluginEnabled')->with('my-plugin')->returns(false);
         app()->instance(Plugins::class, $pluginsMock);
 
         expect(ComponentHelper::validateComponentClass(StubComponent::class))->toBeFalse();
@@ -132,10 +132,10 @@ describe('validateComponentClass', function () {
 
     test('throws MissingComponentException for a disabled plugin class when throwException is true', function () {
         $pluginsMock = Double::for(Plugins::class);
-        $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
-        $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(false);
-        $pluginsMock->shouldReceive('isPluginInstalled')->with('my-plugin')->andReturn(true);
-        $pluginsMock->shouldReceive('getComposerPluginInfo')->with('my-plugin')->andReturn(['name' => 'My Plugin']);
+        $pluginsMock->allows('getPluginHandleByClass')->returns('my-plugin');
+        $pluginsMock->allows('isPluginEnabled')->with('my-plugin')->returns(false);
+        $pluginsMock->allows('isPluginInstalled')->with('my-plugin')->returns(true);
+        $pluginsMock->allows('getComposerPluginInfo')->with('my-plugin')->returns(['name' => 'My Plugin']);
         app()->instance(Plugins::class, $pluginsMock);
 
         ComponentHelper::validateComponentClass(StubComponent::class, throwException: true);
@@ -143,10 +143,10 @@ describe('validateComponentClass', function () {
 
     test('throws MissingComponentException for an uninstalled plugin class when throwException is true', function () {
         $pluginsMock = Double::for(Plugins::class);
-        $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
-        $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(false);
-        $pluginsMock->shouldReceive('isPluginInstalled')->with('my-plugin')->andReturn(false);
-        $pluginsMock->shouldReceive('getComposerPluginInfo')->with('my-plugin')->andReturn(['name' => 'My Plugin']);
+        $pluginsMock->allows('getPluginHandleByClass')->returns('my-plugin');
+        $pluginsMock->allows('isPluginEnabled')->with('my-plugin')->returns(false);
+        $pluginsMock->allows('isPluginInstalled')->with('my-plugin')->returns(false);
+        $pluginsMock->allows('getComposerPluginInfo')->with('my-plugin')->returns(['name' => 'My Plugin']);
         app()->instance(Plugins::class, $pluginsMock);
 
         ComponentHelper::validateComponentClass(StubComponent::class, throwException: true);
@@ -154,10 +154,10 @@ describe('validateComponentClass', function () {
 
     test('uses plugin handle as fallback name when composer info has no name', function () {
         $pluginsMock = Double::for(Plugins::class);
-        $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
-        $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(false);
-        $pluginsMock->shouldReceive('isPluginInstalled')->with('my-plugin')->andReturn(false);
-        $pluginsMock->shouldReceive('getComposerPluginInfo')->with('my-plugin')->andReturn([]);
+        $pluginsMock->allows('getPluginHandleByClass')->returns('my-plugin');
+        $pluginsMock->allows('isPluginEnabled')->with('my-plugin')->returns(false);
+        $pluginsMock->allows('isPluginInstalled')->with('my-plugin')->returns(false);
+        $pluginsMock->allows('getComposerPluginInfo')->with('my-plugin')->returns([]);
         app()->instance(Plugins::class, $pluginsMock);
 
         expect(fn () => ComponentHelper::validateComponentClass(StubComponent::class, throwException: true))
@@ -174,8 +174,8 @@ describe('validateComponentClass', function () {
 
     test('returns true when class belongs to an enabled plugin', function () {
         $pluginsMock = Double::for(Plugins::class);
-        $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
-        $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(true);
+        $pluginsMock->allows('getPluginHandleByClass')->returns('my-plugin');
+        $pluginsMock->allows('isPluginEnabled')->with('my-plugin')->returns(true);
         app()->instance(Plugins::class, $pluginsMock);
 
         expect(ComponentHelper::validateComponentClass(StubComponent::class))->toBeTrue();
@@ -183,7 +183,7 @@ describe('validateComponentClass', function () {
 
     test('returns true when class does not belong to any plugin', function () {
         $pluginsMock = Double::for(Plugins::class);
-        $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn(null);
+        $pluginsMock->allows('getPluginHandleByClass')->returns(null);
         app()->instance(Plugins::class, $pluginsMock);
 
         expect(ComponentHelper::validateComponentClass(StubComponent::class))->toBeTrue();

--- a/tests/Unit/Component/ComponentHelperTest.php
+++ b/tests/Unit/Component/ComponentHelperTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use Carbon\CarbonInterface;
 use CraftCms\Cms\Component\Component;
 use CraftCms\Cms\Component\ComponentHelper;
@@ -121,7 +122,7 @@ describe('validateComponentClass', function () {
     })->throws(RuntimeException::class, 'is not an instance of');
 
     test('returns false when class belongs to a disabled plugin', function () {
-        $pluginsMock = Mockery::mock(Plugins::class);
+        $pluginsMock = Double::for(Plugins::class);
         $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
         $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(false);
         app()->instance(Plugins::class, $pluginsMock);
@@ -130,7 +131,7 @@ describe('validateComponentClass', function () {
     });
 
     test('throws MissingComponentException for a disabled plugin class when throwException is true', function () {
-        $pluginsMock = Mockery::mock(Plugins::class);
+        $pluginsMock = Double::for(Plugins::class);
         $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
         $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(false);
         $pluginsMock->shouldReceive('isPluginInstalled')->with('my-plugin')->andReturn(true);
@@ -141,7 +142,7 @@ describe('validateComponentClass', function () {
     })->throws(MissingComponentException::class, 'belongs to a disabled plugin (My Plugin)');
 
     test('throws MissingComponentException for an uninstalled plugin class when throwException is true', function () {
-        $pluginsMock = Mockery::mock(Plugins::class);
+        $pluginsMock = Double::for(Plugins::class);
         $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
         $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(false);
         $pluginsMock->shouldReceive('isPluginInstalled')->with('my-plugin')->andReturn(false);
@@ -152,7 +153,7 @@ describe('validateComponentClass', function () {
     })->throws(MissingComponentException::class, 'belongs to an uninstalled plugin (My Plugin)');
 
     test('uses plugin handle as fallback name when composer info has no name', function () {
-        $pluginsMock = Mockery::mock(Plugins::class);
+        $pluginsMock = Double::for(Plugins::class);
         $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
         $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(false);
         $pluginsMock->shouldReceive('isPluginInstalled')->with('my-plugin')->andReturn(false);
@@ -172,7 +173,7 @@ describe('validateComponentClass', function () {
     })->throws(RuntimeException::class, 'is not an instance of');
 
     test('returns true when class belongs to an enabled plugin', function () {
-        $pluginsMock = Mockery::mock(Plugins::class);
+        $pluginsMock = Double::for(Plugins::class);
         $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn('my-plugin');
         $pluginsMock->shouldReceive('isPluginEnabled')->with('my-plugin')->andReturn(true);
         app()->instance(Plugins::class, $pluginsMock);
@@ -181,7 +182,7 @@ describe('validateComponentClass', function () {
     });
 
     test('returns true when class does not belong to any plugin', function () {
-        $pluginsMock = Mockery::mock(Plugins::class);
+        $pluginsMock = Double::for(Plugins::class);
         $pluginsMock->shouldReceive('getPluginHandleByClass')->andReturn(null);
         app()->instance(Plugins::class, $pluginsMock);
 

--- a/tests/Unit/Console/PublishCommandTest.php
+++ b/tests/Unit/Console/PublishCommandTest.php
@@ -23,7 +23,7 @@ it('removes stale Craft public assets before publishing', function () {
 
     try {
         $plugins = Double::for(Plugins::class);
-        $plugins->shouldReceive('publishPluginAssets')->once();
+        $plugins->expects('publishPluginAssets');
 
         $command = new class extends PublishCommand
         {

--- a/tests/Unit/Console/PublishCommandTest.php
+++ b/tests/Unit/Console/PublishCommandTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Console\Commands\Setup\PublishCommand;
 use CraftCms\Cms\Plugin\Plugins;
 use CraftCms\Cms\Support\File;
@@ -21,7 +22,7 @@ it('removes stale Craft public assets before publishing', function () {
     app()->usePublicPath($publicPath);
 
     try {
-        $plugins = Mockery::mock(Plugins::class);
+        $plugins = Double::for(Plugins::class);
         $plugins->shouldReceive('publishPluginAssets')->once();
 
         $command = new class extends PublishCommand

--- a/tests/Unit/Cp/FormFieldsTest.php
+++ b/tests/Unit/Cp/FormFieldsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Address\Addresses;
 use CraftCms\Cms\Address\Elements\Address;
 use CraftCms\Cms\Address\Validation\AddressRules;
@@ -161,7 +162,7 @@ describe('config deprecations', function () {
     it('logs a deprecation for unsupported legacy config keys', function (string $method, array $config, string $needle) {
         $logged = false;
 
-        $mock = Mockery::mock(Deprecator::class);
+        $mock = Double::for(Deprecator::class);
         $mock->shouldReceive('log')
             ->once()
             ->withArgs(function (string $key, string $message) use (&$logged, $needle) {
@@ -180,7 +181,7 @@ describe('config deprecations', function () {
     ]);
 
     it('logs nothing for faithfully mapped configs', function () {
-        $mock = Mockery::mock(Deprecator::class);
+        $mock = Double::for(Deprecator::class);
         $mock->shouldNotReceive('log');
         app()->scoped(Deprecator::class, fn () => $mock);
 

--- a/tests/Unit/Cp/FormFieldsTest.php
+++ b/tests/Unit/Cp/FormFieldsTest.php
@@ -182,7 +182,7 @@ describe('config deprecations', function () {
 
     it('logs nothing for faithfully mapped configs', function () {
         $mock = Double::for(Deprecator::class);
-        $mock->shouldNotReceive('log');
+        $mock->expects('log')->never();
         app()->scoped(Deprecator::class, fn () => $mock);
 
         FormFields::lightswitchFromConfig(['id' => 'ls', 'on' => true, 'label' => 'Enabled']);

--- a/tests/Unit/Cp/NavigationTest.php
+++ b/tests/Unit/Cp/NavigationTest.php
@@ -28,8 +28,8 @@ beforeEach(function () {
     Volumes::shouldReceive('getTotalViewableVolumes')->andReturn(0);
 
     $user = Double::for(CraftUser::class);
-    $user->shouldReceive('isAdmin')->andReturnTrue();
-    $user->shouldReceive('can')->andReturnTrue();
+    $user->allows('isAdmin')->returns(true);
+    $user->allows('can')->returns(true);
 
     Auth::shouldReceive('user')->andReturn($user);
     Auth::shouldReceive('userResolver')->andReturn(fn () => $user);
@@ -73,10 +73,7 @@ it('selects parent nav items when a subnav item matches the cp path', function (
 it('uses the cp navigation service for the twig variable', function () {
     app()->instance(
         Navigation::class,
-        Mockery::mock(Navigation::class, fn ($mock) => $mock
-            ->shouldReceive('getItems')
-            ->once()
-            ->andReturn([
+        Mockery::mock(Navigation::class, fn ($mock) => $mock->expects('getItems')->returns([
                 ['label' => 'Dashboard'],
             ])),
     );

--- a/tests/Unit/Cp/NavigationTest.php
+++ b/tests/Unit/Cp/NavigationTest.php
@@ -37,10 +37,16 @@ beforeEach(function () {
 
 it('selects nav items from paths with the cp trigger', function () {
     $request = Request::create('/admin/settings/fields');
+    $plugins2 = Double::for(Plugins::class);
+    $plugins2->allows('getAllPlugins')->returns([]);
+
+    $utilities2 = Double::for(Utilities::class);
+    $utilities2->allows('getAuthorizedUtilityTypes')->returns(new Collection);
+
     $navigation = new Navigation(
         $request,
-        Mockery::mock(Plugins::class, ['getAllPlugins' => []]),
-        Mockery::mock(Utilities::class, ['getAuthorizedUtilityTypes' => new Collection]),
+        $plugins2,
+        $utilities2,
         Cms::config(),
         Double::for(ElementSources::class),
     );
@@ -53,10 +59,16 @@ it('selects nav items from paths with the cp trigger', function () {
 
 it('selects parent nav items when a subnav item matches the cp path', function () {
     $request = Request::create('/admin/graphql/tokens');
+    $plugins = Double::for(Plugins::class);
+    $plugins->allows('getAllPlugins')->returns([]);
+
+    $utilities = Double::for(Utilities::class);
+    $utilities->allows('getAuthorizedUtilityTypes')->returns(new Collection);
+
     $navigation = new Navigation(
         $request,
-        Mockery::mock(Plugins::class, ['getAllPlugins' => []]),
-        Mockery::mock(Utilities::class, ['getAuthorizedUtilityTypes' => new Collection]),
+        $plugins,
+        $utilities,
         Cms::config(),
         Double::for(ElementSources::class),
     );

--- a/tests/Unit/Cp/NavigationTest.php
+++ b/tests/Unit/Cp/NavigationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Cp\Navigation;
 use CraftCms\Cms\Element\ElementSources;
@@ -26,7 +27,7 @@ beforeEach(function () {
     Sections::shouldReceive('getTotalEditableSections')->andReturn(0);
     Volumes::shouldReceive('getTotalViewableVolumes')->andReturn(0);
 
-    $user = Mockery::mock(CraftUser::class);
+    $user = Double::for(CraftUser::class);
     $user->shouldReceive('isAdmin')->andReturnTrue();
     $user->shouldReceive('can')->andReturnTrue();
 
@@ -41,7 +42,7 @@ it('selects nav items from paths with the cp trigger', function () {
         Mockery::mock(Plugins::class, ['getAllPlugins' => []]),
         Mockery::mock(Utilities::class, ['getAuthorizedUtilityTypes' => new Collection]),
         Cms::config(),
-        Mockery::mock(ElementSources::class),
+        Double::for(ElementSources::class),
     );
 
     $settingsItem = collect($navigation->getItems())->firstWhere('label', 'Settings');
@@ -57,7 +58,7 @@ it('selects parent nav items when a subnav item matches the cp path', function (
         Mockery::mock(Plugins::class, ['getAllPlugins' => []]),
         Mockery::mock(Utilities::class, ['getAuthorizedUtilityTypes' => new Collection]),
         Cms::config(),
-        Mockery::mock(ElementSources::class),
+        Double::for(ElementSources::class),
     );
 
     $graphqlItem = collect($navigation->getItems())->firstWhere('label', 'GraphQL');

--- a/tests/Unit/EditionTest.php
+++ b/tests/Unit/EditionTest.php
@@ -128,10 +128,10 @@ it('determines if the edition can be upgraded', function () {
     Cms::setIsInstalled();
 
     $user = Double::for(CraftUser::class);
-    $user->shouldReceive('isAdmin')->andReturnFalse();
+    $user->allows('isAdmin')->returns(false);
 
     $admin = Double::for(CraftUser::class);
-    $admin->shouldReceive('isAdmin')->andReturnTrue();
+    $admin->allows('isAdmin')->returns(true);
 
     Auth::shouldReceive('user')->andReturn(null, $user, $admin, $admin, $admin);
 

--- a/tests/Unit/EditionTest.php
+++ b/tests/Unit/EditionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\License\License;
@@ -126,10 +127,10 @@ it('determines if the edition can be upgraded', function () {
     Edition::set(Edition::Solo);
     Cms::setIsInstalled();
 
-    $user = Mockery::mock(CraftUser::class);
+    $user = Double::for(CraftUser::class);
     $user->shouldReceive('isAdmin')->andReturnFalse();
 
-    $admin = Mockery::mock(CraftUser::class);
+    $admin = Double::for(CraftUser::class);
     $admin->shouldReceive('isAdmin')->andReturnTrue();
 
     Auth::shouldReceive('user')->andReturn(null, $user, $admin, $admin, $admin);

--- a/tests/Unit/Element/ElementWrites/PropagateElementTest.php
+++ b/tests/Unit/Element/ElementWrites/PropagateElementTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\Element;
@@ -36,8 +37,8 @@ beforeEach(function () {
     $this->executor = new TestPropagateElementWrites(
         $this->elements,
         $this->uris,
-        Mockery::mock(ElementCaches::class),
-        Mockery::mock(Search::class),
+        Double::for(ElementCaches::class),
+        Double::for(Search::class),
         $this->sites,
     );
 

--- a/tests/Unit/Element/ElementWrites/PropagateElementsTest.php
+++ b/tests/Unit/Element/ElementWrites/PropagateElementsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Element\BulkOp\BulkOps;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\Element;
@@ -113,14 +114,14 @@ beforeEach(function () {
     Facade::clearResolvedInstance(SitesService::class);
     Sites::setCurrentSite($primarySite);
 
-    $this->elementCaches = Mockery::mock(ElementCaches::class);
-    $this->elements = Mockery::mock(Elements::class);
+    $this->elementCaches = Double::for(ElementCaches::class);
+    $this->elements = Double::for(Elements::class);
 
     $this->action = new TestPropagateElementsWrites(
         $this->elements,
-        Mockery::mock(ElementUris::class),
+        Double::for(ElementUris::class),
         $this->elementCaches,
-        Mockery::mock(Search::class),
+        Double::for(Search::class),
         app(SitesService::class),
     );
     $this->writes = $this->action;
@@ -162,7 +163,7 @@ function fakeBulkOps(): void
 
 function createQueryMock(array $elements): ElementQueryInterface
 {
-    $query = Mockery::mock(ElementQueryInterface::class);
+    $query = Double::for(ElementQueryInterface::class);
 
     $query->shouldReceive('cursor')
         ->once()
@@ -328,7 +329,7 @@ it('swallows aborted queries and still dispatches the final event', function () 
     fakeBulkOps();
     Event::fake([ElementsPropagating::class, ElementsPropagated::class]);
 
-    $query = Mockery::mock(ElementQueryInterface::class);
+    $query = Double::for(ElementQueryInterface::class);
     $query->shouldReceive('cursor')
         ->once()
         ->andThrow(new QueryAbortedException);

--- a/tests/Unit/Element/ElementWrites/PropagateElementsTest.php
+++ b/tests/Unit/Element/ElementWrites/PropagateElementsTest.php
@@ -165,9 +165,7 @@ function createQueryMock(array $elements): ElementQueryInterface
 {
     $query = Double::for(ElementQueryInterface::class);
 
-    $query->shouldReceive('cursor')
-        ->once()
-        ->andReturn(LazyCollection::make(fn () => yield from $elements));
+    $query->expects('cursor')->returns(LazyCollection::make(fn () => yield from $elements));
 
     return $query;
 }
@@ -196,22 +194,11 @@ it('propagates elements to supported target sites and dispatches lifecycle event
     $query = createQueryMock([$element]);
     $olderSiteElement = createElement(100, 2, new DateTime('2026-03-31 12:00:00'));
 
-    $this->elements
-        ->shouldReceive('getElementById')
-        ->once()
-        ->with(100, TestPropagateElementsActionElement::class, 2)
-        ->andReturn($olderSiteElement);
+    $this->elements->expects('getElementById')->with(100, TestPropagateElementsActionElement::class, 2)->returns($olderSiteElement);
 
-    $this->elements
-        ->shouldReceive('getElementById')
-        ->once()
-        ->with(100, TestPropagateElementsActionElement::class, 3)
-        ->andReturnNull();
+    $this->elements->expects('getElementById')->with(100, TestPropagateElementsActionElement::class, 3)->returns(null);
 
-    $this->elementCaches
-        ->shouldReceive('invalidateForElement')
-        ->once()
-        ->with($element);
+    $this->elementCaches->expects('invalidateForElement')->with($element);
 
     $this->action->propagateElements($query);
 
@@ -249,16 +236,9 @@ it('filters requested site ids and skips the source site and newer localized ele
     $query = createQueryMock([$element]);
     $newerSiteElement = createElement(200, 3, new DateTime('2026-04-02 12:00:00'));
 
-    $this->elements
-        ->shouldReceive('getElementById')
-        ->once()
-        ->with(200, TestPropagateElementsActionElement::class, 3)
-        ->andReturn($newerSiteElement);
+    $this->elements->expects('getElementById')->with(200, TestPropagateElementsActionElement::class, 3)->returns($newerSiteElement);
 
-    $this->elementCaches
-        ->shouldReceive('invalidateForElement')
-        ->once()
-        ->with($element);
+    $this->elementCaches->expects('invalidateForElement')->with($element);
 
     $this->action->propagateElements($query, [1, 3, 99]);
 
@@ -273,16 +253,11 @@ it('rethrows propagation errors when continueOnError is false', function () {
     $query = createQueryMock([$element]);
     $exception = new RuntimeException('Propagation failed.');
 
-    $this->elements
-        ->shouldReceive('getElementById')
-        ->once()
-        ->with(300, TestPropagateElementsActionElement::class, 2)
-        ->andReturnNull();
+    $this->elements->expects('getElementById')->with(300, TestPropagateElementsActionElement::class, 2)->returns(null);
 
     $this->writes->exceptionToThrow = $exception;
 
-    $this->elementCaches
-        ->shouldNotReceive('invalidateForElement');
+    $this->elementCaches->expects('invalidateForElement')->never();
 
     expect(fn () => $this->action->propagateElements($query, 2))
         ->toThrow($exception);
@@ -301,18 +276,11 @@ it('continues after propagation errors when continueOnError is true', function (
     $query = createQueryMock([$element]);
     $exception = new RuntimeException('Propagation failed.');
 
-    $this->elements
-        ->shouldReceive('getElementById')
-        ->once()
-        ->with(400, TestPropagateElementsActionElement::class, 2)
-        ->andReturnNull();
+    $this->elements->expects('getElementById')->with(400, TestPropagateElementsActionElement::class, 2)->returns(null);
 
     $this->writes->exceptionToThrow = $exception;
 
-    $this->elementCaches
-        ->shouldReceive('invalidateForElement')
-        ->once()
-        ->with($element);
+    $this->elementCaches->expects('invalidateForElement')->with($element);
 
     $this->action->propagateElements($query, 2, true);
 
@@ -330,12 +298,9 @@ it('swallows aborted queries and still dispatches the final event', function () 
     Event::fake([ElementsPropagating::class, ElementsPropagated::class]);
 
     $query = Double::for(ElementQueryInterface::class);
-    $query->shouldReceive('cursor')
-        ->once()
-        ->andThrow(new QueryAbortedException);
+    $query->expects('cursor')->throws(new QueryAbortedException);
 
-    $this->elementCaches
-        ->shouldNotReceive('invalidateForElement');
+    $this->elementCaches->expects('invalidateForElement')->never();
 
     $this->action->propagateElements($query);
 

--- a/tests/Unit/Element/ElementWrites/ResaveElementsTest.php
+++ b/tests/Unit/Element/ElementWrites/ResaveElementsTest.php
@@ -188,9 +188,7 @@ it('fails silently when the query aborts', function () {
 function mockResaveQuery(array $elements): ElementQueryInterface
 {
     $query = Double::for(ElementQueryInterface::class);
-    $query->shouldReceive('cursor')
-        ->once()
-        ->andReturn(LazyCollection::make(fn () => yield from $elements));
+    $query->expects('cursor')->returns(LazyCollection::make(fn () => yield from $elements));
 
     return $query;
 }
@@ -198,9 +196,7 @@ function mockResaveQuery(array $elements): ElementQueryInterface
 function mockAbortedResaveQuery(): ElementQueryInterface
 {
     $query = Double::for(ElementQueryInterface::class);
-    $query->shouldReceive('cursor')
-        ->once()
-        ->andThrow(new QueryAbortedException);
+    $query->expects('cursor')->throws(new QueryAbortedException);
 
     return $query;
 }

--- a/tests/Unit/Element/ElementWrites/ResaveElementsTest.php
+++ b/tests/Unit/Element/ElementWrites/ResaveElementsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Element\BulkOp\BulkOps as BulkOpsService;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Element\Contracts\NestedElementInterface;
@@ -36,11 +37,11 @@ beforeEach(function () {
     app(BulkOpsService::class)->resume('test-bulk-op');
 
     $this->action = new TestResaveElementWrites(
-        Mockery::mock(Elements::class),
-        Mockery::mock(ElementUris::class),
-        Mockery::mock(ElementCaches::class),
-        Mockery::mock(Search::class),
-        Mockery::mock(Sites::class),
+        Double::for(Elements::class),
+        Double::for(ElementUris::class),
+        Double::for(ElementCaches::class),
+        Double::for(Search::class),
+        Double::for(Sites::class),
     );
     $this->saveElementAction = $this->action;
 });
@@ -186,7 +187,7 @@ it('fails silently when the query aborts', function () {
 
 function mockResaveQuery(array $elements): ElementQueryInterface
 {
-    $query = Mockery::mock(ElementQueryInterface::class);
+    $query = Double::for(ElementQueryInterface::class);
     $query->shouldReceive('cursor')
         ->once()
         ->andReturn(LazyCollection::make(fn () => yield from $elements));
@@ -196,7 +197,7 @@ function mockResaveQuery(array $elements): ElementQueryInterface
 
 function mockAbortedResaveQuery(): ElementQueryInterface
 {
-    $query = Mockery::mock(ElementQueryInterface::class);
+    $query = Double::for(ElementQueryInterface::class);
     $query->shouldReceive('cursor')
         ->once()
         ->andThrow(new QueryAbortedException);

--- a/tests/Unit/FieldLayout/NativeFieldsTest.php
+++ b/tests/Unit/FieldLayout/NativeFieldsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\FieldLayout\FieldLayout;
 use CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField;
 use CraftCms\Cms\FieldLayout\NativeFields;
@@ -15,7 +16,7 @@ it('applies native field providers', function () {
 });
 
 it('resolves provider dependencies from the current scope with contextual arguments', function () {
-    app()->scoped(Sites::class, fn () => Mockery::mock(Sites::class));
+    app()->scoped(Sites::class, fn () => Double::for(Sites::class));
 
     $registry = app(NativeFields::class);
     $registry->remove('craft');

--- a/tests/Unit/Http/Middleware/UseWriteConnectionTest.php
+++ b/tests/Unit/Http/Middleware/UseWriteConnectionTest.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\DB;
 
 it('uses the write connection for unsafe requests', function (string $method) {
     $db = Double::for(Connection::class);
-    $db->expects('useWriteConnectionWhenReading')->with(true)->once()->andReturnSelf();
+    $db->expects('useWriteConnectionWhenReading')->with(true)->returns($db);
     $request = Request::create('/articles', $method);
 
     $response = new UseWriteConnection($db)->handle($request, fn () => 'response');
@@ -25,7 +25,7 @@ it('uses the write connection for unsafe requests', function (string $method) {
 
 it('keeps safe requests on the read connection', function (string $method) {
     $db = Double::for(Connection::class);
-    $db->expects('useWriteConnectionWhenReading')->with(false)->once()->andReturnSelf();
+    $db->expects('useWriteConnectionWhenReading')->with(false)->returns($db);
     $request = Request::create('/articles', $method);
 
     $response = new UseWriteConnection($db)->handle($request, fn () => 'response');
@@ -35,7 +35,7 @@ it('keeps safe requests on the read connection', function (string $method) {
 
 it('keeps read-only controller actions on the read connection', function (string $controller, string $method) {
     $db = Double::for(Connection::class);
-    $db->expects('useWriteConnectionWhenReading')->with(false)->once()->andReturnSelf();
+    $db->expects('useWriteConnectionWhenReading')->with(false)->returns($db);
     $request = Request::create('/renamed-endpoint', 'POST');
     $route = new Route(['POST'], '/renamed-endpoint', $method === '__invoke' ? $controller : [$controller, $method]);
     $request->setRouteResolver(fn () => $route);

--- a/tests/Unit/Http/Middleware/UseWriteConnectionTest.php
+++ b/tests/Unit/Http/Middleware/UseWriteConnectionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ElementIndexController;
 use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ElementIndexSourcesController;
 use CraftCms\Cms\Http\Controllers\Elements\ElementIndex\ExportElementIndexController;
@@ -13,7 +14,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\DB;
 
 it('uses the write connection for unsafe requests', function (string $method) {
-    $db = Mockery::mock(Connection::class);
+    $db = Double::for(Connection::class);
     $db->expects('useWriteConnectionWhenReading')->with(true)->once()->andReturnSelf();
     $request = Request::create('/articles', $method);
 
@@ -23,7 +24,7 @@ it('uses the write connection for unsafe requests', function (string $method) {
 })->with(['POST', 'PATCH', 'DELETE']);
 
 it('keeps safe requests on the read connection', function (string $method) {
-    $db = Mockery::mock(Connection::class);
+    $db = Double::for(Connection::class);
     $db->expects('useWriteConnectionWhenReading')->with(false)->once()->andReturnSelf();
     $request = Request::create('/articles', $method);
 
@@ -33,7 +34,7 @@ it('keeps safe requests on the read connection', function (string $method) {
 })->with(['GET', 'HEAD']);
 
 it('keeps read-only controller actions on the read connection', function (string $controller, string $method) {
-    $db = Mockery::mock(Connection::class);
+    $db = Double::for(Connection::class);
     $db->expects('useWriteConnectionWhenReading')->with(false)->once()->andReturnSelf();
     $request = Request::create('/renamed-endpoint', 'POST');
     $route = new Route(['POST'], '/renamed-endpoint', $method === '__invoke' ? $controller : [$controller, $method]);

--- a/tests/Unit/Image/ImageTransformHelperTest.php
+++ b/tests/Unit/Image/ImageTransformHelperTest.php
@@ -564,9 +564,7 @@ describe('normalizeTransform', function () {
 
     test('throws for invalid string handle', function () {
         $this->mock(ImageTransforms::class, function ($mock) {
-            $mock->shouldReceive('getTransformByHandle')
-                ->with('nonExistent')
-                ->andReturn(null);
+            $mock->allows('getTransformByHandle')->with('nonExistent')->returns(null);
         });
 
         ImageTransformHelper::normalizeTransform('nonExistent');
@@ -576,9 +574,7 @@ describe('normalizeTransform', function () {
         $transform = new ImageTransform(['handle' => 'myHandle', 'width' => 500]);
 
         $this->mock(ImageTransforms::class, function ($mock) use ($transform) {
-            $mock->shouldReceive('getTransformByHandle')
-                ->with('myHandle')
-                ->andReturn($transform);
+            $mock->allows('getTransformByHandle')->with('myHandle')->returns($transform);
         });
 
         $result = ImageTransformHelper::normalizeTransform($handleInput);

--- a/tests/Unit/Twig/Tags/DeprecatedTagTest.php
+++ b/tests/Unit/Twig/Tags/DeprecatedTagTest.php
@@ -35,7 +35,7 @@ it('logs a deprecation warning and continues rendering', function () {
 it('continues rendering after the deprecation tag', function () {
     // Suppress the deprecation log by using a no-op mock
     $mock = Double::for(Deprecator::class);
-    $mock->shouldReceive('log');
+    $mock->allows('log');
     app()->scoped(Deprecator::class, fn () => $mock);
 
     $result = $this->manager->renderString(

--- a/tests/Unit/Twig/Tags/DeprecatedTagTest.php
+++ b/tests/Unit/Twig/Tags/DeprecatedTagTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Deprecator\Deprecator;
 use CraftCms\Cms\View\TemplateManager;
 
@@ -12,7 +13,7 @@ beforeEach(function () {
 it('logs a deprecation warning and continues rendering', function () {
     $logged = false;
 
-    $mock = Mockery::mock(Deprecator::class);
+    $mock = Double::for(Deprecator::class);
     $mock->shouldReceive('log')
         ->once()
         ->withArgs(function (string $key, string $message) use (&$logged) {
@@ -33,7 +34,7 @@ it('logs a deprecation warning and continues rendering', function () {
 
 it('continues rendering after the deprecation tag', function () {
     // Suppress the deprecation log by using a no-op mock
-    $mock = Mockery::mock(Deprecator::class);
+    $mock = Double::for(Deprecator::class);
     $mock->shouldReceive('log');
     app()->scoped(Deprecator::class, fn () => $mock);
 

--- a/tests/Unit/Twig/TemplateLoaderTest.php
+++ b/tests/Unit/Twig/TemplateLoaderTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Aliases\Aliases;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Support\File as Path;
@@ -117,7 +118,7 @@ describe('isFresh', function () {
         // Make request()->isCpRequest() return true
         Cms::config()->cpTrigger = '';
 
-        $updates = Mockery::mock(Updates::class);
+        $updates = Double::for(Updates::class);
         $updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
         app()->instance(Updates::class, $updates);
 
@@ -131,7 +132,7 @@ describe('isFresh', function () {
         // Make request()->isCpRequest() return true
         Cms::config()->cpTrigger = '';
 
-        $updates = Mockery::mock(Updates::class);
+        $updates = Double::for(Updates::class);
         $updates->shouldReceive('isCraftUpdatePending')->andReturn(false);
         app()->instance(Updates::class, $updates);
 
@@ -146,7 +147,7 @@ describe('isFresh', function () {
 
         // Even if an update is pending, site requests should not force recompile
         // The Updates mock should NOT be called
-        $updates = Mockery::mock(Updates::class);
+        $updates = Double::for(Updates::class);
         $updates->shouldNotReceive('isCraftUpdatePending');
         app()->instance(Updates::class, $updates);
 

--- a/tests/Unit/Twig/TemplateLoaderTest.php
+++ b/tests/Unit/Twig/TemplateLoaderTest.php
@@ -119,7 +119,7 @@ describe('isFresh', function () {
         Cms::config()->cpTrigger = '';
 
         $updates = Double::for(Updates::class);
-        $updates->shouldReceive('isCraftUpdatePending')->andReturn(true);
+        $updates->allows('isCraftUpdatePending')->returns(true);
         app()->instance(Updates::class, $updates);
 
         expect($this->loader->isFresh('update-check', time() + 3600))->toBeFalse();
@@ -133,7 +133,7 @@ describe('isFresh', function () {
         Cms::config()->cpTrigger = '';
 
         $updates = Double::for(Updates::class);
-        $updates->shouldReceive('isCraftUpdatePending')->andReturn(false);
+        $updates->allows('isCraftUpdatePending')->returns(false);
         app()->instance(Updates::class, $updates);
 
         expect($this->loader->isFresh('no-update', time() + 3600))->toBeTrue();
@@ -148,7 +148,7 @@ describe('isFresh', function () {
         // Even if an update is pending, site requests should not force recompile
         // The Updates mock should NOT be called
         $updates = Double::for(Updates::class);
-        $updates->shouldNotReceive('isCraftUpdatePending');
+        $updates->expects('isCraftUpdatePending')->never();
         app()->instance(Updates::class, $updates);
 
         expect($this->loader->isFresh('site-fresh', time() + 3600))->toBeTrue();

--- a/tests/Unit/Twig/Templates/LightswitchTemplateTest.php
+++ b/tests/Unit/Twig/Templates/LightswitchTemplateTest.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Deprecator\Deprecator;
 use CraftCms\Cms\View\TemplateMode;
 
 use function CraftCms\Cms\renderString;
 
 it('renders the web component from the legacy variable API', function () {
-    $mock = Mockery::mock(Deprecator::class);
+    $mock = Double::for(Deprecator::class);
     $mock->shouldNotReceive('log');
     app()->scoped(Deprecator::class, fn () => $mock);
 
@@ -25,7 +26,7 @@ it('renders the web component from the legacy variable API', function () {
 it('logs a deprecation for the unsupported descriptionId param', function () {
     $logged = false;
 
-    $mock = Mockery::mock(Deprecator::class);
+    $mock = Double::for(Deprecator::class);
     $mock->shouldReceive('log')
         ->once()
         ->withArgs(function (string $key, string $message) use (&$logged) {

--- a/tests/Unit/Twig/Templates/LightswitchTemplateTest.php
+++ b/tests/Unit/Twig/Templates/LightswitchTemplateTest.php
@@ -10,7 +10,7 @@ use function CraftCms\Cms\renderString;
 
 it('renders the web component from the legacy variable API', function () {
     $mock = Double::for(Deprecator::class);
-    $mock->shouldNotReceive('log');
+    $mock->expects('log')->never();
     app()->scoped(Deprecator::class, fn () => $mock);
 
     $html = renderString(

--- a/tests/Unit/View/TemplateManagerLifecycleTest.php
+++ b/tests/Unit/View/TemplateManagerLifecycleTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Twig\Events\PageEnded;
 use CraftCms\Cms\Twig\Events\PageStarting;
 use CraftCms\Cms\Twig\Exceptions\TemplateExitException;
@@ -55,7 +56,7 @@ beforeEach(function () {
     TemplateMode::set(TemplateMode::Site);
     app()->forgetScopedInstances();
 
-    $this->resolver = Mockery::mock(TemplateResolver::class);
+    $this->resolver = Double::for(TemplateResolver::class);
     $this->resolver->shouldReceive('resolve')->byDefault()->andReturn('/tmp/example.test');
     $this->renderer = new TemplateManagerLifecycleTestRenderer;
     $this->manager = new TemplateManager(app(), $this->resolver, app(PageLifecycle::class));

--- a/tests/Unit/View/TemplateManagerLifecycleTest.php
+++ b/tests/Unit/View/TemplateManagerLifecycleTest.php
@@ -57,7 +57,7 @@ beforeEach(function () {
     app()->forgetScopedInstances();
 
     $this->resolver = Double::for(TemplateResolver::class);
-    $this->resolver->shouldReceive('resolve')->byDefault()->andReturn('/tmp/example.test');
+    $this->resolver->allows('resolve')->returns('/tmp/example.test');
     $this->renderer = new TemplateManagerLifecycleTestRenderer;
     $this->manager = new TemplateManager(app(), $this->resolver, app(PageLifecycle::class));
     $renderer = $this->renderer;
@@ -97,11 +97,7 @@ it('allows template events to mutate input and output', function () {
         $event->templateMode = TemplateMode::Cp;
     });
 
-    $this->resolver
-        ->shouldReceive('resolve')
-        ->once()
-        ->with('mutated', TemplateMode::Cp, false)
-        ->andReturn('/tmp/mutated.test');
+    $this->resolver->expects('resolve')->with('mutated', TemplateMode::Cp, false)->returns('/tmp/mutated.test');
 
     Event::listen(TemplateRendered::class, function (TemplateRendered $event) {
         $event->output = strtoupper($event->output);
@@ -116,7 +112,7 @@ it('allows before events to cancel before template resolution', function () {
         $event->isValid = false;
     });
 
-    $this->resolver->shouldNotReceive('resolve');
+    $this->resolver->expects('resolve')->never();
 
     expect($this->manager->renderTemplate('example', ['value' => 'test'], renderer: 'test'))
         ->toBe('');
@@ -208,7 +204,7 @@ it('returns empty output when page rendering is cancelled', function () {
         $event->isValid = false;
     });
 
-    $this->resolver->shouldNotReceive('resolve');
+    $this->resolver->expects('resolve')->never();
 
     expect($this->manager->renderPageTemplate('example', ['value' => 'test'], renderer: 'test'))
         ->toBe('');
@@ -223,7 +219,7 @@ it('reports the requested renderer when inner template rendering is cancelled', 
         expect($event->rendererName)->toBe('test');
     });
 
-    $this->resolver->shouldNotReceive('resolve');
+    $this->resolver->expects('resolve')->never();
 
     expect($this->manager->renderPageTemplate('example', renderer: 'test'))->toBe('');
 });

--- a/tests/Unit/View/TemplateManagerTest.php
+++ b/tests/Unit/View/TemplateManagerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use JMac\Testing\Double;
 use CraftCms\Cms\Blade\BladeRenderer;
 use CraftCms\Cms\Twig\Contracts\TwigRendererInterface;
 use CraftCms\Cms\Twig\Exceptions\TemplateLoaderException;
@@ -113,7 +114,7 @@ beforeEach(function () {
     TemplateMode::set(TemplateMode::Site);
     app()->forgetScopedInstances();
 
-    $this->resolver = Mockery::mock(TemplateResolver::class);
+    $this->resolver = Double::for(TemplateResolver::class);
     $this->manager = new TemplateManager(app(), $this->resolver, app(PageLifecycle::class));
 });
 

--- a/tests/Unit/View/TemplateManagerTest.php
+++ b/tests/Unit/View/TemplateManagerTest.php
@@ -178,11 +178,7 @@ it('selects the first supporting renderer and appends custom renderers', functio
     $this->manager->extend('first', static fn () => $first);
     $this->manager->extend('second', static fn () => $second);
 
-    $this->resolver
-        ->shouldReceive('resolve')
-        ->once()
-        ->with('example', TemplateMode::Cp, false)
-        ->andReturn('/tmp/example.custom');
+    $this->resolver->expects('resolve')->with('example', TemplateMode::Cp, false)->returns('/tmp/example.custom');
 
     expect($this->manager->renderTemplate('example', ['value' => 'test'], TemplateMode::Cp))
         ->toBe('first')
@@ -200,7 +196,7 @@ it('keeps a replaced renderer in its existing automatic-selection position', fun
     $this->manager->extend('second', static fn () => $second);
     $this->manager->extend('first', static fn () => $replacement);
 
-    $this->resolver->shouldReceive('resolve')->andReturn('/tmp/example.custom');
+    $this->resolver->allows('resolve')->returns('/tmp/example.custom');
 
     expect($this->manager->renderTemplate('example'))->toBe('replacement');
 });
@@ -208,7 +204,7 @@ it('keeps a replaced renderer in its existing automatic-selection position', fun
 it('falls back to Twig for unmatched configured extensions', function () {
     $twig = new TemplateManagerTestTwigRenderer([], 'twig-fallback');
     $this->manager->extend(TemplateEngine::Twig, static fn () => $twig);
-    $this->resolver->shouldReceive('resolve')->andReturn('/tmp/example.txt');
+    $this->resolver->allows('resolve')->returns('/tmp/example.txt');
 
     expect($this->manager->renderTemplate('example'))->toBe('twig-fallback');
 });
@@ -216,7 +212,7 @@ it('falls back to Twig for unmatched configured extensions', function () {
 it('honors an explicitly requested renderer without requiring supports', function () {
     $renderer = new TemplateManagerTestRenderer([], 'explicit');
     $this->manager->extend('custom', static fn () => $renderer);
-    $this->resolver->shouldReceive('resolve')->andReturn('/tmp/example.twig');
+    $this->resolver->allows('resolve')->returns('/tmp/example.twig');
 
     expect($this->manager->renderTemplate('example', renderer: 'custom'))->toBe('explicit');
 });
@@ -232,11 +228,7 @@ it('selects the renderer after before-event template mutation', function () {
         $event->template = 'mutated';
     });
 
-    $this->resolver
-        ->shouldReceive('resolve')
-        ->once()
-        ->with('mutated', TemplateMode::Site, false)
-        ->andReturn('/tmp/mutated.blade.php');
+    $this->resolver->expects('resolve')->with('mutated', TemplateMode::Site, false)->returns('/tmp/mutated.blade.php');
 
     $renderedRendererName = null;
     Event::listen(TemplateRendered::class, function (TemplateRendered $event) use (&$renderedRendererName) {
@@ -248,11 +240,7 @@ it('selects the renderer after before-event template mutation', function () {
 });
 
 it('throws a template loader exception for missing templates', function () {
-    $this->resolver
-        ->shouldReceive('resolve')
-        ->once()
-        ->with('missing/template', TemplateMode::Cp, false)
-        ->andReturnFalse();
+    $this->resolver->expects('resolve')->with('missing/template', TemplateMode::Cp, false)->returns(false);
 
     expect(fn () => $this->manager->renderTemplate('missing/template', templateMode: TemplateMode::Cp))
         ->toThrow(TemplateLoaderException::class);
@@ -261,11 +249,7 @@ it('throws a template loader exception for missing templates', function () {
 it('passes public-only resolution through unchanged', function () {
     $renderer = new TemplateManagerTestRenderer(['/tmp/example.custom'], 'public');
     $this->manager->extend('custom', static fn () => $renderer);
-    $this->resolver
-        ->shouldReceive('resolve')
-        ->once()
-        ->with('example', TemplateMode::Site, true)
-        ->andReturn('/tmp/example.custom');
+    $this->resolver->expects('resolve')->with('example', TemplateMode::Site, true)->returns('/tmp/example.custom');
 
     expect($this->manager->renderTemplate('example', publicOnly: true))->toBe('public');
 });


### PR DESCRIPTION
This pull request contains changes for converting your test suite from Mockery to [Double](https://testdoublephp.com) automated by the [Double Converter](https://laravelshift.com/mockery-to-test-double-converter).

**Before merging**, you need to:

- Checkout the `shift-178966` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install the double package with your dependencies
- Run your test suite to verify the conversion
