### PR TITLE
[6.x] Make plugin settings forms refreshable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added support for refreshable standard plugin settings forms and conditional configuration of core form nodes. ([#19545](https://github.com/craftcms/cms/pull/19545))
 - Added support for sending queued Laravel notifications to `CraftCms\Cms\User\Elements\User` elements. ([#19541](https://github.com/craftcms/cms/pull/19541))
 - Improved the accessibility of element indexes. ([#19520](https://github.com/craftcms/cms/pull/19520))
 - Fixed a bug where validating filesystem attributes could resolve `CraftCms\Cms\Filesystem\Filesystems\Filesystem::getRootUrl()`. ([#19535](https://github.com/craftcms/cms/pull/19535))

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -355,6 +355,7 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
                 Route::post('{handle}/enable', [PluginsController::class, 'enable']);
                 Route::post('{handle}/disable', [PluginsController::class, 'disable']);
                 Route::post('{handle}/switch-edition', [PluginsController::class, 'switchEdition']);
+                Route::post('{handle}/render-form', [PluginsController::class, 'renderSettingsForm']);
                 Route::post('{handle}', [PluginsController::class, 'saveSettings']);
             });
 

--- a/src/Form/Nodes/Action.php
+++ b/src/Form/Nodes/Action.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
+use Illuminate\Support\Traits\Conditionable;
 
 /**
  * A Control rendered without the surrounding field chrome, for use in a
@@ -22,6 +23,8 @@ use CraftCms\Cms\Form\NodePayload;
  */
 class Action implements Node
 {
+    use Conditionable;
+
     private function __construct(private readonly Control $control) {}
 
     public static function make(Control $control): self

--- a/src/Form/Nodes/ActionMenu.php
+++ b/src/Form/Nodes/ActionMenu.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\Form\Contracts\Node;
 use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
+use Illuminate\Support\Traits\Conditionable;
 
 use function CraftCms\Cms\t;
 
@@ -25,6 +26,8 @@ use function CraftCms\Cms\t;
  */
 class ActionMenu implements Node
 {
+    use Conditionable;
+
     private ?string $label = null;
 
     private string $icon = 'ellipsis';

--- a/src/Form/Nodes/Callout.php
+++ b/src/Form/Nodes/Callout.php
@@ -13,9 +13,12 @@ use CraftCms\Cms\Form\NodePayload;
 use CraftCms\Cms\Support\Facades\Markdown;
 use CraftCms\Cms\Support\Html;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Traits\Conditionable;
 
 class Callout implements Node
 {
+    use Conditionable;
+
     private string $variant = 'info';
 
     private ?string $appearance = null;

--- a/src/Form/Nodes/CopyAttribute.php
+++ b/src/Form/Nodes/CopyAttribute.php
@@ -10,6 +10,7 @@ use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
 use CraftCms\Cms\Support\Html;
+use Illuminate\Support\Traits\Conditionable;
 
 /**
  * A `<craft-copy-attribute>` — the field handle, shown inline and copyable.
@@ -20,6 +21,8 @@ use CraftCms\Cms\Support\Html;
  */
 class CopyAttribute implements Node
 {
+    use Conditionable;
+
     private function __construct(
         private readonly string $uid,
         private readonly string $value,

--- a/src/Form/Nodes/Field.php
+++ b/src/Form/Nodes/Field.php
@@ -18,10 +18,12 @@ use CraftCms\Cms\Support\Facades\Markdown;
 use CraftCms\Cms\Support\Html;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 
 class Field implements Node
 {
+    use Conditionable;
     use HasVisibility;
 
     private ?string $label = null;

--- a/src/Form/Nodes/Heading.php
+++ b/src/Form/Nodes/Heading.php
@@ -10,9 +10,12 @@ use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
 use CraftCms\Cms\Support\Html;
+use Illuminate\Support\Traits\Conditionable;
 
 class Heading implements Node
 {
+    use Conditionable;
+
     private ?string $description = null;
 
     private int $level = 2;

--- a/src/Form/Nodes/HiddenField.php
+++ b/src/Form/Nodes/HiddenField.php
@@ -11,9 +11,12 @@ use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
+use Illuminate\Support\Traits\Conditionable;
 
 class HiddenField implements Node
 {
+    use Conditionable;
+
     private function __construct(private readonly Hidden $control) {}
 
     /** @param string|list<string> $path */

--- a/src/Form/Nodes/LineBreak.php
+++ b/src/Form/Nodes/LineBreak.php
@@ -10,9 +10,12 @@ use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
 use CraftCms\Cms\Support\Html;
+use Illuminate\Support\Traits\Conditionable;
 
 class LineBreak implements Node
 {
+    use Conditionable;
+
     public function __construct(private readonly string $uid) {}
 
     public static function renderHtml(NodePayload $node, FormPayload $payload, FormHtmlRenderer $renderer): string

--- a/src/Form/Nodes/MarkdownContent.php
+++ b/src/Form/Nodes/MarkdownContent.php
@@ -12,9 +12,12 @@ use CraftCms\Cms\Form\NodePayload;
 use CraftCms\Cms\Support\Facades\HtmlSanitizers;
 use CraftCms\Cms\Support\Facades\Markdown;
 use CraftCms\Cms\Support\Html;
+use Illuminate\Support\Traits\Conditionable;
 
 class MarkdownContent implements Node
 {
+    use Conditionable;
+
     private bool $displayInPane = true;
 
     private int $width = 100;

--- a/src/Form/Nodes/Missing.php
+++ b/src/Form/Nodes/Missing.php
@@ -11,12 +11,15 @@ use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
 use CraftCms\Cms\Support\Arr;
+use Illuminate\Support\Traits\Conditionable;
 
 use function CraftCms\Cms\t;
 use function CraftCms\Cms\template;
 
 class Missing implements Node
 {
+    use Conditionable;
+
     private function __construct(
         private readonly string $uid,
         private readonly string $provider,

--- a/src/Form/Nodes/Separator.php
+++ b/src/Form/Nodes/Separator.php
@@ -10,9 +10,12 @@ use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
 use CraftCms\Cms\Support\Html;
+use Illuminate\Support\Traits\Conditionable;
 
 class Separator implements Node
 {
+    use Conditionable;
+
     public function __construct(private readonly string $uid) {}
 
     public static function renderHtml(NodePayload $node, FormPayload $payload, FormHtmlRenderer $renderer): string

--- a/src/Form/Nodes/TemplateContent.php
+++ b/src/Form/Nodes/TemplateContent.php
@@ -11,10 +11,13 @@ use CraftCms\Cms\Form\FormPayload;
 use CraftCms\Cms\Form\NodePayload;
 use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\Support\HtmlSanitizer\HtmlSanitizerManager;
+use Illuminate\Support\Traits\Conditionable;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 
 class TemplateContent implements Node
 {
+    use Conditionable;
+
     private int $width = 100;
 
     private function __construct(

--- a/src/Http/Controllers/PluginsController.php
+++ b/src/Http/Controllers/PluginsController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Http\Controllers;
 
 use CraftCms\Cms\Config\GeneralConfig;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\FormResolver;
 use CraftCms\Cms\Http\RespondsWithFlash;
 use CraftCms\Cms\Http\Responses\CpScreenResponse;
 use CraftCms\Cms\Plugin\Contracts\PluginInterface;
@@ -13,7 +15,9 @@ use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use CraftCms\Cms\View\LegacyAssets\PluginsAsset;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use LogicException;
 use Symfony\Component\HttpFoundation\Response;
 
 use function CraftCms\Cms\t;
@@ -25,6 +29,7 @@ readonly class PluginsController
     public function __construct(
         private Plugins $plugins,
         private GeneralConfig $generalConfig,
+        private FormResolver $formResolver,
     ) {}
 
     public function index(): CpScreenResponse
@@ -144,5 +149,39 @@ readonly class PluginsController
         return $success
             ? $this->asSuccess(t('Plugin settings saved.'))
             : $this->editSettings($handle, $plugin);
+    }
+
+    public function renderSettingsForm(Request $request, string $handle): JsonResponse
+    {
+        $data = $request->validate([
+            'values' => ['required', 'array'],
+            'scope' => ['required', 'array', 'min:1'],
+            'scope.0' => ['required', 'in:settings'],
+            'scope.*' => ['string'],
+        ]);
+        $plugin = $this->plugins->getPlugin($handle);
+
+        abort_if(is_null($plugin), 404, 'Plugin not found.');
+
+        $scope = $data['scope'];
+        $settings = $plugin->getSettings()?->validationData() ?? [];
+        $settings = $scope === ['settings']
+            ? $data['values']
+            : data_set($settings, array_slice($scope, 1), $data['values']);
+        $plugin->setSettings($settings);
+        $context = new FormContext(
+            namespace: 'settings',
+            values: ['settings' => $settings],
+            refreshable: true,
+        );
+        $form = $plugin->settingsForm($context);
+
+        if ($form === null) {
+            throw new LogicException("Plugin [{$plugin->handle}] must return a Form from settingsForm().");
+        }
+
+        return new JsonResponse([
+            'form' => $this->formResolver->resolve($form, $context)->forScope($scope),
+        ]);
     }
 }

--- a/src/Plugin/Concerns/HasSettings.php
+++ b/src/Plugin/Concerns/HasSettings.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\Form;
 use CraftCms\Cms\Form\FormContext;
 use CraftCms\Cms\Form\FormResolver;
+use CraftCms\Cms\Http\Controllers\PluginsController;
 use CraftCms\Cms\Http\Responses\CpScreenResponse;
 use CraftCms\Cms\Plugin\Contracts\PluginInterface;
 use CraftCms\Cms\Support\Url;
@@ -96,6 +97,7 @@ trait HasSettings
             values: ['settings' => $settings?->validationData() ?? []],
             errors: $settings?->errors()->getMessages() ?? [],
             mode: $readOnly ? ControlMode::ReadOnly : ControlMode::Editable,
+            refreshable: ! $readOnly,
         );
         $form = $this->settingsForm($context);
 
@@ -114,6 +116,9 @@ trait HasSettings
                     'method' => 'post',
                     'url' => Url::cpUrl("settings/plugins/{$this->handle}"),
                 ],
+                ...($readOnly ? [] : [
+                    'refreshUrl' => action([PluginsController::class, 'renderSettingsForm'], [$this->handle]),
+                ]),
             ]);
     }
 

--- a/src/Plugin/Contracts/PluginInterface.php
+++ b/src/Plugin/Contracts/PluginInterface.php
@@ -8,6 +8,8 @@ use CraftCms\Cms\Cp\Data\NavItem;
 use CraftCms\Cms\Cp\Navigation;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Edition;
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\FormContext;
 use CraftCms\Cms\Plugin\Plugins;
 use CraftCms\Cms\Validation\Contracts\Validatable;
 use Illuminate\Foundation\Http\FormRequest;
@@ -249,6 +251,11 @@ interface PluginInterface
      * @return mixed The response returned by [[\CraftCms\Cms\Http\Controllers\PluginsController::editSettings()]]
      */
     public function getReadOnlySettingsResponse(): mixed;
+
+    /**
+     * Returns the plugin settings form.
+     */
+    public function settingsForm(FormContext $context = new FormContext): ?Form;
 
     /**
      * Returns the control panel nav item definition for this plugin, if it has a section in the control panel.

--- a/tests/Feature/Http/Controllers/PluginsControllerTest.php
+++ b/tests/Feature/Http/Controllers/PluginsControllerTest.php
@@ -40,6 +40,7 @@ test('requires authentication', function () {
     postJson(action([PluginsController::class, 'uninstall'], ['test-plugin']))->assertUnauthorized();
     postJson(action([PluginsController::class, 'enable'], ['test-plugin']))->assertUnauthorized();
     postJson(action([PluginsController::class, 'disable'], ['test-plugin']))->assertUnauthorized();
+    postJson(action([PluginsController::class, 'renderSettingsForm'], ['test-plugin']))->assertUnauthorized();
 });
 
 test('index shows plugin list page', function () {
@@ -179,6 +180,26 @@ test('plugin settings form targets the plugin CP route', function () {
         );
 });
 
+test('plugin settings form is refreshable', function () {
+    get(action([PluginsController::class, 'editSettings'], ['test-plugin']))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('form.refreshable', true)
+            ->where('refreshUrl', action([PluginsController::class, 'renderSettingsForm'], ['test-plugin']))
+        );
+
+    postJson(action([PluginsController::class, 'renderSettingsForm'], ['test-plugin']), [
+        'values' => ['foo' => 'show-bar', 'bar' => 'unsaved value'],
+        'scope' => ['settings'],
+    ])
+        ->assertOk()
+        ->assertJsonPath('form.scope', ['settings'])
+        ->assertJsonPath('form.refreshable', true)
+        ->assertJsonPath('form.values.settings.foo', 'show-bar')
+        ->assertJsonPath('form.values.settings.bar', 'unsaved value')
+        ->assertJsonPath('form.nodes.1.control.path', ['settings', 'bar']);
+});
+
 test('editSettings returns read-only settings response when supported', function () {
     Cms::config()->allowAdminChanges = false;
 
@@ -186,7 +207,9 @@ test('editSettings returns read-only settings response when supported', function
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->where('readOnly', true)
+            ->where('form.refreshable', false)
             ->where('form.nodes.0.control.mode', 'readOnly')
+            ->missing('refreshUrl')
         );
 });
 
@@ -315,4 +338,13 @@ test('respects read-only mode for saveSettings', function () {
         'settings' => [],
     ])
         ->assertForbidden();
+});
+
+test('respects read-only mode for settings form refresh', function () {
+    Cms::config()->allowAdminChanges = false;
+
+    postJson(action([PluginsController::class, 'renderSettingsForm'], ['test-plugin']), [
+        'values' => [],
+        'scope' => ['settings'],
+    ])->assertForbidden();
 });

--- a/tests/TestClasses/TestPlugin/src/TestPlugin.php
+++ b/tests/TestClasses/TestPlugin/src/TestPlugin.php
@@ -341,7 +341,9 @@ class TestPlugin extends Plugin
 
         return Form::make([
             Field::make('Foo', Text::make('foo')),
-        ]);
+        ])->when($this->getSettings()?->foo === 'show-bar', fn (Form $form) => $form->add(
+            Field::make('Bar', Text::make('bar')),
+        ));
     }
 
     #[Override]


### PR DESCRIPTION
### Description

Makes plugin settings forms refreshable so they can re-render from unsaved values. 

Also adds `Conditionable` to core form nodes.