### PR TITLE
[6.x] Fix authentication for legacy CP actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for refreshable standard plugin settings forms and conditional configuration of core form nodes. ([#19545](https://github.com/craftcms/cms/pull/19545))
 - Added support for sending queued Laravel notifications to `CraftCms\Cms\User\Elements\User` elements. ([#19541](https://github.com/craftcms/cms/pull/19541))
 - Improved the accessibility of element indexes. ([#19520](https://github.com/craftcms/cms/pull/19520))
+- Fixed a bug where authenticated Control Panel requests to Yii2 adapter controller actions were treated as unauthenticated. ([#19556](https://github.com/craftcms/cms/pull/19556))
 - Fixed a bug where validating filesystem attributes could resolve `CraftCms\Cms\Filesystem\Filesystems\Filesystem::getRootUrl()`. ([#19535](https://github.com/craftcms/cms/pull/19535))
 - Fixed `CraftCms\Cms\Support\Env::parse()` to preserve unknown aliases rather than throw an exception. ([#19535](https://github.com/craftcms/cms/pull/19535))
 - Fixed a bug where nested Content Block fields’ content could be lost during a batched resave that included revisions. ([#19543](https://github.com/craftcms/cms/issues/19543))

--- a/yii2-adapter/routes/web.php
+++ b/yii2-adapter/routes/web.php
@@ -14,10 +14,10 @@ use Illuminate\Support\Facades\Route;
 
 $routes = app(CraftRoutes::class);
 $sharedActionRouteGroups = $routes->actionTriggerRoutePrefix() === $routes->cpActionTriggerRoutePrefix()
-    ? [[$routes->cpActionTriggerRoutePrefix(), ['craft.cp']]]
+    ? [[$routes->cpActionTriggerRoutePrefix(), ['web', 'craft.cp']]]
     : [
         [$routes->actionTriggerRoutePrefix(), ['craft.web']],
-        [$routes->cpActionTriggerRoutePrefix(), ['craft.cp']],
+        [$routes->cpActionTriggerRoutePrefix(), ['web', 'craft.cp']],
     ];
 
 foreach ($sharedActionRouteGroups as [$prefix, $middleware]) {

--- a/yii2-adapter/tests-laravel/Http/LegacyActionRoutingTest.php
+++ b/yii2-adapter/tests-laravel/Http/LegacyActionRoutingTest.php
@@ -6,6 +6,8 @@ use CraftCms\Cms\View\TemplateMode;
 use CraftCms\Cms\View\TemplateRoots;
 use CraftCms\Yii2Adapter\Http\CaptureOriginalActionRequestUri;
 use Illuminate\Http\Request as IlluminateRequest;
+use Illuminate\Routing\Router;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\File;
 use yii\base\Module;
 use yii\web\Controller;
@@ -69,6 +71,14 @@ it('does not override the URI for direct legacy action route requests', function
         expect($request->getRequestUri())->toBe('/actions/test-plugin/fail')
             ->and($request->attributes->has(CaptureOriginalActionRequestUri::ORIGINAL_ACTION_REQUEST_URI))->toBeFalse();
     });
+});
+
+it('starts the session for legacy control panel actions', function() {
+    $router = app(Router::class);
+    $route = $router->getRoutes()->getByName('craft.cp.legacy.action');
+
+    expect($router->gatherRouteMiddleware($route))
+        ->toContain(StartSession::class);
 });
 
 it('renders template routes from legacy url rules', function() {


### PR DESCRIPTION
### Description

Restores Laravel web middleware for Yii2 adapter Control Panel action routes so authenticated plugin controller requests retain session authentication.

### Related issues

- Fixes #19553