### PR TITLE
Allow safe HTML in Markdown field layout elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Safe HTML elements are now allowed within Markdown field layout elements. ([#19426](https://github.com/craftcms/cms/pull/19426))
 - Added a slideout system for the Inertia/Vue Control Panel, which renders any `CpScreenResponse`-based screen as an in-page panel from a normal Inertia response, alongside the existing legacy `Craft.CpScreenSlideout`. ([#19354](https://github.com/craftcms/cms/pull/19354))
 - Added `CraftCms\Cms\Http\Responses\CpScreenResponse::screenData()`. ([#19354](https://github.com/craftcms/cms/pull/19354))
 - Removed the `Pane.vue` Vue component in favor of the `craft-pane` web component. ([#19398](https://github.com/craftcms/cms/pull/19398))

--- a/src/Form/Nodes/MarkdownContent.php
+++ b/src/Form/Nodes/MarkdownContent.php
@@ -9,6 +9,7 @@ use CraftCms\Cms\Form\Contracts\Node;
 use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
+use CraftCms\Cms\Support\Facades\HtmlSanitizers;
 use CraftCms\Cms\Support\Facades\Markdown;
 use CraftCms\Cms\Support\Html;
 
@@ -39,7 +40,7 @@ class MarkdownContent implements Node
     {
         return new self(
             $uid,
-            Markdown::parse(Html::encode($content), 'pre-encoded'),
+            HtmlSanitizers::sanitize(Markdown::parse($content)),
         );
     }
 

--- a/tests/Feature/FieldLayout/FieldLayoutCompilerTest.php
+++ b/tests/Feature/FieldLayout/FieldLayoutCompilerTest.php
@@ -57,7 +57,7 @@ function persistedEntryLayout(): FieldLayoutModel
             ]),
             new Markdown([
                 'uid' => 'content-note',
-                'content' => '<script>alert(1)</script> **Editorial note**',
+                'content' => "<script>alert(1)</script>\n\n**Editorial note**",
                 'displayInPane' => false,
                 'width' => 50,
             ]),
@@ -123,8 +123,8 @@ it('compiles persisted entry layout intent into a form payload', function () {
             'width' => 50,
         ])
         ->and($content->filter('script'))->toHaveCount(0)
+        ->and($content->text())->not->toContain('alert(1)')
         ->and($content->filter('strong')->text())->toBe('Editorial note')
-        ->and($content->text())->toContain('<script>alert(1)</script>')
         ->and($payload->values)->toBe(['title' => 'Persisted title'])
         ->and($payload->errors)->toBe([[
             'path' => ['title'],


### PR DESCRIPTION
### Description

Updates `CraftCms\Cms\Form\Nodes\MarkdownContent` to HTML-purify the configured content, rather than encode it.

Makes it possible to create detail disclosure elements, for example.

```markdown
## This is a heading

<details>
<summary>Details</summary>

Disclosure paragraph.

</details>
```

### Related issues

- #19424