### PR TITLE
modifyQuery() can return void

### DIFF
--- a/src/Field/Addresses.php
+++ b/src/Field/Addresses.php
@@ -114,7 +114,7 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
     }
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         /** @var self $field */
         $field = reset($instances);
@@ -133,7 +133,9 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
         }
 
         if ($value === ':empty:') {
-            return $query->whereNotExists($exists);
+            $query->whereNotExists($exists);
+
+            return;
         }
 
         if ($value !== ':notempty:') {
@@ -147,7 +149,7 @@ class Addresses extends Field implements EagerLoadingFieldInterface, ElementCont
             $exists->whereIn("addresses_$ns.id", $ids);
         }
 
-        return $query->whereExists($exists);
+        $query->whereExists($exists);
     }
 
     /**

--- a/src/Field/BaseOptionsField.php
+++ b/src/Field/BaseOptionsField.php
@@ -91,16 +91,18 @@ abstract class BaseOptionsField extends Field implements CrossSiteCopyableFieldI
     }
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         if (! static::$multi) {
-            return parent::modifyQuery($query, $instances, $value);
+            parent::modifyQuery($query, $instances, $value);
+
+            return;
         }
 
         $param = QueryParam::parse($value);
 
         if (empty($param->values)) {
-            return $query;
+            return;
         }
 
         if ($param->operator === QueryParam::NOT) {
@@ -113,7 +115,7 @@ abstract class BaseOptionsField extends Field implements CrossSiteCopyableFieldI
         $valueSql = self::valueColumn($instances);
 
         if ($valueSql === null) {
-            return $query;
+            return;
         }
 
         $isEmptyValueParam = fn (mixed $value): bool => is_string($value) &&
@@ -134,13 +136,15 @@ abstract class BaseOptionsField extends Field implements CrossSiteCopyableFieldI
         };
 
         if ($negate && Collection::make($param->values)->doesntContain($isEmptyValueParam)) {
-            return $query->where(function (Builder $query) use ($valueSql, $applyConditions) {
+            $query->where(function (Builder $query) use ($valueSql, $applyConditions) {
                 $query->whereNull($valueSql)
                     ->orWhereNot($applyConditions);
             });
+
+            return;
         }
 
-        return $query->where($applyConditions, boolean: $negate ? 'and not' : 'and');
+        $query->where($applyConditions, boolean: $negate ? 'and not' : 'and');
     }
 
     /** @param list<static> $instances */

--- a/src/Field/BaseRelationField.php
+++ b/src/Field/BaseRelationField.php
@@ -65,6 +65,7 @@ use CraftCms\Cms\View\LegacyAssets\CpAsset;
 use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\Type;
+use Illuminate\Contracts\Database\Query\Builder as BuilderInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
@@ -146,7 +147,7 @@ abstract class BaseRelationField extends Field implements CrossSiteCopyableField
     }
 
     #[Override]
-    public static function modifyQuery(\Illuminate\Contracts\Database\Query\Builder $query, array $instances, mixed $value): \Illuminate\Contracts\Database\Query\Builder
+    public static function modifyQuery(BuilderInterface $query, array $instances, mixed $value): void
     {
         /** @var self $field */
         $field = reset($instances);
@@ -204,19 +205,17 @@ abstract class BaseRelationField extends Field implements CrossSiteCopyableField
             if ($query instanceof ElementQuery) {
                 $filter->apply($query->getQuery(), $relationCriteria, $siteId !== '*' ? $siteId : null);
 
-                return $query;
+                return;
             }
 
             if ($query instanceof Builder) {
                 $filter->apply($query, $relationCriteria);
 
-                return $query;
+                return;
             }
 
             $query->where(fn (Builder $query) => $filter->apply($query, $relationCriteria));
         }
-
-        return $query;
     }
 
     /**

--- a/src/Field/Contracts/FieldInterface.php
+++ b/src/Field/Contracts/FieldInterface.php
@@ -168,17 +168,11 @@ interface FieldInterface extends Chippable, ConfigurableComponentInterface, CpEd
     /**
      * Applies a condition to the query builder for the given field instances, for a user-provided param value.
      *
-     * If `false` is returned, an always-false condition will be used.
-     *
      * @param  Builder  $query  The query instance to modify
      * @param  static[]  $instances  The field instances to search
      * @param  mixed  $value  The user-supplied param value
      */
