### PR TITLE
[6.x] Restore filesystem URL validation behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft CMS 6
 
+## Unreleased
+
+- Fixed a bug where validating filesystem attributes could resolve `CraftCms\Cms\Filesystem\Filesystems\Filesystem::getRootUrl()`. ([#19535](https://github.com/craftcms/cms/pull/19535))
+- Fixed `CraftCms\Cms\Support\Env::parse()` to preserve unknown aliases rather than throw an exception. ([#19535](https://github.com/craftcms/cms/pull/19535))
+
 ## 6.0.0-alpha.18 - 2026-09-01
 
 - Added configurable asset transformers, which can be managed from Settings → Assets → Asset Transformers and assigned to asset volumes by handle.

--- a/src/Filesystem/Filesystems/Filesystem.php
+++ b/src/Filesystem/Filesystems/Filesystem.php
@@ -36,12 +36,6 @@ abstract class Filesystem extends Component implements FsInterface
 
     public ?string $uid = null;
 
-    public ?string $rootUrl {
-        get => $this->getRootUrl();
-        set {
-        }
-    }
-
     public function getRootUrl(): ?string
     {
         return null;

--- a/src/Support/Env.php
+++ b/src/Support/Env.php
@@ -139,7 +139,7 @@ class Env extends \Illuminate\Support\Env
             return null;
         }
 
-        if (str_starts_with((string) $value, '@') && $alias = Aliases::get($value)) {
+        if (str_starts_with((string) $value, '@') && $alias = Aliases::get($value, false)) {
             return $alias;
         }
 

--- a/tests/Feature/Support/EnvTest.php
+++ b/tests/Feature/Support/EnvTest.php
@@ -119,6 +119,7 @@ test('parse', function () {
     expect(Env::parse('$CRAFT_TESTS_PATH/foo/bar'))->toBe(CRAFT_TESTS_PATH.'/foo/bar');
     expect(Env::parse('CRAFT_TESTS_PATH'))->toBe('CRAFT_TESTS_PATH');
     expect(Env::parse('@vendor/foo/bar'))->toBe(Aliases::get('@vendor/foo/bar'));
+    expect(Env::parse('@missingEnvParseAlias'))->toBe('@missingEnvParseAlias');
     expect(Env::parse('$TEST_MISSING'))->toBeNull();
     expect(Env::parse(null))->toBeNull();
 

--- a/tests/Unit/Filesystem/FilesystemValidationTest.php
+++ b/tests/Unit/Filesystem/FilesystemValidationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Filesystem\Filesystems\Filesystem;
+
+it('does not resolve the root URL while validating attributes', function () {
+    $filesystem = new class extends Filesystem
+    {
+        public ?string $url = '@missingFilesystemAlias';
+
+        public function getRootUrl(): ?string
+        {
+            throw new RuntimeException('The root URL was resolved during validation.');
+        }
+
+        public function getDiskConfig(): array
+        {
+            return [];
+        }
+
+        public function getRules(): array
+        {
+            return ['url' => ['required', 'string']];
+        }
+    };
+
+    expect($filesystem->validate(['url']))->toBeTrue();
+});


### PR DESCRIPTION
### Description

Stops exposing `rootUrl` as a reflected filesystem property, preventing validation from resolving computed root URLs.

Preserves unresolved aliases in `Env::parse()`, matching the Craft 5 behavior.