### PR TITLE
[6.x] Run Pest tests in parallel

### DIFF
--- a/.ai/rules/tests.md
+++ b/.ai/rules/tests.md
@@ -6,7 +6,7 @@ paths:
 # Tests
 
 ## Use the main Pest suite
-Run these tests with `composer tests` or `./vendor/bin/pest tests/path/to/TestFile.php`. Tests using `TestCase` share the database lock; `tests/Unit` tests using `UnitTestCase` do not.
+Run these tests with `composer tests` or `./vendor/bin/pest --parallel tests/path/to/TestFile.php`.
 
 ## Prefer real test paths
 Exercise real code paths or use Laravel facades for service mocks. Production `final` and `readonly` keywords are stripped in tests, so focused test-only subclasses are acceptable.

--- a/.github/workflows/laravel-ci.yml
+++ b/.github/workflows/laravel-ci.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Run tests
         uses: ./.github/actions/run-tests
         with:
-          test-command: ./vendor/bin/pest --ci --compact --testsuite=Unit
+          test-command: ./vendor/bin/pest --parallel --ci --compact --testsuite=Unit
           github-token: ${{ secrets.GITHUB_TOKEN }}
           packagist-username: ${{ secrets.packagist_username }}
           packagist-token: ${{ secrets.packagist_token }}
@@ -167,7 +167,7 @@ jobs:
       - name: Run tests
         uses: ./.github/actions/run-tests
         with:
-          test-command: ./vendor/bin/pest --ci --testsuite=Arch
+          test-command: ./vendor/bin/pest --parallel --ci --testsuite=Arch
           github-token: ${{ secrets.GITHUB_TOKEN }}
           packagist-username: ${{ secrets.packagist_username }}
           packagist-token: ${{ secrets.packagist_token }}
@@ -229,7 +229,7 @@ jobs:
         env:
           CRAFT_REQUIRE_VIPS: ${{ matrix.os == 'ubuntu-latest' && matrix.db == 'sqlite' && '1' || '' }}
         with:
-          test-command: ./vendor/bin/pest --ci --compact --testsuite=Feature
+          test-command: ./vendor/bin/pest --parallel --ci --compact --testsuite=Feature
           github-token: ${{ secrets.GITHUB_TOKEN }}
           packagist-username: ${{ secrets.packagist_username }}
           packagist-token: ${{ secrets.packagist_token }}

