### PR TITLE
Preserve expiry dates from nested cache collectors

### DIFF
--- a/src/services/Elements.php
+++ b/src/services/Elements.php
@@ -781,7 +781,7 @@ class Elements extends Component
 
             // Override the parent duration if ours is shorter
             $this->_cacheDuration = array_pop($this->_cacheDurationBuffers);
-            if ($duration && $duration < $this->_cacheDuration) {
+            if ($duration && (!$this->_cacheDuration || $duration < $this->_cacheDuration)) {
                 $this->_cacheDuration = $duration;
             }
         } else {

--- a/tests/unit/services/ElementsTest.php
+++ b/tests/unit/services/ElementsTest.php
@@ -12,6 +12,7 @@ namespace crafttests\unit\services;
 
 use Craft;
 use craft\elements\Entry;
+use craft\helpers\DateTimeHelper;
 use craft\services\Elements;
 use craft\test\TestCase;
 use craft\test\TestSetup;
@@ -81,6 +82,20 @@ class ElementsTest extends TestCase
         foreach ($strings as $label => [$expected, $text]) {
             self::assertEquals($expected, $this->elements->parseRefs($text), $label);
         }
+    }
+
+    public function testNestedCacheInfoPreservesExpiry(): void
+    {
+        $this->elements->startCollectingCacheInfo();
+        $this->elements->collectCacheTags(['test']);
+        $this->elements->startCollectingCacheInfo();
+        $this->elements->setCacheExpiryDate(DateTimeHelper::now()->modify('+60 seconds'));
+        $this->elements->stopCollectingCacheInfo();
+        [, $duration] = $this->elements->stopCollectingCacheInfo();
+
+        self::assertNotNull($duration);
+        self::assertGreaterThan(0, $duration);
+        self::assertLessThanOrEqual(60, $duration);
     }
 
     /**


### PR DESCRIPTION
Nested element-cache collectors could discard their expiry when the parent collector did not have one yet. Preserve the nested duration so outer caches cannot outlive expirable content.

Discovered while reviewing https://github.com/craftcms/cms/pull/19505.