### PR TITLE
[5.11] Ensure addresses are memoized when eager loaded

### DIFF
--- a/CHANGELOG-5.11.md
+++ b/CHANGELOG-5.11.md
@@ -21,3 +21,4 @@
 - Updated Twig to 3.28.
 - Updated yii2-debug to 2.1.28.
 - Fixed an error that could occur when editing an element. ([#17268](https://github.com/craftcms/cms/issues/17268))
+- Fixed a bug where `getEagerLoadedElements()` wasn’t returning results for eager-loaded native fields, such as `authors`. ([#19471](https://github.com/craftcms/cms/pull/19471))

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -2381,6 +2381,9 @@ JS, [
                 $photo = $elements[0] ?? null;
                 $this->setPhoto($photo);
                 break;
+            case 'addresses':
+                $this->_addresses = ElementCollection::make($elements);
+                break;
         }
 
         parent::setEagerLoadedElements($handle, $elements, $plan);

--- a/src/elements/User.php
+++ b/src/elements/User.php
@@ -2382,6 +2382,7 @@ JS, [
                 $this->setPhoto($photo);
                 break;
             case 'addresses':
+                /** @var Address[] $elements */
                 $this->_addresses = ElementCollection::make($elements);
                 break;
         }

--- a/tests/unit/elements/EagerLoadedElementConsistencyTest.php
+++ b/tests/unit/elements/EagerLoadedElementConsistencyTest.php
@@ -234,17 +234,17 @@ class EagerLoadedElementConsistencyTest extends TestCase
         // Check it has been initialized with the eager-loaded addresses
         self::assertTrue($property->isInitialized($user));
 
-        $eagerLoaded = $user->getEagerLoadedElements('addresses');
-        $propertyGetValue = $property->getValue($user);
-        $userAddresses = $user->getAddresses();
-        self::assertNotNull($eagerLoaded);
-        self::assertNotNull($propertyGetValue);
-        self::assertNotNull($userAddresses);
+        $eagerLoaded = $user->getEagerLoadedElements('addresses')->all();
+        $propertyGetValue = $property->getValue($user)->all();
+        $userAddresses = $user->getAddresses()->all();
+        self::assertNotEmpty($eagerLoaded);
+        self::assertNotEmpty($propertyGetValue);
+        self::assertNotEmpty($userAddresses);
         self::assertCount(2, $eagerLoaded);
         self::assertCount(2, $propertyGetValue);
         self::assertCount(2, $userAddresses);
 
-        foreach ([$eagerLoaded->all(), $propertyGetValue->all(), $userAddresses->all()] as $a) {
+        foreach ([$eagerLoaded, $propertyGetValue, $userAddresses] as $a) {
             // Check each address has data matching original `$addressData`
             foreach ($a as $index => $address) {
                 foreach ($addressData[$index] as $key => $value) {

--- a/tests/unit/elements/EagerLoadedElementConsistencyTest.php
+++ b/tests/unit/elements/EagerLoadedElementConsistencyTest.php
@@ -7,6 +7,7 @@
 
 namespace crafttests\unit\elements;
 
+use craft\elements\Address;
 use craft\elements\Asset;
 use craft\elements\db\EagerLoadPlan;
 use craft\elements\Entry;
@@ -195,5 +196,61 @@ class EagerLoadedElementConsistencyTest extends TestCase
 
         self::assertNull($entry->getAuthor());
         self::assertSame([], $entry->getAuthors());
+    }
+
+    public function testAddressesEagerLoading(): void
+    {
+        $user = new User(['id' => 401]);
+        $addressData = [
+            [
+                'id' => 9004,
+                'countryCode' => 'US',
+                'addressLine1' => '123 Main St',
+                'administrativeArea' => 'CA',
+                'locality' => 'Los Angeles',
+                'postalCode' => '90001',
+            ],
+            [
+                'id' => 9005,
+                'countryCode' => 'US',
+                'addressLine1' => '456 Elm St',
+                'administrativeArea' => 'CA',
+                'locality' => 'Los Angeles',
+                'postalCode' => '90002',
+            ]
+        ];
+        $addresses = array_map(fn($data) => new Address($data), $addressData);
+
+        $plan = new EagerLoadPlan(['handle' => 'addresses']);
+
+        $user->setEagerLoadedElements('addresses', $addresses, $plan);
+
+        self::assertTrue($user->hasEagerLoadedElements('addresses'));
+
+        // Check the `User::_addresses` property is set correctly
+        $reflection = new \ReflectionClass($user);
+        $property = $reflection->getProperty('_addresses');
+        $property->setAccessible(true);
+        // Check it has been initialized with the eager-loaded addresses
+        self::assertTrue($property->isInitialized($user));
+
+        $eagerLoaded = $user->getEagerLoadedElements('addresses');
+        $propertyGetValue = $property->getValue($user);
+        $userAddresses = $user->getAddresses();
+        self::assertNotNull($eagerLoaded);
+        self::assertNotNull($propertyGetValue);
+        self::assertNotNull($userAddresses);
+        self::assertCount(2, $eagerLoaded);
+        self::assertCount(2, $propertyGetValue);
+        self::assertCount(2, $userAddresses);
+
+        foreach ([$eagerLoaded->all(), $propertyGetValue->all(), $userAddresses->all()] as $a) {
+            // Check each address has data matching original `$addressData`
+            foreach ($a as $index => $address) {
+                foreach ($addressData[$index] as $key => $value) {
+                    self::assertSame($value, $address->$key);
+                }
+            }
+        }
     }
 }

--- a/tests/unit/elements/EagerLoadedElementConsistencyTest.php
+++ b/tests/unit/elements/EagerLoadedElementConsistencyTest.php
@@ -217,7 +217,7 @@ class EagerLoadedElementConsistencyTest extends TestCase
                 'administrativeArea' => 'CA',
                 'locality' => 'Los Angeles',
                 'postalCode' => '90002',
-            ]
+            ],
         ];
         $addresses = array_map(fn($data) => new Address($data), $addressData);
 


### PR DESCRIPTION
### Description
Similar to how authors on entires works, addresses should be memoized when eager loaded so there aren't any accidental extra queries if someone was to call `getAddresses()`
