### PR TITLE
[6.x] Fix nested blocks stuck on a spinner in the Inertia editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed a bug where legacy asset bundle dependencies could be rendered after their dependent resources when using `craftcms/yii2-adapter`. ([#19394](https://github.com/craftcms/cms/pull/19394))
 - Fixed a bug where jobs run on the sync queue could remain marked as reserved after completing. ([#19431](https://github.com/craftcms/cms/pull/19431))
 - Fixed a bug where Addresses fields weren’t reading the value posted by the Control Panel form, so removing every address didn’t stick and blank addresses could be created. ([#19432](https://github.com/craftcms/cms/pull/19432))
+- Fixed a bug where newly-added Matrix entries and addresses showed a spinner indefinitely in the Inertia/Vue element editor, rather than their fields.
 
 ## 6.0.0-alpha.16 - 2026-08-05
 

--- a/resources/js/modules/elements/composables/useElementAutosave.test.ts
+++ b/resources/js/modules/elements/composables/useElementAutosave.test.ts
@@ -175,4 +175,28 @@ describe('useElementAutosave', () => {
 
     expect(postSpy.mock.calls[0]![1]).toMatchObject({draftId: 99});
   });
+
+  it('keeps the layout the server saved', async () => {
+    const layout = {scope: [], nodes: [], values: {}, errors: []};
+    postSpy.mockResolvedValue({data: {draftId: 7, form: layout}});
+
+    const {autosave} = mount();
+
+    expect(autosave.form.value).toBeNull();
+
+    await autosave.save();
+
+    expect(autosave.form.value).toEqual(layout);
+
+    // A response without one leaves the last known layout in place, rather
+    // than blanking the form the renderer is showing.
+    postSpy.mockResolvedValue({data: {draftId: 7}});
+    await autosave.save();
+
+    expect(autosave.form.value).toEqual(layout);
+
+    autosave.clearForm();
+
+    expect(autosave.form.value).toBeNull();
+  });
 });

--- a/resources/js/modules/elements/composables/useElementAutosave.ts
+++ b/resources/js/modules/elements/composables/useElementAutosave.ts
@@ -2,6 +2,7 @@ import {actionClient} from '@craftcms/ui';
 import {useDebounceFn} from '@vueuse/core';
 import type {InertiaForm} from '@inertiajs/vue3';
 import {readonly, ref, type Ref} from 'vue';
+import type {FormPayload} from '@/modules/forms/types';
 
 export type AutosaveStatus = 'idle' | 'saving' | 'saved' | 'failed';
 
@@ -49,15 +50,18 @@ export function useElementAutosave(
   draftId: Readonly<Ref<number | null>>;
   savedAt: Readonly<Ref<string | null>>;
   error: Readonly<Ref<string | null>>;
+  form: Readonly<Ref<FormPayload | null>>;
   save: () => Promise<void>;
   schedule: () => void;
   suspend: (during: () => void) => void;
   setDraftId: (value: number | null) => void;
+  clearForm: () => void;
 } {
   const status = ref<AutosaveStatus>('idle');
   const draftId = ref<number | null>(options.draftId);
   const savedAt = ref<string | null>(null);
   const error = ref<string | null>(null);
+  const formPayload = ref<FormPayload | null>(null);
 
   let inFlight: Promise<void> | null = null;
   let pending = false;
@@ -88,6 +92,10 @@ export function useElementAutosave(
 
       draftId.value = data.draftId ?? draftId.value;
       savedAt.value = data.timestamp ?? null;
+      // The response carries the field layout as the server now sees it, which
+      // is the only place a nested element created by this save (a new Matrix
+      // entry or address) can get its own Form payload from.
+      formPayload.value = data.form ?? formPayload.value;
       status.value = 'saved';
     } catch (e: any) {
       status.value = 'failed';
@@ -160,14 +168,24 @@ export function useElementAutosave(
     draftId.value = value;
   }
 
+  /**
+   * Drops the saved layout, so a payload arriving from the server by another
+   * route — an Inertia visit — takes over again.
+   */
+  function clearForm(): void {
+    formPayload.value = null;
+  }
+
   return {
     status: readonly(status),
     draftId: readonly(draftId),
     savedAt: readonly(savedAt),
     error: readonly(error),
+    form: readonly(formPayload) as Readonly<Ref<FormPayload | null>>,
     save,
     schedule,
     suspend,
     setDraftId,
+    clearForm,
   };
 }

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -1,7 +1,7 @@
 import {toReactive, useEventListener} from '@vueuse/core';
 import {router, useForm} from '@inertiajs/vue3';
 import {actionClient, t} from '@craftcms/ui';
-import {computed, nextTick, onBeforeUnmount, ref, watch} from 'vue';
+import {computed, nextTick, onBeforeUnmount, ref, shallowRef, watch} from 'vue';
 import {useScreenPageProps} from '@/common/composables/screen';
 import {useSlideout} from '@/common/slideouts/useSlideout';
 import type {FormPayload} from '@/modules/forms/types';
@@ -113,7 +113,12 @@ export function useElementEditPage({saveData}: Options = {}) {
     computed(() => pageProps() as unknown as ElementEditPayload)
   );
 
-  const formPayload = computed(() => props.form);
+  // Autosave answers with the field layout as the server now sees it, and
+  // applying it is the only way a nested element the save just created — a new
+  // Matrix entry or address — receives its own Form payload. Until it does, the
+  // block has nothing to render but a spinner.
+  const savedForm = shallowRef<FormPayload | null>(null);
+  const formPayload = computed(() => savedForm.value ?? props.form);
   const sidebarPayload = computed(() => props.sidebarForm);
   const form = useForm<Record<string, any>>({});
 
@@ -175,11 +180,48 @@ export function useElementEditPage({saveData}: Options = {}) {
     (draftId) => autosave.setDraftId(draftId)
   );
 
+  /**
+   * Whether the layout autosave just returned is being handed to the renderer.
+   * Reconciling it emits a mutation of its own, but that's the server echoing
+   * what it already saved rather than a fresh edit, so it must not re-arm
+   * autosave — which would save again, and never settle.
+   */
+  let applyingSavedForm = false;
+
+  watch(
+    () => autosave.form.value,
+    (payload) => {
+      if (!payload) {
+        return;
+      }
+
+      applyingSavedForm = true;
+      savedForm.value = payload;
+      // Released after the flush, so the renderer's pre-flush reconcile — and
+      // the mutation it emits — is covered.
+      void nextTick(() => (applyingSavedForm = false));
+    },
+    {flush: 'sync'}
+  );
+
+  // A payload arriving by Inertia visit is the newer of the two; drop what
+  // autosave stashed so it stops shadowing it.
+  watch(
+    () => props.form,
+    () => {
+      savedForm.value = null;
+      autosave.clearForm();
+    }
+  );
+
   // The renderers' change callbacks are the authoritative "content changed"
   // signal, so autosave hangs off them rather than watching the form.
   function onMutation(mutation: FormPayload['values']): void {
     onLayoutMutation(mutation);
-    autosave.schedule();
+
+    if (!applyingSavedForm) {
+      autosave.schedule();
+    }
   }
 
   function onSidebarMutation(mutation: FormPayload['values']): void {

--- a/resources/js/modules/forms/FormRenderer.test.ts
+++ b/resources/js/modules/forms/FormRenderer.test.ts
@@ -2383,6 +2383,77 @@ describe('FormRenderer', () => {
     vi.useRealTimers();
   });
 
+  it('renders a just-added entry against the Form the server scoped to its UUID', async () => {
+    const uid = '369f71c3-873f-4842-8fe9-90641773b62b';
+    app.unmount();
+    await mount({
+      scope: ['settings'],
+      refreshable: false,
+      // The block is still keyed the way it was added — with the `uid:` prefix
+      // the server strips before saving — so its Form comes back scoped to the
+      // bare UUID. Failing to match the two leaves the block on its spinner.
+      values: {
+        settings: {
+          matrix: {
+            entries: {[`uid:${uid}`]: {type: 'text'}},
+            sortOrder: [`uid:${uid}`],
+          },
+        },
+      },
+      errors: [],
+      globalErrors: [],
+      nodes: [
+        {
+          type: 'CraftCms\\Cms\\Form\\Nodes\\Field',
+          component: 'craft:field',
+          props: {label: 'Content'},
+          control: {
+            type: 'CraftCms\\Cms\\Form\\Controls\\Matrix',
+            component: 'craft:matrix',
+            props: {
+              entryTypes: [{value: 'text', label: 'Text'}],
+              addLabel: 'Add an entry',
+              minEntries: null,
+              maxEntries: null,
+            },
+            path: ['settings', 'matrix'],
+            mode: 'editable',
+            deltaGroup: ['settings', 'matrix'],
+            forms: [
+              {
+                scope: ['settings', 'matrix', 'entries', uid],
+                refreshable: false,
+                nodes: [
+                  {
+                    type: 'CraftCms\\Cms\\Form\\Nodes\\Field',
+                    component: 'craft:field',
+                    props: {label: 'Heading'},
+                    control: {
+                      type: 'CraftCms\\Cms\\Form\\Controls\\Text',
+                      component: 'craft:text',
+                      props: {inputType: 'text'},
+                      path: ['settings', 'matrix', 'entries', uid, 'heading'],
+                      mode: 'editable',
+                      deltaGroup: ['settings', 'matrix'],
+                      forms: [],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    } as unknown as FormPayload);
+
+    expect(container.querySelector('.matrixblock craft-spinner')).toBeNull();
+    expect(
+      container.querySelector(
+        `input[name="settings[matrix][entries][${uid}][heading]"]`
+      )
+    ).not.toBeNull();
+  });
+
   it('renders and updates permission trees', async () => {
     let mutation: FormPayload['values'] = {};
     app.unmount();

--- a/resources/js/modules/forms/MatrixControl.vue
+++ b/resources/js/modules/forms/MatrixControl.vue
@@ -40,12 +40,20 @@
   }>();
   const matrixHost = ref<HTMLElement>();
   const matrixId = useId();
-  const forms = computed(
-    () =>
-      new Map(
-        (props.control.forms ?? []).map((form) => [form.scope.at(-1)!, form])
-      )
-  );
+  const forms = computed(() => {
+    const map = new Map<string, NestedFormPayload>();
+
+    for (const form of props.control.forms ?? []) {
+      // Entries added client-side are keyed with a `uid:` prefix, which the
+      // server strips before saving — so their forms come back scoped to the
+      // bare UUID while the block is still keyed with the prefix.
+      const uid = form.scope.at(-1)!;
+      map.set(uid, form);
+      map.set(`uid:${uid}`, form);
+    }
+
+    return map;
+  });
   const canAdd = computed(
     () =>
       props.editable &&


### PR DESCRIPTION
### Description

Adding a Matrix entry or an address in the Inertia/Vue element editor left the block showing a spinner forever, because the block's inner Form payload never arrived. Two things were in the way.

`elements/save-draft` answers with the field layout as the server now sees it — the only place a nested element the save just created can get its own Form payload from — and `useElementAutosave` was reading `draftId` and `timestamp` off the response and discarding `form`. Meanwhile `ElementEditPage` renders `FormRenderer` with no `refresh` prop, so nothing else fetched it either: the payload the renderer held was whatever the last Inertia visit supplied. The autosave now keeps the layout it was given and the edit page prefers it over the page prop, which `FormRenderer` already reconciles through its `props.payload` watcher.

Reconciling emits a mutation of its own, so applying it is flagged; that mutation updates the Inertia form but doesn't re-arm autosave, which would otherwise save, reconcile, and never settle. A payload arriving by Inertia visit is the newer of the two and drops what autosave stashed.

`MatrixControl` also keyed its `forms` lookup strictly. Blocks added client-side carry a `uid:` prefix that the server strips before saving, so their forms come back scoped to the bare UUID and never matched the block still keyed with the prefix — a spinner even once the payload was in hand. The lookup now accepts either.

Refreshable controls come along with it: changing an address's Country re-renders its fields for the new country on the autosave cycle, which it did not do before.
