### PR TITLE
[6.x] Autosave element edits on a real difference, not on any reported change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Fixed a bug where jobs run on the sync queue could remain marked as reserved after completing. ([#19431](https://github.com/craftcms/cms/pull/19431))
 - Fixed a bug where Addresses fields weren’t reading the value posted by the Control Panel form, so removing every address didn’t stick and blank addresses could be created. ([#19432](https://github.com/craftcms/cms/pull/19432))
 - Fixed a bug where newly-added Matrix entries and addresses showed a spinner indefinitely in the Inertia/Vue element editor, rather than their fields.
+- Fixed a bug where opening an element edit page with a Money field immediately created a provisional draft, before anything had been edited.
+- Element edit screens now autosave when the form’s values actually differ from the server’s, rather than whenever a control reports a change.
 
 ## 6.0.0-alpha.16 - 2026-08-05
 

--- a/packages/craftcms-ui/src/components/input-money/input-money.test.ts
+++ b/packages/craftcms-ui/src/components/input-money/input-money.test.ts
@@ -36,6 +36,28 @@ describe('craft-input-money', () => {
     );
   });
 
+  it('applies the mask without dispatching user input', async () => {
+    const element = document.createElement('craft-input-money');
+    element.label = 'Price';
+    const inputEvents: Event[] = [];
+    const userChanges: Event[] = [];
+    element.addEventListener('input', (event) => inputEvents.push(event));
+    element.addEventListener('model-value-changed', (event) => {
+      if ((event as CustomEvent).detail?.isTriggeredByUser) {
+        userChanges.push(event);
+      }
+    });
+
+    document.body.append(element);
+    element.modelValue = '1234.56';
+    element.locale = 'de_DE';
+    element.currency = 'EUR';
+    await element.updateComplete;
+
+    expect(inputEvents).toEqual([]);
+    expect(userChanges).toEqual([]);
+  });
+
   it('clears its value', async () => {
     const element = await createInputMoney();
     element.modelValue = '12,50';

--- a/packages/craftcms-ui/src/components/input-money/input-money.ts
+++ b/packages/craftcms-ui/src/components/input-money/input-money.ts
@@ -130,6 +130,9 @@ export default class CraftInputMoney extends CraftInput {
     const value = String(this.modelValue ?? '');
     const format = this.#format();
     input.inputmask?.remove();
+    // Seed the value before masking. `setValue()` afterwards would dispatch a
+    // real `input` event, which the form layer reads as typing.
+    input.value = value;
     new Inputmask({
       alias: 'currency',
       autoGroup: false,
@@ -141,7 +144,6 @@ export default class CraftInputMoney extends CraftInput {
       prefix: '',
       radixPoint: this.decimalSeparator ?? format.decimal,
     }).mask(input);
-    input.inputmask?.setValue(value);
   }
 
   #hasValue(): boolean {

--- a/resources/js/modules/elements/composables/useElementEditPage.test.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.test.ts
@@ -119,4 +119,25 @@ describe('useElementEditPage', () => {
 
     on.mockRestore();
   });
+
+  it('autosaves on a difference from the server, not on being told of a change', () => {
+    const editor = mount(payload({canAutosave: true}));
+    const schedule = vi.spyOn(editor.autosave, 'schedule');
+
+    // The renderers hand over the difference against the server's values, so an
+    // empty one means a control announced itself without changing anything —
+    // populating a field on load, say. That must not create a draft.
+    editor.onMutation({});
+    editor.onSidebarMutation({});
+
+    expect(schedule).not.toHaveBeenCalled();
+
+    editor.onMutation({fields: {money: {value: '12', locale: 'en-US'}}});
+
+    expect(schedule).toHaveBeenCalledTimes(1);
+
+    editor.onSidebarMutation({slug: 'changed'});
+
+    expect(schedule).toHaveBeenCalledTimes(2);
+  });
 });

--- a/resources/js/modules/elements/composables/useElementEditPage.ts
+++ b/resources/js/modules/elements/composables/useElementEditPage.ts
@@ -215,18 +215,21 @@ export function useElementEditPage({saveData}: Options = {}) {
   );
 
   // The renderers' change callbacks are the authoritative "content changed"
-  // signal, so autosave hangs off them rather than watching the form.
+  // signal, so autosave hangs off them rather than watching the form — and off
+  // whether the values actually differ from the server's, not off having been
+  // told a control changed.
   function onMutation(mutation: FormPayload['values']): void {
-    onLayoutMutation(mutation);
+    const changed = onLayoutMutation(mutation);
 
-    if (!applyingSavedForm) {
+    if (!applyingSavedForm && changed) {
       autosave.schedule();
     }
   }
 
   function onSidebarMutation(mutation: FormPayload['values']): void {
-    onSidebarFormMutation(mutation);
-    autosave.schedule();
+    if (onSidebarFormMutation(mutation)) {
+      autosave.schedule();
+    }
   }
 
   // Set for the duration of one submission when an alternate action owns it,

--- a/resources/js/modules/forms/FormRenderer.test.ts
+++ b/resources/js/modules/forms/FormRenderer.test.ts
@@ -2454,6 +2454,103 @@ describe('FormRenderer', () => {
     ).not.toBeNull();
   });
 
+  it('reports no change when a Money field is populated with the server’s empty value', async () => {
+    let mutation: FormPayload['values'] | undefined;
+    const emptyMoney = structuredClone(payload) as Mutable<FormPayload>;
+    emptyMoney.values = {settings: {price: {value: null, locale: 'en-US'}}};
+    emptyMoney.errors = [];
+    emptyMoney.globalErrors = [];
+    emptyMoney.nodes = [
+      {
+        type: 'CraftCms\\Cms\\Form\\Nodes\\Field',
+        component: 'craft:field',
+        props: {label: 'Price', instructions: null, required: false},
+        control: {
+          type: 'CraftCms\\Cms\\Form\\Controls\\Money',
+          component: 'craft:money',
+          props: {currency: 'USD', locale: 'en-US', showCurrency: true},
+          path: ['settings', 'price'],
+          mode: 'editable',
+          deltaGroup: ['settings', 'price'],
+        },
+      },
+    ] as Mutable<FormPayload>['nodes'];
+    app.unmount();
+    await mount(emptyMoney, {onMutation: (value) => (mutation = value)});
+    await nextTick();
+
+    // The control announces itself once as it's populated. happy-dom won't
+    // bootstrap the underlying form control far enough to fire that on its own,
+    // so raise it exactly as the browser does — the field is still empty, and
+    // the announcement is not marked as coming from a person.
+    const control = container.querySelector('craft-input-money')!;
+    control.dispatchEvent(
+      new CustomEvent('model-value-changed', {
+        bubbles: true,
+        detail: {isTriggeredByUser: false},
+      })
+    );
+    await nextTick();
+
+    // Binding the server's own value back onto the control is not an edit. If
+    // the control reshapes empty into `''`, this is `{settings: {price: …}}` —
+    // a difference the editor would autosave before anyone touched the page.
+    expect(mutation ?? {}).toEqual({});
+
+    const input = container.querySelector<HTMLInputElement>(
+      'input[name="settings[price][value]"]'
+    )!;
+    input.value = '12.50';
+    input.dispatchEvent(new Event('input', {bubbles: true}));
+    await nextTick();
+
+    // A real edit still comes through.
+    expect(mutation).toEqual({
+      settings: {price: {value: '12.50', locale: 'en-US'}},
+    });
+  });
+
+  it('treats an absent value and an empty one as the same, for any control', async () => {
+    let mutation: FormPayload['values'] | undefined;
+    const emptyText = structuredClone(payload) as Mutable<FormPayload>;
+    emptyText.values = {settings: {summary: null}};
+    emptyText.errors = [];
+    emptyText.globalErrors = [];
+    emptyText.nodes = [
+      {
+        type: 'CraftCms\\Cms\\Form\\Nodes\\Field',
+        component: 'craft:field',
+        props: {label: 'Summary', instructions: null, required: false},
+        control: {
+          type: 'CraftCms\\Cms\\Form\\Controls\\Text',
+          component: 'craft:text',
+          props: {inputType: 'text'},
+          path: ['settings', 'summary'],
+          mode: 'editable',
+          deltaGroup: ['settings', 'summary'],
+        },
+      },
+    ] as Mutable<FormPayload>['nodes'];
+    app.unmount();
+    await mount(emptyText, {onMutation: (value) => (mutation = value)});
+
+    // Report an empty string where the server sent nothing. Driving the value
+    // directly rather than through the DOM is deliberate: a text input already
+    // showing "" won't re-announce itself, but controls layered on a form
+    // library do exactly this as they're populated on load.
+    renderer.setValue(['settings', 'summary'], '');
+    await nextTick();
+
+    // The same value said two ways, not an edit — so no control has to know how
+    // the server happens to spell "empty".
+    expect(mutation ?? {}).toEqual({});
+
+    renderer.setValue(['settings', 'summary'], 'real');
+    await nextTick();
+
+    expect(mutation).toEqual({settings: {summary: 'real'}});
+  });
+
   it('renders and updates permission trees', async () => {
     let mutation: FormPayload['values'] = {};
     app.unmount();

--- a/resources/js/modules/forms/FormRenderer.vue
+++ b/resources/js/modules/forms/FormRenderer.vue
@@ -387,6 +387,14 @@
   }
 
   function canonicalValue(value: unknown): unknown {
+    // Nothing and empty mean the same thing to a form, so a control reporting
+    // one where the server sent the other has not edited anything. Without
+    // this, populating a field on load can read as a change purely because the
+    // control's idea of empty differs from the server's.
+    if (value === null || value === undefined || value === '') {
+      return '';
+    }
+
     if (Array.isArray(value)) {
       return value.map(canonicalValue);
     }

--- a/resources/js/modules/forms/MoneyControl.vue
+++ b/resources/js/modules/forms/MoneyControl.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
   import CraftInputMoney from '@craftcms/ui/components/input-money/input-money';
   import type {FormControlPayload} from './types';
-  import {
-    ignoreModelValueInitialization,
-    inputName,
-    serverErrorValidators,
-  } from './runtime';
+  import {inputName, serverErrorValidators} from './runtime';
 
-  type MoneyValue = {value: string; locale: string};
+  type MoneyValue = {value: string | null; locale: string};
   type MoneyControlProps = {
     currency: string;
     locale: string;
@@ -33,19 +29,28 @@
   function moneyValue(): MoneyValue {
     return typeof props.value === 'object' && props.value !== null
       ? (props.value as MoneyValue)
-      : {value: String(props.value ?? ''), locale: props.control.props.locale};
+      : {
+          value: props.value == null ? null : String(props.value),
+          locale: props.control.props.locale,
+        };
   }
 
-  const onInput = ignoreModelValueInitialization((event) => {
+  const onInput = (event: Event) => {
+    const modelValue = (event.target as CraftInputMoney).modelValue;
+
     emit(
       'update:value',
       {
-        value: String((event.target as CraftInputMoney).modelValue ?? ''),
+        // Report an empty amount the same way the server sends one. Reshaping
+        // it into `''` reads as a real edit the moment the field is populated
+        // on load, marking the form dirty before anyone has touched it.
+        value:
+          modelValue == null || modelValue === '' ? null : String(modelValue),
         locale: moneyValue().locale,
       },
       'typing'
     );
-  });
+  };
 </script>
 
 <template>

--- a/resources/js/modules/forms/useInertiaFormRenderer.ts
+++ b/resources/js/modules/forms/useInertiaFormRenderer.ts
@@ -60,9 +60,21 @@ export function useInertiaFormRenderer<
     })
   );
 
-  function onMutation(mutation: FormPayload['values']): void {
+  /**
+   * Applies the renderer's mutation to the Inertia form, and reports whether it
+   * carried anything.
+   *
+   * The mutation *is* the difference against the values the server sent, so an
+   * empty one means the screen matches the server — a control announcing itself
+   * as it's populated, say, rather than an edit. Callers that act on changes
+   * (autosave) read that from here rather than deciding for themselves, and
+   * `form.isDirty` says the same thing a tick later for callers that can wait.
+   */
+  function onMutation(mutation: FormPayload['values']): boolean {
     replaceMutation(mutation);
     values.value = renderer.value?.currentValues() ?? values.value;
+
+    return Object.keys(mutation).length > 0;
   }
 
   function replaceMutation(mutation: FormPayload['values']): void {


### PR DESCRIPTION
Previously the autosave process ran on any reported change instead of actual changes. This updates the code to be more in line with Craft 5 and only save when an actual change has been made. 