### PR TITLE
Update field UUID references in field condition rules when possible

### DIFF
--- a/CHANGELOG-5.11.md
+++ b/CHANGELOG-5.11.md
@@ -9,6 +9,8 @@
 - Arrays created from `craft\fields\data\LinkData` objects now include `type`, `value`, `url`, `label`, `filename`, `link`, `attributes`, `defaultLabel`, `elementType`, `elementId`, `elementSiteId`, and `elementTitle` keys. ([craftcms/element-api#201](https://github.com/craftcms/element-api/issues/201)) 
 
 ### Extensibility
+- Added `craft\fieldlayoutelements\CustomField::$oldFieldUid`.
+- Added `craft\fields\conditions\FieldConditionRuleInterface::getFieldUid()`.
 - Added `craft\helpers\UrlHelper::removeAllParams()`. ([#19102](https://github.com/craftcms/cms/pull/19102))
 - Added `craft\helpers\UrlHelper::removeParams()`. ([#19102](https://github.com/craftcms/cms/pull/19102))
 - Added `craft\services\Elements::reorderNestedElements()`. ([#19321](https://github.com/craftcms/cms/issues/19321))
@@ -22,3 +24,4 @@
 - Updated yii2-debug to 2.1.28.
 - Fixed an error that could occur when editing an element. ([#17268](https://github.com/craftcms/cms/issues/17268))
 - Fixed a bug where `getEagerLoadedElements()` wasn’t returning results for eager-loaded native fields, such as `authors`. ([#19471](https://github.com/craftcms/cms/pull/19471))
+- Fixed a bug where field condition rules within field layout components weren’t getting updated when a custom field was replaced within the layout. ([#19515](https://github.com/craftcms/cms/pull/19515))

--- a/src/controllers/FieldsController.php
+++ b/src/controllers/FieldsController.php
@@ -665,6 +665,9 @@ JS, [
                     // If fieldId is set, we're replacing the selected field
                     if ($elementConfig['type'] === CustomField::class && isset($elementConfig['fieldId'])) {
                         if (!empty($elementConfig['fieldId'])) {
+                            // Keep track of the old field's UUID so we can update any conditions referencing it on save
+                            $elementConfig['oldFieldUid'] ??= $elementConfig['fieldUid'] ?? null;
+
                             unset($elementConfig['fieldUid']);
                         } else {
                             unset($elementConfig['fieldId']);

--- a/src/fieldlayoutelements/CustomField.php
+++ b/src/fieldlayoutelements/CustomField.php
@@ -72,6 +72,12 @@ class CustomField extends BaseField
      */
     public ?string $handle = null;
 
+    /**
+     * @var string|null The previously-selected field's UUID, if there was one
+     * @since 5.11.0
+     */
+    public ?string $oldFieldUid = null;
+
     private ?FieldInterface $_field = null;
     private ?string $_fieldUid = null;
     private ?string $_originalName = null;

--- a/src/fields/conditions/FieldConditionRuleInterface.php
+++ b/src/fields/conditions/FieldConditionRuleInterface.php
@@ -20,6 +20,14 @@ use craft\elements\conditions\ElementConditionRuleInterface;
 interface FieldConditionRuleInterface extends ElementConditionRuleInterface
 {
     /**
+     * Returns the UUID of the custom field associated with this rule.
+     *
+     * @return string
+     * @since 5.11.0
+     */
+    public function getFieldUid(): string;
+
+    /**
      * Sets the UUID of the custom field associated with this rule.
      *
      * @param string $uid

--- a/src/fields/conditions/FieldConditionRuleTrait.php
+++ b/src/fields/conditions/FieldConditionRuleTrait.php
@@ -51,6 +51,14 @@ trait FieldConditionRuleTrait
     /**
      * @inheritdoc
      */
+    public function getFieldUid(): string
+    {
+        return $this->_fieldUid;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function setFieldUid(string $uid): void
     {
         $this->_fieldUid = $uid;
@@ -88,10 +96,15 @@ trait FieldConditionRuleTrait
 
             foreach ($this->getCondition()->getFieldLayouts() as $fieldLayout) {
                 foreach ($fieldLayout->getCustomFields() as $field) {
-                    if ($field->uid === $this->_fieldUid) {
+                    if ($field->uid === $this->_fieldUid || $field->layoutElement->oldFieldUid === $this->_fieldUid) {
                         // skip if it doesn't have a label
                         $label = $field->layoutElement->label();
                         if ($label === null) {
+                            continue;
+                        }
+
+                        // make sure this is the expected condition rule class for the field
+                        if (!$this->isExpectedType($field)) {
                             continue;
                         }
 
@@ -141,6 +154,21 @@ trait FieldConditionRuleTrait
         }
 
         return $this->_fieldInstances;
+    }
+
+    private function isExpectedType(FieldInterface $field): bool
+    {
+        $expectedType = $field->getElementConditionRuleType();
+
+        if ($expectedType === null) {
+            return false;
+        }
+
+        if (is_array($expectedType)) {
+            $expectedType = $expectedType['class'];
+        }
+
+        return is_a($this, $expectedType);
     }
 
     /**

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -19,6 +19,7 @@ use craft\behaviors\CustomFieldBehavior;
 use craft\db\FixedOrderExpression;
 use craft\db\Query;
 use craft\db\Table;
+use craft\elements\conditions\ElementConditionInterface;
 use craft\errors\MissingComponentException;
 use craft\events\ApplyFieldSaveEvent;
 use craft\events\ConfigEvent;
@@ -35,6 +36,7 @@ use craft\fields\ButtonGroup;
 use craft\fields\Categories as CategoriesField;
 use craft\fields\Checkboxes;
 use craft\fields\Color;
+use craft\fields\conditions\FieldConditionRuleInterface;
 use craft\fields\ContentBlock;
 use craft\fields\Country;
 use craft\fields\Date;
@@ -1186,6 +1188,12 @@ class Fields extends Component
             $layoutRecord = new FieldLayoutRecord();
         }
 
+        if (!$isNewLayout) {
+            // capture any replaced custom fields, and update internal conditions with the new UUIDs where possible
+            $replacedFields = $this->captureReplacedFields($layout);
+            $this->updateFieldConditionRules($layout, $replacedFields);
+        }
+
         // Save the layout
         $layoutRecord->type = $layout->type;
         $layoutRecord->config = $layout->getConfig();
@@ -1229,6 +1237,64 @@ class Fields extends Component
         }
 
         return true;
+    }
+
+    private function captureReplacedFields(FieldLayout $layout): array
+    {
+        $replacedFields = [];
+
+        foreach ($layout->getCustomFieldElements() as $layoutElement) {
+            if (
+                isset($layoutElement->oldFieldUid) &&
+                $layoutElement->oldFieldUid !== $layoutElement->getFieldUid()
+            ) {
+                $replacedFields[$layoutElement->oldFieldUid] = [$layoutElement->getFieldUid(), $layoutElement->uid];
+                $layoutElement->oldFieldUid = null;
+            }
+        }
+
+        return $replacedFields;
+    }
+
+    private function updateFieldConditionRules(FieldLayout $layout, array $replacedFields): void
+    {
+        if (empty($replacedFields)) {
+            return;
+        }
+
+        foreach ($layout->getTabs() as $tab) {
+            $this->updateElementCondition($tab->getUserCondition(), $replacedFields);
+            $this->updateElementCondition($tab->getElementCondition(), $replacedFields);
+
+            foreach ($tab->getElements() as $layoutElement) {
+                $this->updateElementCondition($layoutElement->getUserCondition(), $replacedFields);
+                $this->updateElementCondition($layoutElement->getElementCondition(), $replacedFields);
+
+                if ($layoutElement instanceof CustomField) {
+                    $this->updateElementCondition($layoutElement->getEditCondition(), $replacedFields);
+                    $this->updateElementCondition($layoutElement->getElementEditCondition(), $replacedFields);
+                }
+            }
+        }
+    }
+
+    private function updateElementCondition(?ElementConditionInterface $condition, array $replacedFields): void
+    {
+        if (!$condition) {
+            return;
+        }
+
+        foreach ($condition->getConditionRules() as $rule) {
+            if (!$rule instanceof FieldConditionRuleInterface) {
+                continue;
+            }
+
+            $fieldUid = $rule->getFieldUid();
+
+            if (isset($replacedFields[$fieldUid])) {
+                $rule->setFieldUid($replacedFields[$fieldUid][0]);
+            }
+        }
     }
 
     /**

--- a/src/templates/_includes/forms/fld/custom-field-settings.twig
+++ b/src/templates/_includes/forms/fld/custom-field-settings.twig
@@ -5,8 +5,12 @@
 
 {% block fieldSettings %}
   {% if originalField %}
+    {% if field.oldFieldUid %}
+      {{ hiddenInput('oldFieldUid', field.oldFieldUid) }}
+    {% endif %}
+
     {% set fieldSelectId = "fieldselect#{random()}" %}
-    <div class="pane no-border p-m">
+    <div class="pane no-border p-m mt-0">
       {{ forms.fieldSelectField({
         id: fieldSelectId,
         name: 'fieldId',


### PR DESCRIPTION
### Description

Keeps `fieldUid` references within field layouts’ field condition rules updated when a custom field is replaced, whenever possible.

Caveats:

- It only will work if the replaced custom field has the same condition rule class as the former.
- It will only update condition rules within the field layout being saved. Other conditions (custom source conditions, element selection conditions on relational fields, etc.) can’t be updated automatically, unfortunately.

### Related issues

- Fixes #19486