--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
     "rector": "rector",
     "tests": [
       "Composer\\Config::disableProcessTimeout",
-      "./vendor/bin/pest --compact"
+      "./vendor/bin/pest --parallel --compact"
     ],
     "tests-adapter": "./yii2-adapter/vendor/bin/pest --configuration ./yii2-adapter/phpunit.xml.dist --test-directory ./tests-laravel",
     "post-autoload-dump": [

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -227,7 +227,7 @@ Relevant tests live in:
 Run the focused tests with:
 
 ```bash
-./vendor/bin/pest --compact tests/Unit/Markdown/MarkdownTest.php
-./vendor/bin/pest --compact tests/Unit/Markdown/CommonMark/PreEncodedExtensionTest.php
-./vendor/bin/pest --compact tests/Unit/Markdown/CommonMark/PreEncodedRenderersTest.php
+./vendor/bin/pest --parallel --compact tests/Unit/Markdown/MarkdownTest.php
+./vendor/bin/pest --parallel --compact tests/Unit/Markdown/CommonMark/PreEncodedExtensionTest.php
+./vendor/bin/pest --parallel --compact tests/Unit/Markdown/CommonMark/PreEncodedRenderersTest.php
 ```

--- a/tests/Feature/Database/Commands/MigrateCommandTest.php
+++ b/tests/Feature/Database/Commands/MigrateCommandTest.php
@@ -6,6 +6,7 @@ use CraftCms\Cms\Database\Commands\MigrateCommand;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Database\Table;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabaseState;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
@@ -13,6 +14,10 @@ use function Pest\Laravel\artisan;
 
 afterEach(function () {
     MigrateCommand::flushState();
+});
+
+afterAll(function () {
+    RefreshDatabaseState::$migrated = false;
 });
 
 it('runs migrations', function () {

--- a/tests/Feature/Http/Controllers/InstallControllerTest.php
+++ b/tests/Feature/Http/Controllers/InstallControllerTest.php
@@ -6,6 +6,8 @@ use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\ConnectionConfig;
 use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Http\Controllers\InstallController;
+use CraftCms\Cms\User\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabaseState;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
@@ -20,6 +22,11 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (! User::query()->exists()) {
+        Cms::setIsInstalled(true);
+        RefreshDatabaseState::$migrated = false;
+    }
+
     putenv('INSTALL_TIMEZONE');
     putenv('INSTALL_BASE_URL');
 });

--- a/tests/Feature/ProjectConfig/Commands/RepairCommandTest.php
+++ b/tests/Feature/ProjectConfig/Commands/RepairCommandTest.php
@@ -12,6 +12,7 @@ it('reports when there is nothing to repair', function () {
 
 it('repairs double-packed associative arrays in project config', function () {
     app(ProjectConfig::class)->set('testFixture.item', doublePackedArray());
+    app(ProjectConfig::class)->writeYamlFiles();
 
     $this->artisan('craft:repair:project-config', ['--no-interaction' => true])
         ->expectsOutputToContain('testFixture.item')
@@ -23,6 +24,7 @@ it('repairs double-packed associative arrays in project config', function () {
 
 it('supports a dry run without changing the project config', function () {
     app(ProjectConfig::class)->set('testFixture.item', doublePackedArray());
+    app(ProjectConfig::class)->writeYamlFiles();
 
     $this->artisan('craft:project-config:repair', ['--dry-run' => true, '--no-interaction' => true])
         ->expectsOutputToContain('testFixture.item')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,10 +51,16 @@ class TestCase extends Orchestra
     use RegistersPackageAliases;
     use WithWorkbench;
 
+    private static bool $parallelDatabaseCreated = false;
+
     #[Override]
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+
+        if (getenv('TEST_TOKEN') !== false) {
+            return;
+        }
 
         DatabaseLock::acquire();
     }
@@ -89,7 +95,8 @@ class TestCase extends Orchestra
             app(Search::class)->useFullText = false;
         }
 
-        File::cleanDirectory(config_path('craft/project'));
+        File::cleanDirectory(config_path('craft/'.app(ProjectConfig::class)->folderName));
+
         File::cleanDirectory(storage_path('runtime/compiled_classes'));
 
         Factory::guessFactoryNamesUsing(
@@ -101,12 +108,14 @@ class TestCase extends Orchestra
         $this->withoutVite();
 
         // Always start with a fresh default admin user
-        User::first()->update([
-            'username' => 'craftcms',
-            'password' => Hash::make('craftcms2018!!'),
-            'email' => 'support@craftcms.com',
-            'admin' => true,
-        ]);
+        if ($user = User::first()) {
+            $user->update([
+                'username' => 'craftcms',
+                'password' => Hash::make('craftcms2018!!'),
+                'email' => 'support@craftcms.com',
+                'admin' => true,
+            ]);
+        }
     }
 
     protected function connectionsToTransact(): array
@@ -225,7 +234,24 @@ class TestCase extends Orchestra
     #[Override]
     protected function defineEnvironment($app): void
     {
-        File::cleanDirectory(config_path('craft/project'));
+        $projectConfigFolder = 'project';
+
+        if (($token = getenv('TEST_TOKEN')) !== false) {
+            $projectConfigFolder .= "_$token";
+            $storagePath = $app->storagePath("parallel_$token");
+            $app->useStoragePath($storagePath);
+            File::ensureDirectoryExists($storagePath);
+            File::ensureDirectoryExists($app->storagePath('framework'));
+            File::ensureDirectoryExists($app->storagePath('framework/testing'));
+
+            $app->afterResolving(ProjectConfig::class, function (ProjectConfig $projectConfig) use ($projectConfigFolder) {
+                $projectConfig->folderName = $projectConfigFolder;
+                $projectConfig->writeYamlAutomatically = false;
+            });
+        }
+
+        File::cleanDirectory(config_path("craft/$projectConfigFolder"));
+
         File::cleanDirectory(storage_path('runtime/compiled_classes'));
         File::cleanDirectory(storage_path('logs'));
 
@@ -253,6 +279,8 @@ class TestCase extends Orchestra
                 $connectionConfig = ConnectionConfig::normalize($connectionConfig);
 
                 if (($connectionConfig['driver'] ?? null) === 'sqlite') {
+                    $connectionConfig['foreign_key_constraints'] = true;
+
                     unset(
                         $connectionConfig['busy_timeout'],
                         $connectionConfig['journal_mode'],
@@ -263,7 +291,23 @@ class TestCase extends Orchestra
                     ConnectionConfig::ensureSqliteDatabaseFile((string) ($connectionConfig['database'] ?? ''));
                 }
 
+                if (($token = getenv('TEST_TOKEN')) !== false && ($database = $connectionConfig['database'] ?? null) !== ':memory:') {
+                    $config->set("database.connections.{$connection}", $connectionConfig);
+                    DB::setDefaultConnection($connection);
+
+                    $parallelDatabase = "{$database}_test_{$token}";
+
+                    if (! self::$parallelDatabaseCreated) {
+                        DB::getSchemaBuilder()->dropDatabaseIfExists($parallelDatabase);
+                        DB::getSchemaBuilder()->createDatabase($parallelDatabase);
+                        self::$parallelDatabaseCreated = true;
+                    }
+
+                    $connectionConfig['database'] = $parallelDatabase;
+                }
+
                 $config->set("database.connections.{$connection}", $connectionConfig);
+                DB::purge($connection);
             }
 
             if ($connection === 'pgsql') {


### PR DESCRIPTION
### Description

- Runs the main Pest suites in parallel locally and in CI.
- Isolates each parallel worker’s database, storage, and project config.
- Resets destructive test state within the affected test files.