-    public static function modifyQuery(
-        Builder $query,
-        array $instances,
-        mixed $value,
-    ): Builder;
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void;
 
     /**
      * Returns the orientation the field should use (`ltr` or `rtl`).

--- a/src/Field/Date.php
+++ b/src/Field/Date.php
@@ -72,11 +72,11 @@ class Date extends Field implements CrossSiteCopyableFieldInterface, InlineEdita
     }
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         $valueSql = self::valueSql($instances);
 
-        return $query->whereDateParam($valueSql, $value);
+        $query->whereDateParam($valueSql, $value);
     }
 
     /**

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -352,12 +352,12 @@ abstract class Field extends Component implements Actionable, FieldInterface, Ic
         return Query::TYPE_TEXT;
     }
 
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         $valueSql = static::valueSql($instances);
 
         if ($valueSql === null) {
-            return $query;
+            return;
         }
 
         $caseInsensitive = false;
@@ -367,7 +367,7 @@ abstract class Field extends Component implements Actionable, FieldInterface, Ic
             $value = $value['value'];
         }
 
-        return $query->whereParam(
+        $query->whereParam(
             column: $valueSql,
             param: $value,
             caseInsensitive: $caseInsensitive,

--- a/src/Field/Lightswitch.php
+++ b/src/Field/Lightswitch.php
@@ -66,7 +66,7 @@ class Lightswitch extends Field implements CrossSiteCopyableFieldInterface, Defa
     }
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         $valueSql = self::valueSql($instances);
         $strict = false;
@@ -78,7 +78,7 @@ class Lightswitch extends Field implements CrossSiteCopyableFieldInterface, Defa
 
         $defaultValue = $strict ? null : $instances[0]->default;
 
-        return $query->whereBooleanParam($valueSql, $value, $defaultValue, Query::TYPE_JSON);
+        $query->whereBooleanParam($valueSql, $value, $defaultValue, Query::TYPE_JSON);
     }
 
     /**

--- a/src/Field/Matrix.php
+++ b/src/Field/Matrix.php
@@ -143,7 +143,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, ElementContain
     }
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         /** @var self $field */
         $field = reset($instances);
@@ -162,7 +162,9 @@ class Matrix extends Field implements EagerLoadingFieldInterface, ElementContain
         }
 
         if ($value === ':empty:') {
-            return $query->whereNotExists($exists);
+            $query->whereNotExists($exists);
+
+            return;
         }
 
         if ($value !== ':notempty:') {
@@ -176,7 +178,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, ElementContain
             $exists->whereIn("entries_$ns.id", $ids);
         }
 
-        return $query->whereExists($exists);
+        $query->whereExists($exists);
     }
 
     /**

--- a/src/Field/Money.php
+++ b/src/Field/Money.php
@@ -197,11 +197,11 @@ class Money extends Field implements CrossSiteCopyableFieldInterface, Defaultabl
     }
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         $valueSql = self::valueSql($instances);
 
-        return $query->whereMoneyParam($valueSql, $instances[0]->currency, $value);
+        $query->whereMoneyParam($valueSql, $instances[0]->currency, $value);
     }
 
     public function getDefaultValue(): float|int|null

--- a/src/Field/Number.php
+++ b/src/Field/Number.php
@@ -80,11 +80,11 @@ class Number extends Field implements CrossSiteCopyableFieldInterface, Defaultab
     }
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         $valueSql = self::valueSql($instances);
 
-        return $query->whereNumericParam($valueSql, $value, columnType: self::dbType());
+        $query->whereNumericParam($valueSql, $value, columnType: self::dbType());
     }
 
     #[Override]

--- a/src/Field/Range.php
+++ b/src/Field/Range.php
@@ -82,11 +82,11 @@ class Range extends Field implements DefaultableFieldInterface, InlineEditableFi
     }
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         $valueSql = self::valueSql($instances);
 
-        return $query->whereNumericParam($valueSql, $value, columnType: self::dbType());
+        $query->whereNumericParam($valueSql, $value, columnType: self::dbType());
     }
 
     /**

--- a/tests/Feature/Element/Queries/Concerns/QueriesCustomFieldsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/QueriesCustomFieldsTest.php
@@ -21,7 +21,7 @@ class TestActiveQueryField extends PlainText
     public static bool $throw = false;
 
     #[Override]
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         self::$activeQueryDuringModify = ElementQuery::$activeQuery;
 
@@ -29,7 +29,7 @@ class TestActiveQueryField extends PlainText
             throw new RuntimeException('Active query failure.');
         }
 
-        return parent::modifyQuery($query, $instances, $value);
+        parent::modifyQuery($query, $instances, $value);
     }
 
     public static function reset(): void

--- a/yii2-adapter/constants/Field/Concerns/LegacyFieldConstants.php
+++ b/yii2-adapter/constants/Field/Concerns/LegacyFieldConstants.php
@@ -47,7 +47,7 @@ use CraftCms\Cms\Field\Events\FieldMergeIntoCompleted;
 use CraftCms\Cms\Field\Events\InputOptionsResolving;
 use CraftCms\Cms\Field\LinkTypes;
 use CraftCms\Cms\Field\LinkTypes\Url;
-use Illuminate\Database\Query\Builder;
+use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Facades\Event;
 use yii\base\InvalidConfigException;
 use yii\validators\Validator;
@@ -441,10 +441,10 @@ trait LegacyFieldConstants
 
     // Other compatibility methods
 
-    public static function modifyQuery(Builder $query, array $instances, mixed $value): Builder
+    public static function modifyQuery(Builder $query, array $instances, mixed $value): void
     {
         if (!method_exists(static::class, 'queryCondition')) {
-            return $query;
+            return;
         }
 
         $params = [];
@@ -452,7 +452,7 @@ trait LegacyFieldConstants
         $condition = static::queryCondition($instances, $value, $params);
 
         if ($condition === null || $condition === false) {
-            return $query;
+            return;
         }
 
         $db = Craft::$app->getDb();
@@ -461,7 +461,7 @@ trait LegacyFieldConstants
         // Yii uses named parameters, Laravel uses positional
         $sql = preg_replace('/:qp\d+/', '?', $sql);
 
-        return $query->whereRaw($sql, array_values($params));
+        $query->whereRaw($sql, array_values($params));
     }
 
     public function getElementValidationRules(): array


### PR DESCRIPTION
### Description

The result from `FieldInterface::modifyQuery()` is never used, so this replaces its return type with `void`.
