### PR TITLE
Improve queue job reservation performance

### DIFF
--- a/CHANGELOG-5.11.md
+++ b/CHANGELOG-5.11.md
@@ -17,6 +17,7 @@
 ### System
 - Added support for `.well-known/passkey-endpoints` requests. ([#19364](https://github.com/craftcms/cms/pull/19364))
 - The front-end login page no longer returns a redirect response for logged-in users, if it’s a preview request. ([#19360](https://github.com/craftcms/cms/discussions/19360))
+- Improved queue job reservation performance when queues contain many large jobs. ([#19097](https://github.com/craftcms/cms/issues/19097))
 - Updated Twig to 3.28.
 - Updated yii2-debug to 2.1.28.
 - Fixed an error that could occur when editing an element. ([#17268](https://github.com/craftcms/cms/issues/17268))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Improved queue job reservation performance when queues contain many large jobs. ([#19097](https://github.com/craftcms/cms/issues/19097))
 - Fixed a bug where entries could deadlock when saving their authors. ([#15768](https://github.com/craftcms/cms/issues/15768))
 - Fixed an error that could occur when upgrading to Craft 5. ([craftcms/commerce#4309](https://github.com/craftcms/commerce/pull/4309))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improved queue job reservation performance when queues contain many large jobs. ([#19097](https://github.com/craftcms/cms/issues/19097))
 - Fixed a bug where entries could deadlock when saving their authors. ([#15768](https://github.com/craftcms/cms/issues/15768))
 - Fixed an error that could occur when upgrading to Craft 5. ([craftcms/commerce#4309](https://github.com/craftcms/commerce/pull/4309))
 

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,7 +4,7 @@ return [
     'id' => 'CraftCMS',
     'name' => 'Craft CMS',
     'version' => '5.10.13.2',
-    'schemaVersion' => '5.10.0.0',
+    'schemaVersion' => '5.10.0.1',
     'minVersionRequired' => '4.5.0',
     'basePath' => dirname(__DIR__), // Defines the @app alias
     'runtimePath' => '@storage/runtime', // Defines the @runtime alias

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -940,6 +940,7 @@ class Install extends Migration
         $this->createIndex(null, Table::PLUGINS, ['handle'], true);
         $this->createIndex(null, Table::QUEUE, ['channel', 'fail', 'timeUpdated', 'timePushed']);
         $this->createIndex(null, Table::QUEUE, ['channel', 'fail', 'timeUpdated', 'delay']);
+        $this->createIndex(null, Table::QUEUE, ['channel', 'fail', 'timeUpdated', 'priority', 'id', 'timePushed', 'delay']);
         $this->createIndex(null, Table::RELATIONS, ['fieldId', 'sourceId', 'sourceSiteId', 'targetId'], true);
         $this->createIndex(null, Table::RELATIONS, ['sourceId'], false);
         $this->createIndex(null, Table::RELATIONS, ['targetId'], false);

--- a/src/migrations/m260817_012148_queue_reserve_index.php
+++ b/src/migrations/m260817_012148_queue_reserve_index.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace craft\migrations;
+
+use craft\db\Migration;
+use craft\db\Table;
+
+/**
+ * m260817_012148_queue_reserve_index migration.
+ */
+class m260817_012148_queue_reserve_index extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->createIndexIfMissing(Table::QUEUE, ['channel', 'fail', 'timeUpdated', 'priority', 'id', 'timePushed', 'delay'], false);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->dropIndexIfExists(Table::QUEUE, ['channel', 'fail', 'timeUpdated', 'priority', 'id', 'timePushed', 'delay'], false);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Why

The queue reserve query filters by channel, fail, and `timeUpdated`, then orders by priority and ID. This adds an index for that access pattern so it can find the next runnable job without sorting through large job payloads.

## Verification

- Ran the reserve query against a MySQL 8.4 queue with 20,000 8 KiB jobs: `EXPLAIN ANALYZE` went from a 541 ms filesort to a 0.008 ms ordered index lookup.
- Ran `php -l` on the changed PHP files and `git diff --check`.

Fixes #19097