### PR TITLE
[6.x] Add password manager rules to password fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Removed per-call immediate generation arguments from the core Asset Transform APIs and GraphQL transform arguments.
 - Removed the core image transformer registry, contracts, fallback transformer, and execution methods from `CraftCms\Cms\Image\ImageTransforms`. Legacy equivalents remain available through `craftcms/yii2-adapter`.
 - Improved environment variable and alias settings fields to show suggestions after typing `$` or `@`, automatically bracing embedded environment variables.
+- Improved new password fields to provide the configured password rules to supported password managers. ([#19516](https://github.com/craftcms/cms/pull/19516))
 - Element edit screens now autosave at the pace of the change — a keystroke waits, a discrete change saves almost immediately.
 - Submitting an element edit screen now cancels any in-flight autosave, and a failed autosave reports its HTTP status.
 - Element edit screens now indicate which fields a draft has unapplied changes to.

--- a/packages/craftcms-ui/src/components/input-password/input-password.test.ts
+++ b/packages/craftcms-ui/src/components/input-password/input-password.test.ts
@@ -48,4 +48,14 @@ describe('craft-input-password', () => {
     expect(element.querySelectorAll('craft-button')).toHaveLength(1);
     expect(revealButton(element)?.getAttribute('slot')).toBe('suffix');
   });
+
+  it('forwards password rules to the native input', async () => {
+    const element = await createInputPassword();
+    element.passwordRules = 'minlength: 8; maxlength: 160;';
+    await element.updateComplete;
+
+    expect(element.querySelector('input')?.getAttribute('passwordrules')).toBe(
+      element.passwordRules
+    );
+  });
 });

--- a/packages/craftcms-ui/src/components/input-password/input-password.ts
+++ b/packages/craftcms-ui/src/components/input-password/input-password.ts
@@ -1,5 +1,5 @@
-import {css, html} from 'lit';
-import {state} from 'lit/decorators.js';
+import {css, html, type PropertyValues} from 'lit';
+import {property, state} from 'lit/decorators.js';
 import {LionInput} from '@lion/ui/input.js';
 import {inputStyles, baseFormControlStyles} from '@src/styles/form.styles';
 import {t} from '@src/utilities/translate';
