### PR TITLE
[6.x] Introduce a shared z-index ladder for the CP

### DIFF
--- a/docs/slideouts.md
+++ b/docs/slideouts.md
@@ -461,8 +461,9 @@ Two things to know if you touch this area:
 
 - **Don't reuse legacy class names.** The legacy stylesheet owns `.slideout-shade` and hides it with
   `:not(.visible) { display: none }`. The shared shade is `.cp-slideout-shade` for that reason, and
-  it sits at `z-index: 99` — one below both kinds of panel, so it stays underneath them regardless
-  of the order they were appended to `<body>` in.
+  it sits at `--c-z-slideout-shade` — one rung below `--c-z-slideout`, which both kinds of panel
+  use, so it stays underneath them regardless of the order they were appended to `<body>` in. See
+  [z-layers.md](z-layers.md).
 - The legacy payload's key order is pinned by `tests/Feature/Http/Responses/CpScreenSlideoutTest.php`.
   If that test goes red, the jQuery slideout stack is broken.
 

--- a/docs/z-layers.md
+++ b/docs/z-layers.md
@@ -1,0 +1,110 @@
+# Z-layers
+
+Every surface in the CP that escapes normal flow picks a **rung** from a shared ladder instead of
+inventing a number. The ladder is declared once, in two mirrored files:
+
+| File | For |
+| --- | --- |
+| [`packages/craftcms-ui/src/styles/shared/z-layers.css`](../packages/craftcms-ui/src/styles/shared/z-layers.css) | CSS (`var(--c-z-modal)`). The source of truth. |
+| [`packages/craftcms-ui/src/constants/z-layers.ts`](../packages/craftcms-ui/src/constants/z-layers.ts) | JS (`ZLayer.Modal`), for overlay configs and inline styles. |
+
+`src/styles/z-layers.test.ts` asserts the two agree, so a rung added or moved in one has to be added
+or moved in the other.
+
+The stylesheet is imported by `@craftcms/ui/styles/cp.css`, which `resources/css/cp.css` pulls in,
+which the CP's only layout (`resources/views/app.blade.php`) always loads. The tokens are therefore
+available on every CP page, including inside shadow roots — custom properties inherit through the
+shadow boundary.
+
+## The ladder
+
+### Local — within a component's own stacking context
+
+| Token | `ZLayer` | Value | Use for |
+| --- | --- | --- | --- |
+| `--c-z-behind` | `Behind` | `-1` | Decorative fill painted behind its own content |
+| `--c-z-base` | `Base` | `0` | Explicitly on the baseline — mostly to reset a lift |
+| `--c-z-raised` | `Raised` | `1` | Lifted above sibling content (a check overlay, a focus ring) |
+| `--c-z-floating` | `Floating` | `2` | Above a sibling that's already raised |
+| `--c-z-sticky` | `Sticky` | `10` | Sticky headers/footers/toolbars inside a scroll container |
+
+### Page-level — competing with the rest of the CP
+
+| Token | `ZLayer` | Value | Use for |
+| --- | --- | --- | --- |
+| `--c-z-page-header` | `PageHeader` | `2000` | Sticky page and editor headers |
+| `--c-z-nav` | `Nav` | `2100` | Persistent CP chrome — the global sidebar |
+| `--c-z-drag` | `Drag` | `3000` | Drag helpers and drop indicators |
+| `--c-z-slideout-shade` | `SlideoutShade` | `4000` | The shade behind a slideout |
+| `--c-z-slideout` | `Slideout` | `4100` | Slideout panels and their container |
+| `--c-z-modal-shade` | `ModalShade` | `5000` | The shade behind a modal |
+| `--c-z-modal` | `Modal` | `5100` | Modal panels |
+| `--c-z-overlay` | `Overlay` | `6000` | Menus, comboboxes, selects, popovers, HUDs |
+| `--c-z-notification` | `Notification` | `7000` | Toasts and notifications |
+| `--c-z-tooltip` | `Tooltip` | `8000` | Tooltips |
+| `--c-z-debug` | `Debug` | `9000` | Dev-only chrome (the debug toolbar) |
+
+Rungs are spaced by 1000 (100 within a shade/panel pair) so a new layer can be slotted between two
+existing ones without renumbering anything.
+
+## Rules
+
+**Pick local unless the thing is attached to `<body>`.** A page-level rung only wins if no ancestor
+has created a stacking context, so using one from inside a component works right up until somebody
+adds a `transform`, an `opacity`, or a `filter` above it. If the surface renders in place, it's
+local; if it's teleported, portalled, or appended to `<body>`, it's page-level.
+
+**Anchored overlays sit above modals on purpose.** `--c-z-overlay` is above `--c-z-modal` because an
+overlay is opened *from* a surface and has to paint above whichever surface opened it — a menu inside
+a modal is ordinary, and there's no reliable way for the menu to know what it was opened from.
+`--c-z-tooltip` is highest for the same reason: anything at all can have a tooltip.
+
+**Don't add a rung for one component.** Reach for `--c-z-raised` / `--c-z-floating` first. A new rung
+is warranted only when a surface genuinely has to be ordered against other page-level surfaces.
+
+## What the ladder doesn't cover
+
+### The top layer
+
+`craft-dialog` is a Lion modal dialog, which opens with `HTMLDialogElement.showModal()`. Top-layer
+content paints above every z-indexed element regardless of the number, so **no rung will ever cover
+it**, and ordering *between* top-layer elements is order-of-entry rather than z-index.
+
+Lion's non-modal overlays (`craft-popover` and everything built on it, `craft-tooltip`,
+`craft-select-rich`, `craft-combobox`) use a `<dialog>` too, but open it non-modally — those stay
+z-indexed and are on the ladder. Lion writes the value inline on its wrapping `<dialog>`, so it can't
+be styled from a stylesheet; each component passes it through `_defineOverlayConfig()`:
+
+```ts
+override _defineOverlayConfig() {
+  return {...super._defineOverlayConfig(), zIndex: ZLayer.Overlay};
+}
+```
+
+A new Lion-based overlay that forgets this inherits Lion's default of `9999`, which lands above every
+rung — visibly wrong only in that it out-stacks tooltips.
+
+### The legacy CP bundle
+
+`packages/craftcms-legacy/cp/src/css` still uses raw numbers, topping out at `1001` (`.prompt`, the
+login screen). That's why the page-level band starts at `2000`: every rung clears legacy without
+legacy having to be renumbered first, and the two stacks can share a page — which they do on any
+`CpScreenResponse` screen, where the Inertia shell wraps PHP-rendered inner HTML.
+
+Roughly, legacy occupies:
+
+| Legacy value | What | Ladder equivalent |
+| --- | --- | --- |
+| `99` | `.craft-tooltip` | `--c-z-tooltip` |
+| `100`/`101` | Garnish HUDs and modals, `#notifications`, datepicker/timepicker, selectize dropdowns, live preview | `--c-z-overlay`, `--c-z-notification`, `--c-z-modal` |
+| `1000` | `.progressbar` | `--c-z-page-header` |
+| `1001` | `.prompt`, login | `--c-z-modal` |
+| `1000000` | chart tooltips | `--c-z-tooltip` |
+
+Migrating those is deliberately **not** part of the ladder's introduction: the legacy CSS is a
+prebuilt webpack bundle whose ordering is load-bearing for surfaces that no longer have tests, and
+its numbers are internally consistent with each other. Port a legacy surface onto the ladder when you
+port the surface itself.
+
+`@craftcms/garnish` is standalone and can't import `@craftcms/ui`, so `Drag`'s `helperBaseZindex`
+default repeats `--c-z-drag`'s value (`3000`) rather than referencing it.

