### PR TITLE
Language-aware case modification

### DIFF
--- a/src/helpers/ElementHelper.php
+++ b/src/helpers/ElementHelper.php
@@ -108,17 +108,18 @@ class ElementHelper
             $slug = StringHelper::toAscii($slug, $language);
         }
 
-        return static::normalizeSlug($slug);
+        return static::normalizeSlug($slug, $language);
     }
 
     /**
      * Normalizes a slug.
      *
      * @param string $slug
+     * @param string|null $language The slug’s langauge
      * @return string
      * @since 3.5.0
      */
-    public static function normalizeSlug(string $slug): string
+    public static function normalizeSlug(string $slug, ?string $language = null): string
     {
         // Special case for the homepage
         if ($slug === Element::HOMEPAGE_URI) {
@@ -134,7 +135,7 @@ class ElementHelper
         // Make it lowercase
         $generalConfig = Craft::$app->getConfig()->getGeneral();
         if (!$generalConfig->allowUppercaseInSlug) {
-            $slug = mb_strtolower($slug);
+            $slug = StringHelper::toLowerCase($slug, $language);
         }
 
         // Get the "words". Split on anything that is not alphanumeric or allowed punctuation

--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -9,12 +9,14 @@ namespace craft\helpers;
 
 use BackedEnum;
 use Craft;
+use craft\i18n\Locale;
 use HTMLPurifier_Config;
 use Illuminate\Support\Str;
 use IteratorAggregate;
 use LitEmoji\LitEmoji;
 use Normalizer;
 use Throwable;
+use Transliterator;
 use voku\helper\ASCII;
 use yii\base\Exception;
 use yii\base\InvalidArgumentException;
@@ -2313,11 +2315,12 @@ class StringHelper extends \yii\helpers\StringHelper
      * Converts all characters in the string to lowercase. An alias for PHP's mb_strtolower().
      *
      * @param string $str The string to convert to lowercase.
+     * @param string|null $language The string’s langauge
      * @return string The lowercase string.
      */
-    public static function toLowerCase(string $str): string
+    public static function toLowerCase(string $str, ?string $language = null): string
     {
-        return Str::lower($str);
+        return self::modifyCase($str, $language, 'Lower') ?? Str::lower($str);
     }
 
     /**
@@ -2414,11 +2417,12 @@ class StringHelper extends \yii\helpers\StringHelper
      * Converts the first character of each word in the string to uppercase.
      *
      * @param string $str The string to convert case.
+     * @param string|null $language The string’s langauge
      * @return string The title-cased string.
      */
-    public static function toTitleCase(string $str): string
+    public static function toTitleCase(string $str, ?string $language = null): string
     {
-        return Str::title($str);
+        return self::modifyCase($str, $language, 'Title') ?? Str::title($str);
     }
 
     /**
@@ -2440,11 +2444,12 @@ class StringHelper extends \yii\helpers\StringHelper
      * Converts all characters in the string to uppercase. An alias for PHP's mb_strtoupper().
      *
      * @param string $str The string to convert to uppercase.
+     * @param string|null $language The string’s langauge
      * @return string The uppercase string.
      */
-    public static function toUpperCase(string $str): string
+    public static function toUpperCase(string $str, ?string $language = null): string
     {
-        return Str::upper($str);
+        return self::modifyCase($str, $language, 'Upper') ?? Str::upper($str);
     }
 
     /**
@@ -2802,5 +2807,20 @@ class StringHelper extends \yii\helpers\StringHelper
         );
 
         return sprintf('/%s/iu', implode('|', $invisibleCharCodes));
+    }
+
+    private static function modifyCase(string $str, ?string $language, string $case): ?string
+    {
+        $language ??= Craft::$app->language;
+        $transliterator = Transliterator::create(sprintf('%s-%s', Locale::languageId($language), $case));
+
+        if (!$transliterator) {
+            return null;
+        }
+
+        // Normalize NFD chars to NFC
+        $str = Normalizer::normalize($str, Normalizer::FORM_C);
+
+        return $transliterator->transliterate($str);
     }
 }

--- a/src/i18n/Locale.php
+++ b/src/i18n/Locale.php
@@ -26,6 +26,19 @@ use yii\base\InvalidArgumentException;
 class Locale extends BaseObject
 {
     /**
+     * Returns a locale’s language ID.
+     *
+     * @return string
+     * @since 5.12.0
+     */
+    public static function languageId(string $locale): string
+    {
+        $pos = strpos($locale, '-');
+        $lang = $pos !== false ? substr($locale, 0, $pos) : $locale;
+        return strtolower($lang);
+    }
+
+    /**
      * @var int Positive prefix.
      */
     public const ATTR_POSITIVE_PREFIX = 0;
@@ -296,11 +309,7 @@ class Locale extends BaseObject
     #[AllowedInSandbox]
     public function getLanguageID(): string
     {
-        if (($pos = strpos($this->id, '-')) !== false) {
-            return substr($this->id, 0, $pos);
-        }
-
-        return $this->id;
+        return static::languageId($this->id);
     }
 
     /**

--- a/src/web/twig/Extension.php
+++ b/src/web/twig/Extension.php
@@ -230,6 +230,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('base64_encode', 'base64_encode'),
             new TwigFilter('boolean', 'boolval'),
             new TwigFilter('camel', [$this, 'camelFilter']),
+            new TwigFilter('capitalize', [$this, 'capitalizeFilter'], ['needs_charset' => true]),
             new TwigFilter('column', [$this, 'columnFilter'], ['needs_is_sandboxed' => true]),
             new TwigFilter('contains', [$this, 'containsFilter'], ['needs_is_sandboxed' => true]),
             new TwigFilter('currency', [$this, 'currencyFilter']),
@@ -261,6 +262,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('length', [$this, 'lengthFilter'], ['needs_environment' => true]),
             new TwigFilter('lcfirst', [$this, 'lcfirstFilter']),
             new TwigFilter('literal', [$this, 'literalFilter']),
+            new TwigFilter('lower', [$this, 'lowerFilter']),
             new TwigFilter('map', [$this, 'mapFilter'], ['needs_environment' => true, 'needs_is_sandboxed' => true]),
             new TwigFilter('markdown', [$this, 'markdownFilter'], ['is_safe' => ['html']]),
             new TwigFilter('md', [$this, 'markdownFilter'], ['is_safe' => ['html']]),
@@ -289,6 +291,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('string', 'strval'),
             new TwigFilter('time', [$this, 'timeFilter'], ['needs_environment' => true]),
             new TwigFilter('timestamp', [$this, 'timestampFilter']),
+            new TwigFilter('title', [$this, 'titleFilter']),
             new TwigFilter('translate', [$this, 'translateFilter']),
             new TwigFilter('truncate', [$this, 'truncateFilter']),
             new TwigFilter('t', [$this, 'translateFilter']),
@@ -296,6 +299,7 @@ class Extension extends AbstractExtension implements GlobalsInterface
             new TwigFilter('ucwords', [$this, 'ucwordsFilter'], ['needs_environment' => true]),
             new TwigFilter('unique', 'array_unique'),
             new TwigFilter('unshift', [$this, 'unshiftFilter']),
+            new TwigFilter('upper', [$this, 'upperFilter']),
             new TwigFilter('values', 'array_values'),
             new TwigFilter('where', [$this, 'whereFilter'], ['needs_is_sandboxed' => true]),
             new TwigFilter('widont', [$this, 'widontFilter'], ['is_safe' => ['html']]),
@@ -499,6 +503,18 @@ class Extension extends AbstractExtension implements GlobalsInterface
         return StringHelper::toCamelCase((string)$string);
     }
 
+    /**
+     * Capitalizes a string.
+     *
+     * @param string $charset
+     * @param string|null $string
+     * @param string|null $language
+     * @since 5.12.0
+     */
+    public function capitalizeFilter(string $charset, ?string $string, ?string $language = null): string
+    {
+        return StringHelper::toUpperCase(mb_substr($string ?? '', 0, 1, $charset), $language) . StringHelper::toLowerCase(mb_substr($string ?? '', 1, null, $charset), $language);
+    }
 
     /**
      * Throws a RuntimeError if the given name/key is a string containing a "." character and the environment is
@@ -765,6 +781,19 @@ class Extension extends AbstractExtension implements GlobalsInterface
     }
 
     /**
+     * Title-cases a string
+     *
+     * @param string|null $string
+     * @param string|null $language
+     * @return string
+     * @since 5.12.0
+     */
+    public function titleFilter(?string $string, ?string $language = null): string
+    {
+        return StringHelper::toTitleCase($string ?? '', $language);
+    }
+
+    /**
      * This method will JSON encode a variable. We're overriding Twig's default implementation to set some stricter
      * encoding options on text/html/xml requests.
      *
@@ -980,6 +1009,19 @@ class Extension extends AbstractExtension implements GlobalsInterface
         array_shift($args);
         array_unshift($array, ...$args);
         return $array;
+    }
+
+    /**
+     * Upper-cases a string
+     *
+     * @param string|null $string
+     * @param string|null $language
+     * @return string
+     * @since 5.12.0
+     */
+    public function upperFilter(?string $string, ?string $language = null): string
+    {
+        return StringHelper::toUpperCase($string ?? '', $language);
     }
 
     /**
@@ -1465,6 +1507,19 @@ class Extension extends AbstractExtension implements GlobalsInterface
     public function literalFilter(mixed $value): string
     {
         return Db::escapeParam((string)$value);
+    }
+
+    /**
+     * Lower-cases a string
+     *
+     * @param string|null $string
+     * @param string|null $language
+     * @return string
+     * @since 5.12.0
+     */
+    public function lowerFilter(?string $string, ?string $language = null): string
+    {
+        return StringHelper::toLowerCase($string ?? '', $language);
     }
 
     /**

--- a/tests/unit/helpers/ElementHelperTest.php
+++ b/tests/unit/helpers/ElementHelperTest.php
@@ -70,6 +70,21 @@ class ElementHelperTest extends TestCase
     }
 
     /**
+     * @dataProvider normalizeSlugRespectsLanguageDataProvider
+     * @param string $expected
+     * @param string $slug
+     * @param string|null $language
+     */
+    public function testNormalizeSlugRespectsLanguage(string $expected, string $slug, ?string $language): void
+    {
+        // The slug can only get lowercased if uppercase characters aren't allowed
+        $general = Craft::$app->getConfig()->getGeneral();
+        $general->allowUppercaseInSlug = false;
+
+        self::assertSame($expected, ElementHelper::normalizeSlug($slug, $language));
+    }
+
+    /**
      * @dataProvider isTempSlugDataProvider
      * @param bool $expected
      * @param string|null $slug
@@ -216,6 +231,19 @@ class ElementHelperTest extends TestCase
             ['Audi[separator-here]S8[separator-here]4E[separator-here]2006-2010', 'Audi S8 4E (2006-2010)'], // https://github.com/craftcms/cms/issues/4607
             ['こんにちは', 'こんにちは'], // https://github.com/craftcms/cms/issues/4628
             ['Сертификация', 'Сертификация'], // https://github.com/craftcms/cms/issues/1535
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public static function normalizeSlugRespectsLanguageDataProvider(): array
+    {
+        return [
+            // Turkish lowercases a dotless "I" to a dotless "ı", not "i"
+            // (https://github.com/craftcms/cms/discussions/19555)
+            ['ıstanbul', 'Istanbul', 'tr'],
+            ['istanbul', 'Istanbul', null],
         ];
     }
 

--- a/tests/unit/helpers/StringHelperTest.php
+++ b/tests/unit/helpers/StringHelperTest.php
@@ -1354,10 +1354,11 @@ class StringHelperTest extends TestCase
      * @dataProvider toLowerCaseDataProvider
      * @param string $expected
      * @param string $string
+     * @param string|null $language
      */
-    public function testToLowerCase(string $expected, string $string): void
+    public function testToLowerCase(string $expected, string $string, ?string $language = null): void
     {
-        $actual = StringHelper::toLowerCase($string);
+        $actual = StringHelper::toLowerCase($string, $language);
         self::assertSame($expected, $actual);
     }
 
@@ -1423,10 +1424,11 @@ class StringHelperTest extends TestCase
      * @dataProvider toTitleCaseDataProvider
      * @param string $expected
      * @param string $string
+     * @param string|null $language
      */
-    public function testToTitleCase(string $expected, string $string): void
+    public function testToTitleCase(string $expected, string $string, ?string $language = null): void
     {
-        $actual = StringHelper::toTitleCase($string);
+        $actual = StringHelper::toTitleCase($string, $language);
         self::assertSame($expected, $actual);
     }
 
@@ -1445,10 +1447,11 @@ class StringHelperTest extends TestCase
      * @dataProvider toUppercaseDataProvider
      * @param string $expected
      * @param string $string
+     * @param string|null $language
      */
-    public function testToUppercase(string $expected, string $string): void
+    public function testToUppercase(string $expected, string $string, ?string $language = null): void
     {
-        $actual = StringHelper::toUpperCase($string);
+        $actual = StringHelper::toUpperCase($string, $language);
         self::assertSame($expected, $actual);
     }
 
@@ -1657,6 +1660,10 @@ class StringHelperTest extends TestCase
             ['😘', '😘'],
             ['22 Alphan Numeric', '22 AlphaN Numeric'],
             ['!@#$%  ^&*()', '!@#$%  ^&*()'],
+            // Dutch "ij" is treated as a single letter, so title-casing it capitalizes both characters
+            // (https://github.com/craftcms/cms/discussions/19555)
+            ['IJsselmeer', 'ijsselmeer', 'nl'],
+            ['Ijsselmeer', 'ijsselmeer'],
         ];
     }
 
