### PR TITLE
[6.x] Preserve legacy log targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed a bug where POST requests to legacy action URLs weren’t getting routed properly. ([#19478](https://github.com/craftcms/cms/issues/19478))
 - Fixed a JavaScript error that occurred when creating a new Dashboard widget. ([#19479](https://github.com/craftcms/cms/issues/19479))
 - Fixed a bug where users without a local password could not start an elevated session using OAuth. ([#19512](https://github.com/craftcms/cms/pull/19512))
+- Fixed a bug where Yii log targets configured via `config/craft/app.php` did not receive messages logged with `Craft::info()` and related methods. ([#19517](https://github.com/craftcms/cms/pull/19517))
 
 ## 6.0.0-alpha.17 - 2026-08-18
 

--- a/yii2-adapter/legacy/log/Dispatcher.php
+++ b/yii2-adapter/legacy/log/Dispatcher.php
@@ -37,16 +37,6 @@ class Dispatcher extends \yii\log\Dispatcher
     public array $monologTargetConfig = [];
 
     /**
-     * @inheritdoc
-     */
-    public function init(): void
-    {
-        parent::init();
-
-        $this->targets = array_merge($this->getDefaultTargets()->all(), $this->targets);
-    }
-
-    /**
      * Gets the active default target, or one specified by key.
      *
      * @param string|null $key The target key to use (`web`, `console`, or `queue`).

--- a/yii2-adapter/src/Log/Logger.php
+++ b/yii2-adapter/src/Log/Logger.php
@@ -9,44 +9,15 @@
 
 namespace CraftCms\Yii2Adapter\Log;
 
-use Illuminate\Support\Facades\Log;
-use Throwable;
 use yii\base\Component;
-use yii\helpers\VarDumper;
 
 class Logger extends \yii\log\Logger
 {
-    use LogTrait;
-
     /**
      * {@inheritdoc}
      */
     public function init(): void
     {
         Component::init(); // skip parent init, avoiding `register_shutdown_function()` call.
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function log($message, $level, $category = 'application'): void
-    {
-        $level = $this->convertLogLevel($level);
-
-        $context = [
-            'category' => $category,
-        ];
-
-        if (!is_string($message)) {
-            // exceptions may not be serializable if in the call stack somewhere is a Closure
-            if ($message instanceof Throwable) {
-                $context['exception'] = $message;
-                $message = (string) $message;
-            } else {
-                $message = VarDumper::export($message);
-            }
-        }
-
-        Log::log($level, $message, $context);
     }
 }

--- a/yii2-adapter/src/Yii2ServiceProvider.php
+++ b/yii2-adapter/src/Yii2ServiceProvider.php
@@ -334,7 +334,10 @@ class Yii2ServiceProvider extends ServiceProvider
             $this->ensureNewSessionsTable();
         });
 
-        $this->app->terminating(fn() => $this->triggerAfterRequestForLaravelRequest());
+        $this->app->terminating(function(): void {
+            $this->triggerAfterRequestForLaravelRequest();
+            Craft::getLogger()->flush(true);
+        });
 
         if (!$this->app->runningInConsole()) {
             return;

--- a/yii2-adapter/tests-laravel/Legacy/LoggingCompatibilityTest.php
+++ b/yii2-adapter/tests-laravel/Legacy/LoggingCompatibilityTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Yii2Adapter\Log\LogTarget;
+use Illuminate\Support\Facades\Log;
+use yii\log\Target;
+
+it('dispatches legacy log messages to configured targets', function(): void {
+    CapturingLegacyLogTarget::$exportedMessages = [];
+    Craft::$app->getLog()->targets['custom-module'] = new CapturingLegacyLogTarget([
+        'categories' => ['custom-module'],
+        'logVars' => [],
+    ]);
+
+    Craft::info('included', 'custom-module');
+    Craft::info('excluded', 'other-module');
+
+    app()->terminate();
+
+    expect(CapturingLegacyLogTarget::$exportedMessages)
+        ->toHaveCount(1)
+        ->and(CapturingLegacyLogTarget::$exportedMessages[0][0])->toBe('included')
+        ->and(CapturingLegacyLogTarget::$exportedMessages[0][2])->toBe('custom-module');
+});
+
+it('forwards legacy log messages to Laravel without legacy default targets', function(): void {
+    Log::spy();
+
+    expect(Craft::$app->getLog()->targets)
+        ->toHaveCount(1)
+        ->and(array_values(Craft::$app->getLog()->targets)[0])->toBeInstanceOf(LogTarget::class);
+
+    Craft::info('forwarded', 'custom-module');
+
+    app()->terminate();
+
+    Log::shouldHaveReceived('log')
+        ->withArgs(fn(string $level, string $message, array $context): bool => $level === 'info'
+            && $message === 'forwarded'
+            && $context['category'] === 'custom-module')
+        ->atLeast()
+        ->once();
+});
+
+class CapturingLegacyLogTarget extends Target
+{
+    public static array $exportedMessages = [];
+
+    public function export(): void
+    {
+        self::$exportedMessages = array_merge(self::$exportedMessages, $this->messages);
+    }
+}


### PR DESCRIPTION
### Description

Restores Yii log dispatching for legacy `Craft::*()` logging calls so configured targets continue to receive and filter messages. The adapter’s existing `LogTarget` still forwards messages to Laravel, and buffered Yii messages are flushed when Laravel terminates.

Deprecated default Yii targets are no longer added automatically, preventing duplicate log output alongside Laravel channels.