--- a/packages/craftcms-garnish/docs/api-reference.md
+++ b/packages/craftcms-garnish/docs/api-reference.md
@@ -398,7 +398,7 @@ also `new Drag(settings)` (param shift when the first arg is a plain object).
 | `helperOpacity` | `1` | Helper opacity (`1` → no override). |
 | `moveHelperToCursor` | `false` | Put the helper's top-left at the cursor instead of the grab offset. |
 | `helper` | `null` | Helper wrapper: `(helper, index) => wrapped`, an element/markup to wrap into, or `null` (bare clone). |
-| `helperBaseZindex` | `1000` | Base z-index for helpers. |
+| `helperBaseZindex` | `3000` | Base z-index for helpers — the `--c-z-drag` rung of the CP's stacking ladder. |
 | `helperLagBase` | `3` | Base follow-lag divisor. |
 | `helperLagIncrementDividend` | `1.5` | Per-helper lag increment dividend. |
 | `helperSpacingX` / `helperSpacingY` | `5` / `5` | Per-index helper offset (px). |

--- a/packages/craftcms-garnish/src/drag/drag.ts
+++ b/packages/craftcms-garnish/src/drag/drag.ts
@@ -79,6 +79,12 @@ export interface DragSettings extends BaseDragSettings {
    * element/markup the clone is appended into. `null` → use the bare clone.
    */
   helper: DragHelper;
+  /**
+   * Base z-index for drag helpers, which are appended to `<body>` and follow
+   * the pointer over the CP's chrome. Defaults to the `--c-z-drag` rung of the
+   * CP's stacking ladder (see `docs/z-layers.md`) — Garnish is standalone and
+   * can't import `@craftcms/ui`, so the number is repeated here.
+   */
   helperBaseZindex: number;
   helperLagBase: number;
   helperLagIncrementDividend: number;
@@ -110,7 +116,7 @@ export class Drag<S extends DragSettings = DragSettings> extends BaseDrag<S> {
     helperOpacity: 1,
     moveHelperToCursor: false,
     helper: null,
-    helperBaseZindex: 1000,
+    helperBaseZindex: 3000,
     helperLagBase: 3,
     helperLagIncrementDividend: 1.5,
     helperSpacingX: 5,

--- a/packages/craftcms-garnish/tests/drag-drop.test.ts
+++ b/packages/craftcms-garnish/tests/drag-drop.test.ts
@@ -108,7 +108,7 @@ describe('Drag settings + defaults', () => {
     expect(d.settings!.minMouseDist).toBe(7);
     // Drag default survives.
     expect(d.settings!.hideDraggee).toBe(true);
-    expect(d.settings!.helperBaseZindex).toBe(1000);
+    expect(d.settings!.helperBaseZindex).toBe(3000);
     // BaseDrag default survives.
     expect(d.settings!.ignoreHandleSelector).toBe(
       'input, textarea, button, select, .btn'
@@ -332,8 +332,8 @@ describe('Drag._createHelper', () => {
     expect(helper.style.boxSizing).toBe('border-box');
     expect(helper.style.display).toBe('block');
     expect(helper.style.pointerEvents).toBe('none');
-    // zIndex = base(1000) + draggeeLength(1) - index(0) = 1001
-    expect(helper.style.zIndex).toBe('1001');
+    // zIndex = base(3000) + draggeeLength(1) - index(0) = 3001
+    expect(helper.style.zIndex).toBe('3001');
     // real=true target: mouseX - mouseOffsetX = 90, mouseY - mouseOffsetY = 45
     expect(helper.style.left).toBe('90px');
     expect(helper.style.top).toBe('45px');

--- a/packages/craftcms-ui/src/components/combobox/combobox.ts
+++ b/packages/craftcms-ui/src/components/combobox/combobox.ts
@@ -1,4 +1,5 @@
 import {LionCombobox} from '@lion/ui/combobox.js';
+import {ZLayer} from '@src/constants/z-layers.js';
 import {html, nothing, render} from 'lit';
 import {property} from 'lit/decorators.js';
 import styles from './combobox.styles.js';
@@ -62,6 +63,12 @@ interface VisibleEntry {
 export default class CraftCombobox extends LionCombobox {
   static override get styles() {
     return [...super.styles, styles];
+  }
+
+  /** Puts the listbox on the CP's stacking ladder instead of Lion's 9999. */
+  // @ts-ignore Lion's OverlayMixin is typed via JSDoc.
+  override _defineOverlayConfig() {
+    return {...super._defineOverlayConfig(), zIndex: ZLayer.Overlay};
   }
 
   /** Options to render. Groups are supported via `type: 'optgroup'`. */

--- a/packages/craftcms-ui/src/components/field/field.styles.ts
+++ b/packages/craftcms-ui/src/components/field/field.styles.ts
@@ -36,7 +36,7 @@ export default css`
     width: 2px;
     height: 100%;
     cursor: help;
-    z-index: 1;
+    z-index: var(--c-z-raised, 1);
     border-radius: 1px;
   }
 

--- a/packages/craftcms-ui/src/components/pane/pane.styles.ts
+++ b/packages/craftcms-ui/src/components/pane/pane.styles.ts
@@ -148,7 +148,7 @@ export default css`
     padding-block: var(--_pane-spacing) 0;
     position: sticky;
     inset-block-start: 0;
-    z-index: 10;
+    z-index: var(--c-z-sticky, 10);
     background-color: var(--_pane-background);
   }
 
@@ -179,7 +179,7 @@ export default css`
     padding-block: calc(var(--_pane-spacing) / 2);
     position: sticky;
     inset-block-end: 0;
-    z-index: 10;
+    z-index: var(--c-z-sticky, 10);
   }
 
   .cp-pane__spacer {

--- a/packages/craftcms-ui/src/components/popover/popover.ts
+++ b/packages/craftcms-ui/src/components/popover/popover.ts
@@ -1,6 +1,7 @@
 import {html, LitElement, type PropertyValues} from 'lit';
 import {property} from 'lit/decorators.js';
 import {OverlayMixin, withDropdownConfig} from '@lion/ui/overlays.js';
+import {ZLayer} from '@src/constants/z-layers.js';
 import type {VirtualElement} from '@popperjs/core';
 import {wireOverlayLifecycleEvents} from '@src/utilities/overlay-events.js';
 import {viewportEscapingModifiers} from '@src/utilities/overlay-position.js';
@@ -73,6 +74,11 @@ export default class CraftPopover extends OverlayMixin(LitElement) {
   _defineOverlayConfig() {
     return {
       ...withDropdownConfig(),
+      // Lion renders the overlay into a non-modal `<dialog>` appended to
+      // `<body>` and writes this inline, defaulting to 9999 — high enough to
+      // clear anything, which is how it ended up above the CP's modals by
+      // accident. Put it on the ladder instead.
+      zIndex: ZLayer.Overlay,
       inheritsReferenceWidth: this.matchInvokerWidth ? 'min' : 'none',
       popperConfig: {
         // Position relative to the viewport so the overlay escapes any

--- a/packages/craftcms-ui/src/components/select-rich/select-rich.ts
+++ b/packages/craftcms-ui/src/components/select-rich/select-rich.ts
@@ -1,4 +1,5 @@
 import {LionSelectRich} from '@lion/ui/select-rich.js';
+import {ZLayer} from '@src/constants/z-layers.js';
 import {html} from 'lit';
 import {property} from 'lit/decorators.js';
 import styles from './select-rich.styles.js';
@@ -33,6 +34,12 @@ export default class CraftSelectRich extends LionSelectRich {
       ...super.scopedElements,
       'lion-select-invoker': CraftSelectInvoker,
     };
+  }
+
+  /** Puts the listbox on the CP's stacking ladder instead of Lion's 9999. */
+  // @ts-ignore Lion's OverlayMixin is typed via JSDoc.
+  override _defineOverlayConfig() {
+    return {...super._defineOverlayConfig(), zIndex: ZLayer.Overlay};
   }
 
   /** Renders the invoker at a smaller size. */

--- a/packages/craftcms-ui/src/components/slide-picker/slide-picker.styles.ts
+++ b/packages/craftcms-ui/src/components/slide-picker/slide-picker.styles.ts
@@ -54,7 +54,7 @@ export default css`
     outline: var(--c-focus-outline-width) solid var(--c-color-focus-outline);
     outline-offset: var(--c-focus-outline-offset);
     position: relative;
-    z-index: 1;
+    z-index: var(--c-z-raised, 1);
   }
 
   :host([read-only]) .slide-picker__segment {

--- a/packages/craftcms-ui/src/components/slide-rule/slide-rule.styles.ts
+++ b/packages/craftcms-ui/src/components/slide-rule/slide-rule.styles.ts
@@ -24,7 +24,7 @@ export default css`
     margin-inline-start: calc(-4 / 16 * 1rem);
     margin-block-start: 4px;
     inset-inline-start: 50%;
-    z-index: 1;
+    z-index: var(--c-z-raised, 1);
     width: 0;
     height: 0;
     border-inline-start: calc(5 / 16 * 1rem) solid transparent;
@@ -43,7 +43,7 @@ export default css`
   }
 
   .overlay {
-    z-index: 2;
+    z-index: var(--c-z-floating, 2);
     position: absolute;
     inset-block: 0 1px;
     inset-inline: 0;

--- a/packages/craftcms-ui/src/components/tabs/tabs.styles.ts
+++ b/packages/craftcms-ui/src/components/tabs/tabs.styles.ts
@@ -76,7 +76,7 @@ export default css`
     /* Above the tabs, so the invoker's own click-target pseudo-element can't
        be covered by the tab beside it. */
     position: relative;
-    z-index: 1;
+    z-index: var(--c-z-raised, 1);
   }
 
   .tabs__overflow[hidden] {

--- a/packages/craftcms-ui/src/components/tooltip/tooltip.ts
+++ b/packages/craftcms-ui/src/components/tooltip/tooltip.ts
@@ -4,6 +4,7 @@ import {LionTooltip} from '@lion/ui/tooltip.js';
 import {withTooltipConfig} from '@lion/ui/overlays.js';
 import {wireOverlayLifecycleEvents} from '../../utilities/overlay-events.js';
 import {viewportEscapingModifiers} from '../../utilities/overlay-position.js';
+import {ZLayer} from '../../constants/z-layers.js';
 
 /**
  * craft-tooltip shows contextual text for an external trigger element
@@ -114,7 +115,7 @@ export default class CraftTooltip extends LionTooltip {
 
   // @ts-ignore Lion's OverlayMixin is typed via JSDoc.
   override _defineOverlayConfig() {
-    const config = {...super._defineOverlayConfig()};
+    const config = {...super._defineOverlayConfig(), zIndex: ZLayer.Tooltip};
 
     if (this.#isClickTriggered || this.#isManual) {
       // Disable Lion's hover/focus interaction.

--- a/packages/craftcms-ui/src/constants/z-layers.ts
+++ b/packages/craftcms-ui/src/constants/z-layers.ts
@@ -1,0 +1,45 @@
+/**
+ * The CP's stacking ladder, as numbers.
+ *
+ * A mirror of `styles/shared/z-layers.css`, which is the documented source of
+ * truth — read that file for what each rung means and why the page-level band
+ * starts at 2000. This copy exists for the places that can't reach a custom
+ * property: Lion overlay configs (which write `z-index` inline onto the
+ * wrapping `<dialog>`) and JS that sets `style.zIndex` directly.
+ *
+ * `z-layers.test.ts` parses the CSS and asserts the two agree, so a rung added
+ * or moved in one file has to be added or moved in the other.
+ */
+export const ZLayer = {
+  /* Local: within a component's own stacking context. */
+  Behind: -1,
+  Base: 0,
+  Raised: 1,
+  Floating: 2,
+  Sticky: 10,
+
+  /* Page-level: competing with the rest of the CP. */
+  PageHeader: 2000,
+  Nav: 2100,
+  Drag: 3000,
+  SlideoutShade: 4000,
+  Slideout: 4100,
+  ModalShade: 5000,
+  Modal: 5100,
+  Overlay: 6000,
+  Notification: 7000,
+  Tooltip: 8000,
+  Debug: 9000,
+} as const;
+
+export type ZLayerKey = keyof typeof ZLayer;
+export type ZLayerValue = (typeof ZLayer)[ZLayerKey];
+
+/**
+ * The custom property each rung is published as, e.g. `PageHeader` →
+ * `--c-z-page-header`. Used by the sync test, and by anything that would rather
+ * hand CSS a `var()` than a hard number.
+ */
+export function zLayerProperty(layer: ZLayerKey): string {
+  return `--c-z-${layer.replace(/(?!^)([A-Z])/g, '-$1').toLowerCase()}`;
+}

--- a/packages/craftcms-ui/src/index.ts
+++ b/packages/craftcms-ui/src/index.ts
@@ -146,3 +146,4 @@ export {default as visuallyHiddenStyles} from './styles/visually-hidden.styles.j
 export * from './constants/variants';
 export * from './constants/appearances';
 export * from './constants/colors';
+export * from './constants/z-layers';

--- a/packages/craftcms-ui/src/styles/cp.css
+++ b/packages/craftcms-ui/src/styles/cp.css
@@ -3,6 +3,7 @@
 @import './shared/preflight.css' layer(preflight);
 @import './shared/variables.css' layer(theme);
 @import './shared/tokens.css' layer(theme);
+@import './shared/z-layers.css' layer(theme);
 @import './shared/colorable.css' layer(theme);
 @import './shared/base.css' layer(base);
 

--- a/packages/craftcms-ui/src/styles/shared/z-layers.css
+++ b/packages/craftcms-ui/src/styles/shared/z-layers.css
@@ -1,0 +1,94 @@
+/**
+ * Z-layers — the CP's stacking ladder.
+ *
+ * Every surface that escapes normal flow picks a rung here instead of inventing
+ * a number. Mirrored one-for-one by `constants/z-layers.ts` for the places that
+ * need the value in JS (Lion overlay configs, inline styles); a unit test keeps
+ * the two in sync, so change both together.
+ *
+ * Two bands, and the distinction matters:
+ *
+ * - **Local** (`behind`…`sticky`) is for stacking *inside* a component's own
+ *   stacking context — a check overlay on a thumbnail, a sticky footer inside a
+ *   scroll pane. These are deliberately tiny and are safe to use anywhere,
+ *   because they only ever compete with their own siblings.
+ *
+ * - **Page-level** (`page-header` and up) is for surfaces that compete with the
+ *   rest of the CP. Reaching for one of these from inside a component is almost
+ *   always the wrong call: it only wins if no ancestor has created a stacking
+ *   context, so it works until someone adds a `transform` or an `opacity` above
+ *   it. Use these on things attached to `<body>` (or to the CP shell).
+ *
+ * Two things live outside the ladder entirely and can't be ordered against it:
+ *
+ * - **The top layer.** `craft-dialog` is a Lion modal dialog, which opens via
+ *   `HTMLDialogElement.showModal()`. Top-layer content paints above every
+ *   z-indexed element no matter how large the number, so no rung here will ever
+ *   cover it. Order between top-layer elements is order-of-entry, not z-index.
+ * - **The legacy CP bundle** (`packages/craftcms-legacy/cp/src/css`), which
+ *   still uses raw numbers topping out at 1001. That's why the page-level band
+ *   starts at 2000 rather than at 1 — every rung clears legacy without legacy
+ *   having to be renumbered first. See `docs/z-layers.md`.
+ *
+ * Rungs are spaced by 1000 (100 within a pair) so a new layer can be slotted
+ * between two existing ones without a renumber.
+ */
+:root,
+:host {
+  /* --- Local: within a component's own stacking context --- */
+
+  /** Decorative fill painted behind its own content. */
+  --c-z-behind: -1;
+
+  /** Explicitly on the flow's baseline — mostly for resetting a lift. */
+  --c-z-base: 0;
+
+  /** Lifted above sibling content (a check overlay, a focus ring). */
+  --c-z-raised: 1;
+
+  /** Above a sibling that's already `--c-z-raised`. */
+  --c-z-floating: 2;
+
+  /** Sticky headers/footers/toolbars pinned inside a scroll container. */
+  --c-z-sticky: 10;
+
+  /* --- Page-level: competing with the rest of the CP --- */
+
+  /** Sticky page and editor headers, above the content they scroll over. */
+  --c-z-page-header: 2000;
+
+  /** Persistent CP chrome — the global sidebar. Above page headers, because a
+      collapsed rail's labels overflow across them. */
+  --c-z-nav: 2100;
+
+  /** Drag helpers and drop indicators, which follow the pointer over chrome. */
+  --c-z-drag: 3000;
+
+  /** The shade behind a slideout. */
+  --c-z-slideout-shade: 4000;
+
+  /** Slideout panels and their container. */
+  --c-z-slideout: 4100;
+
+  /** The shade behind a modal. */
+  --c-z-modal-shade: 5000;
+
+  /** Modal panels. */
+  --c-z-modal: 5100;
+
+  /** Anchored overlays — menus, comboboxes, selects, popovers, HUDs. Above
+      modals on purpose: an overlay is opened *from* a surface, so it has to
+      paint above whichever surface opened it, and a menu inside a modal is
+      ordinary. */
+  --c-z-overlay: 6000;
+
+  /** Toasts and notifications, which have to stay readable over an overlay. */
+  --c-z-notification: 7000;
+
+  /** Tooltips. Above everything else that's addressable, since anything at all
+      can have one. */
+  --c-z-tooltip: 8000;
+
+  /** Dev-only chrome (the debug toolbar). Nothing ships above this. */
+  --c-z-debug: 9000;
+}

--- a/packages/craftcms-ui/src/styles/z-layers.test.ts
+++ b/packages/craftcms-ui/src/styles/z-layers.test.ts
@@ -1,0 +1,55 @@
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
+
+import {describe, expect, it} from 'vite-plus/test';
+
+import {
+  ZLayer,
+  zLayerProperty,
+  type ZLayerKey,
+} from '@src/constants/z-layers.js';
+
+// Read rather than import: Vitest stubs CSS imports (`test.css` defaults to
+// off), so `?raw` would hand back an empty string. `cwd` is the package root.
+const css = readFileSync(
+  join(process.cwd(), 'src/styles/shared/z-layers.css'),
+  'utf8'
+);
+
+/** Every `--c-z-*: <n>;` declaration in the stylesheet, as a name → value map. */
+const declared = new Map(
+  [...css.matchAll(/(--c-z-[a-z-]+):\s*(-?\d+);/g)].map(([, name, value]) => [
+    name,
+    Number(value),
+  ])
+);
+
+const layers = Object.keys(ZLayer) as ZLayerKey[];
+
+/**
+ * `z-layers.css` is the documented source of truth and `constants/z-layers.ts`
+ * is its mirror for JS. Nothing generates one from the other, so these assert
+ * they haven't drifted.
+ */
+describe('z-layers', () => {
+  it.each(layers)('publishes %s as a custom property', (layer) => {
+    expect(declared.get(zLayerProperty(layer))).toBe(ZLayer[layer]);
+  });
+
+  it('declares no custom property the constant map is missing', () => {
+    const expected = layers.map(zLayerProperty).sort();
+    expect([...declared.keys()].sort()).toEqual(expected);
+  });
+
+  it('orders the rungs the same way it lists them', () => {
+    const values = layers.map((layer) => ZLayer[layer] as number);
+    expect(values).toEqual([...values].sort((a, b) => a - b));
+  });
+
+  it('clears the legacy CP bundle, which tops out at 1001', () => {
+    const pageLevel = layers.slice(layers.indexOf('PageHeader'));
+    for (const layer of pageLevel) {
+      expect(ZLayer[layer]).toBeGreaterThan(1001);
+    }
+  });
+});

--- a/resources/css/cp.css
+++ b/resources/css/cp.css
@@ -146,7 +146,7 @@ Remove once we have a stable way to create a `<craft-checkbox/>` via twig
  */
 .cp-checkbox-select__item craft-reorder-button {
   position: relative;
-  z-index: 1;
+  z-index: var(--c-z-raised);
 }
 
 /**

--- a/resources/css/fld.css
+++ b/resources/css/fld.css
@@ -412,7 +412,7 @@ body:not(.dragging) .fld-element {
   padding-inline: var(--padding);
   box-shadow: var(--c-pane-shadow);
   background-color: var(--c-color-neutral-fill-quiet);
-  z-index: 3;
+  z-index: var(--c-z-floating);
 }
 
 .fld-element-settings-footer > .ee-site-select {

--- a/resources/css/global-sidebar.css
+++ b/resources/css/global-sidebar.css
@@ -13,7 +13,10 @@
   border-inline-end: 1px solid var(--border-hairline);
   width: var(--global-sidebar-width);
   isolation: isolate;
-  z-index: 1;
+  /* Local, not `--c-z-nav`: this is the sidebar as rendered inside the legacy
+     CP shell, whose modals and HUDs still sit at 100/101. The Inertia shell's
+     sidebar is `CpSidebar.vue`, which is on the ladder. */
+  z-index: var(--c-z-raised);
 
   @media only screen and (width <= 1999px) {
     --is-always-visible: false;

--- a/resources/css/slideout.css
+++ b/resources/css/slideout.css
@@ -7,7 +7,7 @@ the shade, the positioned container, the panel itself, and the generic
 sidebar, preview thumb, image actions) are not included here.
  */
 .slideout-shade {
-  z-index: 100;
+  z-index: var(--c-z-slideout-shade);
   position: fixed;
   inset-block-start: 0;
   inset-inline-start: 0;
@@ -31,7 +31,7 @@ sidebar, preview thumb, image actions) are not included here.
 }
 
 .slideout-container {
-  z-index: 100;
+  z-index: var(--c-z-slideout);
   box-sizing: border-box;
   position: fixed;
   inset-block-start: 0;
@@ -55,7 +55,7 @@ body.has-debug-toolbar .slideout-container {
 }
 
 .slideout {
-  z-index: 100;
+  z-index: var(--c-z-slideout);
   box-sizing: border-box;
   position: absolute;
   background-color: var(--c-modal-fill);
@@ -153,7 +153,8 @@ body.has-debug-toolbar .slideout-container {
   padding-inline: var(--c-spacing-md);
   border-block-start: var(--c-color-neutral-border-quiet);
   background: var(--c-modal-fill);
-  z-index: 3;
+  /* Above the scrolled body it overlaps, inside the slideout's own context. */
+  z-index: var(--c-z-floating);
 }
 
 .slideout__footer > .so-notice {

--- a/resources/js/common/components/CpSidebar.vue
+++ b/resources/js/common/components/CpSidebar.vue
@@ -81,11 +81,11 @@
 
 <style scoped lang="scss">
   .cp-sidebar {
-    /* Above page content and its sticky headers — the element editor's is 1000
-     — but below modals (10001+). The sidebar is chrome: a floating drawer
-     overlays the page, and a collapsed rail's label tooltips overflow across
-     it. Both get sliced by a sticky header otherwise. */
-    z-index: 1001;
+    /* Above page content and its sticky headers (`--c-z-page-header`), below
+       slideouts and modals. The sidebar is chrome: a floating drawer overlays
+       the page, and a collapsed rail's label tooltips overflow across it. Both
+       get sliced by a sticky header otherwise. */
+    z-index: var(--c-z-nav);
     height: 100dvh;
     width: var(--global-sidebar-width);
     display: flex;

--- a/resources/js/common/components/DropIndicator.vue
+++ b/resources/js/common/components/DropIndicator.vue
@@ -35,7 +35,9 @@
     height: calc(2rem / 16);
     background-color: var(--c-color-accent-fill-loud, #2563eb);
     pointer-events: none;
-    z-index: 10;
+    /* Local, not `--c-z-drag`: the indicator is drawn inside the list it's
+       marking a position in, so it only needs to clear that list's rows. */
+    z-index: var(--c-z-sticky);
   }
 
   .drop-indicator--contained {

--- a/resources/js/common/components/Modal.vue
+++ b/resources/js/common/components/Modal.vue
@@ -86,7 +86,7 @@
   }
 
   .cp-modal {
-    z-index: 10002;
+    z-index: var(--c-z-modal);
     display: grid;
     justify-content: center;
     align-items: center;
@@ -94,11 +94,7 @@
   }
 
   .cp-overlay {
-    /**
-    Action menu items are z-index 10000, so we want to be above that
-    @TODO make this less fragile/weird
-     */
-    z-index: 10001;
+    z-index: var(--c-z-modal-shade);
     background-color: rgba(0, 0, 0, 0.5);
   }
 

--- a/resources/js/common/slideouts/SlideoutPanel.vue
+++ b/resources/js/common/slideouts/SlideoutPanel.vue
@@ -212,8 +212,8 @@
     background: var(--c-surface-default, #fff);
     box-shadow: 0 0 16px rgb(0 0 0 / 15%);
     overflow: hidden;
-    /* Same as the legacy `.slideout-container`. */
-    z-index: 100;
+    /* Same as the legacy `.slideout-container`, one rung above the shade. */
+    z-index: var(--c-z-slideout);
     /* Leading corners only — the trailing edge meets the viewport. */
     border-start-start-radius: var(--c-radius-lg, 0.5rem);
     border-end-start-radius: var(--c-radius-lg, 0.5rem);

--- a/resources/js/common/slideouts/panel-stack.css
+++ b/resources/js/common/slideouts/panel-stack.css
@@ -14,13 +14,10 @@
      than removed on close, so it must not swallow clicks in between —
      removing it on a `transitionend` that may never fire would. */
   pointer-events: none;
-  /* One below `.slideout-container` / `.slideout-panel`, which both sit at
-     100. The Vue stack teleports its panels into `<body>` and the legacy
-     stack appends its own, so their relative DOM order isn't something this
-     module can rely on to keep the shade underneath — the z-index does it
-     instead. Nothing else in the CP occupies 99 but tooltips, which belong
-     under the shade anyway. */
-  z-index: 99;
+  /* The Vue stack teleports its panels into `<body>` and the legacy stack
+     appends its own, so their relative DOM order isn't something this module
+     can rely on to keep the shade underneath — the ladder does it instead. */
+  z-index: var(--c-z-slideout-shade);
 }
 
 .cp-slideout-shade.is-visible {

--- a/resources/js/modules/element-select-input/base-element-select-input.ts
+++ b/resources/js/modules/element-select-input/base-element-select-input.ts
@@ -13,6 +13,7 @@ import {
   UP_KEY,
   type GarnishBaseSettings,
 } from '@craftcms/garnish';
+import {ZLayer} from '@craftcms/ui';
 import {elementSelectInputData} from './support';
 
 declare const Craft: any;
@@ -1007,7 +1008,7 @@ export class BaseElementSelectInput extends Base<BaseElementSelectInputSettings>
     const width = $element.width();
 
     $element.appendTo($(bod)).css({
-      'z-index': 0,
+      'z-index': ZLayer.Base,
       position: 'absolute',
       top: offset.top,
       left: offset.left,
@@ -1350,7 +1351,7 @@ export class BaseElementSelectInput extends Base<BaseElementSelectInputSettings>
 
       $helper.css({
         position: 'absolute',
-        zIndex: 10000,
+        zIndex: ZLayer.Drag,
         top: oldOffset.top,
         left: oldOffset.left,
       });

--- a/resources/js/modules/elements/components/BaseElementIndex.vue
+++ b/resources/js/modules/elements/components/BaseElementIndex.vue
@@ -225,7 +225,7 @@
   .element-index__footer {
     position: sticky;
     bottom: 0;
-    z-index: 1;
+    z-index: var(--c-z-sticky);
     display: flex;
     align-items: center;
     border-block-start: 1px solid var(--c-color-neutral-border-quiet);

--- a/resources/js/modules/elements/components/ElementEditScreen.vue
+++ b/resources/js/modules/elements/components/ElementEditScreen.vue
@@ -390,7 +390,7 @@
     border-block-end: 1px solid var(--color-neutral-border-quiet);
     position: sticky;
     top: 0;
-    z-index: 1000;
+    z-index: var(--c-z-page-header);
     background-color: white;
   }
 

--- a/resources/js/modules/elements/components/ElementThumbs.vue
+++ b/resources/js/modules/elements/components/ElementThumbs.vue
@@ -229,7 +229,7 @@
     position: absolute;
     inset-block-start: var(--c-spacing-sm);
     inset-inline-start: var(--c-spacing-sm);
-    z-index: 1;
+    z-index: var(--c-z-raised);
   }
 
   .thumb-tile {

--- a/resources/js/modules/markdown-field/markdown-field.css
+++ b/resources/js/modules/markdown-field/markdown-field.css
@@ -119,7 +119,7 @@
 .markdown-field .overtype-stats {
   padding-block: var(--c-spacing-md) !important;
   padding-inline: var(--c-input-spacing-inline) !important;
-  z-index: 0 !important;
+  z-index: var(--c-z-base) !important;
 }
 
 .markdown-field .overtype-link-tooltip,
@@ -137,7 +137,7 @@
   position: absolute !important;
   inset-block-end: var(--c-spacing-md) !important;
   inset-inline-end: var(--c-input-spacing-inline) !important;
-  z-index: 2 !important;
+  z-index: var(--c-z-floating) !important;
   display: flex !important;
   gap: var(--c-spacing-sm) !important;
   align-items: center !important;
@@ -250,10 +250,6 @@
 
 .markdown-link-popover {
   --max-width: min(360px, calc(100vw - var(--c-spacing-xl)));
-}
-
-.markdown-link-popover::part(dialog) {
-  z-index: 10001;
 }
 
 .markdown-link-popover::part(body) {


### PR DESCRIPTION
### Description

Every z-index in the CP was an independent guess. The modern stack alone spanned `1`, `2`, `3`, `10`, `99`, `100`, `1000`, `1001`, `10000`, `10001`, `10002`, with numbers picked defensively against each other — `Modal.vue` carried a `@TODO make this less fragile/weird`, the slideout shade sat at `99` only to be "one below" a `100` chosen elsewhere, and two pairs collided outright (`CpSidebar` tied with legacy `.prompt` at `1001`; the element-editor's sticky header tied with legacy `.progressbar` at `1000`).

This adds a named ladder and moves the modern stack onto it.

The ladder is declared in `packages/craftcms-ui/src/styles/shared/z-layers.css` as `--c-z-*` custom properties and mirrored in `packages/craftcms-ui/src/constants/z-layers.ts` as `ZLayer` for the places that need a number in JS. A unit test asserts the two can't drift. There are two bands: **local** (`behind` `-1` → `sticky` `10`) for stacking inside a component's own stacking context, and **page-level** (`page-header` `2000` → `debug` `9000`) for surfaces that compete with the rest of the CP. Rungs are spaced by 1000 so a new layer can be slotted in without a renumber.

The page-level band starts at `2000` deliberately: the legacy CP bundle still uses raw numbers topping out at `1001`, so every rung clears legacy without legacy having to be renumbered first — which matters because the two stacks share a page on any `CpScreenResponse` screen. Legacy SCSS is intentionally untouched; `docs/z-layers.md` carries a mapping table and says to port a legacy surface onto the ladder when you port the surface itself.

Two things turned up along the way that the docs now record:

- Lion's `OverlayController` defaults to `zIndex: 9999` and writes it inline on a wrapping `<dialog>`, so `craft-popover`, `craft-action-menu`, `craft-tooltip`, `craft-select-rich`, and `craft-combobox` were floating above everything by default rather than by design. Each now passes its rung through `_defineOverlayConfig()`.
- `craft-dialog` is a Lion *modal* dialog, so it opens via `showModal()` and lands in the browser's top layer — above every z-index regardless of value. No rung can order against it.
- `markdown-field.css`'s `::part(dialog) { z-index: 10001 }` was dead code: `craft-popover` only exposes `part="popup"`, and an inline style beats `::part` anyway. Removed.

Garnish is standalone and can't import `@craftcms/ui`, so `Drag`'s `helperBaseZindex` default moves `1000` → `3000` to match `--c-z-drag`, with a pointer comment; its docs and two assertions are updated to match.

Two intentional behavior changes worth knowing: the element-editor header now clears legacy `.progressbar`, and the Vue sidebar now sits above legacy `.prompt`/login rather than tying with them.

Verified with the `@craftcms/ui` (670) and Garnish (375) unit suites, the new sync test, `vp fmt --check`, and `oxlint`. No PHP changed, so `composer ci` wasn't run. The Storybook browser suite hasn't been run against this yet and is worth a pass before merge.