@@ -1676,6 +1683,10 @@ class StringHelperTest extends TestCase
             ['😘', '😘'],
             ['22 alphan numeric', '22 AlphaN Numeric'],
             ['!@#$%  ^&*()', '!@#$%  ^&*()'],
+            // Turkish lowercases a dotless "I" to a dotless "ı", not "i"
+            // (https://github.com/craftcms/cms/discussions/19555)
+            ['ıstanbul', 'Istanbul', 'tr'],
+            ['istanbul', 'Istanbul'],
         ];
     }
 
@@ -2249,6 +2260,14 @@ class StringHelperTest extends TestCase
             ['😘', '😘'],
             ['22 ALPHAN NUMERIC', '22 AlphaN Numeric'],
             ['!@#$%  ^&*()', '!@#$%  ^&*()'],
+            // Turkish uppercases a dotted "i" to a dotted "İ", not "I"
+            // (https://github.com/craftcms/cms/discussions/19555)
+            ['İSTANBUL', 'istanbul', 'tr'],
+            ['ISTANBUL', 'istanbul'],
+            // Greek strips accents when uppercasing
+            // (https://github.com/craftcms/cms/discussions/19555)
+            ['ΑΝΘΡΩΠΟΣ', 'άνθρωπος', 'el'],
+            ['ΆΝΘΡΩΠΟΣ', 'άνθρωπος'],
         ];
     }
 

