### PR TITLE
fix: Skip automatic plugin license writes in read-only mode

### DIFF
--- a/src/helpers/Api.php
+++ b/src/helpers/Api.php
@@ -201,7 +201,7 @@ abstract class Api
 
         // did we just get any new plugin license keys?
         $pluginsService = Craft::$app->getPlugins();
-        if (isset($headers['x-craft-plugin-licenses'])) {
+        if (isset($headers['x-craft-plugin-licenses']) && !Craft::$app->getProjectConfig()->readOnly) {
             $pluginLicenseKeys = explode(',', reset($headers['x-craft-plugin-licenses']));
             foreach ($pluginLicenseKeys as $key) {
                 [$pluginHandle, $key] = explode(':', $key);

--- a/tests/unit/helpers/ApiHelperTest.php
+++ b/tests/unit/helpers/ApiHelperTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace crafttests\unit\helpers;
+
+use Craft;
+use craft\helpers\Api;
+use craft\helpers\App;
+use craft\services\Plugins;
+use craft\test\TestCase;
+use craft\test\TestSetup;
+use Yii;
+
+class ApiHelperTest extends TestCase
+{
+    private bool $_craftWasWarmed = false;
+
+    protected function setUp(): void
+    {
+        if (Craft::$app === null) {
+            $app = TestSetup::warmCraft();
+            Craft::$app = $app;
+            Yii::$app = $app;
+            $this->_craftWasWarmed = true;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->_craftWasWarmed) {
+            TestSetup::tearDownCraft();
+        }
+    }
+
+    public function testPluginLicenseWriteIsSkippedWhenProjectConfigIsReadOnly(): void
+    {
+        $cache = Craft::$app->getCache();
+        $cache->delete(App::CACHE_KEY_LICENSE_INFO);
+
+        $projectConfig = Craft::$app->getProjectConfig();
+        $readOnly = $projectConfig->readOnly;
+        $plugins = Craft::$app->getPlugins();
+
+        try {
+            $projectConfig->readOnly = true;
+            $pluginsMock = $this->createMock(Plugins::class);
+            $pluginsMock->expects(self::never())
+                ->method('setPluginLicenseKey');
+            Craft::$app->set('plugins', $pluginsMock);
+
+            Api::processResponseHeaders([
+                'X-Craft-Plugin-Licenses' => 'example-plugin:license-key',
+                'X-Craft-License-Info' => 'example-plugin:123;standard;valid',
+            ]);
+
+            $licenseInfo = $cache->get(App::CACHE_KEY_LICENSE_INFO);
+            self::assertSame('123', $licenseInfo['example-plugin']['id']);
+            self::assertSame('standard', $licenseInfo['example-plugin']['edition']);
+            self::assertSame('valid', $licenseInfo['example-plugin']['status']);
+        } finally {
+            Craft::$app->set('plugins', $plugins);
+            $projectConfig->readOnly = $readOnly;
+        }
+    }
+
+    public function testPluginLicenseWriteOccursWhenProjectConfigIsWritable(): void
+    {
+        $projectConfig = Craft::$app->getProjectConfig();
+        $readOnly = $projectConfig->readOnly;
+        $plugins = Craft::$app->getPlugins();
+
+        try {
+            $projectConfig->readOnly = false;
+            $pluginsMock = $this->createMock(Plugins::class);
+            $pluginsMock->expects(self::once())
+                ->method('setPluginLicenseKey')
+                ->with('example-plugin', 'license-key')
+                ->willReturn(true);
+            Craft::$app->set('plugins', $pluginsMock);
+
+            Api::processResponseHeaders([
+                'X-Craft-Plugin-Licenses' => 'example-plugin:license-key',
+            ]);
+        } finally {
+            Craft::$app->set('plugins', $plugins);
+            $projectConfig->readOnly = $readOnly;
+        }
+    }
+
+    /**
+     * @dataProvider projectConfigReadOnlyDataProvider
+     */
+    public function testResponseWithoutPluginLicensesDoesNotWritePluginLicense(bool $readOnly): void
+    {
+        $cache = Craft::$app->getCache();
+        $cache->delete('licensedDomain');
+
+        $projectConfig = Craft::$app->getProjectConfig();
+        $originalReadOnly = $projectConfig->readOnly;
+        $plugins = Craft::$app->getPlugins();
+
+        try {
+            $projectConfig->readOnly = $readOnly;
+            $pluginsMock = $this->createMock(Plugins::class);
+            $pluginsMock->expects(self::never())
+                ->method('setPluginLicenseKey');
+            Craft::$app->set('plugins', $pluginsMock);
+
+            Api::processResponseHeaders([
+                'X-Craft-License-Domain' => 'example.test',
+            ]);
+
+            self::assertSame('example.test', $cache->get('licensedDomain'));
+        } finally {
+            Craft::$app->set('plugins', $plugins);
+            $projectConfig->readOnly = $originalReadOnly;
+        }
+    }
+
+    public static function projectConfigReadOnlyDataProvider(): array
+    {
+        return [
+            [false],
+            [true],
+        ];
+    }
+}


### PR DESCRIPTION
### Description

Gate only the automatic plugin-license persistence block in `Api::processResponseHeaders()` on the project config service’s `readOnly` state. Continue processing non-mutating response metadata, including license-domain and license-info cache updates, so read-only environments can still consume update responses. Leave `Plugins::setPluginLicenseKey()` and its explicit controller/install callers unchanged, preserving their current validation and read-only enforcement when a user directly requests a license change.

Craftnet API responses can include `X-Craft-Plugin-Licenses`, which `Api::processResponseHeaders()` currently persists through `Plugins::setPluginLicenseKey()`. When project config is read-only, a returned key that differs from the deployed config reaches `ProjectConfig::set()` and throws `NotSupportedException`, preventing the Updates utility from displaying otherwise valid update information. The thread’s stack trace identifies this automatic response-header path, and a missing plugin license key supplies a concrete reproduction. A later report about project-config writes during database migrations is a separate deployment flow and is outside this fix.

Fixes #17750

### Related issues

Not applicable to this change.
