### PR TITLE
make positive lookahead non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `craft\helpers\ElementHelper::containsTempSlug()`.
 - Added `craft\services\Config::doesEnvVarExist()`.
+- Improved `craft\helpers\App::parseEnv()` behavior. ([#19524](https://github.com/craftcms/cms/pull/19524), [#19522](https://github.com/craftcms/cms/issues/19522))
 - Fixed a bug where `craft\web\Controller::asModelSuccess()` and `asModelFailure()` could include more data than expected. ([#19469](https://github.com/craftcms/cms/issues/19469))
 - Fixed a bug where eager-loading users’ addresses would also eager-load any addresses defined by custom Addresses fields.
 - Fixed a bug where the primary site’s content wasn’t preferred when propagating a Single section’s entry to new sites. ([#19473](https://github.com/craftcms/cms/issues/19473))

--- a/src/helpers/App.php
+++ b/src/helpers/App.php
@@ -260,7 +260,7 @@ class App
         }
 
         // …/$VAR/…
-        $value = preg_replace_callback('/(?<=^|\/)\$(\w+)(?=$|\/)?/', function($m) {
+        $value = preg_replace_callback('/(?<=^|\/)\$(\w+)(?=$|\/)/', function($m) {
             $result = self::env($m[1]);
 
             if (is_bool($result)) {

--- a/tests/unit/helpers/AppHelperTest.php
+++ b/tests/unit/helpers/AppHelperTest.php
@@ -135,6 +135,13 @@ class AppHelperTest extends TestCase
         self::assertNull(App::parseEnv('$TEST_MISSING'));
         self::assertNull(App::parseEnv(null));
 
+        // https://github.com/craftcms/cms/issues/19522
+        self::assertSame('$58 million', App::parseEnv('$58 million'));
+        self::assertSame('the $58 million', App::parseEnv('the $58 million'));
+        self::assertSame('test/', App::parseEnv('test/$58'));
+        self::assertSame('/test', App::parseEnv('$58/test'));
+        self::assertSame('test//test', App::parseEnv('test/$58/test'));
+
         foreach (array_keys($variables) as $name) {
             putenv($name);
         }

--- a/tests/unit/helpers/AppHelperTest.php
+++ b/tests/unit/helpers/AppHelperTest.php
@@ -138,9 +138,10 @@ class AppHelperTest extends TestCase
         // https://github.com/craftcms/cms/issues/19522
         self::assertSame('$58 million', App::parseEnv('$58 million'));
         self::assertSame('the $58 million', App::parseEnv('the $58 million'));
-        self::assertSame('test/', App::parseEnv('test/$58'));
+        self::assertSame('the $58', App::parseEnv('the $58'));
         self::assertSame('/test', App::parseEnv('$58/test'));
         self::assertSame('test//test', App::parseEnv('test/$58/test'));
+        self::assertSame('test/', App::parseEnv('test/$58'));
 
         foreach (array_keys($variables) as $name) {
             putenv($name);


### PR DESCRIPTION
### Description
In the `…/$VAR/…` branch, the environment variable should only be parsed if it’s preceded or followed by a forward slash or is at the start or end of the string.

`App::parseEnv('$58 million')` => `$58 million`
`App::parseEnv('the $58 million')` => `the $58 million`
`App::parseEnv('the $58')` => `the $58`
`App::parseEnv('$58/test')` => `/test`
`App::parseEnv('test/$58/test')` => `test//test`
`App::parseEnv('test/$58')` => `test/`

### Related issues
#19522 