--- a/tests/unit/i18n/LocaleTest.php
+++ b/tests/unit/i18n/LocaleTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace crafttests\unit\i18n;
+
+use craft\i18n\Locale;
+use craft\test\TestCase;
+
+/**
+ * Unit tests for the Locale class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.12.0
+ */
+class LocaleTest extends TestCase
+{
+    /**
+     * @param string $expected
+     * @param string $locale
+     * @dataProvider languageIdDataProvider
+     */
+    public function testLanguageId(string $expected, string $locale): void
+    {
+        self::assertSame($expected, Locale::languageId($locale));
+    }
+
+    /**
+     * @return array[]
+     */
+    public static function languageIdDataProvider(): array
+    {
+        return [
+            ['en', 'en'],
+            ['en', 'EN'],
+            ['en', 'en-US'],
+            ['en', 'EN-US'],
+            ['zh', 'zh-Hans-CN'],
+            ['de', 'de-DE'],
+            ['', ''],
+            ['pt', 'pt-BR'],
+        ];
+    }
+}

--- a/tests/unit/web/twig/ExtensionTest.php
+++ b/tests/unit/web/twig/ExtensionTest.php
@@ -373,6 +373,75 @@ class ExtensionTest extends TestCase
     }
 
     /**
+     * `title`, `capitalize`, `upper`, and `lower` all accept an optional `language` argument
+     * that should be respected for language-specific casing rules
+     * (https://github.com/craftcms/cms/discussions/19555).
+     */
+    public function testTitleFilter(): void
+    {
+        $this->testRenderResult(
+            'Ijsselmeer',
+            '{{ "ijsselmeer"|title }}'
+        );
+
+        // Dutch title-cases the "ij" digraph as a single letter, capitalizing both characters
+        $this->testRenderResult(
+            'IJsselmeer',
+            '{{ "ijsselmeer"|title("nl") }}'
+        );
+    }
+
+    /**
+     * @see testTitleFilter()
+     */
+    public function testCapitalizeFilter(): void
+    {
+        $this->testRenderResult(
+            'Istanbul',
+            '{{ "istanbul"|capitalize }}'
+        );
+
+        // Turkish uppercases a dotted "i" to a dotted "İ", not "I"
+        $this->testRenderResult(
+            'İstanbul',
+            '{{ "istanbul"|capitalize("tr") }}'
+        );
+    }
+
+    /**
+     * @see testTitleFilter()
+     */
+    public function testUpperFilter(): void
+    {
+        $this->testRenderResult(
+            'ISTANBUL',
+            '{{ "istanbul"|upper }}'
+        );
+
+        $this->testRenderResult(
+            'İSTANBUL',
+            '{{ "istanbul"|upper("tr") }}'
+        );
+    }
+
+    /**
+     * @see testTitleFilter()
+     */
+    public function testLowerFilter(): void
+    {
+        $this->testRenderResult(
+            'istanbul',
+            '{{ "Istanbul"|lower }}'
+        );
+
+        // Turkish lowercases a dotless "I" to a dotless "ı", not "i"
+        $this->testRenderResult(
+            'ıstanbul',
+            '{{ "Istanbul"|lower("tr") }}'
+        );
+    }
+
+    /**
      *
      */
     public function testKebabFilter(): void


### PR DESCRIPTION
### Description

Makes the `upper`, `lower`, `title`, and `capitalize` Twig filters language-aware, with a new `language` argument (defaults to the current app language).

Also applies to `StringHelper::toUpperCase()`, `::toLowerCase()`, `::toTitleCase()`, and `ElementHelper::normalizeSlug()`.

### Related issues

- #19555