### PR TITLE
[6.x] Fix stuck sync queue progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fixed a JavaScript error that occurred on non-Inertial pages that rendered field layout designers. ([#19380](https://github.com/craftcms/cms/discussions/19380))
 - Fixed a bug where Yii asset bundles registered with `craft\web\View::registerAssetBundle()` during plugin initialization were not included in rendered pages. ([#19393](https://github.com/craftcms/cms/pull/19393))
 - Fixed a bug where legacy asset bundle dependencies could be rendered after their dependent resources when using `craftcms/yii2-adapter`. ([#19394](https://github.com/craftcms/cms/pull/19394))
-- Fixed a bug where jobs run on the sync queue could remain marked as reserved after completing.
+- Fixed a bug where jobs run on the sync queue could remain marked as reserved after completing. ([#19431](https://github.com/craftcms/cms/pull/19431))
 
 ## 6.0.0-alpha.16 - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a JavaScript error that occurred on non-Inertial pages that rendered field layout designers. ([#19380](https://github.com/craftcms/cms/discussions/19380))
 - Fixed a bug where Yii asset bundles registered with `craft\web\View::registerAssetBundle()` during plugin initialization were not included in rendered pages. ([#19393](https://github.com/craftcms/cms/pull/19393))
 - Fixed a bug where legacy asset bundle dependencies could be rendered after their dependent resources when using `craftcms/yii2-adapter`. ([#19394](https://github.com/craftcms/cms/pull/19394))
+- Fixed a bug where jobs run on the sync queue could remain marked as reserved after completing.
 
 ## 6.0.0-alpha.16 - 2026-08-05
 

--- a/src/Queue/Listeners/ProgressListener.php
+++ b/src/Queue/Listeners/ProgressListener.php
@@ -20,7 +20,7 @@ abstract readonly class ProgressListener
     {
         $defaultQueueName = Queue::getConfig()['queue'] ?? $this->generalConfig->queueName;
 
-        return in_array($queueName ?? $defaultQueueName, $this->generalConfig->trackedQueueNames, true);
+        return in_array($queueName === 'sync' ? $defaultQueueName : $queueName ?? $defaultQueueName, $this->generalConfig->trackedQueueNames, true);
     }
 
     /**

--- a/src/Queue/Listeners/StoreCompleted.php
+++ b/src/Queue/Listeners/StoreCompleted.php
@@ -10,13 +10,15 @@ readonly class StoreCompleted extends ProgressListener
 {
     public function handle(JobProcessed $event): void
     {
-        if (! $this->shouldTrackQueue($event->job->getQueue())) {
+        $queue = $event->job->getQueue();
+
+        if (! $this->shouldTrackQueue($queue)) {
             return;
         }
 
         $uuid = $this->jobUuid($event->job->payload());
 
-        if ($uuid === null) {
+        if ($uuid === null || ($queue === 'sync' && ! $this->progress->exists($uuid))) {
             return;
         }
 

--- a/src/Queue/Listeners/StoreFailed.php
+++ b/src/Queue/Listeners/StoreFailed.php
@@ -10,13 +10,15 @@ readonly class StoreFailed extends ProgressListener
 {
     public function handle(JobFailed $event): void
     {
-        if (! $this->shouldTrackQueue($event->job->getQueue())) {
+        $queue = $event->job->getQueue();
+
+        if (! $this->shouldTrackQueue($queue)) {
             return;
         }
 
         $uuid = $this->jobUuid($event->job->payload());
 
-        if ($uuid === null) {
+        if ($uuid === null || ($queue === 'sync' && ! $this->progress->exists($uuid))) {
             return;
         }
 

--- a/src/Queue/Listeners/StoreReserved.php
+++ b/src/Queue/Listeners/StoreReserved.php
@@ -10,13 +10,15 @@ readonly class StoreReserved extends ProgressListener
 {
     public function handle(JobProcessing $event): void
     {
-        if (! $this->shouldTrackQueue($event->job->getQueue())) {
+        $queue = $event->job->getQueue();
+
+        if (! $this->shouldTrackQueue($queue)) {
             return;
         }
 
         $uuid = $this->jobUuid($event->job->payload());
 
-        if ($uuid === null) {
+        if ($uuid === null || ($queue === 'sync' && ! $this->progress->exists($uuid))) {
             return;
         }
 

--- a/tests/Feature/Queue/QueueServiceProviderTest.php
+++ b/tests/Feature/Queue/QueueServiceProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Queue\Enums\JobStatus;
+use CraftCms\Cms\Queue\Job;
 use CraftCms\Cms\Queue\JobProgress;
 use CraftCms\Cms\Queue\QueueServiceProvider;
 use Illuminate\Queue\Events\JobFailed;
@@ -71,6 +72,14 @@ it('tracks failed jobs with error message', function () {
         ->not->toBeNull()
         ->status->toBe(JobStatus::Failed)
         ->error->toBe('Test failure');
+});
+
+it('marks sync jobs as completed', function () {
+    dispatch(new SyncProgressJob);
+
+    $progress = app(JobProgress::class)->getAll()->firstWhere('description', SyncProgressJob::class);
+
+    expect($progress?->status)->toBe(JobStatus::Done);
 });
 
 it('handles jobs without uuid method gracefully', function () {
@@ -164,3 +173,11 @@ it('does not track jobs on non-tracked queues', function () {
     // Progress should still exist because the queue is not tracked
     expect($progressService->getProgress($uid))->not->toBeNull();
 });
+
+class SyncProgressJob extends Job
+{
+    public function handle(): void
+    {
+        $this->setProgress(50);
+    }
+}


### PR DESCRIPTION
### Description

Fixes sync queue jobs remaining marked as reserved after completing. Sync lifecycle events now resolve the configured default queue while only updating jobs that already have progress records.