### PR TITLE
[6.x] Fix Addresses fields not reading the posted form value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fixed a bug where Yii asset bundles registered with `craft\web\View::registerAssetBundle()` during plugin initialization were not included in rendered pages. ([#19393](https://github.com/craftcms/cms/pull/19393))
 - Fixed a bug where legacy asset bundle dependencies could be rendered after their dependent resources when using `craftcms/yii2-adapter`. ([#19394](https://github.com/craftcms/cms/pull/19394))
 - Fixed a bug where jobs run on the sync queue could remain marked as reserved after completing. ([#19431](https://github.com/craftcms/cms/pull/19431))
-- Fixed a bug where Addresses fields weren’t reading the value posted by the Control Panel form, so removing every address didn’t stick and blank addresses could be created.
+- Fixed a bug where Addresses fields weren’t reading the value posted by the Control Panel form, so removing every address didn’t stick and blank addresses could be created. ([#19432](https://github.com/craftcms/cms/pull/19432))
 
 ## 6.0.0-alpha.16 - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed a bug where Yii asset bundles registered with `craft\web\View::registerAssetBundle()` during plugin initialization were not included in rendered pages. ([#19393](https://github.com/craftcms/cms/pull/19393))
 - Fixed a bug where legacy asset bundle dependencies could be rendered after their dependent resources when using `craftcms/yii2-adapter`. ([#19394](https://github.com/craftcms/cms/pull/19394))
 - Fixed a bug where jobs run on the sync queue could remain marked as reserved after completing. ([#19431](https://github.com/craftcms/cms/pull/19431))
+- Fixed a bug where Addresses fields weren’t reading the value posted by the Control Panel form, so removing every address didn’t stick and blank addresses could be created.
 
 ## 6.0.0-alpha.16 - 2026-08-05
 

--- a/src/Field/Addresses.php
+++ b/src/Field/Addresses.php
@@ -396,7 +396,11 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
 
         // Set the initially matched elements if $value is already set, which is the case if there was a validation
         // error or we're loading an entry revision.
-        if ($value === '') {
+        // An empty POST value means every address was removed. It arrives as
+        // null rather than '' because of Laravel's ConvertEmptyStringsToNull
+        // middleware — and delta ensures the value is only applied from the
+        // request when the field was actually modified.
+        if ($value === '' || ($fromRequest && $value === null)) {
             $query->setResultOverride([]);
         } elseif ($value === '*') {
             // preload the nested entries so NestedElementManager::saveNestedElements() doesn't resave them all
@@ -417,6 +421,37 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
      */
     private function createAddressesFromSerializedData(array $value, ElementInterface $element, bool $fromRequest): array
     {
+        // Was the value posted in the new (delta) format?
+        $delta = isset($value['entries']) || isset($value['blocks']) || isset($value['sortOrder']);
+
+        if ($delta) {
+            $newAddressData = $value['entries'] ?? $value['blocks'] ?? [];
+            $newSortOrder = $value['sortOrder'] ?? null;
+
+            // Were the addresses posted by UUID or ID?
+            $firstKey = (string) array_key_first($newAddressData);
+            $firstSortOrder = $newSortOrder !== null ? (string) reset($newSortOrder) : '';
+            $uids = (
+                str_starts_with($firstKey, 'uid:') ||
+                str_starts_with($firstSortOrder, 'uid:') ||
+                Str::isUuid($firstKey) ||
+                Str::isUuid($firstSortOrder)
+            );
+
+            if ($uids) {
+                // Strip out the `uid:` key prefixes. New addresses are posted with them; addresses
+                // that were already on the element aren't, so both need to be normalized.
+                $newAddressData = array_combine(
+                    array_map(fn (string $key) => Str::chopStart($key, 'uid:'), array_keys($newAddressData)),
+                    array_values($newAddressData),
+                );
+            }
+        } else {
+            $uids = false;
+            $newAddressData = $value;
+            $newSortOrder = array_keys($value);
+        }
+
         // Get the old addresses
         if ($element->id) {
             /** @var Address[] $oldAddressesById */
@@ -426,10 +461,38 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
                 ->drafts(null)
                 ->revisions(null)
                 ->status(null)
-                ->indexBy('id')
+                ->get()
+                ->keyBy($uids ? 'uid' : 'id')
                 ->all();
         } else {
             $oldAddressesById = [];
+        }
+
+        // Fall back to the addresses' current order if only their data was posted
+        $newSortOrder ??= array_keys($oldAddressesById);
+
+        // Map the canonical addresses' UUIDs to the derivatives', in case the data was posted
+        // with them (which is the case for the first save after a draft was created)
+        $canonicalUidMap = [];
+
+        if ($uids) {
+            $derivativeIds = [];
+
+            foreach ($oldAddressesById as $uid => $address) {
+                if ($address->getIsDerivative()) {
+                    $derivativeIds[$address->getCanonicalId()] = $uid;
+                }
+            }
+
+            if ($derivativeIds !== []) {
+                $canonicalUids = DB::table(DbTable::ELEMENTS)
+                    ->whereIn('id', array_keys($derivativeIds))
+                    ->pluck('uid', 'id');
+
+                foreach ($canonicalUids as $canonicalId => $canonicalUid) {
+                    $canonicalUidMap[$canonicalUid] = $derivativeIds[$canonicalId];
+                }
+            }
         }
 
         $addresses = [];
@@ -437,6 +500,10 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
 
         $fieldNamespace = $element->getFieldParamNamespace();
         $baseAddressFieldNamespace = $fieldNamespace ? "$fieldNamespace.$this->handle" : null;
+
+        if ($delta && $baseAddressFieldNamespace) {
+            $baseAddressFieldNamespace .= '.entries';
+        }
 
         $nativeFields = [
             'title',
@@ -458,7 +525,18 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
             'longitude',
         ];
 
-        foreach ($value as $addressId => $addressData) {
+        foreach ($newSortOrder as $postedAddressId) {
+            // New addresses are posted with a `uid:` key prefix; addresses that were already
+            // on the element aren't
+            $addressId = $uids ? Str::chopStart((string) $postedAddressId, 'uid:') : $postedAddressId;
+            $addressData = $newAddressData[$addressId] ?? [];
+
+            // If this is a preexisting address but we don't have a record of it,
+            // check to see if it was recently duplicated for a draft.
+            if (! isset($oldAddressesById[$addressId]) && isset($canonicalUidMap[$addressId])) {
+                $addressId = $canonicalUidMap[$addressId];
+            }
+
             // Existing address?
             if (isset($oldAddressesById[$addressId])) {
                 /** @var Address $address */
@@ -484,10 +562,20 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
                 $address->setPrimaryOwner($element);
                 $address->setOwner($element);
                 $address->siteId = $element->siteId;
+
+                // Use the provided UUID, so the address can persist across future autosaves
+                if ($uids) {
+                    $address->uid = $addressId;
+                }
             }
 
             if (isset($addressData['enabled'])) {
                 $address->enabled = (bool) $addressData['enabled'];
+            }
+
+            // The Address form control nests the address format fields under an `address` key
+            if (isset($addressData['address']) && is_array($addressData['address'])) {
+                $addressData += $addressData['address'];
             }
 
             foreach ($nativeFields as $field) {
@@ -500,7 +588,7 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
 
             // Set the content post location on the entry if we can
             if ($baseAddressFieldNamespace) {
-                $address->setFieldParamNamespace("$baseAddressFieldNamespace.$addressId.fields");
+                $address->setFieldParamNamespace("$baseAddressFieldNamespace.$postedAddressId.fields");
             }
 
             if (isset($addressData['fields'])) {

--- a/tests/Feature/Field/AddressesEmptyValueTest.php
+++ b/tests/Feature/Field/AddressesEmptyValueTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Field\Addresses;
+
+function addressesEmptyValueField(): array
+{
+    $result = EntryModel::factory()
+        ->withField('addressesField', Addresses::class, [], value: '')
+        ->createElementWithFields(save: false);
+
+    /** @var Addresses $field */
+    $field = $result->element->getFieldLayout()->getFieldByHandle('addressesField');
+
+    return [$field, $result->element];
+}
+
+test('an empty request value clears all addresses', function () {
+    [$field, $element] = addressesEmptyValueField();
+
+    // An empty POST value arrives as null (Laravel's ConvertEmptyStringsToNull
+    // middleware), and means every address was removed.
+    expect($field->normalizeValueFromRequest(null, $element)->getResultOverride())->toBe([])
+        ->and($field->normalizeValueFromRequest('', $element)->getResultOverride())->toBe([])
+        // Outside a request, null keeps lazy-loading the stored addresses.
+        ->and($field->normalizeValue(null, $element)->getResultOverride())->toBeNull();
+});
+
+test('an empty delta value clears all addresses', function () {
+    [$field, $element] = addressesEmptyValueField();
+
+    // What the Matrix form control posts once every address has been removed.
+    $value = ['entries' => [], 'sortOrder' => []];
+
+    expect($field->normalizeValueFromRequest($value, $element)->getResultOverride())->toBe([]);
+});
+
+test('delta values are keyed by UUID rather than treated as addresses', function () {
+    [$field, $element] = addressesEmptyValueField();
+
+    $uid = '369f71c3-873f-4842-8fe9-90641773b62b';
+
+    $value = [
+        'entries' => [
+            "uid:$uid" => [
+                'type' => 'address',
+                'countryCode' => 'US',
+                'title' => 'Home',
+                'address' => [
+                    'addressLine1' => '123 Fake St.',
+                    'locality' => 'Chicago',
+                    'administrativeArea' => 'IL',
+                    'postalCode' => '60641',
+                ],
+            ],
+        ],
+        'sortOrder' => ["uid:$uid"],
+    ];
+
+    $addresses = $field->normalizeValueFromRequest($value, $element)->getResultOverride();
+
+    expect($addresses)->toHaveCount(1)
+        ->and($addresses[0]->uid)->toBe($uid)
+        ->and($addresses[0]->title)->toBe('Home')
+        ->and($addresses[0]->countryCode)->toBe('US')
+        // The Address form control nests the address format fields under `address`
+        ->and($addresses[0]->addressLine1)->toBe('123 Fake St.')
+        ->and($addresses[0]->locality)->toBe('Chicago')
+        ->and($addresses[0]->administrativeArea)->toBe('IL')
+        ->and($addresses[0]->postalCode)->toBe('60641');
+});
+
+test('the legacy flat value format still creates addresses', function () {
+    [$field, $element] = addressesEmptyValueField();
+
+    $value = [
+        'new1' => [
+            'title' => 'Home',
+            'countryCode' => 'US',
+            'addressLine1' => '123 Fake St.',
+        ],
+    ];
+
+    $addresses = $field->normalizeValueFromRequest($value, $element)->getResultOverride();
+
+    expect($addresses)->toHaveCount(1)
+        ->and($addresses[0]->title)->toBe('Home')
+        ->and($addresses[0]->addressLine1)->toBe('123 Fake St.');
+});


### PR DESCRIPTION
### Description

`Addresses::formControl()` renders the field with the Matrix form control, which posts its value as `{"entries": {…}, "sortOrder": […]}`, but `Addresses::createAddressesFromSerializedData()` still expected the legacy flat `[addressId => data]` shape. It iterated the envelope's own keys, so every save fabricated one blank address per key — always exactly two — and never applied removals or edits.

The user-visible symptom: removing every address from an entry left two blank addresses attached, and the entry could no longer be saved ("Validation errors found in two addresses within the **Address** field").

`createAddressesFromSerializedData()` now reads the same format `Matrix::_createEntriesFromSerializedData()` does — the `entries`/`blocks`/`sortOrder` envelope, addresses keyed by UUID (with or without the `uid:` prefix), and the canonical→derivative UUID map so draft autosaves match up their addresses instead of recreating them. New addresses keep their posted UUID, and the address format attributes the Address control nests under `address` are applied alongside the top-level native attributes. The legacy flat format still works.

`normalizeValueFromRequest()` also now treats a `null` value as "every address was removed", matching the Matrix fix in 42516a1 — Laravel's `ConvertEmptyStringsToNull` middleware turns the `''` sentinel into `null` before the field sees it.
