### PR TITLE
[6.x] Make text expander labels configurable

### DIFF
--- a/packages/craftcms-ui/src/components/text-expander/text-expander.stories.ts
+++ b/packages/craftcms-ui/src/components/text-expander/text-expander.stories.ts
@@ -23,8 +23,8 @@ const variables = [
 ];
 
 const triggers: TextExpanderTriggers = {
-  '@': {options: people},
-  '#': {options: variables},
+  '@': {label: 'People', options: people},
+  '#': {label: 'Environment', options: variables},
 };
 
 const meta = {
@@ -44,7 +44,7 @@ export const TextInput: Story = {
     </label>
     <craft-text-expander
       for="mention-input"
-      .triggers=${{'@': {options: people}}}
+      .triggers=${{'@': {label: 'People', options: people}}}
     ></craft-text-expander>
   `,
   play: async ({canvas, canvasElement, userEvent}) => {

--- a/packages/craftcms-ui/src/components/text-expander/text-expander.test.ts
+++ b/packages/craftcms-ui/src/components/text-expander/text-expander.test.ts
@@ -653,7 +653,10 @@ describe('craft-text-expander', () => {
     expander.setAttribute(
       'triggers',
       JSON.stringify({
-        '@': {options: [{label: 'Brad', value: '@brad'}]},
+        '@': {
+          label: 'People',
+          options: [{label: 'Brad', value: '@brad'}],
+        },
       })
     );
     document.body.append(expander);
@@ -662,12 +665,21 @@ describe('craft-text-expander', () => {
     type(target, '@b');
 
     expect(options(expander)).toHaveLength(1);
+    expect(
+      expander.querySelector('[role="listbox"]')?.getAttribute('aria-label')
+    ).toBe('People');
   });
 
   it('labels the listbox for the active trigger, falling back to a default label', async () => {
     const {expander, target} = await createFixture({
-      '#': {options: [{label: 'General', value: '#general'}]},
-      '@': {options: [{label: 'Brad', value: '@brad'}]},
+      '#': {
+        label: 'Channels',
+        options: [{label: 'General', value: '#general'}],
+      },
+      '@': {
+        label: 'People',
+        options: [{label: 'Brad', value: '@brad'}],
+      },
       ':': {options: [{label: 'Smile', value: ':smile'}]},
     });
     const listbox = expander.querySelector('[role="listbox"]')!;
@@ -676,11 +688,11 @@ describe('craft-text-expander', () => {
 
     type(target, '#g');
     await waitForFirstOption(expander);
-    expect(listbox.getAttribute('aria-label')).toBe('Environment');
+    expect(listbox.getAttribute('aria-label')).toBe('Channels');
 
     type(target, '@b');
     await waitForFirstOption(expander);
-    expect(listbox.getAttribute('aria-label')).toBe('Users');
+    expect(listbox.getAttribute('aria-label')).toBe('People');
 
     type(target, ':sm');
     await waitForFirstOption(expander);
@@ -689,7 +701,10 @@ describe('craft-text-expander', () => {
 
   it('announces the active trigger label when the popover closes', async () => {
     const {expander, target} = await createFixture({
-      '#': {options: [{label: 'General', value: '#general'}]},
+      '#': {
+        label: 'Channels',
+        options: [{label: 'General', value: '#general'}],
+      },
       ':': {options: [{label: 'Smile', value: ':smile'}]},
     });
     const liveRegion = expander.shadowRoot!.querySelector('[aria-live]')!;
@@ -700,7 +715,7 @@ describe('craft-text-expander', () => {
 
     await vi.waitFor(() =>
       expect(liveRegion.textContent?.trim()).toBe(
-        'Environment suggestions collapsed'
+        'Channels suggestions collapsed'
       )
     );
 

--- a/packages/craftcms-ui/src/components/text-expander/text-expander.ts
+++ b/packages/craftcms-ui/src/components/text-expander/text-expander.ts
@@ -18,6 +18,7 @@ export interface TextExpanderOption<Data = unknown> {
 }
 
 interface TextExpanderTriggerBase<Data = unknown> {
+  label?: string;
   limit?: number;
   renderOption?: (option: Readonly<TextExpanderOption<Data>>) => Node;
 }
@@ -65,12 +66,6 @@ interface TextExpanderMatch {
 // any other character terminates the active query.
 const queryPattern = /^[\p{L}\p{N}_-]*$/u;
 const defaultListboxLabel = t('Suggestions');
-// Label announced for the suggestion listbox, keyed by trigger character.
-// Add an entry here whenever a new trigger character is introduced.
-const triggerLabels: Readonly<Record<string, string>> = {
-  '#': t('Environment'),
-  '@': t('Users'),
-};
 const targetAttributes = [
   'role',
   'aria-autocomplete',
@@ -550,27 +545,16 @@ export default class CraftTextExpander extends LitElement {
     return result;
   }
 
-  /** The character of the currently active trigger, if a match is open. */
-  get #activeTrigger(): string | null {
-    return this.#match?.character ?? null;
-  }
-
-  #updateListboxLabel(): void {
-    const label =
-      (this.#activeTrigger !== null
-        ? triggerLabels[this.#activeTrigger]
-        : undefined) ?? defaultListboxLabel;
-
-    this.#listbox.setAttribute('aria-label', label);
-  }
-
   #showOptions(options: readonly TextExpanderOption[]): void {
     this.#stopCombobox();
     this.#visibleOptions = options;
     this.#listbox.replaceChildren();
     this.#listbox.hidden = this.loading;
 
-    this.#updateListboxLabel();
+    this.#listbox.setAttribute(
+      'aria-label',
+      this.#match?.trigger.label ?? defaultListboxLabel
+    );
 
     options.forEach((option, index) => {
       const element = document.createElement('craft-option');

--- a/src/Form/Controls/Concerns/HasTextExpander.php
+++ b/src/Form/Controls/Concerns/HasTextExpander.php
@@ -16,8 +16,8 @@ use CraftCms\Cms\Support\Json;
  *     data?: mixed,
  * }
  * @phpstan-type TextExpanderTrigger (
- *     array{options: list<TextExpanderOption>, source?: never, limit?: int}
- *     | array{source: string, options?: never, limit?: int}
+ *     array{label?: string, options: list<TextExpanderOption>, source?: never, limit?: int}
+ *     | array{label?: string, source: string, options?: never, limit?: int}
  * )
  * @phpstan-type TextExpanderTriggers array<string, TextExpanderTrigger>
  */

--- a/tests/Unit/Form/CompositeControlsTest.php
+++ b/tests/Unit/Form/CompositeControlsTest.php
@@ -26,7 +26,7 @@ function compositeControlsForm(): Form
                 ->placeholder('Write <Markdown>')
                 ->toolbarButtons(['bold', 'link'])
                 ->textExpanderTriggers([
-                    '@' => ['options' => [
+                    '@' => ['label' => 'People', 'options' => [
                         ['label' => 'Ada Lovelace', 'value' => '@ada'],
                     ]],
                 ]),
@@ -100,7 +100,7 @@ it('resolves documented composite Control shapes and properties', function () {
         'placeholder' => 'Write <Markdown>',
         'toolbarButtons' => ['bold', 'link'],
         'textExpanderTriggers' => [
-            '@' => ['options' => [
+            '@' => ['label' => 'People', 'options' => [
                 ['label' => 'Ada Lovelace', 'value' => '@ada'],
             ]],
         ],
@@ -167,7 +167,7 @@ it('preserves keyed Table rows in payloads and PHP submission names', function (
 
 it('renders text expanders for text and textarea Controls', function () {
     $triggers = [
-        '@' => ['source' => 'users/text-expander-options'],
+        '@' => ['label' => 'People', 'source' => 'users/text-expander-options'],
     ];
     $form = Form::make([
         Field::make('Name', Text::make('name')->textExpanderTriggers($triggers)),

--- a/workbench/app/Forms/FormKitchenSink.php
+++ b/workbench/app/Forms/FormKitchenSink.php
@@ -56,14 +56,14 @@ use CraftCms\Cms\User\Data\PermissionGroup;
 class FormKitchenSink
 {
     private const array TextExpanderTriggers = [
-        ':' => ['options' => [
+        ':' => ['label' => 'Emoji', 'options' => [
             ['label' => '😀', 'value' => '😀', 'keywords' => ['grinning', 'face', 'smile', 'happy']],
             ['label' => '🎉', 'value' => '🎉', 'keywords' => ['party', 'popper', 'celebration', 'confetti']],
             ['label' => '👍', 'value' => '👍', 'keywords' => ['thumbs', 'up', 'approve', 'yes']],
             ['label' => '❤️', 'value' => '❤️', 'keywords' => ['red', 'heart', 'love']],
             ['label' => '🚀', 'value' => '🚀', 'keywords' => ['rocket', 'launch', 'ship']],
         ]],
-        '@' => ['source' => 'workbench/text-expander-options'],
+        '@' => ['label' => 'Users', 'source' => 'workbench/text-expander-options'],
     ];
 
     /** @var array<string, array<string, class-string>> */


### PR DESCRIPTION
### Description

Allows text expander trigger configurations to define their listbox labels, with the existing generic label retained as a fallback.