### PR TITLE
[6.x] Include OAuth options in elevated session prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed a bug where Typecast would throw when trying to set properties that didn’t exist. ([#19492](https://github.com/craftcms/cms/pull/19492))
 - Fixed a bug where POST requests to legacy action URLs weren’t getting routed properly. ([#19478](https://github.com/craftcms/cms/issues/19478))
 - Fixed a JavaScript error that occurred when creating a new Dashboard widget. ([#19479](https://github.com/craftcms/cms/issues/19479))
+- Fixed a bug where users without a local password could not start an elevated session using OAuth. ([#19512](https://github.com/craftcms/cms/pull/19512))
 
 ## 6.0.0-alpha.17 - 2026-08-18
 

--- a/src/Http/Controllers/Auth/SessionInfoController.php
+++ b/src/Http/Controllers/Auth/SessionInfoController.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\Http\Controllers\Auth;
 
 use CraftCms\Cms\Auth\Concerns\ConfirmsPasswords;
 use CraftCms\Cms\Auth\Impersonation;
+use CraftCms\Cms\Auth\OAuth\OAuth;
 use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\View\HtmlStack;
 use CraftCms\Cms\View\TemplateGlobals;
@@ -47,6 +48,7 @@ readonly class SessionInfoController
         Request $request,
         GeneralConfig $generalConfig,
         Impersonation $impersonation,
+        OAuth $oauth,
         HtmlStack $htmlStack,
         TemplateGlobals $templateGlobals,
         TemplateHooks $templateHooks,
@@ -90,7 +92,10 @@ readonly class SessionInfoController
             'username' => $loginName,
         ];
         $alternativeLoginMethods = $htmlStack->capture(
-            fn (): string => $templateHooks->invoke('cp.login.alternative-login-methods', $context),
+            fn (): string => implode('', [
+                ...$oauth->getLoginButtons(true),
+                $templateHooks->invoke('cp.login.alternative-login-methods', $context),
+            ]),
         );
 
         return new JsonResponse([

--- a/tests/Feature/Http/Controllers/Auth/SessionInfoControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/SessionInfoControllerTest.php
@@ -3,14 +3,18 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Auth\Impersonation;
+use CraftCms\Cms\Config\GeneralConfig;
+use CraftCms\Cms\Edition;
 use CraftCms\Cms\Http\Controllers\Auth\SessionInfoController;
 use CraftCms\Cms\Support\Facades\HtmlStack;
+use CraftCms\Cms\Tests\TestClasses\OAuth\FakeOAuthProvider;
 use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\User\Models\User as UserModel;
 use CraftCms\Cms\View\TemplateHooks;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Session;
 
+use function CraftCms\Cms\cp_url;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\getJson;
 use function Pest\Laravel\postJson;
@@ -145,6 +149,24 @@ test('password confirmation captures alternative login methods and assets', func
         ->assertJsonPath('alternativeLoginMethods.html', '<button>Alternative login</button>')
         ->assertJsonPath('alternativeLoginMethods.headHtml', fn (string $html): bool => str_contains($html, '/alternative-login.css'))
         ->assertJsonPath('alternativeLoginMethods.bodyHtml', fn (string $html): bool => str_contains($html, 'window.alternativeLoginReady = true'));
+});
+
+test('password confirmation includes configured OAuth buttons', function () {
+    Edition::set(Edition::Pro);
+    actingAs(User::findOne());
+    app(GeneralConfig::class)->oauthProviders([
+        'test' => [
+            'driver' => FakeOAuthProvider::class,
+            'clientId' => 'client-id',
+            'clientSecret' => 'client-secret',
+            'label' => 'Continue with Test OAuth',
+        ],
+    ]);
+
+    postJson(action([SessionInfoController::class, 'confirmPassword']))
+        ->assertOk()
+        ->assertJsonPath('alternativeLoginMethods.html', fn (string $html): bool => str_contains($html, 'Continue with Test OAuth') &&
+            str_contains($html, cp_url('oauth/test/redirect')));
 });
 
 test('password confirmation validates its options', function () {


### PR DESCRIPTION
### Description

Includes configured OAuth provider buttons in the elevated-session prompt so users without a local password can reauthenticate.

### Related issues

- Fixes #19487