### PR TITLE
[6.x] Own the element selector modal registry

### DIFF
--- a/packages/craftcms-legacy/cp/src/js/Craft.js
+++ b/packages/craftcms-legacy/cp/src/js/Craft.js
@@ -1990,7 +1990,6 @@ $.extend(Craft, {
   },
 
   _elementIndexClasses: {},
-  _elementSelectorModalClasses: {},
   _elementEditorClasses: {},
   _uploaderClasses: {},
   _authFormHandlers: {},
@@ -2029,24 +2028,6 @@ $.extend(Craft, {
     }
 
     this._uploaderClasses[fsType] = func;
-  },
-
-  /**
-   * Registers an element selector modal class for a given element type.
-   *
-   * @param {string} elementType
-   * @param {function} func
-   */
-  registerElementSelectorModalClass: function (elementType, func) {
-    if (typeof this._elementSelectorModalClasses[elementType] !== 'undefined') {
-      throw (
-        'An element selector modal class has already been registered for the element type “' +
-        elementType +
-        '”.'
-      );
-    }
-
-    this._elementSelectorModalClasses[elementType] = func;
   },
 
   registerAuthFormHandler(method, func) {
@@ -2095,24 +2076,6 @@ $.extend(Craft, {
     uploader.fsType = fsType;
 
     return uploader;
-  },
-
-  /**
-   * Creates a new element selector modal for a given element type.
-   *
-   * @param {string} elementType
-   * @param {Object} settings
-   */
-  createElementSelectorModal: function (elementType, settings) {
-    var func;
-
-    if (typeof this._elementSelectorModalClasses[elementType] !== 'undefined') {
-      func = this._elementSelectorModalClasses[elementType];
-    } else {
-      func = Craft.BaseElementSelectorModal;
-    }
-
-    return new func(elementType, settings);
   },
 
   /**

--- a/resources/js/modules/element-select-input/base-element-select-input.ts
+++ b/resources/js/modules/element-select-input/base-element-select-input.ts
@@ -12,6 +12,7 @@ import {
   RETURN_KEY,
   UP_KEY,
 } from '@craftcms/garnish';
+import {createElementSelectorModal} from '@/modules/element-selector-modal/registry';
 import {elementSelectInputData} from './support';
 
 declare const Craft: any;
@@ -914,7 +915,7 @@ export class BaseElementSelectInput extends Base {
   }
 
   createModal(): any {
-    return Craft.createElementSelectorModal(
+    return createElementSelectorModal(
       this.settings.elementType,
       this.getModalSettings()
     );

--- a/resources/js/modules/element-selector-modal/README.md
+++ b/resources/js/modules/element-selector-modal/README.md
@@ -1,0 +1,58 @@
+# element-selector-modal
+
+Replaces `Craft.BaseElementSelectorModal` / `Craft.AssetSelectorModal` /
+`Craft.VolumeFolderSelectorModal` from the legacy cp bundle, plus the
+`createElementSelectorModal` / `registerElementSelectorModalClass` registry that
+used to live in `cp/src/js/Craft.js`.
+
+## Shape
+
+This module does **not** follow the `<name>.ce.ts` + `support.ts` shape described
+in [the modules README](../README.md). That pattern is for behavior wrapped
+around server-rendered markup; a selector modal has none — it is constructed
+imperatively and builds its own container. So there is no custom element and no
+element-keyed instance registry.
+
+What does carry over is the rest of the pattern: the module owns the behavior,
+`window.Craft.*` is a shim, and the legacy source is deleted.
+
+| File | Role |
+| --- | --- |
+| `base-element-selector-modal.ts` | The base modal, on `@craftcms/garnish` `Modal`. |
+| `asset-selector-modal.ts` | Adds the "Select transform" menu. |
+| `volume-folder-selector-modal.ts` | Folder picker used by asset moves. |
+| `registry.ts` | Element type → modal class map, and the factory. |
+| `index.ts` | Registers the built-in asset mapping, assigns the `Craft.*` shims, re-exports. |
+
+## Registry
+
+`registry.ts` holds the map. `createElementSelectorModal(elementType, settings)`
+constructs the registered class, or `BaseElementSelectorModal`.
+`registerElementSelectorModalClass()` throws on a duplicate, as the legacy
+registry did.
+
+In-repo callers import the factory directly rather than going through `Craft`.
+The globals remain for plugins and for PHP-emitted boots — `MoveAssets.php` and
+the legacy `AssetIndex` still emit `new Craft.VolumeFolderSelectorModal(…)`.
+
+### Load order
+
+The legacy bundle is a plain `<script>` and runs before this module, so a plugin
+can register a class before there is anywhere modern to put it.
+`adoptLegacyRegistrations()` drains anything sitting on
+`Craft._elementSelectorModalClasses` on load, and the built-in asset registration
+yields to an entry that is already there.
+
+That covers a plugin assigning into the object. A plugin *calling*
+`Craft.registerElementSelectorModalClass()` before this module evaluates will
+still fail — the function no longer exists in the legacy bundle. If that turns up
+in practice, the fix is a queueing stub in the legacy bundle, not moving the
+registry back.
+
+## Still jQuery
+
+`base-element-selector-modal.ts` builds its chrome with jQuery (`$body`,
+`$footer`, `Craft.ui.createSubmitButton`) and binds the jQuery-synthetic
+`doubletap` event. The element index inside the modal is still the legacy
+`Craft.AssetIndex` / `BaseElementIndex` via the `Craft.createElementIndex` seam —
+the next registry worth porting the same way.

--- a/resources/js/modules/element-selector-modal/index.test.ts
+++ b/resources/js/modules/element-selector-modal/index.test.ts
@@ -5,8 +5,32 @@ afterEach(() => {
   vi.resetModules();
 });
 
-it('loads without the legacy selector modal registry', async () => {
+it('owns the registry rather than reaching into the legacy bundle', async () => {
   vi.stubGlobal('Craft', {});
 
-  await expect(import('./index')).resolves.toBeDefined();
+  const module = await import('./index');
+  const Craft = (window as any).Craft;
+
+  // The factory and the registration hook now come from here, so the legacy
+  // bundle no longer has to ship either.
+  expect(typeof Craft.createElementSelectorModal).toBe('function');
+  expect(typeof Craft.registerElementSelectorModalClass).toBe('function');
+  expect(
+    module.elementSelectorModalClass('CraftCms\\Cms\\Asset\\Elements\\Asset')
+  ).toBe(module.AssetSelectorModal);
+});
+
+it('yields to a modal class the legacy bundle already registered for assets', async () => {
+  class PluginAssetModal {}
+  vi.stubGlobal('Craft', {
+    _elementSelectorModalClasses: {
+      'CraftCms\\Cms\\Asset\\Elements\\Asset': PluginAssetModal,
+    },
+  });
+
+  const module = await import('./index');
+
+  expect(
+    module.elementSelectorModalClass('CraftCms\\Cms\\Asset\\Elements\\Asset')
+  ).toBe(PluginAssetModal);
 });

--- a/resources/js/modules/element-selector-modal/index.ts
+++ b/resources/js/modules/element-selector-modal/index.ts
@@ -3,31 +3,42 @@ import {t} from '@craftcms/ui';
 import {BaseElementSelectorModal} from './base-element-selector-modal';
 import {AssetSelectorModal} from './asset-selector-modal';
 import {VolumeFolderSelectorModal} from './volume-folder-selector-modal';
+import {
+  adoptLegacyRegistrations,
+  createElementSelectorModal,
+  hasElementSelectorModalClass,
+  registerElementSelectorModalClass,
+} from './registry';
 
-declare const Craft: any;
+const ASSET = 'CraftCms\\Cms\\Asset\\Elements\\Asset';
 
 BaseElementSelectorModal.defaults.modalTitle ??= t('Select element');
 BaseElementSelectorModal.defaults.selectBtnLabel ??= t('Select');
 
-// Assign legacy `Craft.*` globals so PHP-emitted `new Craft.BaseElementSelectorModal(...)`
-// and plugin code that calls `Craft.registerElementSelectorModalClass(...)` keep working.
+adoptLegacyRegistrations();
+
+// Skipped when something got there first, so a plugin can replace the built-in
+// asset modal without the duplicate-registration throw.
+if (!hasElementSelectorModalClass(ASSET)) {
+  registerElementSelectorModalClass(ASSET, AssetSelectorModal);
+}
+
+// The classes stay on `Craft` for PHP-emitted boots (`new
+// Craft.VolumeFolderSelectorModal(…)`); the registry functions stay for plugins.
 registerCraftGlobals({
   BaseElementSelectorModal,
   AssetSelectorModal,
   VolumeFolderSelectorModal,
+  createElementSelectorModal,
+  registerElementSelectorModalClass,
 });
-
-if (
-  typeof Craft._elementSelectorModalClasses?.[
-    'CraftCms\\Cms\\Asset\\Elements\\Asset'
-  ] === 'undefined'
-) {
-  Craft.registerElementSelectorModalClass?.(
-    'CraftCms\\Cms\\Asset\\Elements\\Asset',
-    AssetSelectorModal
-  );
-}
 
 export {BaseElementSelectorModal} from './base-element-selector-modal';
 export {AssetSelectorModal} from './asset-selector-modal';
 export {VolumeFolderSelectorModal} from './volume-folder-selector-modal';
+export {
+  createElementSelectorModal,
+  elementSelectorModalClass,
+  registerElementSelectorModalClass,
+  type ElementSelectorModalClass,
+} from './registry';

--- a/resources/js/modules/element-selector-modal/registry.test.ts
+++ b/resources/js/modules/element-selector-modal/registry.test.ts
@@ -1,0 +1,75 @@
+import {afterEach, beforeEach, expect, it, vi} from 'vite-plus/test';
+import {BaseElementSelectorModal} from './base-element-selector-modal';
+import {
+  adoptLegacyRegistrations,
+  createElementSelectorModal,
+  elementSelectorModalClass,
+  hasElementSelectorModalClass,
+  registerElementSelectorModalClass,
+  resetElementSelectorModalClasses,
+} from './registry';
+
+class FakeModal {
+  constructor(
+    public elementType: string,
+    public settings?: Record<string, any>
+  ) {}
+}
+
+const ENTRY = 'CraftCms\\Cms\\Entry\\Elements\\Entry';
+
+beforeEach(() => resetElementSelectorModalClasses());
+
+afterEach(() => {
+  resetElementSelectorModalClasses();
+  vi.unstubAllGlobals();
+});
+
+it('falls back to the base modal for an unregistered element type', () => {
+  expect(elementSelectorModalClass(ENTRY)).toBe(BaseElementSelectorModal);
+  expect(hasElementSelectorModalClass(ENTRY)).toBe(false);
+});
+
+it('constructs the registered class with the element type and settings', () => {
+  registerElementSelectorModalClass(ENTRY, FakeModal as never);
+
+  const modal = createElementSelectorModal(ENTRY, {modalTitle: 'Choose'});
+
+  expect(modal).toBeInstanceOf(FakeModal);
+  expect((modal as unknown as FakeModal).elementType).toBe(ENTRY);
+  expect((modal as unknown as FakeModal).settings).toEqual({
+    modalTitle: 'Choose',
+  });
+});
+
+it('refuses a second registration for one element type', () => {
+  registerElementSelectorModalClass(ENTRY, FakeModal as never);
+
+  expect(() =>
+    registerElementSelectorModalClass(ENTRY, FakeModal as never)
+  ).toThrow(/already been registered/);
+});
+
+it('adopts classes the legacy bundle registered before it loaded', () => {
+  vi.stubGlobal('Craft', {_elementSelectorModalClasses: {[ENTRY]: FakeModal}});
+
+  adoptLegacyRegistrations();
+
+  expect(elementSelectorModalClass(ENTRY)).toBe(FakeModal);
+});
+
+it('keeps its own registration when the legacy bundle claims the same type', () => {
+  class Newer {}
+  registerElementSelectorModalClass(ENTRY, Newer as never);
+  vi.stubGlobal('Craft', {_elementSelectorModalClasses: {[ENTRY]: FakeModal}});
+
+  adoptLegacyRegistrations();
+
+  expect(elementSelectorModalClass(ENTRY)).toBe(Newer);
+});
+
+it('tolerates the legacy registry being gone', () => {
+  vi.stubGlobal('Craft', {});
+
+  expect(() => adoptLegacyRegistrations()).not.toThrow();
+});

--- a/resources/js/modules/element-selector-modal/registry.ts
+++ b/resources/js/modules/element-selector-modal/registry.ts
@@ -1,0 +1,76 @@
+import {BaseElementSelectorModal} from './base-element-selector-modal';
+
+export type ElementSelectorModalClass = new (
+  elementType: string,
+  settings?: Record<string, any>
+) => BaseElementSelectorModal;
+
+const classes = new Map<string, ElementSelectorModalClass>();
+
+/**
+ * Registers the modal class to use for an element type.
+ *
+ * Throws on a second registration for the same type, matching the legacy
+ * registry — two plugins claiming one element type is a conflict to surface,
+ * not to resolve by last-write-wins.
+ */
+export function registerElementSelectorModalClass(
+  elementType: string,
+  modalClass: ElementSelectorModalClass
+): void {
+  if (classes.has(elementType)) {
+    throw new Error(
+      `An element selector modal class has already been registered for the element type “${elementType}”.`
+    );
+  }
+
+  classes.set(elementType, modalClass);
+}
+
+export function hasElementSelectorModalClass(elementType: string): boolean {
+  return classes.has(elementType);
+}
+
+/** The class registered for an element type, or the base modal. */
+export function elementSelectorModalClass(
+  elementType: string
+): ElementSelectorModalClass {
+  return classes.get(elementType) ?? BaseElementSelectorModal;
+}
+
+export function createElementSelectorModal(
+  elementType: string,
+  settings?: Record<string, any>
+): BaseElementSelectorModal {
+  return new (elementSelectorModalClass(elementType))(elementType, settings);
+}
+
+/**
+ * Takes over anything already on the legacy `Craft._elementSelectorModalClasses`
+ * object.
+ *
+ * The legacy bundle is a plain script and runs before this module, so a plugin
+ * can have registered before there was anywhere modern to put it. Existing
+ * entries win over nothing here — a type this module registers itself is left
+ * alone.
+ */
+export function adoptLegacyRegistrations(): void {
+  const legacy = (window as any).Craft?._elementSelectorModalClasses as
+    | Record<string, ElementSelectorModalClass>
+    | undefined;
+
+  if (!legacy) {
+    return;
+  }
+
+  for (const [elementType, modalClass] of Object.entries(legacy)) {
+    if (!classes.has(elementType)) {
+      classes.set(elementType, modalClass);
+    }
+  }
+}
+
+/** Test seam. */
+export function resetElementSelectorModalClasses(): void {
+  classes.clear();
+}

--- a/resources/js/modules/link-field/craft-link-field.ts
+++ b/resources/js/modules/link-field/craft-link-field.ts
@@ -1,4 +1,5 @@
 import {t} from '@craftcms/ui';
+import {createElementSelectorModal} from '@/modules/element-selector-modal/registry';
 import '@craftcms/ui/components/disclosure/disclosure';
 import '@craftcms/ui/components/field-group/field-group';
 import {
@@ -175,7 +176,7 @@ class CraftLinkField extends LitElement {
       event.currentTarget instanceof HTMLElement ? event.currentTarget : null
     );
 
-    const modal = Craft.createElementSelectorModal(type.elementType, {
+    const modal = createElementSelectorModal(type.elementType, {
       ...config,
       closeOtherModals: false,
       hideOnSelect: true,

--- a/resources/js/modules/markdown-field/behaviors/assets.ts
+++ b/resources/js/modules/markdown-field/behaviors/assets.ts
@@ -1,4 +1,5 @@
 import {t} from '@craftcms/ui';
+import {createElementSelectorModal} from '@/modules/element-selector-modal/registry';
 import type {OverType as OverTypeInstance} from 'overtype';
 import type {PreviewController} from './preview';
 import {escapeMarkdownLabel} from './utilities';
@@ -33,24 +34,21 @@ export function createAssetController(
 
   function open(): void {
     if (!assetSelectorModal) {
-      assetSelectorModal = Craft.createElementSelectorModal(
-        ASSET_ELEMENT_TYPE,
-        {
-          closeOtherModals: false,
-          criteria: assetCriteria,
-          hideOnSelect: true,
-          modalTitle: t('Choose an asset'),
-          multiSelect: false,
-          onSelect: (assets: AssetInfo[]) => {
-            const [asset] = assets;
+      assetSelectorModal = createElementSelectorModal(ASSET_ELEMENT_TYPE, {
+        closeOtherModals: false,
+        criteria: assetCriteria,
+        hideOnSelect: true,
+        modalTitle: t('Choose an asset'),
+        multiSelect: false,
+        onSelect: (assets: AssetInfo[]) => {
+          const [asset] = assets;
 
-            if (asset) {
-              insert(asset);
-            }
-          },
-          sources: assetSources,
-        }
-      );
+          if (asset) {
+            insert(asset);
+          }
+        },
+        sources: assetSources,
+      });
 
       return;
     }


### PR DESCRIPTION
### Description

The element selector modal classes were ported to modern TypeScript a while back, but the registry that resolves one for a given element type stayed behind in the legacy bundle. That left the modern module reaching backwards into `Craft._elementSelectorModalClasses` to register its own asset modal, and every caller going through the `Craft` global to construct one.

The registry and factory move into `resources/js/modules/element-selector-modal/registry.ts`, which owns the element type → modal class map, throws on a duplicate registration the way the legacy registry did, and falls back to `BaseElementSelectorModal`. In-repo callers — `BaseElementSelectInput`, the link field, and the Markdown field's asset behavior — import `createElementSelectorModal` directly rather than resolving it off `Craft`. `_elementSelectorModalClasses`, `registerElementSelectorModalClass()` and `createElementSelectorModal()` are deleted from `Craft.js`.

Nothing changes for consumers outside the repo: `Craft.createElementSelectorModal` and `Craft.registerElementSelectorModalClass` are still assigned, now by the modern module, and the modal classes remain on `Craft` for the PHP-emitted `new Craft.VolumeFolderSelectorModal(…)` boots in `MoveAssets` and the legacy asset index.

The legacy bundle is a plain script and runs before this module, so a plugin can register a class before there is anywhere modern to put it. Anything already sitting on the old registry object is adopted on load, and the built-in asset registration yields to an entry that is already there — so a plugin replacing the asset modal still wins.

This module does not take the `<name>.ce.ts` + `support.ts` shape from the modules README, because a selector modal wraps no server-rendered markup — it is constructed imperatively and builds its own container. The README added alongside it explains that, and records the remaining jQuery seams and the `Craft.createElementIndex` registry as the next one worth the same treatment.
