### PR TITLE
[6.x] Fix undefined siteId property error on element redirect

### DIFF
--- a/src/Http/Requests/ElementRequest.php
+++ b/src/Http/Requests/ElementRequest.php
@@ -117,6 +117,10 @@ class ElementRequest extends FormRequest
             return null;
         }
 
+        if ($element instanceof Response) {
+            return $element;
+        }
+
         abort_unless($this->craftUser()->can('view', $element), 403, 'User not authorized to view this element.');
 
         // When site resolution is non-strict, the element may have been resolved

--- a/src/Http/Requests/ElementRequest.php
+++ b/src/Http/Requests/ElementRequest.php
@@ -137,9 +137,7 @@ class ElementRequest extends FormRequest
             return redirect($element->getCpEditUrl());
         }
 
-        if ($element instanceof ElementInterface) {
-            $this->element = $element;
-        }
+        $this->element = $element;
 
         return $element;
     }


### PR DESCRIPTION
`ElementRequest::element()` could receive a redirect `Response` from `elementByDraftOrRevision()` (when falling back to the canonical element in a non-strict-site context) but still treated the result as an `ElementInterface`, causing an "Undefined property: ...RedirectResponse::$siteId" error. Now returns the redirect response immediately instead of falling through to the element checks.