### PR TITLE
allow Users location on Windows

### DIFF
--- a/src/services/Security.php
+++ b/src/services/Security.php
@@ -249,7 +249,6 @@ class Security extends \yii\base\Security
             $drive = substr($winRoot, 0, 3); // e.g. "C:/" because we've normalized it
             $sensitiveDirs = [
                 $winRoot, // C:/Windows
-                $drive . 'Users', // C:/Users
                 $drive . 'Program Files',
                 $drive . 'Program Files (x86)',
                 $drive . 'ProgramData',


### PR DESCRIPTION
### Description
Allow `Users` location (e.g. `C:/Users`) on Windows.


### Related issues