@@ -7,6 +7,8 @@ import '../icon/icon.js';
 import '../button/button.js';
 
 export default class CraftInputPassword extends LionInput {
+  @property({attribute: 'passwordrules'}) passwordRules = '';
+
   @state()
   protected _visible = false;
 
@@ -26,11 +28,17 @@ export default class CraftInputPassword extends LionInput {
           transform: translateY(calc(-50%));
           border: none;
         }
-        
+
         ::slotted(.form-control) {
           ${baseFormControlStyles}
-          --_input-end-end-radius: var(--c-input-radius, var(--c-radius-sm)) !important;
-          --_input-start-end-radius: var(--c-input-radius, var(--c-radius-sm)) !important;
+          --_input-end-end-radius: var(
+            --c-input-radius,
+            var(--c-radius-sm)
+          ) !important;
+          --_input-start-end-radius: var(
+            --c-input-radius,
+            var(--c-radius-sm)
+          ) !important;
         }
       `,
     ];
@@ -39,6 +47,29 @@ export default class CraftInputPassword extends LionInput {
   constructor() {
     super();
     this.type = 'password';
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.#syncPasswordRules();
+  }
+
+  override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has('passwordRules')) {
+      this.#syncPasswordRules();
+    }
+  }
+
+  #syncPasswordRules() {
+    if (this.passwordRules) {
+      this._inputNode?.setAttribute('passwordrules', this.passwordRules);
+
+      return;
+    }
+
+    this._inputNode?.removeAttribute('passwordrules');
   }
 
   reveal = () => {

--- a/resources/js/modules/auth/components/set-password/set-password-form.ts
+++ b/resources/js/modules/auth/components/set-password/set-password-form.ts
@@ -13,6 +13,7 @@ export default class CraftSetPasswordForm extends LitElement {
   @property() action = '';
   @property() uid = '';
   @property() code = '';
+  @property({attribute: 'password-rules'}) passwordRules = '';
   @property({attribute: 'initial-error'}) initialError = '';
   @property({type: Boolean, attribute: 'new-user'}) newUser = false;
 
@@ -45,6 +46,7 @@ export default class CraftSetPasswordForm extends LitElement {
               id="newPassword"
               name="newPassword"
               autocomplete="new-password"
+              passwordrules="${this.passwordRules}"
               required
               autofocus
             ></craft-input-password>

--- a/resources/js/pages/auth/SetPassword.vue
+++ b/resources/js/pages/auth/SetPassword.vue
@@ -10,6 +10,7 @@
     code: string;
     newUser: boolean;
     action: string;
+    passwordRules: string;
   }>();
 
   const page = usePage<{
@@ -29,6 +30,7 @@
       :code="code"
       :initial-error="page.props.errors?.newPassword"
       :new-user="newUser ? '' : null"
+      :password-rules="passwordRules"
     ></craft-set-password-form>
   </AuthBase>
 </template>

--- a/resources/js/pages/users/Password.vue
+++ b/resources/js/pages/users/Password.vue
@@ -15,6 +15,7 @@
 
   const page = usePage<{
     authMethods: AuthMethod[];
+    passwordRules: string;
   }>();
 
   interface PasswordForm {
@@ -54,6 +55,7 @@
               id="newPassword"
               name="newPassword"
               autocomplete="new-password"
+              :password-rules="page.props.passwordRules"
               :error="form.errors.newPassword"
             />
           </craft-field-group>

--- a/resources/templates/set-password.twig
+++ b/resources/templates/set-password.twig
@@ -12,6 +12,7 @@
     <craft-set-password-form {{ attr({
         uid: uid,
         code: code,
+        'password-rules': passwordRules,
         'initial-error': passwordErrors ? passwordErrors|first : null,
         'new-user': newUser,
     }) }}></craft-set-password-form>

--- a/src/Cp/Components/InputPassword.php
+++ b/src/Cp/Components/InputPassword.php
@@ -24,6 +24,16 @@ class InputPassword extends Input
     #[\Override]
     protected string $type = 'password';
 
+    protected ?string $passwordRules = null;
+
+    public function passwordRules(?string $passwordRules): static
+    {
+        $this->passwordRules = $passwordRules;
+        $this->inputAttributes['passwordrules'] = $passwordRules;
+
+        return $this;
+    }
+
     #[\Override]
     protected function tagName(): string
     {
@@ -45,6 +55,8 @@ class InputPassword extends Input
         foreach (['type', 'maxlength', 'size', 'small', 'width', 'center', 'monospace', 'hidden-input'] as $key) {
             unset($attributes[$key]);
         }
+
+        $attributes['passwordrules'] = $this->passwordRules;
 
         return $attributes;
     }

--- a/src/Cp/FormFields.php
+++ b/src/Cp/FormFields.php
@@ -41,6 +41,7 @@ use DateTimeInterface;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\ViewErrorBag;
+use Illuminate\Validation\Rules\Password;
 use InvalidArgumentException;
 use Stringable;
 
@@ -1028,6 +1029,9 @@ readonly class FormFields
     public static function passwordFromConfig(array $config): InputPassword
     {
         $config['type'] = 'password';
+        if (($config['autocomplete'] ?? null) === 'new-password') {
+            $config['inputAttributes']['passwordrules'] ??= Password::defaults()->toPasswordRulesString();
+        }
         $classes = Html::explodeClass($config['class'] ?? []);
         $classes[] = 'password';
         $config['class'] = $classes;

--- a/src/Cp/FormFields.php
+++ b/src/Cp/FormFields.php
@@ -1038,6 +1038,9 @@ readonly class FormFields
 
         $input = InputPassword::make();
         self::textFromConfig($config, $input);
+        $input->passwordRules(isset($config['inputAttributes']['passwordrules'])
+            ? (string) $config['inputAttributes']['passwordrules']
+            : null);
 
         return $input;
     }

--- a/src/Http/Controllers/Auth/SetPasswordController.php
+++ b/src/Http/Controllers/Auth/SetPasswordController.php
@@ -52,11 +52,13 @@ readonly class SetPasswordController extends AuthenticationController
                 'uid' => $uid,
                 'newUser' => ! $user->password,
                 'action' => $request->isCpRequest() ? action([self::class, 'store']) : action_url('users/set-password'),
+                'passwordRules' => Password::defaults()->toPasswordRulesString(),
             ],
             data: [
                 'code' => $code,
                 'uid' => $uid,
                 'newUser' => ! $user->password,
+                'passwordRules' => Password::defaults()->toPasswordRulesString(),
             ],
         );
     }

--- a/src/Http/ViewModels/UserPasswordViewModel.php
+++ b/src/Http/ViewModels/UserPasswordViewModel.php
@@ -7,6 +7,7 @@ namespace CraftCms\Cms\Http\ViewModels;
 use CraftCms\Cms\Auth\AuthMethods;
 use CraftCms\Cms\Auth\Methods\AuthMethodInterface;
 use CraftCms\Cms\User\Elements\User;
+use Illuminate\Validation\Rules\Password;
 
 class UserPasswordViewModel extends ViewModel
 {
@@ -18,6 +19,11 @@ class UserPasswordViewModel extends ViewModel
     public function userId(): int
     {
         return $this->user->id;
+    }
+
+    public function passwordRules(): string
+    {
+        return Password::defaults()->toPasswordRulesString();
     }
 
     /**

--- a/tests/Feature/Asset/AssetsTest.php
+++ b/tests/Feature/Asset/AssetsTest.php
@@ -277,11 +277,13 @@ it('invalidates Asset Transforms once for each source lifecycle operation', func
     $rootFolder = app(Folders::class)->getRootFolderByVolumeId($volume->id);
     $folder = VolumeFolderModel::factory()->create([
         'volumeId' => $volume->id,
+        'name' => 'source',
         'parentId' => $rootFolder->id,
         'path' => 'source/',
     ]);
     $destination = VolumeFolderModel::factory()->create([
         'volumeId' => $volume->id,
+        'name' => 'destination',
         'parentId' => $rootFolder->id,
         'path' => 'destination/',
     ]);

--- a/tests/Feature/Http/Controllers/Auth/SetPasswordControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/SetPasswordControllerTest.php
@@ -7,6 +7,7 @@ use CraftCms\Cms\Support\Facades\Users;
 use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\View\TemplateMode;
 use Illuminate\Support\MessageBag;
+use Illuminate\Validation\Rules\Password;
 use Inertia\Testing\AssertableInertia;
 
 use function CraftCms\Cms\cp_url;
@@ -54,10 +55,12 @@ test('fallback template renders set-password web component', function () {
         'uid' => 'user-uid',
         'code' => 'token-code',
         'newUser' => false,
+        'passwordRules' => Password::defaults()->toPasswordRulesString(),
         'errors' => new MessageBag,
     ])->render());
 
-    expect($html)->toContain('craft-set-password-form');
+    expect($html)->toContain('craft-set-password-form')
+        ->and($html)->toContain('password-rules=');
 });
 
 test('store validates required fields', function () {

--- a/tests/Unit/Cp/Components/InputPasswordTest.php
+++ b/tests/Unit/Cp/Components/InputPasswordTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use CraftCms\Cms\Cp\Components\InputPassword;
 use CraftCms\Cms\Cp\FormFields;
+use Illuminate\Validation\Rules\Password;
 
 describe('input-password', function () {
     it('renders a craft-input-password with a slotted password input', function () {
@@ -57,6 +58,7 @@ describe('FormFields::passwordFromConfig', function () {
             ->and($html)->toContain('id="newPassword"')
             ->and($html)->toContain('name="newPassword"')
             ->and($html)->toContain('autocomplete="new-password"')
+            ->and($html)->toContain('passwordrules="'.Password::defaults()->toPasswordRulesString().'"')
             // Preserves the legacy `.password` input class for CSS/JS keyed on it.
             ->and($html)->toContain('password');
     });


### PR DESCRIPTION
### Description

Adds `passwordrules` attributes to new-password fields so password managers can generate passwords that satisfy the configured rules. 

See https://securinglaravel.com/security-tip-help-password-managers-get-it-right/