### PR TITLE
Fix invalidation of cached GraphQL responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft CMS 4
 
+## Unreleased
+
+- Fixed a bug where cached GraphQL queries weren’t registering the original queries’ cache tags or cache expiration date. ([#19508](https://github.com/craftcms/cms/pull/19508)) 
+
 ## 4.18.7 - 2026-08-18
 
 - Fixed a [high-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) RCE vulnerability. (GHSA-5m2g-hhqr-84pc)

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -1322,7 +1322,7 @@ class Gql extends Component
         }
 
         try {
-            $cacheKey = self::CACHE_TAG .
+            $cacheKey = self::CACHE_TAG . '::cacheInfo' .
                 '::' . Craft::$app->getSites()->getCurrentSite()->id .
                 '::' . $schema->uid .
                 '::' . md5($query) .

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -581,7 +581,22 @@ class Gql extends Component
      */
     public function getCachedResult(string $cacheKey): ?array
     {
-        return Craft::$app->getCache()->get($cacheKey) ?: null;
+        $data = Craft::$app->getCache()->get($cacheKey);
+
+        if (!isset($data['result'], $data['cacheInfo']['tags'])) {
+            return null;
+        }
+
+        // If we're actively collecting element cache info, register this cache's tags and duration
+        $elementsService = Craft::$app->getElements();
+        if ($elementsService->getIsCollectingCacheInfo()) {
+            $elementsService->collectCacheTags($data['cacheInfo']['tags']);
+            if (isset($data['cacheInfo']['expiryDate'])) {
+                $elementsService->setCacheExpiryDate(DateTimeHelper::toDateTime($data['cacheInfo']['expiryDate']));
+            }
+        }
+
+        return $data['result'];
     }
 
     /**
@@ -602,7 +617,19 @@ class Gql extends Component
         // Add the global graphql cache tag
         $dependency->tags[] = self::CACHE_TAG;
 
-        Craft::$app->getCache()->set($cacheKey, $result, $duration, $dependency);
+        $cacheInfo = [
+            'tags' => $dependency->tags,
+        ];
+
+        if ($duration) {
+            $expiryDate = DateTimeHelper::now()->modify("+$duration seconds");
+            $cacheInfo['expiryDate'] = DateTimeHelper::toIso8601($expiryDate);
+        }
+
+        Craft::$app->getCache()->set($cacheKey, [
+            'result' => $result,
+            'cacheInfo' => $cacheInfo,
+        ], $duration, $dependency);
     }
 
     /**

--- a/src/services/Gql.php
+++ b/src/services/Gql.php
@@ -1322,7 +1322,7 @@ class Gql extends Component
         }
 
         try {
-            $cacheKey = self::CACHE_TAG . '::cacheInfo' .
+            $cacheKey = self::CACHE_TAG .
                 '::' . Craft::$app->getSites()->getCurrentSite()->id .
                 '::' . $schema->uid .
                 '::' . md5($query) .

--- a/tests/unit/services/GqlTest.php
+++ b/tests/unit/services/GqlTest.php
@@ -44,6 +44,7 @@ use GraphQL\Type\Definition\ObjectType;
 use UnitTester;
 use yii\base\Event;
 use yii\base\Exception;
+use yii\caching\TagDependency;
 
 class GqlTest extends TestCase
 {
@@ -404,6 +405,34 @@ class GqlTest extends TestCase
         $gql->saveSchema($schema);
         self::assertNull($gql->getCachedResult($cacheKey));
         $gql->deleteSchemaById($schema->id);
+    }
+
+    public function testCachedResultCollectsCacheInfo(): void
+    {
+        $gql = Craft::$app->getGql();
+        $cache = Craft::$app->getCache();
+        $cacheKey = 'testCachedResultCollectsCacheInfo';
+        $cacheValue = ['testValue'];
+
+        $cache->set($cacheKey, $cacheValue);
+        self::assertNull($gql->getCachedResult($cacheKey));
+
+        $gql->setCachedResult($cacheKey, $cacheValue, new TagDependency([
+            'tags' => ['testTag'],
+        ]), 60);
+
+        $elements = Craft::$app->getElements();
+        $elements->startCollectingCacheInfo();
+        $cachedResult = $gql->getCachedResult($cacheKey);
+        [$dependency, $duration] = $elements->stopCollectingCacheInfo();
+
+        self::assertSame($cacheValue, $cachedResult);
+        self::assertInstanceOf(TagDependency::class, $dependency);
+        self::assertContains('testTag', $dependency->tags);
+        self::assertContains(Gql::CACHE_TAG, $dependency->tags);
+        self::assertNotNull($duration);
+        self::assertGreaterThan(0, $duration);
+        self::assertLessThanOrEqual(60, $duration);
     }
 
     /**


### PR DESCRIPTION
GraphQL result cache hits could omit the element cache dependencies and expiry collected during the original query.

This matters for downstream consumers such as Craft Cloud, which use the tags to invalidate statically cached GraphQL GET responses and the expiry to bound their cache duration.