### PR TITLE
[6.x] Fix Sync CMS Assets flake from concurrent same-commit runs

### DIFF
--- a/.github/workflows/sync-cms-assets.yml
+++ b/.github/workflows/sync-cms-assets.yml
@@ -12,6 +12,14 @@ on:
 permissions:
   contents: read
 
+# A tag push and its accompanying branch push (e.g. cutting a release) can trigger two runs for the same
+# commit at the same instant. Queue same-commit runs instead of letting them install frontend dependencies
+# concurrently, since simultaneous installs hit the private FontAwesome kit registry with the same token
+# and can come back with an incomplete package.
+concurrency:
+  group: sync-cms-assets-${{ github.sha }}
+  cancel-in-progress: false
+
 jobs:
   sync:
     name: Sync CMS assets

--- a/scripts/copyicons.php
+++ b/scripts/copyicons.php
@@ -82,6 +82,14 @@ if (! is_dir($iconsDir)) {
 }
 
 $metaPath = "$kitDir/icons/metadata/icons.json";
+
+if (! is_file($metaPath) || ! is_dir($kitSvgsDir)) {
+    fwrite(STDERR, "Font Awesome kit is missing or incomplete at $kitDir.\n".
+        "Expected metadata at $metaPath and SVGs at $kitSvgsDir.\n".
+        "Try re-running \`vp install\` — this can happen if the private kit registry (npm.fontawesome.com) returned an incomplete package.\n");
+    exit(1);
+}
+
 $meta = json_decode(file_get_contents($metaPath), true);
 $index = [];
 $aliasesPhp = <<<PHP


### PR DESCRIPTION
### Description

The `Sync CMS Assets` workflow errored out on run https://github.com/craftcms/cms/actions/runs/32186570910/job/96550298120, failing in `copyicons.php` with `json_decode(): Argument #1 ($json) must be of type string, false given` because the private Font Awesome kit package (`@awesome.me/kit-ddaed3f5c5`) installed by `vp install` was missing its `icons/metadata/icons.json` file even though npm reported the install as successful.                                                                                                                                                                                                    

That run coincided exactly with a second run of the same workflow for the same commit — a push that updated the `6.x` branch and pushed the `6.0.0-alpha.17` tag at the same instant, which each fired their own workflow run. Both ran `vp install` against the private `npm.fontawesome.com` registry with the same `CRAFT_FONTAWESOME_TOKEN` at the same moment, and this run came back with an incomplete kit package.         

This PR:                                                                                                                                                                                                          
- Adds a `concurrency` group to the workflow keyed on the commit SHA, so same-commit runs (e.g. a branch push landing alongside its release tag) queue instead of installing frontend dependencies concurrently against the same private registry/token.                                                                                                                                                                          
- Makes `copyicons.php` fail with a clear, actionable error if the Font Awesome kit is missing or incomplete, instead of a raw `TypeError` from `json_decode()`.  

### Related issues

- Fixes #19456