### PR TITLE
don't try to create duplicates of composite unique index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed a bug where cached GraphQL queries weren’t registering the original queries’ cache tags or cache expiration date. ([#19508](https://github.com/craftcms/cms/pull/19508)) 
 - Fixed a bug where the control panel could become non-interactive after a slideout was closed. ([#9912](https://github.com/craftcms/cms/issues/9912), [#19511](https://github.com/craftcms/cms/pull/19511))
 - Fixed a bug where typing an environment variable name into a plugin’s license key input could result in multiple additions to the `.env` file, and cause the license key input to disappear. ([#19518](https://github.com/craftcms/cms/issues/19518))
+- Fixed an error that could occur when running the `fields/auto-merge` command. ([#19519](https://github.com/craftcms/cms/issues/19519))
 
 ## 5.10.14 - 2026-08-18
 

--- a/src/base/Field.php
+++ b/src/base/Field.php
@@ -8,6 +8,7 @@
 namespace craft\base;
 
 use Craft;
+use craft\db\Query;
 use craft\db\Table as DbTable;
 use craft\elements\db\ElementQueryInterface;
 use craft\enums\AttributeStatus;
@@ -930,6 +931,24 @@ JS, [
     public function afterMergeFrom(FieldInterface $outgoingField)
     {
         if ($this instanceof RelationalFieldInterface) {
+            // find the outgoing field's relations that would collide with the persisting field's relations
+            $conflictingIds = (new Query())
+                ->select(['outgoing.id'])
+                ->from(['outgoing' => DbTable::RELATIONS])
+                ->innerJoin(['persisting' => DbTable::RELATIONS], [
+                    'and',
+                    '[[persisting.sourceId]] = [[outgoing.sourceId]]',
+                    '[[persisting.sourceSiteId]] = [[outgoing.sourceSiteId]]',
+                    '[[persisting.targetId]] = [[outgoing.targetId]]',
+                ])
+                ->where(['outgoing.fieldId' => $outgoingField->id])
+                ->andWhere(['persisting.fieldId' => $this->id])
+                ->column();
+
+            if (!empty($conflictingIds)) {
+                Db::delete(DbTable::RELATIONS, ['id' => $conflictingIds]);
+            }
+
             Db::update(DbTable::RELATIONS, ['fieldId' => $this->id], ['fieldId' => $outgoingField->id]);
         }
 


### PR DESCRIPTION
### Description
Steps to reproduce are accurate, but you need at least 2 sites to reproduce. When creating the fields, you can leave all the default settings but ensure the fields are translatable (e.g. for each site). 

The unique index constraint doesn’t fail when there’s only one site, as it has `sourceSiteId` value set to `NULL` in that case (and two `NULL` values are not considered equal to each other).

This PR checks whether there are any relations for the outgoing field that would conflict with those of the persisting one. Relation rows that could conflict after the update are deleted.


### Related issues
#19519
