### PR TITLE
[6.x] Grab bag refactors & fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added `CraftCms\Cms\Http\ResponseHeaders` and `CraftCms\Cms\Support\Facades\ResponseHeaders` for accumulating response headers within the current request scope.
 - Fixed inconsistent handling of forced-disabled plugin configuration values.
 - Improved job progress persistence by using an atomic upsert.
 - Changed `CraftCms\Cms\Support\Json::decode()` to use exception-based JSON decoding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Changed `CraftCms\Cms\Auth\Passkeys\Passkeys::verifyPasskey()` to return the updated credential record on success.
 - Changed GraphQL AST value decoding to use `webonyx/graphql-php` while preserving Craft-specific query condition validation.
 - Fixed a bug where cached user permission trees could become stale after permission changes or be modified by assignability filtering.
 - Improved element queries to retain only explicitly supplied custom-field criteria.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where `CraftCms\Cms\Edition` capability checks could report capabilities from the configured edition rather than the receiver.
+- Fixed a bug where `CraftCms\Cms\Element\ElementCollection::with()` could pass incompatible element classes into eager loading.
 - Changed `craft:db:drop-all-tables` to use Laravel’s schema API.
 - Added `CraftCms\Cms\Plugin\Plugin::settingsForm()` for defining standard plugin settings pages with the Control Panel Form system. ([#19439](https://github.com/craftcms/cms/pull/19439))
 - Removed `CraftCms\Cms\Plugin\Plugin::settingsHtml()`. `settingsForm()` should be used instead; Yii-era plugin settings HTML remains supported by `craftcms/yii2-adapter`. ([#19439](https://github.com/craftcms/cms/pull/19439))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improved element queries to retain only explicitly supplied custom-field criteria.
 - Improved `CraftCms\Cms\Form\FormResolver` performance by indexing control paths and node UIDs for membership checks.
 - Added `CraftCms\Cms\Http\ResponseHeaders` and `CraftCms\Cms\Support\Facades\ResponseHeaders` for accumulating response headers within the current request scope.
 - Fixed inconsistent handling of forced-disabled plugin configuration values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improved job progress persistence by using an atomic upsert.
 - Fixed a bug where `CraftCms\Cms\Edition` capability checks could report capabilities from the configured edition rather than the receiver.
 - Fixed a bug where throwing validation could run the validation lifecycle twice.
 - Fixed a bug where `CraftCms\Cms\Element\ElementCollection::with()` could pass incompatible element classes into eager loading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where `CraftCms\Cms\Edition` capability checks could report capabilities from the configured edition rather than the receiver.
 - Changed `craft:db:drop-all-tables` to use Laravel’s schema API.
 - Added `CraftCms\Cms\Plugin\Plugin::settingsForm()` for defining standard plugin settings pages with the Control Panel Form system. ([#19439](https://github.com/craftcms/cms/pull/19439))
 - Removed `CraftCms\Cms\Plugin\Plugin::settingsHtml()`. `settingsForm()` should be used instead; Yii-era plugin settings HTML remains supported by `craftcms/yii2-adapter`. ([#19439](https://github.com/craftcms/cms/pull/19439))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improved template resource cache collection by replaying structured HTML stack entries without parsing rendered tags.
 - Changed `CraftCms\Cms\Auth\Passkeys\Passkeys::verifyPasskey()` to return the updated credential record on success.
 - Changed GraphQL AST value decoding to use `webonyx/graphql-php` while preserving Craft-specific query condition validation.
 - Fixed a bug where cached user permission trees could become stale after permission changes or be modified by assignability filtering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where nested or concurrent searches could overwrite another search’s parser state.
 - Improved template resource cache collection by replaying structured HTML stack entries without parsing rendered tags.
 - Changed `CraftCms\Cms\Auth\Passkeys\Passkeys::verifyPasskey()` to return the updated credential record on success.
 - Changed GraphQL AST value decoding to use `webonyx/graphql-php` while preserving Craft-specific query condition validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Changed GraphQL AST value decoding to use `webonyx/graphql-php` while preserving Craft-specific query condition validation.
 - Fixed a bug where cached user permission trees could become stale after permission changes or be modified by assignability filtering.
 - Improved element queries to retain only explicitly supplied custom-field criteria.
 - Improved `CraftCms\Cms\Form\FormResolver` performance by indexing control paths and node UIDs for membership checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improved job progress persistence by using an atomic upsert.
+- Changed `CraftCms\Cms\Support\Json::decode()` to use exception-based JSON decoding.
 - Fixed a bug where `CraftCms\Cms\Edition` capability checks could report capabilities from the configured edition rather than the receiver.
 - Fixed a bug where throwing validation could run the validation lifecycle twice.
 - Fixed a bug where `CraftCms\Cms\Element\ElementCollection::with()` could pass incompatible element classes into eager loading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where Table field column handles became arrays after failed validation.
 - Fixed a bug where nested or concurrent searches could overwrite another search’s parser state.
 - Improved template resource cache collection by replaying structured HTML stack entries without parsing rendered tags.
 - Changed `CraftCms\Cms\Auth\Passkeys\Passkeys::verifyPasskey()` to return the updated credential record on success.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed inconsistent handling of forced-disabled plugin configuration values.
 - Improved job progress persistence by using an atomic upsert.
 - Changed `CraftCms\Cms\Support\Json::decode()` to use exception-based JSON decoding.
 - Fixed a bug where `CraftCms\Cms\Edition` capability checks could report capabilities from the configured edition rather than the receiver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where cached user permission trees could become stale after permission changes or be modified by assignability filtering.
 - Improved element queries to retain only explicitly supplied custom-field criteria.
 - Improved `CraftCms\Cms\Form\FormResolver` performance by indexing control paths and node UIDs for membership checks.
 - Added `CraftCms\Cms\Http\ResponseHeaders` and `CraftCms\Cms\Support\Facades\ResponseHeaders` for accumulating response headers within the current request scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Changed `craft:db:drop-all-tables` to use Laravel’s schema API.
 - Added `CraftCms\Cms\Plugin\Plugin::settingsForm()` for defining standard plugin settings pages with the Control Panel Form system. ([#19439](https://github.com/craftcms/cms/pull/19439))
 - Removed `CraftCms\Cms\Plugin\Plugin::settingsHtml()`. `settingsForm()` should be used instead; Yii-era plugin settings HTML remains supported by `craftcms/yii2-adapter`. ([#19439](https://github.com/craftcms/cms/pull/19439))
 - Safe HTML elements are now allowed within Markdown field layout elements. ([#19426](https://github.com/craftcms/cms/pull/19426))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where `CraftCms\Cms\Edition` capability checks could report capabilities from the configured edition rather than the receiver.
+- Fixed a bug where throwing validation could run the validation lifecycle twice.
 - Fixed a bug where `CraftCms\Cms\Element\ElementCollection::with()` could pass incompatible element classes into eager loading.
 - Changed `craft:db:drop-all-tables` to use Laravel’s schema API.
 - Added `CraftCms\Cms\Plugin\Plugin::settingsForm()` for defining standard plugin settings pages with the Control Panel Form system. ([#19439](https://github.com/craftcms/cms/pull/19439))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improved `CraftCms\Cms\Form\FormResolver` performance by indexing control paths and node UIDs for membership checks.
 - Added `CraftCms\Cms\Http\ResponseHeaders` and `CraftCms\Cms\Support\Facades\ResponseHeaders` for accumulating response headers within the current request scope.
 - Fixed inconsistent handling of forced-disabled plugin configuration values.
 - Improved job progress persistence by using an atomic upsert.

--- a/composer.json
+++ b/composer.json
@@ -217,6 +217,7 @@
         "Path": "CraftCms\\Cms\\Support\\Facades\\Path",
         "Plugins": "CraftCms\\Cms\\Support\\Facades\\Plugins",
         "ProjectConfig": "CraftCms\\Cms\\Support\\Facades\\ProjectConfig",
+        "ResponseHeaders": "CraftCms\\Cms\\Support\\Facades\\ResponseHeaders",
         "Revisions": "CraftCms\\Cms\\Support\\Facades\\Revisions",
         "Search": "CraftCms\\Cms\\Support\\Facades\\Search",
         "Sections": "CraftCms\\Cms\\Support\\Facades\\Sections",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a70fee4a1b126c8967a01d48132ddb4f",
+    "content-hash": "19b037e2250902259f0ef6f00c199866",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5206,7 +5206,6 @@
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/resources/js/modules/forms/FormRenderer.test.ts
+++ b/resources/js/modules/forms/FormRenderer.test.ts
@@ -433,6 +433,70 @@ describe('FormRenderer', () => {
     );
   });
 
+  it('renders table cell errors beside scalar values', async () => {
+    const table: FormPayload = {
+      scope: [],
+      refreshable: false,
+      nodes: [
+        {
+          type: 'CraftCms\\Cms\\Form\\Nodes\\Field',
+          component: 'craft:field',
+          props: {},
+          control: {
+            type: 'CraftCms\\Cms\\Form\\Controls\\Table',
+            component: 'craft:table',
+            props: {
+              columns: {
+                handle: {type: 'singleline'},
+              },
+              keyed: true,
+              errors: {
+                first: {handle: true},
+                third: {handle: true},
+              },
+            },
+            path: ['columns'],
+            mode: 'editable',
+            deltaGroup: ['columns'],
+          },
+        },
+      ],
+      values: {
+        columns: {
+          first: {handle: 'invalid-handle'},
+          second: {handle: 'validHandle'},
+          third: {handle: 'col3'},
+        },
+      },
+      errors: [],
+      globalErrors: [],
+    };
+    app.unmount();
+    await mount(table);
+
+    const inputs = [
+      ...container.querySelectorAll<HTMLTextAreaElement>('tbody textarea'),
+    ];
+
+    expect(inputs.map((input) => input.value)).toEqual([
+      'invalid-handle',
+      'validHandle',
+      'col3',
+    ]);
+    expect(
+      inputs.map((input) => input.closest('td')?.classList.contains('error'))
+    ).toEqual([true, false, true]);
+    expect(renderer.currentValues()).toEqual(table.values);
+
+    const successful = structuredClone(table);
+    successful.nodes[0]!.control!.props.errors = {};
+    currentPayload.value = successful;
+    await nextTick();
+
+    expect(container.querySelector('td.error')).toBeNull();
+    expect(renderer.currentValues()).toEqual(table.values);
+  });
+
   it('reports control changes and applies external value updates', async () => {
     const derived: FormPayload = {
       scope: [],

--- a/resources/js/modules/forms/TableControl.vue
+++ b/resources/js/modules/forms/TableControl.vue
@@ -15,6 +15,7 @@
     minRows?: number;
     maxRows?: number;
     keyed?: boolean;
+    errors?: Record<string, Record<string, true>>;
   };
   type TableRow = Record<string, unknown>;
   type TableValue = TableRow[] | Record<string, TableRow>;
@@ -89,6 +90,14 @@
         props.editable && props.control.props.allowDelete,
         !props.editable
       ).appendTo(bodyElement);
+
+      const rowElement = bodyElement.lastElementChild as HTMLTableRowElement;
+      Object.keys(props.control.props.columns).forEach((column, index) => {
+        rowElement.cells[index]?.classList.toggle(
+          'error',
+          props.control.props.errors?.[rowId]?.[column] === true
+        );
+      });
     });
 
     if (!props.editable) {

--- a/resources/templates/_includes/forms/editableTable.twig
+++ b/resources/templates/_includes/forms/editableTable.twig
@@ -7,6 +7,7 @@
 {%- set maxRows = maxRows ?? null %}
 {%- set describedBy = describedBy ?? null %}
 {%- set includeRowId = includeRowId ?? false %}
+{%- set errors = errors ?? [] %}
 
 {%- set totalRows = rows|length %}
 {%- set staticRows = static or (staticRows ?? false) or (minRows == 1 and maxRows == 1 and totalRows == 1) %}
@@ -132,7 +133,7 @@
               <td class="{{ _self.cellClass(fullWidth, col, cell.class ?? col.class ?? []) }}"{{ widthAttributes|raw }}>{{ value|raw }}</td>
             {% else %}
               {% set headingId = "#{id}-heading-#{loop.index}" %}
-              {% set hasErrors = cell.errors.isNotEmpty() ?? false %}
+              {% set hasErrors = errors[rowId][colId] ?? (cell.errors.isNotEmpty() ?? false) %}
               {% set cellName = static ? null : name~'['~rowId~']['~colId~']' %}
               {% set isCode = (col.code ?? false) or col.type == 'color' %}
               <td class="{{ _self.cellClass(fullWidth, col, col.class ?? []) }} {% if isCode %}code{% endif %} {% if hasErrors %}error{% endif %}"{{ widthAttributes|raw }}>

--- a/src/Auth/AuthMethods.php
+++ b/src/Auth/AuthMethods.php
@@ -330,16 +330,14 @@ class AuthMethods
 
         // Validate the security key
         try {
-            $keyValid = $this->passkeys->verifyPasskey($user, $requestOptions, $response);
+            $updatedCredentialRecord = $this->passkeys->verifyPasskey($user, $requestOptions, $response);
         } catch (InvalidUserHandleException) {
-            $keyValid = $this->passkeys->verifyPasskey($user, $requestOptions, $response, checkOldUserHandle: true);
+            $updatedCredentialRecord = $this->passkeys->verifyPasskey($user, $requestOptions, $response, checkOldUserHandle: true);
         } catch (InvalidArgumentException) {
-            $keyValid = false;
+            $updatedCredentialRecord = false;
         }
 
-        $updatedCredentialRecord = Session::remove($this->passkeys->passkeyCredSourceParam);
-
-        if (! $keyValid) {
+        if ($updatedCredentialRecord === false) {
             $this->authError = AuthError::InvalidCredentials;
 
             return false;

--- a/src/Auth/Passkeys/Passkeys.php
+++ b/src/Auth/Passkeys/Passkeys.php
@@ -43,10 +43,6 @@ class Passkeys
          * @var string The session variable name used to store passkey request options.
          */
         public readonly string $passkeyRequestOptionsParam = 'pkReqOptions',
-        /**
-         * @var string The session variable name used to store updated passkey credential source.
-         */
-        public readonly string $passkeyCredSourceParam = 'pkCredSource',
     ) {}
 
     public function hasPasskeys(CraftUser $user): bool
@@ -188,7 +184,7 @@ class Passkeys
     }
 
     /**
-     * Verifies a passkey authentication response and stores the passkey.
+     * Verifies a passkey authentication response and returns the updated credential record.
      *
      * @param  string  $requestOptions  The public key credential request options
      * @param  string  $response  The authentication response data
@@ -198,7 +194,7 @@ class Passkeys
         string $requestOptions,
         string $response,
         bool $checkOldUserHandle = false,
-    ): bool {
+    ): CredentialRecord|false {
         $serializer = $this->webauthnServer()->getSerializer();
 
         $requestOptions = $serializer->deserialize(
@@ -233,18 +229,13 @@ class Passkeys
         }
 
         try {
-            $updatedCredentialRecord = $this->webauthnServer()->getAuthenticatorAssertionResponseValidator()->check(
+            return $this->webauthnServer()->getAuthenticatorAssertionResponseValidator()->check(
                 $credentialRecord,
                 $authenticatorAssertionResponse,
                 $requestOptions,
                 request()->host(),
                 $userEntity->id,
             );
-
-            // we can't save the updated credential record to db here as in AuthMethods::authenticateWithPasskey()
-            // we might need to call this method (Passkeys::verifyPasskey()) again, with checkOldUserHandle set to true;
-            // so, we're going to store it in the session and then save from the AuthMethods::authenticateWithPasskey() method
-            Session::put($this->passkeyCredSourceParam, $updatedCredentialRecord);
         } catch (InvalidUserHandleException $exception) {
             throw $exception;
         } catch (Throwable $e) {
@@ -252,10 +243,6 @@ class Passkeys
 
             return false;
         }
-
-        $this->webauthnServer()->getCredentialRepository()->saveCredentialSource($credentialRecord);
-
-        return true;
     }
 
     public function deletePasskey(CraftUser $user, string $uid): void

--- a/src/Blade/Directives/ResponseDirective.php
+++ b/src/Blade/Directives/ResponseDirective.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Blade\Directives;
 
-use CraftCms\Cms\Http\Middleware\SetHeaders;
 use CraftCms\Cms\Support\DateTimeHelper;
+use CraftCms\Cms\Support\Facades\ResponseHeaders;
 use CraftCms\Cms\Support\Flash;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\Twig\Exceptions\TemplateExitException;
@@ -39,7 +39,7 @@ class ResponseDirective
     {
         $parts = array_map(trim(...), explode(':', $header, 2));
 
-        SetHeaders::add($parts[0], $parts[1] ?? '');
+        ResponseHeaders::add($parts[0], $parts[1] ?? '');
     }
 
     public static function expires(DateTimeInterface|string|int|null $expiration = null, ?string $unit = null): void
@@ -54,7 +54,7 @@ class ResponseDirective
             $duration = 0;
         }
 
-        SetHeaders::setCache($duration);
+        ResponseHeaders::setCache($duration);
     }
 
     public static function templateExit(?int $status = null, ?string $message = null): void

--- a/src/Database/Commands/Concerns/ManagesDatabaseTables.php
+++ b/src/Database/Commands/Concerns/ManagesDatabaseTables.php
@@ -6,7 +6,6 @@ namespace CraftCms\Cms\Database\Commands\Concerns;
 
 use Illuminate\Console\Command;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 use function Laravel\Prompts\confirm;
@@ -34,47 +33,9 @@ trait ManagesDatabaseTables
     {
         $this->components->info('Dropping all database tables ...');
 
-        $schema = Schema::connection($connection->getName());
-
-        foreach ($this->tableNames($connection) as $tableName) {
-            $this->components->task(
-                "Dropping $tableName",
-                function () use ($connection, $schema, $tableName) {
-                    $this->dropAllForeignKeysToTable($tableName, $connection);
-                    $schema->drop($tableName);
-                }
-            );
-        }
+        $connection->getSchemaBuilder()->dropAllTables();
 
         $this->components->success('Finished dropping all database tables.');
-    }
-
-    private function dropAllForeignKeysToTable(string $table, Connection $connection): void
-    {
-        $schema = Schema::connection($connection->getName());
-        $rawTableName = $this->rawTableName($table);
-
-        foreach ($this->tableNames($connection) as $otherTableName) {
-            foreach ($schema->getForeignKeys($otherTableName) as $foreignKey) {
-                if (! isset($foreignKey['foreign_table'], $foreignKey['name'])) {
-                    continue;
-                }
-                if ($this->rawTableName($foreignKey['foreign_table']) !== $rawTableName) {
-                    continue;
-                }
-                $schema->table($otherTableName, function (Blueprint $blueprint) use ($foreignKey) {
-                    $blueprint->dropForeign($foreignKey['name']);
-                });
-            }
-        }
-    }
-
-    private function rawTableName(string $tableName): string
-    {
-        return str($tableName)
-            ->replace('"', '')
-            ->afterLast('.')
-            ->value();
     }
 
     /**

--- a/src/Edition.php
+++ b/src/Edition.php
@@ -181,12 +181,12 @@ enum Edition: int implements Arrayable
 
     public function supportsRequiring2FA(): bool
     {
-        return self::isAtLeast(self::Team);
+        return $this->value >= self::Team->value;
     }
 
     public function supportsPublicRegistration(): bool
     {
-        return self::isAtLeast(self::Pro);
+        return $this->value >= self::Pro->value;
     }
 
     public function toArray(): array

--- a/src/Element/ElementCollection.php
+++ b/src/Element/ElementCollection.php
@@ -95,7 +95,7 @@ class ElementCollection extends Collection
         $elementsByClass = $this->groupBy(fn (ElementInterface $element) => $element::class)->all();
 
         foreach ($elementsByClass as $class => $classElements) {
-            app(Elements::class)->eagerLoadElements($class, $this->items, $with);
+            Elements::eagerLoadElements($class, $classElements, $with);
         }
 
         return $this;

--- a/src/Element/Queries/Concerns/QueriesCustomFields.php
+++ b/src/Element/Queries/Concerns/QueriesCustomFields.php
@@ -54,13 +54,6 @@ trait QueriesCustomFields
 
     protected function initQueriesCustomFields(): void
     {
-        foreach ([
-            ...array_keys(Fields::allFieldHandles()),
-            ...array_keys(Fields::allGeneratedFieldHandles()),
-        ] as $handle) {
-            $this->customFieldValues[$handle] = null;
-        }
-
         $this->beforeQuery(function (ElementQuery $elementQuery) {
             // Gather custom fields and generated field handles
             $elementQuery->customFields = [];
@@ -198,20 +191,25 @@ trait QueriesCustomFields
 
         $fieldsByHandle = $this->fieldsByHandle($elementQuery);
 
-        foreach (array_keys(Fields::allFieldHandles()) as $handle) {
+        $fieldHandles = Fields::allFieldHandles();
+
+        foreach ($elementQuery->customFieldValues as $handle => $value) {
             // $fieldAttributes->$handle will return true even if it's set to null, so can't use isset() here
             if ($handle === 'owner') {
                 continue;
             }
-            if (($elementQuery->customFieldValues[$handle] ?? null) === null) {
+            if (! array_key_exists($handle, $fieldHandles)) {
+                continue;
+            }
+            if ($value === null) {
                 continue;
             }
             // Make sure the custom field exists in one of the field layouts
             if (! isset($fieldsByHandle[$handle])) {
                 // If it looks like null/:empty: is a valid option, let it slide
-                $value = is_array($elementQuery->customFieldValues[$handle]) && isset($elementQuery->customFieldValues[$handle]['value'])
-                    ? $elementQuery->customFieldValues[$handle]['value']
-                    : $elementQuery->customFieldValues[$handle];
+                $value = is_array($value) && isset($value['value'])
+                    ? $value['value']
+                    : $value;
 
                 if (is_array($value) && in_array(null, $value, true)) {
                     $values = [...$value];
@@ -224,16 +222,16 @@ trait QueriesCustomFields
                 throw new QueryAbortedException("No custom field with the handle \"$handle\" exists in the field layouts involved with this element query.");
             }
 
-            $glue = $elementQuery->customFieldValues[$handle] === ':empty:'
+            $glue = $value === ':empty:'
                 ? QueryParam::AND
                 : QueryParam::OR;
 
-            $this->where(function (Builder $query) use ($fieldsByHandle, $glue, $handle, $elementQuery) {
+            $this->where(function (Builder $query) use ($fieldsByHandle, $glue, $handle, $value) {
                 foreach ($fieldsByHandle[$handle] as $instances) {
-                    $query->where(function (Builder $query) use ($handle, $elementQuery, $instances) {
+                    $query->where(function (Builder $query) use ($instances, $value) {
                         static::$activeQuery = $this;
                         try {
-                            $instances[0]::modifyQuery($query, $instances, $elementQuery->customFieldValues[$handle]);
+                            $instances[0]::modifyQuery($query, $instances, $value);
                         } finally {
                             static::$activeQuery = null;
                         }
@@ -288,5 +286,18 @@ trait QueriesCustomFields
         }
 
         return $fieldsByHandle;
+    }
+
+    private function isCustomFieldHandle(string $handle): bool
+    {
+        if (array_key_exists($handle, $this->customFieldValues)) {
+            return true;
+        }
+
+        if (array_key_exists($handle, Fields::allFieldHandles())) {
+            return true;
+        }
+
+        return array_key_exists($handle, Fields::allGeneratedFieldHandles());
     }
 }

--- a/src/Element/Queries/ElementQuery.php
+++ b/src/Element/Queries/ElementQuery.php
@@ -1003,8 +1003,8 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     #[Override]
     public function __get($key): mixed
     {
-        if (array_key_exists($key, $this->customFieldValues)) {
-            return $this->customFieldValues[$key];
+        if ($this->isCustomFieldHandle($key)) {
+            return $this->customFieldValues[$key] ?? null;
         }
 
         if (in_array($key, $this->propertyPassthru)) {
@@ -1017,7 +1017,7 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
     #[Override]
     public function __set(string $name, mixed $value): void
     {
-        if (array_key_exists($name, $this->customFieldValues)) {
+        if ($this->isCustomFieldHandle($name)) {
             $this->customFieldValues[$name] = $value;
 
             return;
@@ -1053,7 +1053,7 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
             return null;
         }
 
-        if (array_key_exists($method, $this->customFieldValues)) {
+        if ($this->isCustomFieldHandle($method)) {
             $this->customFieldValues[$method] = $parameters[0];
 
             return $this;

--- a/src/Field/Table.php
+++ b/src/Field/Table.php
@@ -49,7 +49,7 @@ use function CraftCms\Cms\template;
  *
  * @phpstan-type TableColumnType 'checkbox'|'color'|'date'|'select'|'email'|'heading'|'lightswitch'|'multiline'|'number'|'singleline'|'time'|'url'
  * @phpstan-type TableOption array{label: string, value: string, default?: bool}
- * @phpstan-type TableColumn array{heading: string, handle: string|array{value: string, hasErrors: true}, type: TableColumnType, width?: int|string, options?: list<TableOption>}
+ * @phpstan-type TableColumn array{heading: string, handle: string, type: TableColumnType, width?: int|string, options?: list<TableOption>}
  * @phpstan-type TableCellValue bool|float|int|string|DateTimeInterface|ColorData|null
  * @phpstan-type TableRowData array<string, TableCellValue>
  */
@@ -57,6 +57,9 @@ class Table extends Field implements CrossSiteCopyableFieldInterface, Defaultabl
 {
     /** @var array<string, string> */
     private static array $typeOptions;
+
+    /** @var array<string, array<string, true>> */
+    private array $columnErrors = [];
 
     #[Override]
     public static function displayName(): string
@@ -158,6 +161,7 @@ class Table extends Field implements CrossSiteCopyableFieldInterface, Defaultabl
                     ->allowAdd()
                     ->allowDelete()
                     ->allowReorder()
+                    ->errors($this->columnErrors)
                     ->value($columnRows)),
             FormField::make(t('Default Values'))
                 ->instructions(t('Define the default values for the field.'))
@@ -292,9 +296,10 @@ class Table extends Field implements CrossSiteCopyableFieldInterface, Defaultabl
 
     public function afterValidate(?Validator $validator = null): void
     {
+        $this->columnErrors = [];
         $typeOptions = self::typeOptions();
 
-        foreach ($this->columns as &$col) {
+        foreach ($this->columns as $colId => &$col) {
             if (! isset($typeOptions[$col['type']])) {
                 $col['type'] = 'singleline';
             }
@@ -316,11 +321,7 @@ class Table extends Field implements CrossSiteCopyableFieldInterface, Defaultabl
             }
 
             if ($error) {
-                $col['handle'] = [
-                    'value' => $col['handle'],
-                    'hasErrors' => true,
-                ];
-
+                $this->columnErrors[$colId]['handle'] = true;
                 $validator?->errors()->add('columns', $error);
             }
         }

--- a/src/Form/Controls/Table.php
+++ b/src/Form/Controls/Table.php
@@ -31,6 +31,9 @@ class Table extends Control
 
     private bool $keyed = false;
 
+    /** @var array<string, array<string, true>> */
+    private array $errors = [];
+
     public static function renderHtml(ControlPayload $control, mixed $value, array $attributes, FormHtmlRenderer $renderer): string
     {
         $rows = is_array($value)
@@ -48,6 +51,7 @@ class Table extends Control
             'minRows' => $control->props['minRows'] ?? null,
             'maxRows' => $control->props['maxRows'] ?? null,
             'static' => $attributes['name'] === null,
+            'errors' => $control->props['errors'] ?? [],
         ]);
     }
 
@@ -106,6 +110,14 @@ class Table extends Control
         return $this;
     }
 
+    /** @param array<string, array<string, true>> $errors */
+    public function errors(array $errors): static
+    {
+        $this->errors = $errors;
+
+        return $this;
+    }
+
     #[\Override]
     public function props(mixed $value = null): array
     {
@@ -117,6 +129,7 @@ class Table extends Control
             'minRows' => $this->minRows,
             'maxRows' => $this->maxRows,
             'keyed' => $this->keyed,
+            'errors' => $this->errors ?: null,
         ]);
     }
 }

--- a/src/Form/FormResolver.php
+++ b/src/Form/FormResolver.php
@@ -13,11 +13,11 @@ use JsonException;
 
 class FormResolver
 {
-    /** @var list<list<string>> */
-    private array $controlPaths = [];
+    /** @var array<string, true> */
+    private array $controlPathIndex = [];
 
-    /** @var list<string> */
-    private array $nodeUids = [];
+    /** @var array<string, true> */
+    private array $nodeUidIndex = [];
 
     /** @var array<string, mixed> */
     private array $values = [];
@@ -30,8 +30,8 @@ class FormResolver
     /** @throws JsonException */
     public function resolve(Form $form, FormContext $context): FormPayload
     {
-        $this->controlPaths = [];
-        $this->nodeUids = [];
+        $this->controlPathIndex = [];
+        $this->nodeUidIndex = [];
         $this->values = [];
         $namespace = $this->normalizePath($context->namespace, 'Form context');
         $nodes = array_map(
@@ -89,11 +89,11 @@ class FormResolver
 
             $scopedUid = Json::encode([...$namespace, $uid], JSON_THROW_ON_ERROR);
 
-            if (in_array($scopedUid, $this->nodeUids, true)) {
+            if (isset($this->nodeUidIndex[$scopedUid])) {
                 throw new InvalidArgumentException("Duplicate Node UID [{$uid}] for Form Node [{$type}] with component [{$component}].");
             }
 
-            $this->nodeUids[] = $scopedUid;
+            $this->nodeUidIndex[$scopedUid] = true;
         }
 
         return new NodePayload(
@@ -156,7 +156,9 @@ class FormResolver
             throw new InvalidArgumentException("Control [{$type}] requires a path; component [{$component}], identity [unknown].");
         }
 
-        if (in_array($path, $this->controlPaths, true)) {
+        $pathKey = Json::encode($path, JSON_THROW_ON_ERROR);
+
+        if (isset($this->controlPathIndex[$pathKey])) {
             throw new InvalidArgumentException("Duplicate Control path [{$identity}] for type [{$type}] with component [{$component}].");
         }
 
@@ -174,7 +176,7 @@ class FormResolver
         }
 
         $this->set($this->values, $path, $value);
-        $this->controlPaths[] = $path;
+        $this->controlPathIndex[$pathKey] = true;
 
         $forms = array_map(function (array $definition) use ($context, $path, $deltaGroup, $mode, $type, $component, $identity): NestedFormPayload {
             if (! isset($definition['scope'], $definition['form'], $definition['refreshable']) || ! $definition['form'] instanceof Form || ! is_bool($definition['refreshable'])) {
@@ -246,18 +248,15 @@ class FormResolver
      */
     private function owningControlPath(array $path): ?array
     {
-        $matches = array_filter(
-            $this->controlPaths,
-            fn (array $controlPath): bool => array_slice($path, 0, count($controlPath)) === $controlPath,
-        );
+        while ($path !== []) {
+            if (isset($this->controlPathIndex[Json::encode($path, JSON_THROW_ON_ERROR)])) {
+                return $path;
+            }
 
-        if ($matches === []) {
-            return null;
+            array_pop($path);
         }
 
-        usort($matches, fn (array $a, array $b): int => count($b) <=> count($a));
-
-        return $matches[0];
+        return null;
     }
 
     /**

--- a/src/Gql/ElementQueryConditionBuilder.php
+++ b/src/Gql/ElementQueryConditionBuilder.php
@@ -27,14 +27,11 @@ use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\FragmentDefinitionNode;
 use GraphQL\Language\AST\FragmentSpreadNode;
 use GraphQL\Language\AST\InlineFragmentNode;
-use GraphQL\Language\AST\ListValueNode;
 use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeList;
-use GraphQL\Language\AST\ObjectFieldNode;
-use GraphQL\Language\AST\ObjectValueNode;
-use GraphQL\Language\AST\VariableNode;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
+use GraphQL\Utils\AST;
 use InvalidArgumentException;
 
 class ElementQueryConditionBuilder extends Component
@@ -130,56 +127,10 @@ class ElementQueryConditionBuilder extends Component
         $arguments = [];
 
         foreach ($argumentNodes as $argumentNode) {
-            $arguments[$argumentNode->name->value] = $this->_extractArgumentValue($argumentNode);
+            $arguments[$argumentNode->name->value] = AST::valueFromASTUntyped($argumentNode->value, $this->_resolveInfo->variableValues);
         }
 
         return $arguments;
-    }
-
-    private function _extractArgumentValue(Node $argumentNode): mixed
-    {
-        // Deal with a raw object value.
-        if ($argumentNode->kind === 'ObjectValue') {
-            /** @var ObjectValueNode $argumentNode */
-            $extractedValue = [];
-            foreach ($argumentNode->fields as $fieldNode) {
-                $extractedValue[$fieldNode->name->value] = $this->_extractArgumentValue($fieldNode);
-            }
-
-            return $extractedValue;
-        }
-
-        if (in_array($argumentNode->kind, ['Argument', 'Variable', 'ListValue', 'ObjectField'], true)) {
-            /** @var ArgumentNode|VariableNode|ListValueNode|ObjectFieldNode $argumentNode */
-            $argumentNodeValue = $argumentNode->value;
-
-            switch ($argumentNodeValue->kind) {
-                case 'Variable':
-                    return $this->_resolveInfo->variableValues[$argumentNodeValue->name->value];
-                case 'ListValue':
-                    $extractedValue = [];
-                    foreach ($argumentNodeValue->values as $value) {
-                        $extractedValue[] = $this->_extractArgumentValue($value);
-                    }
-
-                    return $extractedValue;
-                case 'ObjectValue':
-                    $extractedValue = [];
-                    foreach ($argumentNodeValue->fields as $fieldNode) {
-                        $extractedValue[$fieldNode->name->value] = $this->_extractArgumentValue($fieldNode);
-                    }
-
-                    return $extractedValue;
-                case 'NullValue':
-                    return null;
-                default:
-                    return $argumentNodeValue->value;
-            }
-        }
-
-        $value = $argumentNode->value ?? null;
-
-        return $argumentNode->kind === 'IntValue' ? (int) $value : $value;
     }
 
     private function _isAdditionalEagerLoadableNode(string $nodeName, mixed $parentField): bool

--- a/src/Gql/GqlHelper.php
+++ b/src/Gql/GqlHelper.php
@@ -17,8 +17,7 @@ use CraftCms\Cms\Site\Data\Site;
 use CraftCms\Cms\Support\Facades\Sections;
 use CraftCms\Cms\Support\Facades\Sites;
 use GraphQL\Error\Error;
-use GraphQL\Language\AST\ListValueNode;
-use GraphQL\Language\AST\VariableNode;
+use GraphQL\Executor\Values;
 use GraphQL\Language\Parser;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
@@ -234,13 +233,7 @@ class GqlHelper
                 continue;
             }
 
-            $arguments = [];
-
-            if (isset($directive->arguments[0])) {
-                foreach ($directive->arguments as $argument) {
-                    $arguments[$argument->name->value] = self::_convertArgumentValue($argument->value, $resolveInfo->variableValues);
-                }
-            }
+            $arguments = Values::getArgumentValues($directiveEntity, $directive, $resolveInfo->variableValues, $resolveInfo->schema);
 
             $value = $directiveEntity::apply($source, $value, $arguments, $resolveInfo);
         }
@@ -301,20 +294,6 @@ class GqlHelper
             ->filter(fn (Site $site) => in_array($site->uid, $allowedSiteUids, true))
             ->values()
             ->all();
-    }
-
-    /** @param array<string, mixed> $variableValues */
-    private static function _convertArgumentValue(mixed $value, array $variableValues = []): mixed
-    {
-        if ($value instanceof VariableNode) {
-            return $variableValues[$value->name->value];
-        }
-
-        if ($value instanceof ListValueNode) {
-            return array_map(fn ($node) => self::_convertArgumentValue($node), iterator_to_array($value->values));
-        }
-
-        return $value->value;
     }
 
     /** @param array{conditionBuilder?: ElementQueryConditionBuilder}|null $context */

--- a/src/Gql/Types/QueryArgument.php
+++ b/src/Gql/Types/QueryArgument.php
@@ -7,10 +7,8 @@ namespace CraftCms\Cms\Gql\Types;
 use CraftCms\Cms\Gql\Contracts\SingularTypeInterface;
 use CraftCms\Cms\Gql\Exceptions\GqlException;
 use CraftCms\Cms\Gql\GqlEntityRegistry;
-use GraphQL\Language\AST\BooleanValueNode;
-use GraphQL\Language\AST\IntValueNode;
-use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Utils\AST;
 use Override;
 
 class QueryArgument extends ScalarType implements SingularTypeInterface
@@ -52,11 +50,6 @@ class QueryArgument extends ScalarType implements SingularTypeInterface
 
     public function parseLiteral($valueNode, ?array $variables = null)
     {
-        return match (true) {
-            $valueNode instanceof StringValueNode => $valueNode->value,
-            $valueNode instanceof IntValueNode => (int) $valueNode->value,
-            $valueNode instanceof BooleanValueNode => $valueNode->value,
-            default => throw new GqlException('QueryArgument must be either a string, an integer, or a boolean value.'),
-        };
+        return $this->parseValue(AST::valueFromASTUntyped($valueNode, $variables));
     }
 }

--- a/src/Http/Middleware/SetHeaders.php
+++ b/src/Http/Middleware/SetHeaders.php
@@ -7,111 +7,72 @@ namespace CraftCms\Cms\Http\Middleware;
 use Closure;
 use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\Http\Controllers\Auth\LoginController;
+use CraftCms\Cms\Http\ResponseHeaders;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class SetHeaders
 {
-    private static bool $noCache = false;
-
-    private static ?int $duration = null;
-
-    private static bool $replace = true;
-
-    /** @var list<array{header:string, value:string, replace:bool}> */
-    private static array $headers = [];
-
     public function __construct(
         private readonly GeneralConfig $generalConfig,
+        private readonly ResponseHeaders $responseHeaders,
     ) {}
-
-    public static function noCache(): void
-    {
-        self::$noCache = true;
-    }
-
-    public static function setCache(int $duration = 31536000, bool $replace = true): void
-    {
-        self::$duration = $duration;
-        self::$replace = $replace;
-    }
-
-    public static function add(string $header, string $value, bool $replace = true): void
-    {
-        self::$headers[] = [
-            'header' => $header,
-            'value' => $value,
-            'replace' => $replace,
-        ];
-    }
 
     public function handle(Request $request, Closure $next): mixed
     {
-        try {
-            $response = $next($request);
+        $response = $next($request);
 
-            if (! $response instanceof Response) {
-                if ($response instanceof SymfonyResponse) {
-                    $this->setPoweredByHeader($response);
-                }
-
-                return $response;
+        if (! $response instanceof Response) {
+            if ($response instanceof SymfonyResponse) {
+                $this->setPoweredByHeader($response);
             }
-
-            $hasPreviewParam = $request->previewParam() !== null;
-
-            if ($request->isCpRequest() || $request->isActionRequest() || $hasPreviewParam || self::$noCache) {
-                $response->setNoCacheHeaders();
-            } elseif (! is_null(self::$duration)) {
-                if (self::$duration <= 0) {
-                    $response->setNoCacheHeaders();
-                } else {
-                    $response
-                        ->setExpires(now()->addSeconds(self::$duration))
-                        ->header('Pragma', 'cache', self::$replace)
-                        ->setPublic()
-                        ->setMaxAge(self::$duration);
-                }
-            }
-
-            // Tell bots not to index/follow control panel and tokenized pages
-            if (
-                $this->generalConfig->disallowRobots ||
-                $request->isCpRequest() ||
-                $request->has(HandleTokenRequest::TOKEN_KEY) ||
-                $request->hasHeader(HandleTokenRequest::TOKEN_HEADER) ||
-                $hasPreviewParam ||
-                ($request->isActionRequest() && ! ($request->route()?->getActionName() === LoginController::class && $request->isMethod('GET')))
-            ) {
-                $response->headers->set('X-Robots-Tag', 'none');
-            }
-
-            // Prevent some possible XSS attack vectors
-            if ($request->isCpRequest()) {
-                $response->headers->set('Content-Security-Policy', "frame-ancestors 'self'", replace: false);
-                $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
-                $response->headers->set('X-Content-Type-Options', 'nosniff');
-            }
-
-            foreach (self::$headers as $header) {
-                $response->header($header['header'], $header['value'], $header['replace'] ?? true);
-            }
-
-            $this->setPoweredByHeader($response);
 
             return $response;
-        } finally {
-            self::reset();
         }
-    }
 
-    public static function reset(): void
-    {
-        self::$noCache = false;
-        self::$duration = null;
-        self::$replace = true;
-        self::$headers = [];
+        $hasPreviewParam = $request->previewParam() !== null;
+
+        if ($request->isCpRequest() || $request->isActionRequest() || $hasPreviewParam || $this->responseHeaders->noCache) {
+            $response->setNoCacheHeaders();
+        } elseif ($this->responseHeaders->duration !== null) {
+            if ($this->responseHeaders->duration <= 0) {
+                $response->setNoCacheHeaders();
+            } else {
+                $response
+                    ->setExpires(now()->addSeconds($this->responseHeaders->duration))
+                    ->header('Pragma', 'cache', $this->responseHeaders->replace)
+                    ->setPublic()
+                    ->setMaxAge($this->responseHeaders->duration);
+            }
+        }
+
+        // Tell bots not to index/follow control panel and tokenized pages
+        if (
+            $this->generalConfig->disallowRobots ||
+            $request->isCpRequest() ||
+            $request->has(HandleTokenRequest::TOKEN_KEY) ||
+            $request->hasHeader(HandleTokenRequest::TOKEN_HEADER) ||
+            $hasPreviewParam ||
+            ($request->isActionRequest() && ! ($request->route()?->getActionName() === LoginController::class && $request->isMethod('GET')))
+        ) {
+            $response->headers->set('X-Robots-Tag', 'none');
+        }
+
+        // Prevent some possible XSS attack vectors
+        if ($request->isCpRequest()) {
+            $response->headers->set('Content-Security-Policy', "frame-ancestors 'self'", replace: false);
+            $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+            $response->headers->set('X-Content-Type-Options', 'nosniff');
+        }
+
+        foreach ($this->responseHeaders->headers as $header) {
+            $response->header($header['header'], $header['value'], $header['replace']);
+        }
+
+        $this->setPoweredByHeader($response);
+
+        return $response;
     }
 
     private function setPoweredByHeader(SymfonyResponse $response): void

--- a/src/Http/ResponseHeaders.php
+++ b/src/Http/ResponseHeaders.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http;
+
+use Illuminate\Container\Attributes\Scoped;
+
+#[Scoped]
+class ResponseHeaders
+{
+    public private(set) bool $noCache = false;
+
+    public private(set) ?int $duration = null;
+
+    public private(set) bool $replace = true;
+
+    /** @var list<array{header:string, value:string, replace:bool}> */
+    public private(set) array $headers = [];
+
+    public function noCache(): void
+    {
+        $this->noCache = true;
+    }
+
+    public function setCache(int $duration = 31536000, bool $replace = true): void
+    {
+        $this->duration = $duration;
+        $this->replace = $replace;
+    }
+
+    public function add(string $header, string $value, bool $replace = true): void
+    {
+        $this->headers[] = [
+            'header' => $header,
+            'value' => $value,
+            'replace' => $replace,
+        ];
+    }
+}

--- a/src/Image/ImageTransformer.php
+++ b/src/Image/ImageTransformer.php
@@ -11,7 +11,6 @@ use CraftCms\Cms\Asset\Exceptions\ImageTransformException;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Filesystem\Exceptions\FilesystemException;
-use CraftCms\Cms\Http\Middleware\SetHeaders;
 use CraftCms\Cms\Image\Contracts\EagerImageTransformerInterface;
 use CraftCms\Cms\Image\Contracts\ImageEditorTransformerInterface;
 use CraftCms\Cms\Image\Contracts\ImageTransformerInterface;
@@ -24,6 +23,7 @@ use CraftCms\Cms\Shared\Exceptions\NotSupportedException;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\DateTimeHelper;
 use CraftCms\Cms\Support\Facades\I18N;
+use CraftCms\Cms\Support\Facades\ResponseHeaders;
 use CraftCms\Cms\Support\File;
 use CraftCms\Cms\Support\Query;
 use CraftCms\Cms\Support\Str;
@@ -103,7 +103,7 @@ class ImageTransformer implements EagerImageTransformerInterface, ImageEditorTra
 
                 // Prevent the page from being cached
                 if (! app()->runningInConsole()) {
-                    SetHeaders::noCache();
+                    ResponseHeaders::noCache();
                 }
 
                 // Return the temporary transform URL

--- a/src/Plugin/Plugins.php
+++ b/src/Plugin/Plugins.php
@@ -91,10 +91,8 @@ class Plugins
      */
     private array $storedPluginInfo;
 
-    /**
-     * @var string[]|string|null Any plugin handles that must be disabled per the `disablePlugins` config setting
-     */
-    private string|array|null $forceDisabledPlugins;
+    /** @var array<string, true> Plugin handles that must be disabled per the `disabledPlugins` config setting */
+    private array $forceDisabledPlugins;
 
     /**
      * @var string[] Cache for [[getPluginHandleByClass()]]
@@ -117,11 +115,8 @@ class Plugins
         GeneralConfig $generalConfig,
         private readonly PackageManifest $packageManifest,
     ) {
-        if ($generalConfig->safeMode) {
-            $this->forceDisabledPlugins = '*';
-        } else {
-            $this->forceDisabledPlugins = is_array($generalConfig->disabledPlugins) ? array_flip($generalConfig->disabledPlugins) : $generalConfig->disabledPlugins;
-        }
+        $forceDisabledPlugins = $generalConfig->safeMode ? '*' : $generalConfig->disabledPlugins;
+        $this->forceDisabledPlugins = array_fill_keys(is_string($forceDisabledPlugins) ? str($forceDisabledPlugins)->explode(',')->all() : ($forceDisabledPlugins ?? []), true);
 
         $this->composerPluginInfo = [];
 
@@ -992,7 +987,7 @@ class Plugins
 
         $info['isInstalled'] = $installed = $pluginInfo !== null;
         $info['isEnabled'] = $plugin !== null;
-        $info['isForceDisabled'] = ! ($this->forceDisabledPlugins === null) && ($this->forceDisabledPlugins === '*' || in_array($handle, $this->forceDisabledPlugins, true));
+        $info['isForceDisabled'] = $this->isPluginForceDisabled($handle);
         $info['private'] = str_starts_with($handle, '_');
         $info['moduleId'] = $handle;
         $info['edition'] = $edition;
@@ -1353,13 +1348,15 @@ class Plugins
         }
 
         // Force disable it?
-        if (
-            $this->forceDisabledPlugins === '*' ||
-            (is_array($this->forceDisabledPlugins) && isset($this->forceDisabledPlugins[$handle]))
-        ) {
+        if ($this->isPluginForceDisabled($handle)) {
             $data['enabled'] = false;
         }
 
         return $data;
+    }
+
+    private function isPluginForceDisabled(string $handle): bool
+    {
+        return isset($this->forceDisabledPlugins['*']) || isset($this->forceDisabledPlugins[$handle]);
     }
 }

--- a/src/Queue/JobProgress.php
+++ b/src/Queue/JobProgress.php
@@ -271,8 +271,7 @@ readonly class JobProgress
 
     /**
      * Upserts a job entry.
-     */
-    /**
+     *
      * @param  array<string, mixed>  $attributes
      */
     private function upsertJob(
@@ -280,31 +279,14 @@ readonly class JobProgress
         JobStatus $status,
         array $attributes = [],
     ): void {
-        DB::beginTransaction();
-
-        $now = now();
-        $exists = JobProgressModel::query()->where('uid', $uid)->exists();
-
-        if (! $exists) {
-            JobProgressModel::create(array_merge($attributes, [
+        JobProgressModel::query()->upsert(
+            [
+                ...$attributes,
                 'uid' => $uid,
                 'status' => $status->value,
-                'dateCreated' => $now,
-                'dateUpdated' => $now,
-            ]));
-
-            DB::commit();
-
-            return;
-        }
-
-        $data = array_merge($attributes, [
-            'status' => $status->value,
-            'dateUpdated' => $now,
-        ]);
-
-        JobProgressModel::query()->where('uid', $uid)->update($data);
-
-        DB::commit();
+            ],
+            uniqueBy: 'uid',
+            update: [...array_keys($attributes), 'status'],
+        );
     }
 }

--- a/src/Search/Search.php
+++ b/src/Search/Search.php
@@ -44,16 +44,6 @@ class Search
      */
     public ?int $minFullTextWordLength = null;
 
-    /**
-     * @var SearchQueryTerm[]
-     */
-    private array $terms;
-
-    /**
-     * @var SearchQueryTerm[][]
-     */
-    private array $groups;
-
     private readonly bool $isMysql;
 
     private readonly bool $isPgsql;
@@ -344,7 +334,7 @@ class Search
         event($event = new SearchResultsResolving($elementQuery, $searchQuery, $results));
 
         $results = $event->results;
-        $scores = $this->scoreResults($results);
+        $scores = $this->scoreResults($results, $searchQuery);
 
         event($event = new SearchScoresResolving($elementQuery, $searchQuery, $results, $scores));
 
@@ -363,16 +353,7 @@ class Search
     {
         $searchQuery = $this->normalizeSearchQuery($searchQuery);
 
-        $this->terms = [];
-        $this->groups = [];
-
-        foreach ($searchQuery->getTokens() as $obj) {
-            if ($obj instanceof SearchQueryTermGroup) {
-                $this->groups[] = $obj->terms;
-            } else {
-                $this->terms[] = $obj;
-            }
-        }
+        [$terms, $groups] = $this->splitQueryTokens($searchQuery);
 
         if ($elementQuery->customFields !== null) {
             $customFields = new MemoizableArray($elementQuery->customFields);
@@ -380,7 +361,7 @@ class Search
             $customFields = null;
         }
 
-        $where = $this->getWhereClause($elementQuery->siteId, $customFields);
+        $where = $this->getWhereClause($terms, $groups, $elementQuery->siteId, $customFields);
 
         if ($where === false) {
             return false;
@@ -397,10 +378,12 @@ class Search
 
     /**
      * @param  list<array{elementId: int|string, siteId: int|string, keywords: string, attribute: string}>  $results
+     * @param  SearchQuery  $searchQuery  The operation-local query whose terms should score the results
      * @return array<string, int>
      */
-    private function scoreResults(array $results): array
+    private function scoreResults(array $results, SearchQuery $searchQuery): array
     {
+        [$terms, $groups] = $this->splitQueryTokens($searchQuery);
         $scores = [];
 
         foreach ($results as $row) {
@@ -410,10 +393,27 @@ class Search
                 $scores[$key] = 0;
             }
 
-            $scores[$key] += $this->scoreRow($row);
+            $scores[$key] += $this->scoreRow($row, $terms, $groups);
         }
 
         return $scores;
+    }
+
+    /** @return array{list<SearchQueryTerm>, list<list<SearchQueryTerm>>} */
+    private function splitQueryTokens(SearchQuery $searchQuery): array
+    {
+        $terms = [];
+        $groups = [];
+
+        foreach ($searchQuery->getTokens() as $token) {
+            if ($token instanceof SearchQueryTermGroup) {
+                $groups[] = $token->terms;
+            } else {
+                $terms[] = $token;
+            }
+        }
+
+        return [$terms, $groups];
     }
 
     /** @param string|array{query: string, subLeft?: bool, subRight?: bool, exclude?: bool, exact?: bool}|SearchQuery $searchQuery */
@@ -506,19 +506,23 @@ class Search
         }, 1_000, fn (Throwable $e) => $e instanceof QueryException && str_contains($e->getMessage(), 'deadlock'));
     }
 
-    /** @param array{elementId: int|string, siteId: int|string, keywords: string, attribute: string} $row */
-    private function scoreRow(array $row): int
+    /**
+     * @param  array{elementId: int|string, siteId: int|string, keywords: string, attribute: string}  $row
+     * @param  list<SearchQueryTerm>  $terms
+     * @param  list<list<SearchQueryTerm>>  $groups
+     */
+    private function scoreRow(array $row, array $terms, array $groups): int
     {
         $score = 0;
 
-        foreach ($this->terms as $term) {
+        foreach ($terms as $term) {
             $score += $this->scoreTerm($term, $row, 1);
         }
 
-        foreach ($this->groups as $terms) {
-            $weight = 1 / count($terms);
+        foreach ($groups as $group) {
+            $weight = 1 / count($group);
 
-            foreach ($terms as $term) {
+            foreach ($group as $term) {
                 $score += $this->scoreTerm($term, $row, $weight);
             }
         }
@@ -566,16 +570,18 @@ class Search
     }
 
     /**
+     * @param  list<SearchQueryTerm>  $terms
+     * @param  list<list<SearchQueryTerm>>  $groups
      * @param  int|int[]|null  $siteId
      * @param  MemoizableArray<FieldInterface>|null  $customFields
      * @return array{sql: string, bindings: list<int|float|string|bool|null>}|false
      */
-    private function getWhereClause(array|int|null $siteId, ?MemoizableArray $customFields): array|false
+    private function getWhereClause(array $terms, array $groups, array|int|null $siteId, ?MemoizableArray $customFields): array|false
     {
         $where = [];
 
-        if (! empty($this->terms)) {
-            $condition = $this->processTokens($this->terms, true, $siteId, $customFields);
+        if (! empty($terms)) {
+            $condition = $this->processTokens($terms, true, $siteId, $customFields);
 
             if ($condition === false) {
                 return false;
@@ -584,7 +590,7 @@ class Search
             $where[] = $condition;
         }
 
-        foreach ($this->groups as $group) {
+        foreach ($groups as $group) {
             $condition = $this->processTokens($group, false, $siteId, $customFields);
 
             if ($condition === false) {

--- a/src/Support/Facades/ResponseHeaders.php
+++ b/src/Support/Facades/ResponseHeaders.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Support\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Override;
+
+/**
+ * @method static void noCache()
+ * @method static void setCache(int $duration = 31536000, bool $replace = true)
+ * @method static void add(string $header, string $value, bool $replace = true)
+ *
+ * @see \CraftCms\Cms\Http\ResponseHeaders
+ */
+class ResponseHeaders extends Facade
+{
+    #[Override]
+    protected static $cached = false;
+
+    #[Override]
+    protected static function getFacadeAccessor(): string
+    {
+        return \CraftCms\Cms\Http\ResponseHeaders::class;
+    }
+}

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -7,10 +7,10 @@ namespace CraftCms\Cms\Support;
 use CraftCms\Aliases\Aliases;
 use CraftCms\Cms\Asset\Elements\Asset;
 use CraftCms\Cms\Cms;
-use CraftCms\Cms\Http\Middleware\SetHeaders;
 use CraftCms\Cms\Image\SvgAllowedAttributes;
 use CraftCms\Cms\Support\Exceptions\InvalidHtmlTagException;
 use CraftCms\Cms\Support\Facades\HtmlStack;
+use CraftCms\Cms\Support\Facades\ResponseHeaders;
 use CraftCms\Cms\Support\Facades\Security;
 use CraftCms\Cms\View\TemplateMode;
 use DOMElement;
@@ -180,7 +180,7 @@ class Html
             ?? (request()->isSiteRequest() && Cms::config()->asyncCsrfInputs);
 
         if (! $async) {
-            SetHeaders::noCache();
+            ResponseHeaders::noCache();
 
             return (string) csrf_field();
         }

--- a/src/Support/Json.php
+++ b/src/Support/Json.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\Support;
 
 use CraftCms\Aliases\Aliases;
 use InvalidArgumentException;
+use JsonException;
 use Throwable;
 
 /**
@@ -41,11 +42,15 @@ class Json
             return null;
         }
 
-        if (! Str::isJson($json)) {
+        if (! is_string($json)) {
             throw new InvalidArgumentException('Invalid JSON data.');
         }
 
-        return json_decode($json, $asArray);
+        try {
+            return json_decode($json, $asArray, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new InvalidArgumentException('Invalid JSON data.');
+        }
     }
 
     /**

--- a/src/Twig/Nodes/ExpiresNode.php
+++ b/src/Twig/Nodes/ExpiresNode.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Twig\Nodes;
 
-use CraftCms\Cms\Http\Middleware\SetHeaders;
 use CraftCms\Cms\Support\DateTimeHelper;
+use CraftCms\Cms\Support\Facades\ResponseHeaders;
 use Override;
 use Twig\Attribute\YieldReady;
 use Twig\Compiler;
@@ -37,6 +37,6 @@ class ExpiresNode extends Node
             $compiler->write("\$duration = $duration;\n");
         }
 
-        $compiler->write(SetHeaders::class."::setCache(\$duration);\n");
+        $compiler->write(ResponseHeaders::class."::setCache(\$duration);\n");
     }
 }

--- a/src/Twig/Nodes/HeaderNode.php
+++ b/src/Twig/Nodes/HeaderNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Twig\Nodes;
 
-use CraftCms\Cms\Http\Middleware\SetHeaders;
+use CraftCms\Cms\Support\Facades\ResponseHeaders;
 use Override;
 use Twig\Attribute\YieldReady;
 use Twig\Compiler;
@@ -20,7 +20,7 @@ class HeaderNode extends Node
             ->write('$_headerParts = array_map(\'trim\', explode(\':\', ')
             ->subcompile($this->getNode('header'))
             ->raw(", 2));\n")
-            ->write(SetHeaders::class."::add(\$_headerParts[0], \$_headerParts[1] ?? '');\n")
+            ->write(ResponseHeaders::class."::add(\$_headerParts[0], \$_headerParts[1] ?? '');\n")
             ->write("unset(\$_headerParts);\n");
     }
 }

--- a/src/User/UserPermissions.php
+++ b/src/User/UserPermissions.php
@@ -61,20 +61,6 @@ use function CraftCms\Cms\t;
 class UserPermissions
 {
     /**
-     * @var Collection<int, PermissionGroup>
-     *
-     * @see getAllPermissions()
-     */
-    private Collection $allPermissions;
-
-    /**
-     * @var Collection<string, string>
-     *
-     * @see validatePermission()
-     */
-    private Collection $permissionNamesByLowercase;
-
-    /**
      * @var Collection<int, Collection<int, string>>
      */
     private Collection $permissionsByGroupId;
@@ -120,20 +106,16 @@ class UserPermissions
      */
     public function getAllPermissions(): Collection
     {
-        if (isset($this->allPermissions)) {
-            return $this->allPermissions;
-        }
+        $permissions = new Collection;
 
-        $this->allPermissions = new Collection;
+        $this->generalPermissions($permissions);
+        $this->userPermissions($permissions);
+        $this->sitePermissions($permissions);
+        $this->entryPermissions($permissions);
+        $this->volumePermissions($permissions);
+        $this->utilityPermissions($permissions);
 
-        $this->generalPermissions($this->allPermissions);
-        $this->userPermissions($this->allPermissions);
-        $this->sitePermissions($this->allPermissions);
-        $this->entryPermissions($this->allPermissions);
-        $this->volumePermissions($this->allPermissions);
-        $this->utilityPermissions($this->allPermissions);
-
-        return $this->allPermissions = $this->permissionGroupCatalog->apply($this->allPermissions);
+        return $this->permissionGroupCatalog->apply($permissions);
     }
 
     /**
@@ -178,7 +160,7 @@ class UserPermissions
                 ->join(new Alias(Table::USERPERMISSIONS_USERGROUPS, 'p_g'), 'p_g.permissionId', 'p.id')
                 ->where('p_g.groupId', $groupId)
                 ->pluck('p.name')
-                ->map(fn (string $permission) => $this->canonicalPermissionName($permission)),
+                ->pipe(fn (Collection $permissions) => collect($this->canonicalPermissionNames($permissions->all()))),
         );
     }
 
@@ -200,7 +182,7 @@ class UserPermissions
             ->join(new Alias(Table::USERGROUPS_USERS, 'g_u'), 'g_u.groupId', 'p_g.groupId')
             ->where('g_u.userId', $userId)
             ->pluck('p.name')
-            ->map(fn (string $permission) => $this->canonicalPermissionName($permission));
+            ->pipe(fn (Collection $permissions) => collect($this->canonicalPermissionNames($permissions->all())));
     }
 
     /**
@@ -261,7 +243,7 @@ class UserPermissions
                         ->join(new Alias(Table::USERPERMISSIONS_USERS, 'p_u'), 'p_u.permissionId', 'p.id')
                         ->where('p_u.userId', $userId)
                         ->pluck('p.name')
-                        ->map(fn (string $permission) => $this->canonicalPermissionName($permission));
+                        ->pipe(fn (Collection $permissions) => collect($this->canonicalPermissionNames($permissions->all())));
                 } else {
                     $userPermissions = [];
                 }
@@ -273,7 +255,7 @@ class UserPermissions
 
     public function validatePermission(string $permission): bool
     {
-        return $this->permissionNamesByLowercase()->has(strtolower($permission));
+        return $this->permissionNamesByLowercase()->has(Str::lower($permission));
     }
 
     /**
@@ -889,9 +871,7 @@ class UserPermissions
      */
     private function getPermissionModelByName(string $permissionName): UserPermission
     {
-        $permissionName = $this->canonicalPermissionName($permissionName);
-
-        if ($permissionModel = UserPermission::whereIn('name', [$permissionName, strtolower($permissionName)])->first()) {
+        if ($permissionModel = UserPermission::whereIn('name', [$permissionName, Str::lower($permissionName)])->first()) {
             return $permissionModel;
         }
 
@@ -903,18 +883,14 @@ class UserPermissions
     /** @return Collection<string, string> */
     private function permissionNamesByLowercase(): Collection
     {
-        if (! isset($this->permissionNamesByLowercase)) {
-            $this->permissionNamesByLowercase = $this->getAllPermissions()
-                ->flatMap(fn (PermissionGroup $group) => $this->collectPermissionNames($group->permissions))
-                ->mapWithKeys(fn (string $permission) => [strtolower($permission) => $permission]);
-        }
-
-        return $this->permissionNamesByLowercase;
+        return $this->getAllPermissions()
+            ->flatMap(fn (PermissionGroup $group) => $this->collectPermissionNames($group->permissions))
+            ->mapWithKeys(fn (string $permission) => [Str::lower($permission) => $permission]);
     }
 
     private function canonicalPermissionName(string $permission): string
     {
-        return $this->permissionNamesByLowercase()->get(strtolower($permission), $permission);
+        return $this->permissionNamesByLowercase()->get(Str::lower($permission), $permission);
     }
 
     /**
@@ -923,7 +899,12 @@ class UserPermissions
      */
     private function canonicalPermissionNames(array $permissions): array
     {
-        return array_values(array_unique(array_map($this->canonicalPermissionName(...), $permissions)));
+        $permissionNamesByLowercase = $this->permissionNamesByLowercase();
+
+        return array_values(array_unique(array_map(
+            fn (string $permission) => $permissionNamesByLowercase->get(Str::lower($permission), $permission),
+            $permissions,
+        )));
     }
 
     private function createUserPermissionsQuery(): Builder
@@ -937,8 +918,6 @@ class UserPermissions
     public function reset(): void
     {
         unset(
-            $this->allPermissions,
-            $this->permissionNamesByLowercase,
             $this->permissionsByGroupId,
             $this->permissionsByUserId,
         );

--- a/src/Validation/Concerns/Validates.php
+++ b/src/Validation/Concerns/Validates.php
@@ -93,9 +93,10 @@ trait Validates
 
         if ($throw) {
             $ruleset->validate();
+            $result = true;
+        } else {
+            $result = $ruleset->passes();
         }
-
-        $result = $ruleset->passes();
 
         $this->errors()->merge($ruleset->getValidator()->errors());
 

--- a/src/View/CacheCollectors/ResourceCollector.php
+++ b/src/View/CacheCollectors/ResourceCollector.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\View\CacheCollectors;
 
-use CraftCms\Cms\Support\Arr;
-use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\View\Contracts\CacheCollectorInterface;
+use CraftCms\Cms\View\Data\ResourceEntry;
 use CraftCms\Cms\View\Data\TemplateCacheContext;
 use CraftCms\Cms\View\Enums\Position;
 use CraftCms\Cms\View\HtmlStack;
@@ -55,12 +54,12 @@ readonly class ResourceCollector implements CacheCollectorInterface
 
         return array_filter([
             'js' => $buffer['js'],
-            'scripts' => array_map($this->parseInlineResourceTags(...), $buffer['scripts']),
-            'css' => $this->parseInlineResourceTags($buffer['css']),
-            'jsFiles' => array_map(fn (array $tags) => $this->parseExternalResourceTags($tags, 'src'), $buffer['jsFiles']),
-            'cssFiles' => $this->parseExternalResourceTags($buffer['cssFiles'], 'href'),
+            'scripts' => array_map($this->resourceArguments(...), $buffer['scripts']),
+            'css' => $this->resourceArguments($buffer['css']),
+            'jsFiles' => array_map($this->resourceArguments(...), $buffer['jsFiles']),
+            'cssFiles' => $this->resourceArguments($buffer['cssFiles']),
             'html' => $buffer['html'],
-            'metaTags' => $this->parseSelfClosingTags($buffer['metaTags']),
+            'metaTags' => $this->resourceArguments($buffer['metaTags']),
             'jsImports' => $buffer['jsImports'],
         ], fn (mixed $payload) => $payload !== [] && $payload !== null);
     }
@@ -132,49 +131,11 @@ readonly class ResourceCollector implements CacheCollectorInterface
     }
 
     /**
-     * @param  array<string, \Stringable|string>  $tags
-     * @return array<string, array{string, array<string, mixed>}>
+     * @param  array<string, ResourceEntry>  $entries
+     * @return array<string, array<array-key, mixed>>
      */
-    private function parseInlineResourceTags(array $tags): array
+    private function resourceArguments(array $entries): array
     {
-        return array_map(function ($tag) {
-            $tag = Html::parseTag((string) $tag);
-
-            return [$tag['children'][0]['value'] ?? '', $tag['attributes']];
-        }, $tags);
-    }
-
-    /**
-     * @param  array<string, \Stringable|string>  $tags
-     * @return array<string, array{mixed, array<string, mixed>}>
-     */
-    private function parseExternalResourceTags(array $tags, string $urlAttribute): array
-    {
-        return array_map(function ($tag) use ($urlAttribute) {
-            [$tag, $condition] = Html::unwrapCondition((string) $tag);
-            [$tag, $noscript] = Html::unwrapNoscript($tag);
-            $tag = Html::parseTag($tag);
-            $url = Arr::pull($tag['attributes'], $urlAttribute);
-            $options = $tag['attributes'];
-
-            if ($condition) {
-                $options['condition'] = $condition;
-            }
-
-            if ($noscript) {
-                $options['noscript'] = true;
-            }
-
-            return [$url, $options];
-        }, $tags);
-    }
-
-    /**
-     * @param  array<string, \Stringable|string>  $tags
-     * @return array<string, array<string, mixed>>
-     */
-    private function parseSelfClosingTags(array $tags): array
-    {
-        return array_map(fn ($tag) => Html::parseTagAttributes((string) $tag), $tags);
+        return array_map(fn (ResourceEntry $entry) => $entry->arguments, $entries);
     }
 }

--- a/src/View/Data/ResourceEntry.php
+++ b/src/View/Data/ResourceEntry.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\View\Data;
+
+use Stringable;
+
+readonly class ResourceEntry implements Stringable
+{
+    /** @param array<array-key, mixed> $arguments */
+    public function __construct(
+        private Stringable|string $html,
+        public array $arguments,
+    ) {}
+
+    public function __toString(): string
+    {
+        return (string) $this->html;
+    }
+}

--- a/src/View/HtmlStack.php
+++ b/src/View/HtmlStack.php
@@ -9,6 +9,7 @@ use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\Support\Str;
+use CraftCms\Cms\View\Data\ResourceEntry;
 use CraftCms\Cms\View\Enums\Position;
 use CraftCms\Cms\View\Events\ViewAssetsRendering;
 use Illuminate\Container\Attributes\Scoped;
@@ -149,7 +150,10 @@ class HtmlStack
         $position = Position::tryFrom((int) Arr::pull($options, 'position', Position::BodyEnd->value)) ?? Position::BodyEnd;
 
         $entries = $this->jsFiles[$position->value] ?? [];
-        $this->registerEntry($entries, $key, Html::javaScriptFile($url, $options));
+        $this->registerEntry($entries, $key, new ResourceEntry(
+            Html::javaScriptFile($url, $options),
+            [$url, $options],
+        ));
         $this->jsFiles[$position->value] = $entries;
     }
 
@@ -166,7 +170,10 @@ class HtmlStack
     public function cssFile(string $url, array $options = [], ?string $key = null): void
     {
         $entries = $this->cssFiles;
-        $this->registerEntry($entries, $key ?? $url, Html::cssFile($url, $options));
+        $this->registerEntry($entries, $key ?? $url, new ResourceEntry(
+            Html::cssFile($url, $options),
+            [$url, $options],
+        ));
         $this->cssFiles = $entries;
     }
 
@@ -183,7 +190,10 @@ class HtmlStack
     public function css(string $css, array $options = [], ?string $key = null): void
     {
         $entries = $this->css;
-        $this->registerEntry($entries, $key ?? md5($css), Html::style($css, $options));
+        $this->registerEntry($entries, $key ?? md5($css), new ResourceEntry(
+            Html::style($css, $options),
+            [$css, $options],
+        ));
         $this->css = $entries;
     }
 
@@ -202,7 +212,10 @@ class HtmlStack
     public function script(string $script, Position $position = Position::BodyEnd, array $options = [], ?string $key = null): void
     {
         $entries = $this->scripts[$position->value] ?? [];
-        $this->registerEntry($entries, $key ?? md5($script), Html::script($script, $options));
+        $this->registerEntry($entries, $key ?? md5($script), new ResourceEntry(
+            Html::script($script, $options),
+            [$script, $options],
+        ));
         $this->scripts[$position->value] = $entries;
     }
 
@@ -283,7 +296,10 @@ class HtmlStack
     public function metaTag(array $attributes, ?string $key = null): void
     {
         $entries = $this->metaTags;
-        $this->registerEntry($entries, $key ?? md5(serialize($attributes)), Html::tag('meta', attributes: $attributes));
+        $this->registerEntry($entries, $key ?? md5(serialize($attributes)), new ResourceEntry(
+            Html::tag('meta', attributes: $attributes),
+            $attributes,
+        ));
         $this->metaTags = $entries;
     }
 

--- a/tests/.pest/snapshots/Unit/Twig/Nodes/ExpiresNodeTest/it_compiles_with_dynamic_expiration.snap
+++ b/tests/.pest/snapshots/Unit/Twig/Nodes/ExpiresNodeTest/it_compiles_with_dynamic_expiration.snap
@@ -1,3 +1,3 @@
 $expiration = // line 1
 ($context["expiresAt"] ?? null);
-$duration = CraftCms\Cms\Support\DateTimeHelper::toDateTime($expiration)->getTimestamp() - now()->getTimestamp();CraftCms\Cms\Http\Middleware\SetHeaders::setCache($duration);
+$duration = CraftCms\Cms\Support\DateTimeHelper::toDateTime($expiration)->getTimestamp() - now()->getTimestamp();CraftCms\Cms\Support\Facades\ResponseHeaders::setCache($duration);

--- a/tests/.pest/snapshots/Unit/Twig/Nodes/ExpiresNodeTest/it_compiles_with_static_duration.snap
+++ b/tests/.pest/snapshots/Unit/Twig/Nodes/ExpiresNodeTest/it_compiles_with_static_duration.snap
@@ -1,2 +1,2 @@
 $duration = 3600;
-CraftCms\Cms\Http\Middleware\SetHeaders::setCache($duration);
+CraftCms\Cms\Support\Facades\ResponseHeaders::setCache($duration);

--- a/tests/.pest/snapshots/Unit/Twig/Nodes/HeaderNodeTest/it_compiles.snap
+++ b/tests/.pest/snapshots/Unit/Twig/Nodes/HeaderNodeTest/it_compiles.snap
@@ -1,3 +1,3 @@
 $_headerParts = array_map('trim', explode(':', "X-Custom: value", 2));
-CraftCms\Cms\Http\Middleware\SetHeaders::add($_headerParts[0], $_headerParts[1] ?? '');
+CraftCms\Cms\Support\Facades\ResponseHeaders::add($_headerParts[0], $_headerParts[1] ?? '');
 unset($_headerParts);

--- a/tests/Feature/Auth/Auth/AuthPasskeyTest.php
+++ b/tests/Feature/Auth/Auth/AuthPasskeyTest.php
@@ -13,7 +13,6 @@ use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\User\Elements\User as UserElement;
 use CraftCms\Cms\User\Models\User;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Session;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\CredentialRecord;
 use Webauthn\TrustPath\EmptyTrustPath;
@@ -44,7 +43,6 @@ test('authenticateWithPasskey enforces user status after a valid response', func
     ]);
 
     $passkeys = mockAuthPasskeys();
-    Session::put($passkeys->passkeyCredSourceParam, $updatedCredentialSource);
 
     $credentialRepository = Mockery::mock(CredentialRepository::class);
     $credentialRepository
@@ -62,7 +60,7 @@ test('authenticateWithPasskey enforces user status after a valid response', func
         ->shouldReceive('verifyPasskey')
         ->once()
         ->with(Mockery::type(UserElement::class), $requestOptions, $response)
-        ->andReturn(true);
+        ->andReturn($updatedCredentialSource);
     $passkeys
         ->shouldReceive('webauthnServer')
         ->once()
@@ -72,7 +70,6 @@ test('authenticateWithPasskey enforces user status after a valid response', func
 
     expect($result)->toBe($expectedResult);
     expect(app(AuthMethods::class)->authError)->toBe($expectedError);
-    expect(Session::has($passkeys->passkeyCredSourceParam))->toBeFalse();
 })->with([
     'active' => [[], true, null],
     'disabled' => [['enabled' => false], false, AuthError::InvalidCredentials],
@@ -93,13 +90,10 @@ test('authenticateWithPasskey with mismatched credential', function () {
 
 test('authenticateWithPasskey with invalid response', function () {
     $user = User::factory()->withPasskey('test-credential-id')->createElement();
-    $updatedCredentialSource = authPasskeyCredentialSource('test-credential-id');
-
     $requestOptions = Json::encode(['challenge' => 'test-challenge']);
     $response = Json::encode(['id' => 'test-credential-id', 'response' => 'invalid-response']);
 
     $passkeys = mockAuthPasskeys();
-    Session::put($passkeys->passkeyCredSourceParam, $updatedCredentialSource);
 
     $passkeys
         ->shouldReceive('verifyPasskey')
@@ -110,7 +104,88 @@ test('authenticateWithPasskey with invalid response', function () {
     $result = app(AuthMethods::class)->authenticateWithPasskey($user, $requestOptions, $response);
 
     expect($result)->toBeFalse();
-    expect(Session::has($passkeys->passkeyCredSourceParam))->toBeFalse();
+});
+
+test('authenticateWithPasskey does not persist a prior result when a replay is rejected', function () {
+    $user = User::factory()->withPasskey('valid-credential-id')->createElement();
+    $updatedCredentialSource = authPasskeyCredentialSource('valid-credential-id');
+    $requestOptions = Json::encode(['challenge' => 'test-challenge']);
+    $response = Json::encode(['id' => 'valid-credential-id', 'response' => 'valid-response']);
+
+    $credentialRepository = Mockery::mock(CredentialRepository::class);
+    $credentialRepository
+        ->shouldReceive('saveCredentialSource')
+        ->once()
+        ->with($updatedCredentialSource);
+
+    $webauthnServer = Mockery::mock(WebauthnServer::class);
+    $webauthnServer
+        ->shouldReceive('getCredentialRepository')
+        ->once()
+        ->andReturn($credentialRepository);
+
+    $passkeys = mockAuthPasskeys();
+    $passkeys
+        ->shouldReceive('verifyPasskey')
+        ->twice()
+        ->andReturn($updatedCredentialSource, false);
+    $passkeys
+        ->shouldReceive('webauthnServer')
+        ->once()
+        ->andReturn($webauthnServer);
+
+    $authMethods = app(AuthMethods::class);
+
+    expect($authMethods->authenticateWithPasskey($user, $requestOptions, $response))->toBeTrue();
+    expect($authMethods->authenticateWithPasskey($user, $requestOptions, $response))->toBeFalse();
+});
+
+test('authenticateWithPasskey keeps credential results scoped to concurrent attempts', function () {
+    $firstUser = User::factory()->withPasskey('first-credential-id')->createElement();
+    $secondUser = User::factory()->withPasskey('second-credential-id')->createElement();
+    $firstCredentialSource = authPasskeyCredentialSource('first-credential-id');
+    $secondCredentialSource = authPasskeyCredentialSource('second-credential-id');
+    $requestOptions = Json::encode(['challenge' => 'test-challenge']);
+    $firstResponse = Json::encode(['id' => 'first-credential-id', 'response' => 'first-response']);
+    $secondResponse = Json::encode(['id' => 'second-credential-id', 'response' => 'second-response']);
+
+    $credentialRepository = Mockery::mock(CredentialRepository::class);
+    $credentialRepository->shouldReceive('saveCredentialSource')->once()->with($firstCredentialSource);
+    $credentialRepository->shouldReceive('saveCredentialSource')->once()->with($secondCredentialSource);
+
+    $webauthnServer = Mockery::mock(WebauthnServer::class);
+    $webauthnServer->shouldReceive('getCredentialRepository')->twice()->andReturn($credentialRepository);
+
+    $passkeys = mockAuthPasskeys();
+    $passkeys
+        ->shouldReceive('verifyPasskey')
+        ->twice()
+        ->andReturnUsing(function (UserElement $user, string $options, string $response) use (
+            $firstResponse,
+            $firstCredentialSource,
+            $secondCredentialSource,
+        ): CredentialRecord {
+            if ($response === $firstResponse) {
+                Fiber::suspend();
+
+                return $firstCredentialSource;
+            }
+
+            return $secondCredentialSource;
+        });
+    $passkeys->shouldReceive('webauthnServer')->twice()->andReturn($webauthnServer);
+
+    $authMethods = app(AuthMethods::class);
+
+    $firstAttempt = new Fiber(fn () => $authMethods->authenticateWithPasskey($firstUser, $requestOptions, $firstResponse));
+    $secondAttempt = new Fiber(fn () => $authMethods->authenticateWithPasskey($secondUser, $requestOptions, $secondResponse));
+
+    $firstAttempt->start();
+    $secondAttempt->start();
+    $firstAttempt->resume();
+
+    expect($firstAttempt->getReturn())->toBeTrue();
+    expect($secondAttempt->getReturn())->toBeTrue();
 });
 
 test('authenticateWithPasskey with user without passkeys', function () {
@@ -158,7 +233,7 @@ test('authenticateWithPasskey event can skip verification', function () {
 
 function mockAuthPasskeys(): Passkeys
 {
-    $passkeys = Mockery::mock(Passkeys::class, ['pkCredCreationOptions', 'pkReqOptions', 'pkCredSource'])->makePartial();
+    $passkeys = Mockery::mock(Passkeys::class, ['pkCredCreationOptions', 'pkReqOptions'])->makePartial();
 
     app()->instance(Passkeys::class, $passkeys);
     app()->forgetInstance(AuthMethods::class);

--- a/tests/Feature/Auth/PasskeysTest.php
+++ b/tests/Feature/Auth/PasskeysTest.php
@@ -108,7 +108,7 @@ test('getPasskeyRequestOptions returns PublicKeyCredentialRequestOptions', funct
     expect($options->userVerification)->toBe(PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED);
 });
 
-test('verifyPasskey persists the validated credential source', function () {
+test('verifyPasskey returns the validated credential source', function () {
     $requestOptionsJson = '{"challenge":"test-challenge"}';
     $responseJson = '{"id":"test-credential-id"}';
     $requestOptions = PublicKeyCredentialRequestOptions::create(challenge: 'test-challenge');
@@ -129,6 +129,8 @@ test('verifyPasskey persists the validated credential source', function () {
         userHandle: 'user-handle',
         counter: 1,
     );
+    $updatedCredentialRecord = clone $credentialRecord;
+    $updatedCredentialRecord->counter = 2;
 
     $serializer = Mockery::mock(SerializerInterface::class);
     $serializer
@@ -148,17 +150,14 @@ test('verifyPasskey persists the validated credential source', function () {
         ->once()
         ->with('test-credential-id', false)
         ->andReturn($credentialRecord);
-    $credentialRepository
-        ->shouldReceive('saveCredentialSource')
-        ->once()
-        ->with($credentialRecord);
+    $credentialRepository->shouldNotReceive('saveCredentialSource');
 
     $assertionResponseValidator = Mockery::mock(AuthenticatorAssertionResponseValidator::class);
     $assertionResponseValidator
         ->shouldReceive('check')
         ->once()
         ->with($credentialRecord, $authenticatorAssertionResponse, $requestOptions, 'localhost', $this->passkeys->passkeyUserEntity($this->user)->id)
-        ->andReturn($credentialRecord);
+        ->andReturn($updatedCredentialRecord);
 
     $webauthnServer = Mockery::mock(WebauthnServer::class);
     $webauthnServer->shouldReceive('getSerializer')->andReturn($serializer);
@@ -168,7 +167,7 @@ test('verifyPasskey persists the validated credential source', function () {
     $property = new ReflectionProperty($this->passkeys, 'webauthnServer');
     $property->setValue($this->passkeys, $webauthnServer);
 
-    expect($this->passkeys->verifyPasskey($this->user, $requestOptionsJson, $responseJson))->toBeTrue();
+    expect($this->passkeys->verifyPasskey($this->user, $requestOptionsJson, $responseJson))->toBe($updatedCredentialRecord);
 });
 
 test('deletePasskey removes passkey from database', function () {

--- a/tests/Feature/Database/Commands/DropAllTablesCommandTest.php
+++ b/tests/Feature/Database/Commands/DropAllTablesCommandTest.php
@@ -24,14 +24,16 @@ it('drops all tables from an isolated database', function () {
     withIsolatedSqliteConnectionForDropAllTables(function (string $connectionName) {
         $schema = Schema::connection($connectionName);
 
-        foreach (['drop_me_one', 'drop_me_two'] as $tableName) {
-            $schema->create($tableName, function (Blueprint $table) {
-                $table->string('name')->nullable();
-            });
-        }
+        $schema->create('drop_me_parent', function (Blueprint $table) {
+            $table->id();
+        });
 
-        expect($schema->hasTable('drop_me_one'))->toBeTrue();
-        expect($schema->hasTable('drop_me_two'))->toBeTrue();
+        $schema->create('drop_me_child', function (Blueprint $table) {
+            $table->foreignId('drop_me_parent_id')->constrained('drop_me_parent');
+        });
+
+        expect($schema->hasTable('drop_me_parent'))->toBeTrue();
+        expect($schema->hasTable('drop_me_child'))->toBeTrue();
 
         $exitCode = artisan('craft:db:drop-all-tables')
             ->expectsConfirmation('Are you sure you want to drop all tables from the database?', 'yes')
@@ -40,8 +42,8 @@ it('drops all tables from an isolated database', function () {
             ->run();
 
         expect($exitCode)->toBe(0);
-        expect($schema->hasTable('drop_me_one'))->toBeFalse();
-        expect($schema->hasTable('drop_me_two'))->toBeFalse();
+        expect($schema->hasTable('drop_me_parent'))->toBeFalse();
+        expect($schema->hasTable('drop_me_child'))->toBeFalse();
     });
 });
 

--- a/tests/Feature/Element/ElementCollectionTest.php
+++ b/tests/Feature/Element/ElementCollectionTest.php
@@ -3,10 +3,12 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Element\ElementCollection;
+use CraftCms\Cms\Element\Events\ElementsEagerLoading;
 use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Entry\Models\Entry as EntryModel;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
 
 beforeEach(function () {
     $entry = EntryModel::factory()->create();
@@ -54,6 +56,38 @@ test('ids', function () {
 
     $ids = $collection->map(fn (Entry $entry) => $entry->id)->all();
     expect($collection->ids()->all())->toBe($ids);
+});
+
+test('with preserves an empty collection', function () {
+    Event::fake([ElementsEagerLoading::class]);
+
+    $collection = ElementCollection::empty();
+
+    expect($collection->with([]))->toBe($collection);
+    Event::assertNotDispatched(ElementsEagerLoading::class);
+});
+
+test('with eager-loads a homogeneous collection in order', function () {
+    Event::fake([ElementsEagerLoading::class]);
+
+    $collection = Entry::find()->limit(2)->collect();
+
+    expect($collection->with([]))->toBe($collection);
+    Event::assertDispatched(fn (ElementsEagerLoading $event) => $event->elementType === Entry::class && $event->elements === $collection->all());
+    Event::assertDispatchedTimes(ElementsEagerLoading::class, 1);
+});
+
+test('with eager-loads only compatible elements from a mixed collection', function () {
+    Event::fake([ElementsEagerLoading::class]);
+
+    $entries = Entry::find()->limit(2)->get();
+    $user = User::find()->one();
+    $collection = new ElementCollection([$entries[1], $user, $entries[0]]);
+
+    expect($collection->with([]))->toBe($collection);
+    Event::assertDispatched(fn (ElementsEagerLoading $event) => $event->elementType === Entry::class && $event->elements === [$entries[1], $entries[0]]);
+    Event::assertDispatched(fn (ElementsEagerLoading $event) => $event->elementType === User::class && $event->elements === [$user]);
+    Event::assertDispatchedTimes(ElementsEagerLoading::class, 2);
 });
 
 test('merge', function () {

--- a/tests/Feature/Element/Queries/Concerns/QueriesCustomFieldsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/QueriesCustomFieldsTest.php
@@ -87,6 +87,51 @@ it('can query custom fields', function () {
     expect(entryQuery()->textField('bar')->count())->toBe(0);
 });
 
+it('only stores explicitly supplied custom field criteria', function () {
+    $queriedField = Field::factory()->create([
+        'handle' => 'queriedField',
+        'type' => PlainText::class,
+    ]);
+    Field::factory()->create([
+        'handle' => 'unusedField',
+        'type' => PlainText::class,
+    ]);
+
+    EntryModel::factory()
+        ->withFieldLayout(FieldLayout::factory()->forField($queriedField))
+        ->create();
+
+    $query = entryQuery()->queriedField('Foo');
+    $queryWithExplicitNull = entryQuery()
+        ->queriedField('Foo')
+        ->unusedField(null);
+    $querySql = $query->toSql();
+    $queryBindings = $query->getBindings();
+    $clone = clone $query;
+    $roundTrippedCriteria = $query->getCriteria()
+        |> (fn (array $criteria) => array_intersect_key($criteria, array_flip(['queriedField', 'unusedField'])))
+        |> serialize(...)
+        |> unserialize(...);
+
+    expect($query->getCriteria())
+        ->toHaveKey('queriedField', 'Foo')
+        ->not->toHaveKey('unusedField')
+        ->and($queryWithExplicitNull->getCriteria())
+        ->toHaveKey('unusedField', null)
+        ->and($clone->getCriteria())
+        ->toHaveKey('queriedField', 'Foo')
+        ->not->toHaveKey('unusedField')
+        ->and($roundTrippedCriteria)
+        ->toHaveKey('queriedField', 'Foo')
+        ->not->toHaveKey('unusedField')
+        ->and(entryQuery()->unusedField('Foo')->count())
+        ->toBe(0)
+        ->and($querySql)
+        ->toBe($queryWithExplicitNull->toSql())
+        ->and($queryBindings)
+        ->toEqual($queryWithExplicitNull->getBindings());
+});
+
 it('includes entries whose multi-option field is still empty in not one of queries', function () {
     actingAs(User::findOne());
 

--- a/tests/Feature/Gql/GqlTest.php
+++ b/tests/Feature/Gql/GqlTest.php
@@ -17,6 +17,7 @@ use CraftCms\Cms\Gql\Exceptions\GqlException;
 use CraftCms\Cms\Gql\Gql;
 use CraftCms\Cms\Gql\GqlDirectives;
 use CraftCms\Cms\Gql\GqlEntityRegistry;
+use CraftCms\Cms\Gql\GqlHelper;
 use CraftCms\Cms\Gql\GqlMutations;
 use CraftCms\Cms\Gql\GqlQueries;
 use CraftCms\Cms\Gql\GqlTypes;
@@ -89,6 +90,19 @@ it('uses currently registered directives', function () {
     expect($schema->getDirective(MockDirective::name()))->toBeNull()
         ->and($schema->getDirective('parseRefs'))->not->toBeNull()
         ->and($schema->getDirective('transform'))->not->toBeNull();
+});
+
+it('coerces custom scalar directive arguments', function () {
+    $registry = app(GqlDirectives::class);
+    $registry->register(MockDirective::class);
+    app(GqlQueries::class)->register(MockQuery::class);
+
+    $gql = app(Gql::class);
+    $result = $gql->executeQuery(new GqlSchema, '{ mockQuery @mockDirective(prefix: "custom") }');
+
+    $registry->remove(MockDirective::class);
+
+    expect($result)->toBe(['data' => ['mockQuery' => 'mockmocked']]);
 });
 
 it('uses registered types', function () {
@@ -354,7 +368,7 @@ class MockQuery extends BaseQuery
             'mockQuery' => [
                 'type' => Type::string(),
                 'args' => [],
-                'resolve' => static fn () => 'mocked',
+                'resolve' => static fn ($source, $arguments, $context, $resolveInfo) => GqlHelper::applyDirectives($source, $resolveInfo, 'mocked'),
             ],
         ];
     }

--- a/tests/Feature/Http/Controllers/Auth/PasskeyControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/PasskeyControllerTest.php
@@ -56,7 +56,7 @@ test('login counts an invalid passkey once', function () {
             string $requestOptions,
             string $response,
             bool $checkOldUserHandle = false,
-        ): bool {
+        ): false {
             return false;
         }
     };

--- a/tests/Feature/Http/Middleware/SetHeadersTest.php
+++ b/tests/Feature/Http/Middleware/SetHeadersTest.php
@@ -5,13 +5,24 @@ declare(strict_types=1);
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Http\Middleware\HandleTokenRequest;
 use CraftCms\Cms\Http\Middleware\SetHeaders;
+use CraftCms\Cms\Http\ResponseHeaders as ResponseHeaderAccumulator;
+use CraftCms\Cms\Support\Facades\ResponseHeaders;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Illuminate\Support\Facades\Route;
 
 beforeEach(function () {
     $this->generalConfig = Cms::config();
+    $this->responseHeaders = app(ResponseHeaderAccumulator::class);
     $this->middleware = app(SetHeaders::class);
+
+    Route::get('/test-response-headers', function () {
+        if (($value = request()->query('value')) !== null) {
+            ResponseHeaders::add('X-Test', $value);
+        }
+
+        return response('');
+    })->middleware(SetHeaders::class);
 });
 
 it('passes through non-Response values', function () {
@@ -150,11 +161,53 @@ it('appends the powered-by header to existing values', function () {
     expect($response->headers->get('X-Powered-By'))->toBe('Foo,Craft CMS');
 });
 
-it('resets header state after Symfony responses', function () {
-    SetHeaders::add('X-Test', 'value');
+it('applies request-scoped headers', function () {
+    $this->responseHeaders->add('X-Test', 'value');
 
-    $this->middleware->handle(Request::create('/'), fn () => new JsonResponse);
     $response = $this->middleware->handle(Request::create('/'), fn () => new Response);
 
-    expect($response->headers->has('X-Test'))->toBeFalse();
+    expect($response->headers->get('X-Test'))->toBe('value');
+});
+
+it('preserves request-scoped header order and duplicate values', function () {
+    $this->responseHeaders->add('X-Test', 'first', false);
+    $this->responseHeaders->add('X-Test', 'second', false);
+
+    $response = $this->middleware->handle(Request::create('/'), fn () => new Response);
+
+    expect($response->headers->all('X-Test'))->toBe(['first', 'second']);
+});
+
+it('replaces request-scoped header values by default', function () {
+    $this->responseHeaders->add('X-Test', 'first');
+    $this->responseHeaders->add('X-Test', 'second');
+
+    $response = $this->middleware->handle(Request::create('/'), fn () => new Response);
+
+    expect($response->headers->all('X-Test'))->toBe(['second']);
+});
+
+it('applies request-scoped cache settings', function () {
+    $this->responseHeaders->setCache(60);
+
+    $response = $this->middleware->handle(Request::create('/'), fn () => new Response);
+
+    expect($response->getMaxAge())->toBe(60)
+        ->and($response->headers->get('Pragma'))->toBe('cache');
+});
+
+it('applies request-scoped no-cache settings', function () {
+    $this->responseHeaders->noCache();
+
+    $response = $this->middleware->handle(Request::create('/'), fn () => new Response);
+
+    expect($response->headers->hasCacheControlDirective('no-cache'))->toBeTrue();
+});
+
+it('isolates facade state across long-lived request scopes', function () {
+    $this->get('/test-response-headers?value=first')->assertHeader('X-Test', 'first');
+
+    app()->forgetScopedInstances();
+
+    $this->get('/test-response-headers?value=second')->assertHeader('X-Test', 'second');
 });

--- a/tests/Feature/Plugin/PluginsTest.php
+++ b/tests/Feature/Plugin/PluginsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\Plugin\Events\PluginSettingsSaved;
 use CraftCms\Cms\Plugin\Events\PluginsLoading;
 use CraftCms\Cms\Plugin\Events\PluginsRegistered;
@@ -133,6 +134,27 @@ it('can get plugin handle by class', function () {
 it('can get all plugins', function () {
     expect($this->plugins->getAllPlugins())->toHaveKey('test-plugin');
 });
+
+it('normalizes forced-disabled plugin configuration', function (string|array|null $disabledPlugins, bool $isForceDisabled) {
+    Cms::config()->disabledPlugins = $disabledPlugins;
+    app()->forgetInstance(Plugins::class);
+    loadTestPlugin();
+
+    $plugins = app(Plugins::class);
+
+    expect($plugins->getPluginInfo('test-plugin')['isForceDisabled'])->toBe($isForceDisabled);
+})->with([
+    'matching string' => ['test-plugin', true],
+    'non-matching string' => ['test', false],
+    'matching comma-separated string' => ['other,test-plugin', true],
+    'non-matching comma-separated string' => ['other,another', false],
+    'matching list' => [['test-plugin'], true],
+    'non-matching list' => [['test'], false],
+    'empty string' => ['', false],
+    'empty list' => [[], false],
+    'null' => [null, false],
+    'wildcard' => ['*', true],
+]);
 
 it('can enable and disable a plugin', function () {
     expect($this->plugins->isPluginEnabled('test-plugin'))->toBeFalse();

--- a/tests/Feature/Queue/JobProgressServiceTest.php
+++ b/tests/Feature/Queue/JobProgressServiceTest.php
@@ -34,11 +34,20 @@ it('can set and retrieve job progress', function () {
         ->label->toBe('Processing item 5 of 10');
 });
 
-it('can update existing job progress', function () {
+it('atomically creates and updates existing job progress', function () {
     $uid = 'test-job-456';
 
+    DB::enableQueryLog();
+
     $this->service->setProgress($uid, 'Test Job', 25, 'Starting');
+    $creationQueries = DB::getQueryLog();
+
+    DB::flushQueryLog();
+
     $this->service->setProgress($uid, 'Test Job Updated', 75, 'Almost done');
+    $updateQueries = DB::getQueryLog();
+
+    DB::disableQueryLog();
 
     $progress = $this->service->getProgress($uid);
 
@@ -47,9 +56,32 @@ it('can update existing job progress', function () {
         ->progress->toBe(75)
         ->label->toBe('Almost done');
 
-    // Verify only one row exists
     $count = DB::table(Table::JOBPROGRESS)->where('uid', $uid)->count();
-    expect($count)->toBe(1);
+
+    expect($creationQueries)->toHaveCount(1)
+        ->and($updateQueries)->toHaveCount(1)
+        ->and($count)->toBe(1);
+});
+
+it('does not leak a transaction when persistence fails', function () {
+    $transactionLevel = DB::transactionLevel();
+    $fail = true;
+
+    DB::beforeExecuting(function () use (&$fail) {
+        if (! $fail) {
+            return;
+        }
+
+        $fail = false;
+
+        throw new RuntimeException('Job progress persistence failed.');
+    });
+
+    expect(fn () => $this->service->setProgress('failed-write', 'Failed write', 50))
+        ->toThrow(RuntimeException::class);
+
+    expect(DB::transactionLevel())->toBe($transactionLevel)
+        ->and($this->service->getProgress('failed-write'))->toBeNull();
 });
 
 it('returns null for non-existent job', function () {

--- a/tests/Feature/Search/SearchTest.php
+++ b/tests/Feature/Search/SearchTest.php
@@ -249,6 +249,78 @@ describe('searchElements', function () {
             ->and(array_unique(array_column($performed->results, 'elementId')))->toBe([$entry2->id])
             ->and($performed->scores)->toBe($scores);
     });
+
+    test('nested searches retain their own scoring terms', function () {
+        createIndexedEntry('Alpha');
+        createIndexedEntry('Alpha Beta');
+
+        $expectedOuterScores = Search::searchElements(entryQuery()->search('Alpha'));
+        $expectedNestedScores = Search::searchElements(entryQuery()->search('Beta'));
+        $nestedScores = null;
+
+        Event::listen(function (SearchResultsResolving $event) use (&$nestedScores) {
+            if ($event->query->getQuery() === 'Alpha') {
+                $nestedScores = Search::searchElements(entryQuery()->search('Beta'));
+            }
+        });
+
+        $outerScores = Search::searchElements(entryQuery()->search('Alpha'));
+
+        expect($outerScores)->toBe($expectedOuterScores)
+            ->and($nestedScores)->toBe($expectedNestedScores);
+    });
+
+    test('sequential searches retain their own scoring terms', function () {
+        createIndexedEntry('Alpha');
+        createIndexedEntry('Alpha Beta');
+
+        $alphaScores = Search::searchElements(entryQuery()->search('Alpha'));
+        $betaScores = Search::searchElements(entryQuery()->search('Beta'));
+
+        expect(Search::searchElements(entryQuery()->search('Alpha')))->toBe($alphaScores)
+            ->and(Search::searchElements(entryQuery()->search('Beta')))->toBe($betaScores);
+    });
+
+    test('failed nested searches do not clear outer scoring terms', function () {
+        createIndexedEntry('Alpha');
+        createIndexedEntry('Alpha Beta');
+
+        $expectedScores = Search::searchElements(entryQuery()->search('Alpha'));
+        $failedQuery = null;
+
+        Event::listen(function (SearchResultsResolving $event) use (&$failedQuery) {
+            if ($event->query->getQuery() === 'Alpha') {
+                $failedQuery = Search::createDbQuery('', entryQuery());
+            }
+        });
+
+        $scores = Search::searchElements(entryQuery()->search('Alpha'));
+
+        expect($failedQuery)->toBeFalse()
+            ->and($scores)->toBe($expectedScores);
+    });
+
+    test('concurrent searches retain their own scoring terms', function () {
+        createIndexedEntry('Alpha');
+        createIndexedEntry('Alpha Beta');
+
+        $expectedScores = Search::searchElements(entryQuery()->search('Alpha'));
+        $searchFiber = null;
+
+        Event::listen(function (SearchResultsResolving $event) use (&$searchFiber) {
+            if ($event->query->getQuery() === 'Alpha' && Fiber::getCurrent() === $searchFiber) {
+                Fiber::suspend();
+            }
+        });
+
+        $searchFiber = new Fiber(fn () => Search::searchElements(entryQuery()->search('Alpha')));
+        $searchFiber->start();
+
+        Search::searchElements(entryQuery()->search('Beta'));
+        $searchFiber->resume();
+
+        expect($searchFiber->getReturn())->toBe($expectedScores);
+    });
 });
 
 describe('normalizeSearchQuery', function () {

--- a/tests/Feature/Support/JsonTest.php
+++ b/tests/Feature/Support/JsonTest.php
@@ -16,10 +16,23 @@ test('encode', function (string $expected, mixed $data) {
 test('decode', function (mixed $expected, mixed $str, bool $asArray) {
     expect(Json::decode($str, $asArray))->toEqualCanonicalizing($expected);
 })->with([
-    [['test' => 'test'], '{"test":"test"}', true],
-    [(object) ['test' => 'test'], '{"test":"test"}', false],
-    [null, '', true],
-    [null, null, true],
+    'object as array' => [['test' => 'test'], '{"test":"test"}', true],
+    'object as object' => [(object) ['test' => 'test'], '{"test":"test"}', false],
+    'array' => [['test'], '["test"]', true],
+    'string' => ['test', '"test"', true],
+    'integer' => [42, '42', true],
+    'boolean' => [true, 'true', true],
+    'JSON null' => [null, 'null', true],
+    'empty string' => [null, '', true],
+    'null' => [null, null, true],
+]);
+
+test('decode rejects invalid values', function (mixed $value) {
+    expect(fn () => Json::decode($value))
+        ->toThrow(InvalidArgumentException::class, 'Invalid JSON data.');
+})->with([
+    'malformed JSON' => ['{"test":"test"'],
+    'non-string value' => [[]],
 ]);
 
 test('decodeIfJson', function (mixed $expected, string $str) {

--- a/tests/Feature/User/UserPermissionsTest.php
+++ b/tests/Feature/User/UserPermissionsTest.php
@@ -4,6 +4,7 @@ use CraftCms\Cms\Asset\Models\Volume;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\Section\Models\Section;
+use CraftCms\Cms\Section\Sections;
 use CraftCms\Cms\Site\Models\Site;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Str;
@@ -27,23 +28,39 @@ test('getAllPermissions', function () {
 });
 
 test('permission groups can be registered and removed', function () {
+    expect($this->userPermissions->getAllPermissions()->contains('heading', 'Modern plugin'))->toBeFalse()
+        ->and($this->userPermissions->validatePermission('manageModernPlugin'))->toBeFalse();
+
     $this->userPermissions->registerPermissionGroup('plugin:modern', fn () => new PermissionGroup(
         handle: 'plugin:modern',
         heading: 'Modern plugin',
         permissions: collect([new Permission('manageModernPlugin', 'Manage modern plugin')]),
     ));
 
-    expect($this->userPermissions->getAllPermissions()->contains('heading', 'Modern plugin'))->toBeTrue();
+    expect($this->userPermissions->getAllPermissions()->contains('heading', 'Modern plugin'))->toBeTrue()
+        ->and($this->userPermissions->validatePermission('manageModernPlugin'))->toBeTrue();
 
     app()->forgetScopedInstances();
     $this->userPermissions = app(UserPermissions::class);
 
-    expect($this->userPermissions->getAllPermissions()->contains('heading', 'Modern plugin'))->toBeTrue();
+    expect($this->userPermissions->getAllPermissions()->contains('heading', 'Modern plugin'))->toBeTrue()
+        ->and($this->userPermissions->validatePermission('manageModernPlugin'))->toBeTrue();
 
     $this->userPermissions->removePermissionGroups('plugin:modern');
-    $this->userPermissions->reset();
 
-    expect($this->userPermissions->getAllPermissions()->contains('heading', 'Modern plugin'))->toBeFalse();
+    expect($this->userPermissions->getAllPermissions()->contains('heading', 'Modern plugin'))->toBeFalse()
+        ->and($this->userPermissions->validatePermission('manageModernPlugin'))->toBeFalse();
+});
+
+test('getAllPermissions reflects sections created between calls', function () {
+    $section = Section::factory()->make(['name' => 'Dynamic']);
+
+    expect($this->userPermissions->getAllPermissions()->contains('handle', "section:$section->uid"))->toBeFalse();
+
+    $section->save();
+    app(Sections::class)->refreshSections();
+
+    expect($this->userPermissions->getAllPermissions()->contains('handle', "section:$section->uid"))->toBeTrue();
 });
 
 test('getAllPermissions contains headings', function (string $heading) {

--- a/tests/TestClasses/Gql/MockDirective.php
+++ b/tests/TestClasses/Gql/MockDirective.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Tests\TestClasses\Gql;
 
 use CraftCms\Cms\Gql\Directives\Directive;
+use CraftCms\Cms\Gql\GqlEntityRegistry;
 use GraphQL\Language\DirectiveLocation;
 use GraphQL\Type\Definition\Directive as GqlDirective;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -19,12 +20,18 @@ class MockDirective extends Directive
      */
     public static function create(): GqlDirective
     {
-        return new self([
+        return GqlEntityRegistry::getOrCreate(static::name(), fn () => new self([
             'name' => static::name(),
             'locations' => [
                 DirectiveLocation::FIELD,
             ],
-        ]);
+            'args' => [
+                [
+                    'name' => 'prefix',
+                    'type' => MockType::getType(),
+                ],
+            ],
+        ]));
     }
 
     /**

--- a/tests/Unit/EditionTest.php
+++ b/tests/Unit/EditionTest.php
@@ -58,6 +58,26 @@ it('can set the current edition', function () {
     expect(Edition::get())->toBe(Edition::Solo);
 });
 
+it('reports capabilities from the receiver', function (Edition $edition, Edition $globalEdition, array $expected, bool $installed) {
+    Cms::setIsInstalled($installed);
+    Edition::set($globalEdition);
+
+    expect([
+        $edition->registersFrontendUserRoutes(),
+        $edition->supportsOAuth(),
+        $edition->supportsRequiring2FA(),
+        $edition->supportsPublicRegistration(),
+    ])->toBe($expected);
+})->with([
+    'solo' => [Edition::Solo, Edition::Enterprise, [false, false, false, false]],
+    'team' => [Edition::Team, Edition::Solo, [false, false, true, false]],
+    'pro' => [Edition::Pro, Edition::Solo, [true, true, true, true]],
+    'enterprise' => [Edition::Enterprise, Edition::Solo, [true, true, true, true]],
+])->with([
+    'installed' => true,
+    'uninstalled' => false,
+]);
+
 it('knows when oauth is supported', function () {
     expect(Edition::Solo->supportsOAuth())->toBeFalse()
         ->and(Edition::Team->supportsOAuth())->toBeFalse()

--- a/tests/Unit/Field/TableTest.php
+++ b/tests/Unit/Field/TableTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Field\Table;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\FormHtmlRenderer;
+use CraftCms\Cms\Form\FormResolver;
+use Symfony\Component\DomCrawler\Crawler;
+
+it('keeps column handles scalar while rendering validation errors by cell', function () {
+    $field = new Table([
+        'name' => 'Details',
+        'handle' => 'details',
+        'columns' => [
+            'first' => ['heading' => 'First', 'handle' => 'invalid-handle', 'type' => 'singleline'],
+            'second' => ['heading' => 'Second', 'handle' => 'validHandle', 'type' => 'singleline'],
+            'third' => ['heading' => 'Third', 'handle' => 'col3', 'type' => 'singleline'],
+        ],
+    ]);
+
+    expect($field->columns['first']['handle'])->toBeString()
+        ->and($field->columns['second']['handle'])->toBeString()
+        ->and($field->columns['third']['handle'])->toBeString()
+        ->and($field->validate())->toBeFalse()
+        ->and($field->columns['first']['handle'])->toBe('invalid-handle')
+        ->and($field->columns['second']['handle'])->toBe('validHandle')
+        ->and($field->columns['third']['handle'])->toBe('col3')
+        ->and($field->errors()->get('columns'))->toHaveCount(2);
+
+    $context = new FormContext(errors: $field->errors()->getMessages());
+    $payload = app(FormResolver::class)->resolve($field->settingsForm($context), $context);
+    $rerenderedPayload = app(FormResolver::class)->resolve($field->settingsForm($context), $context);
+    $crawler = new Crawler(app(FormHtmlRenderer::class)->render($payload));
+
+    expect($payload->values['columns']['first']['handle'])->toBe('invalid-handle')
+        ->and($payload->values['columns']['second']['handle'])->toBe('validHandle')
+        ->and($payload->values['columns']['third']['handle'])->toBe('col3')
+        ->and($payload->nodes[0]->control->props['errors'])->toBe([
+            'first' => ['handle' => true],
+            'third' => ['handle' => true],
+        ])
+        ->and($rerenderedPayload->values)->toBe($payload->values)
+        ->and($rerenderedPayload->nodes[0]->control->props['errors'])->toBe($payload->nodes[0]->control->props['errors'])
+        ->and($crawler->filter('td.error textarea[name="columns[first][handle]"]')->text())->toBe('invalid-handle')
+        ->and($crawler->filter('td.error textarea[name="columns[second][handle]"]'))->toHaveCount(0)
+        ->and($crawler->filter('td.error textarea[name="columns[third][handle]"]')->text())->toBe('col3');
+
+    $columns = $field->columns;
+    $columns['first']['handle'] = 'firstHandle';
+    $columns['third']['handle'] = 'thirdHandle';
+    $field = new Table(['name' => 'Details', 'handle' => 'details', 'columns' => $columns]);
+
+    expect($field->validate())->toBeTrue();
+
+    $payload = app(FormResolver::class)->resolve($field->settingsForm(), new FormContext);
+    $crawler = new Crawler(app(FormHtmlRenderer::class)->render($payload));
+
+    expect($payload->values['columns']['first']['handle'])->toBe('firstHandle')
+        ->and($payload->values['columns']['third']['handle'])->toBe('thirdHandle')
+        ->and($payload->nodes[0]->control->props)->not->toHaveKey('errors')
+        ->and($crawler->filter('td.error'))->toHaveCount(0);
+});

--- a/tests/Unit/Form/PlainTextSettingsFormTest.php
+++ b/tests/Unit/Form/PlainTextSettingsFormTest.php
@@ -88,11 +88,26 @@ it('rejects identities that cannot reconcile stably', function () {
     $missingUid = Form::make([
         Group::make('', [Field::make()->control(Text::make('child'))]),
     ]);
+    $duplicateUids = Form::make([
+        Group::make('same'),
+        Group::make('same'),
+    ]);
 
     expect(fn () => app(FormResolver::class)->resolve($duplicatePaths, new FormContext))
         ->toThrow(InvalidArgumentException::class, 'Duplicate Control path')
         ->and(fn () => app(FormResolver::class)->resolve($missingUid, new FormContext))
-        ->toThrow(InvalidArgumentException::class, 'stable UID');
+        ->toThrow(InvalidArgumentException::class, 'stable UID')
+        ->and(fn () => app(FormResolver::class)->resolve($duplicateUids, new FormContext))
+        ->toThrow(InvalidArgumentException::class, 'Duplicate Node UID');
+});
+
+it('resolves empty Forms', function () {
+    $payload = app(FormResolver::class)->resolve(Form::make(), new FormContext(namespace: 'settings'));
+
+    expect($payload->scope)->toBe(['settings'])
+        ->and($payload->nodes)->toBe([])
+        ->and($payload->values)->toBe([])
+        ->and($payload->errors)->toBe([]);
 });
 
 it('keeps stable identities for pathless presentational leaves', function () {

--- a/tests/Unit/Gql/ElementQueryConditionBuilderTest.php
+++ b/tests/Unit/Gql/ElementQueryConditionBuilderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Gql\ArgumentManager;
+use CraftCms\Cms\Gql\ElementQueryConditionBuilder;
+use CraftCms\Cms\Support\Facades\Fields;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use GraphQL\Language\Parser;
+use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+
+it('decodes standard GraphQL values in eager-loading conditions', function () {
+    Fields::shouldReceive('getAllFields')->once()->with(false)->andReturn(collect());
+
+    $document = Parser::parse(<<<'GRAPHQL'
+query Entries($criteria: [String]) {
+  entries {
+    children(
+      slug: $criteria
+      status: null
+      customEnum: DRAFT
+      relatedTo: [{ source: "news", nested: { enabled: true } }]
+      limit: 2
+    ) {
+      id
+    }
+  }
+}
+GRAPHQL);
+    $operation = $document->definitions[0];
+    expect($operation)->toBeInstanceOf(OperationDefinitionNode::class);
+
+    $fieldNode = $operation->selectionSet->selections[0];
+    $returnType = new ObjectType(['name' => 'EntryInterface', 'fields' => []]);
+    $resolveInfo = new ResolveInfo(
+        new FieldDefinition(['name' => 'entries', 'type' => Type::listOf($returnType)]),
+        new ArrayObject([$fieldNode]),
+        new ObjectType(['name' => 'Query', 'fields' => []]),
+        ['entries'],
+        new Schema([]),
+        [],
+        null,
+        $operation,
+        ['criteria' => ['one', 'two']],
+    );
+
+    $builder = new ElementQueryConditionBuilder(['resolveInfo' => $resolveInfo]);
+    $builder->setArgumentManager(new ArgumentManager);
+    $conditions = $builder->extractQueryConditions();
+
+    expect($conditions['with'][0]->criteria)->toBe([
+        'slug' => ['one', 'two'],
+        'status' => null,
+        'customEnum' => 'DRAFT',
+        'relatedTo' => [
+            [
+                'source' => 'news',
+                'nested' => ['enabled' => true],
+            ],
+        ],
+        'limit' => 2,
+    ]);
+});

--- a/tests/Unit/Gql/Types/QueryArgumentTest.php
+++ b/tests/Unit/Gql/Types/QueryArgumentTest.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Gql\Exceptions\GqlException;
+use CraftCms\Cms\Gql\Types\QueryArgument;
+use GraphQL\Language\AST\FloatValueNode;
+
+it('rejects invalid query condition values', function () {
+    QueryArgument::getType()->parseLiteral(new FloatValueNode(['value' => '1.5']));
+})->throws(GqlException::class, 'QueryArgument must be either a string, an integer, or a boolean value.');

--- a/tests/Unit/Support/HtmlTest.php
+++ b/tests/Unit/Support/HtmlTest.php
@@ -2,7 +2,24 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Http\Middleware\SetHeaders;
 use CraftCms\Cms\Support\Html;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+it('isolates CSRF cache headers to the request scope', function () {
+    app()->instance('request', Request::create('/'));
+
+    Html::csrfInput();
+    app()->forgetScopedInstances();
+
+    $response = app(SetHeaders::class)->handle(
+        request(),
+        fn () => new Response(headers: ['Cache-Control' => 'public, max-age=3600']),
+    );
+
+    expect($response->headers->hasCacheControlDirective('no-cache'))->toBeFalse();
+});
 
 test('EncodeParams', function (string $expected, string $html, array $variables) {
     $this->assertSame($expected, Html::encodeParams($html, $variables));

--- a/tests/Unit/Validation/ValidatesWithRulesetTest.php
+++ b/tests/Unit/Validation/ValidatesWithRulesetTest.php
@@ -6,6 +6,7 @@ use CraftCms\Cms\Validation\Concerns\Validates;
 use CraftCms\Cms\Validation\Contracts\Validatable;
 use CraftCms\Cms\Validation\Ruleset;
 use CraftCms\Cms\Validation\ValidatableRules;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 
 function createValidatableComponent(array $attributes, ?string $rulesetClass = null): Validatable
@@ -98,14 +99,15 @@ class PlainValidatable implements Validatable
 {
     use Validates;
 
-    public bool $prepareForValidationCalled = false;
+    public int $prepareForValidationCalls = 0;
 
-    public bool $passedValidationCalled = false;
+    public int $passedValidationCalls = 0;
 
-    public bool $afterValidateCalled = false;
+    public int $afterValidateCalls = 0;
 
     public function __construct(
         private array $testAttributes,
+        private bool $throwAfterValidation = false,
     ) {}
 
     public function setAttributes(array $values): void
@@ -125,19 +127,30 @@ class PlainValidatable implements Validatable
         ];
     }
 
+    public function getMessages(): array
+    {
+        return [
+            'title.required' => 'Title is required.',
+        ];
+    }
+
     public function prepareForValidation(): void
     {
-        $this->prepareForValidationCalled = true;
+        $this->prepareForValidationCalls++;
     }
 
     public function passedValidation(): void
     {
-        $this->passedValidationCalled = true;
+        $this->passedValidationCalls++;
     }
 
     public function afterValidate(?Validator $validator = null): void
     {
-        $this->afterValidateCalled = true;
+        $this->afterValidateCalls++;
+
+        if ($this->throwAfterValidation) {
+            throw new RuntimeException('After validation failed.');
+        }
     }
 }
 
@@ -187,9 +200,9 @@ describe('validate', function () {
 
         expect($component->ruleset)->toBeFalse();
         expect($result)->toBeTrue();
-        expect($component->prepareForValidationCalled)->toBeTrue();
-        expect($component->passedValidationCalled)->toBeTrue();
-        expect($component->afterValidateCalled)->toBeTrue();
+        expect($component->prepareForValidationCalls)->toBe(1);
+        expect($component->passedValidationCalls)->toBe(1);
+        expect($component->afterValidateCalls)->toBe(1);
     });
 
     test('stores errors from fallback ruleset when no ruleset is configured', function () {
@@ -200,9 +213,9 @@ describe('validate', function () {
         expect($component->ruleset)->toBeFalse();
         expect($result)->toBeFalse();
         expect($component->errors()->has('title'))->toBeTrue();
-        expect($component->prepareForValidationCalled)->toBeTrue();
-        expect($component->passedValidationCalled)->toBeFalse();
-        expect($component->afterValidateCalled)->toBeTrue();
+        expect($component->prepareForValidationCalls)->toBe(1);
+        expect($component->passedValidationCalls)->toBe(0);
+        expect($component->afterValidateCalls)->toBe(1);
     });
 
     test('passes attribute names to prepareForValidation', function () {
@@ -251,6 +264,45 @@ describe('validate', function () {
         $component->validate();
 
         expect($component->afterValidateCalled)->toBeTrue();
+    });
+
+    test('runs the validation lifecycle once when throwing validation passes', function () {
+        $component = new PlainValidatable(['title' => 'Test']);
+
+        $result = $component->validate(throw: true);
+
+        expect($result)->toBeTrue();
+        expect($component->prepareForValidationCalls)->toBe(1);
+        expect($component->passedValidationCalls)->toBe(1);
+        expect($component->afterValidateCalls)->toBe(1);
+    });
+
+    test('runs the validation lifecycle once and preserves errors when throwing validation fails', function () {
+        $component = new PlainValidatable(['title' => null]);
+        $errors = null;
+
+        try {
+            $component->validate(throw: true);
+        } catch (ValidationException $caught) {
+            $errors = $caught->errors();
+        }
+
+        expect($errors)->toBe([
+            'title' => ['Title is required.'],
+        ]);
+        expect($component->prepareForValidationCalls)->toBe(1);
+        expect($component->passedValidationCalls)->toBe(0);
+        expect($component->afterValidateCalls)->toBe(1);
+    });
+
+    test('propagates exceptions from validation hooks after one lifecycle', function () {
+        $component = new PlainValidatable(['title' => 'Test'], throwAfterValidation: true);
+
+        expect(fn () => $component->validate(throw: true))
+            ->toThrow(RuntimeException::class, 'After validation failed.');
+        expect($component->prepareForValidationCalls)->toBe(1);
+        expect($component->passedValidationCalls)->toBe(0);
+        expect($component->afterValidateCalls)->toBe(1);
     });
 });
 

--- a/tests/Unit/View/BladeDirectives/ResponseDirectiveTest.php
+++ b/tests/Unit/View/BladeDirectives/ResponseDirectiveTest.php
@@ -15,10 +15,6 @@ beforeEach(function () {
     $this->renderer = app(BladeRenderer::class);
 });
 
-afterEach(function () {
-    SetHeaders::reset();
-});
-
 function renderBladeAndApplyHeaders(string $template): Response
 {
     app(BladeRenderer::class)->renderString($template);
@@ -30,6 +26,16 @@ it('sets a response header', function () {
     $response = renderBladeAndApplyHeaders('@craftHeader("X-Custom: test-value")');
 
     expect($response->headers->get('X-Custom'))->toBe('test-value');
+});
+
+it('isolates response headers to the request scope', function () {
+    app(BladeRenderer::class)->renderString('@craftHeader("X-Custom: test-value")');
+
+    app()->forgetScopedInstances();
+
+    $response = app(SetHeaders::class)->handle(Request::create('foo'), fn () => new Response);
+
+    expect($response->headers->has('X-Custom'))->toBeFalse();
 });
 
 it('sets cache headers with duration', function () {

--- a/tests/Unit/View/ResourceCollectorTest.php
+++ b/tests/Unit/View/ResourceCollectorTest.php
@@ -21,19 +21,58 @@ beforeEach(function () {
 });
 
 it('captures and reapplies buffered html stack resources', function () {
-    $this->collector->begin($this->context);
+    $registerResources = function (HtmlStack $htmlStack): void {
+        $htmlStack->js('console.log("hello")', Position::Head, 'js-key');
+        $htmlStack->script('window.__craft = true', Position::BodyEnd, ['type' => 'module'], 'script-key');
+        $htmlStack->css('body { color: red }', ['media' => 'screen', 'data' => ['theme' => 'dark']], 'css-key');
+        $htmlStack->jsFile('/app.js', [
+            'defer' => true,
+            'condition' => 'IE 9',
+            'noscript' => true,
+            'data' => ['module' => 'app'],
+            'position' => Position::BodyEnd->value,
+        ], 'file-key');
+        $htmlStack->cssFile('/app.css', ['media' => 'print'], 'css-file-key');
+        $htmlStack->metaTag(['name' => 'description', 'content' => 'cached'], 'meta-key');
+        $htmlStack->jsImport('alpine', '/alpine.js');
+        $htmlStack->css('body { color: blue }', ['nonce' => 'updated'], 'css-key');
+    };
 
-    $this->htmlStack->js('console.log("hello")', Position::Head, 'js-key');
-    $this->htmlStack->script('window.__craft = true', Position::BodyEnd, ['type' => 'module'], 'script-key');
-    $this->htmlStack->css('body { color: red }', ['media' => 'screen'], 'css-key');
-    $this->htmlStack->jsFile('/app.js', ['defer' => true, 'position' => Position::BodyEnd->value], 'file-key');
-    $this->htmlStack->metaTag(['name' => 'description', 'content' => 'cached'], 'meta-key');
-    $this->htmlStack->jsImport('alpine', '/alpine.js');
+    $registerResources($this->htmlStack);
+    $expectedHead = $this->htmlStack->headHtml();
+    $expectedBody = $this->htmlStack->bodyEndHtml();
+
+    app()->forgetScopedInstances();
+    $this->collector = app(ResourceCollector::class);
+    $this->htmlStack = app(HtmlStack::class);
+
+    $this->collector->begin($this->context);
+    $registerResources($this->htmlStack);
 
     $payload = $this->collector->end($this->context);
 
     expect($payload['js'][Position::Head->value]['js-key'])->toContain('console.log("hello")')
-        ->and($payload['css']['css-key'][0])->toContain('body { color: red }')
+        ->and($payload['scripts'][Position::BodyEnd->value]['script-key'])->toBe([
+            'window.__craft = true',
+            ['type' => 'module'],
+        ])
+        ->and($payload['css']['css-key'])->toBe([
+            'body { color: blue }',
+            ['nonce' => 'updated'],
+        ])
+        ->and($payload['jsFiles'][Position::BodyEnd->value]['file-key'])->toBe([
+            '/app.js',
+            [
+                'defer' => true,
+                'condition' => 'IE 9',
+                'noscript' => true,
+                'data' => ['module' => 'app'],
+            ],
+        ])
+        ->and($payload['cssFiles']['css-file-key'])->toBe([
+            '/app.css',
+            ['media' => 'print'],
+        ])
         ->and($payload['metaTags']['meta-key'])->toBe([
             'name' => 'description',
             'content' => 'cached',
@@ -42,13 +81,12 @@ it('captures and reapplies buffered html stack resources', function () {
     $this->htmlStack->clear();
     $this->collector->apply($payload, $this->context);
 
-    $head = $this->htmlStack->headHtml();
-    $body = $this->htmlStack->bodyEndHtml();
+    expect($this->htmlStack->headHtml())->toBe($expectedHead)
+        ->and($this->htmlStack->bodyEndHtml())->toBe($expectedBody);
+});
 
-    expect($head)->toContain('body { color: red }')
-        ->toContain('console.log("hello");')
-        ->toContain('name="description"')
-        ->toContain('alpine')
-        ->and($body)->toContain('/app.js')
-        ->toContain('type="module"');
+it('returns an empty payload when no resources were buffered', function () {
+    $this->collector->begin($this->context);
+
+    expect($this->collector->end($this->context))->toBe([]);
 });

--- a/yii2-adapter/legacy/services/Auth.php
+++ b/yii2-adapter/legacy/services/Auth.php
@@ -297,7 +297,16 @@ class Auth extends Component
                 ->serialize($requestOptions, 'json');
         }
 
-        return app(Passkeys::class)->verifyPasskey($user, $requestOptions, $response);
+        $passkeys = app(Passkeys::class);
+        $credentialRecord = $passkeys->verifyPasskey($user, $requestOptions, $response);
+
+        if ($credentialRecord === false) {
+            return false;
+        }
+
+        $passkeys->webauthnServer()->getCredentialRepository()->saveCredentialSource($credentialRecord);
+
+        return true;
     }
 
     /**

--- a/yii2-adapter/legacy/test/mockclasses/gql/MockDirective.php
+++ b/yii2-adapter/legacy/test/mockclasses/gql/MockDirective.php
@@ -6,6 +6,7 @@ use craft\gql\base\Directive;
 use GraphQL\Language\DirectiveLocation;
 use GraphQL\Type\Definition\Directive as GqlDirective;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
 
 /**
  * Class MockDirective
@@ -21,6 +22,12 @@ class MockDirective extends Directive
             'name' => static::name(),
             'locations' => [
                 DirectiveLocation::FIELD,
+            ],
+            'args' => [
+                [
+                    'name' => 'prefix',
+                    'type' => Type::string(),
+                ],
             ],
         ]);
     }

--- a/yii2-adapter/tests-laravel/Legacy/AuthServiceTest.php
+++ b/yii2-adapter/tests-laravel/Legacy/AuthServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use craft\services\Auth;
+use CraftCms\Cms\Auth\Passkeys\CredentialRepository;
+use CraftCms\Cms\Auth\Passkeys\Passkeys;
+use CraftCms\Cms\Auth\Passkeys\WebauthnServer;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\CredentialRecord;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+it('persists the credential returned by passkey verification', function() {
+    $user = Mockery::mock(craft\elements\User::class);
+    $credentialRecord = CredentialRecord::create(
+        publicKeyCredentialId: 'test-credential-id',
+        type: 'public-key',
+        transports: [],
+        attestationType: 'none',
+        trustPath: EmptyTrustPath::create(),
+        aaguid: Uuid::v4(),
+        credentialPublicKey: 'credential-public-key',
+        userHandle: 'user-handle',
+        counter: 1,
+    );
+
+    $credentialRepository = Mockery::mock(CredentialRepository::class);
+    $credentialRepository->shouldReceive('saveCredentialSource')->once()->with($credentialRecord);
+
+    $webauthnServer = Mockery::mock(WebauthnServer::class);
+    $webauthnServer->shouldReceive('getCredentialRepository')->once()->andReturn($credentialRepository);
+
+    $passkeys = Mockery::mock(Passkeys::class)->makePartial();
+    $passkeys->shouldReceive('verifyPasskey')->once()->andReturn($credentialRecord);
+    $passkeys->shouldReceive('webauthnServer')->once()->andReturn($webauthnServer);
+    app()->instance(Passkeys::class, $passkeys);
+
+    expect(new Auth()->verifyPasskey($user, '{}', '{}'))->toBeTrue();
+});

--- a/yii2-adapter/tests/unit/gql/DirectiveTest.php
+++ b/yii2-adapter/tests/unit/gql/DirectiveTest.php
@@ -29,7 +29,9 @@ use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\Support\Str;
 use DateTime;
 use DateTimeZone;
+use GraphQL\Language\Parser;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Schema;
 
 class DirectiveTest extends TestCase
 {
@@ -59,11 +61,12 @@ class DirectiveTest extends TestCase
         $element = new ExampleElement();
         $element->someField = $in;
 
-        $fieldNodes = new ArrayObject([Json::decode('{"directives":[' . implode(',', $directives) . ']}', false)]);
+        $fieldNodes = new ArrayObject([Parser::field('someField ' . implode(' ', $directives))]);
 
         $resolveInfo = $this->make(ResolveInfo::class, [
             'fieldName' => 'someField',
             'fieldNodes' => $fieldNodes,
+            'schema' => new Schema([]),
         ]);
 
         self::assertEquals($result, $type->resolveWithDirectives($element, [], null, $resolveInfo));
@@ -83,11 +86,12 @@ class DirectiveTest extends TestCase
         /** @var GqlAssetType $type */
         $type = $this->make(GqlAssetType::class);
 
-        $fieldNodes = new ArrayObject([Json::decode('{"directives":[' . self::_buildDirective(Transform::class, ['width' => 200]) . ']}', false)]);
+        $fieldNodes = new ArrayObject([Parser::field('filename ' . self::_buildDirective(Transform::class, ['width' => 200]))]);
 
         $resolveInfo = $this->make(ResolveInfo::class, [
             'fieldName' => 'filename',
             'fieldNodes' => $fieldNodes,
+            'schema' => new Schema([]),
         ]);
 
         self::assertEquals($asset->getFilename(), $type->resolveWithDirectives($asset, [], null, $resolveInfo));
@@ -173,7 +177,7 @@ class DirectiveTest extends TestCase
     }
 
     /**
-     * Build the JSON string to be used as a directive object
+     * Build the GraphQL string to be used as a directive
      *
      * @param string $className
      * @phpstan-param class-string<Directive> $className
@@ -182,15 +186,16 @@ class DirectiveTest extends TestCase
      */
     private static function _buildDirective(string $className, array $arguments = []): string
     {
-        $directiveTemplate = '{"name": {"value": "%s"}, "arguments": [%s]}';
-        $argumentTemplate = '{"name": {"value":"%s"}, "value": {"value": %s}}';
+        $argumentTemplate = '%s: %s';
 
         $argumentList = [];
         foreach ($arguments as $key => $value) {
             $argumentList[] = sprintf($argumentTemplate, $key, Json::encode($value));
         }
 
-        return sprintf($directiveTemplate, $className::name(), implode(', ', $argumentList));
+        $arguments = $argumentList === [] ? '' : sprintf('(%s)', implode(', ', $argumentList));
+
+        return sprintf('@%s%s', $className::name(), $arguments);
     }
 
     /**


### PR DESCRIPTION
### Description

A collection of refactors / fixes from both manual reviews/spelunking and a Codex review, bundled into one not-too-large PR. Click on each commit to review the individual changes.

#### [Use Laravel database teardown API](https://github.com/craftcms/cms/commit/e13ed311229a38f73fe128e36507071f9795e38d)

Delegates schema teardown to Laravel’s cross-driver API, removing redundant driver-specific table enumeration and drop logic.

#### [Fix Edition capability checks](https://github.com/craftcms/cms/commit/a4e85f22df613b480d18c49c0c335cf450a827f0)

Makes each `Edition` report capabilities from its own value, rather than potentially returning results based on the globally configured edition.

#### [Fix mixed element collection eager loading](https://github.com/craftcms/cms/commit/7d04082a67b6701d0a3763f411037db33ef6300a)

Passes only class-compatible elements to eager loading, preventing mixed collections from sending incompatible elements to a type-specific loader.

#### [Fix duplicate validation lifecycle](https://github.com/craftcms/cms/commit/91050ef6d190eb09403a3b23ff5113ef45413db3)

Runs throwing validation through one lifecycle, preventing validation hooks and their side effects from executing twice.

#### [Use atomic job progress upserts](https://github.com/craftcms/cms/commit/ef1357bce8dbe14a1ad923f82b6ce84b2cedc9b4)

Replaces separate job-progress lookup, insert, and update paths with one atomic upsert, removing duplicated assignments and a concurrent-write race window.

#### [Use exception-based JSON decoding](https://github.com/craftcms/cms/commit/979024f150df2f2778e436290ff3f9d3af617265)

Uses native exception-based JSON decoding as the single parsing path, avoiding a second check against global parser error state.

#### [Normalize forced-disabled plugin configuration](https://github.com/craftcms/cms/commit/55b6bf811d2c25867b280b7a362e1e5173abb564)

Normalizes supported forced-disabled plugin formats at the boundary so all lifecycle checks use consistent membership semantics.

#### [Add request-scoped response headers](https://github.com/craftcms/cms/commit/df4367fed4c88b659d9aac4c064671b673c00de9)

Moves response-header accumulation and core producers to request-scoped state, preventing headers from leaking between requests under long-lived or concurrent workers.

#### [Improve FormResolver membership checks](https://github.com/craftcms/cms/commit/f37b1f56de5021fdae421daaaa367390fb52c13f)

Indexes control paths and node IDs once per resolution, avoiding repeated scans while preserving form output order.

#### [Keep custom field query criteria sparse](https://github.com/craftcms/cms/commit/73391f67f1a432bcbf93d0021bdcab1ebe3d520d)

Stores only explicitly supplied custom-field criteria, preserving the distinction between absent and explicit-null values and avoiding unnecessary query state.

#### [Prevent stale user permission trees](https://github.com/craftcms/cms/commit/a6e4ee3ebde5565f8ad48cb3e4e60bf58619ae55)

Derives permission trees from current permissions and plugin contributions instead of retaining mutable cached state that can become stale.

#### [Use GraphQL AST value decoders](https://github.com/craftcms/cms/commit/9c63e202b3655d42e5208322a1eb9eca5a74249e)

Replaces duplicate handwritten AST conversion with the installed GraphQL library’s decoder while retaining Craft-specific query-condition validation.

#### [Return verified passkey credentials explicitly](https://github.com/craftcms/cms/commit/40ae69497fabc64c5a5967a82e934a3f16c41ee7)

Returns verified credential data directly to persistence instead of transporting it through hidden session state, keeping independent authentication attempts isolated.

#### [Replay structured HTML stack resources](https://github.com/craftcms/cms/commit/66680a68409de8b0467369269a6426a503e2c1dd)

Retains structured resource entries in the HTML stack so cache collection can replay them directly instead of rendering tags and parsing them back into data.

#### [Keep search state local](https://github.com/craftcms/cms/commit/934fa4c2fec6dfd6b7a8e09c8a9bc12d283518f6)

Keeps parsed terms, groups, and query-building state local to each search, preventing nested or concurrent operations from overwriting shared service state.

#### [Keep table validation errors beside values](https://github.com/craftcms/cms/commit/6a93fa9240e38558391c19f1dfdfc897c5c1bbfa)

Carries Table column validation errors in a row-and-cell sidecar map so persisted handles remain scalar through failed validation and rerendering.