### PR TITLE
[6.x] Fix error ownership for nested form controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug where save errors using shortened field paths could fail to appear on Controls within nested Forms.
+- Fixed a bug where save errors using shortened field paths could fail to appear on Controls within nested Forms. ([#19565](https://github.com/craftcms/cms/pull/19565))
 - Added support for refreshable standard plugin settings forms and conditional configuration of core form nodes. ([#19545](https://github.com/craftcms/cms/pull/19545))
 - Added support for sending queued Laravel notifications to `CraftCms\Cms\User\Elements\User` elements. ([#19541](https://github.com/craftcms/cms/pull/19541))
 - Improved the accessibility of element indexes. ([#19520](https://github.com/craftcms/cms/pull/19520))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where save errors using shortened field paths could fail to appear on Controls within nested Forms.
 - Added support for refreshable standard plugin settings forms and conditional configuration of core form nodes. ([#19545](https://github.com/craftcms/cms/pull/19545))
 - Added support for sending queued Laravel notifications to `CraftCms\Cms\User\Elements\User` elements. ([#19541](https://github.com/craftcms/cms/pull/19541))
 - Improved the accessibility of element indexes. ([#19520](https://github.com/craftcms/cms/pull/19520))

--- a/resources/js/modules/forms/FormRenderer.vue
+++ b/resources/js/modules/forms/FormRenderer.vue
@@ -25,6 +25,7 @@
     setValue as setPathValue,
     unsetValue,
     valueAt,
+    visitControls,
   } from './runtime';
   import type {
     FormChange,
@@ -361,22 +362,6 @@
   }
 
   defineExpose({advanceBaseline, currentValues, resetValues, setValue});
-
-  function visitControls(
-    nodes: FormNodePayload[],
-    visit: (control: FormControlPayload) => void
-  ): void {
-    for (const node of nodes) {
-      if (node.control) {
-        visit(node.control);
-        node.control.forms?.forEach((form) => visitControls(form.nodes, visit));
-      }
-
-      if (node.children) {
-        visitControls(node.children, visit);
-      }
-    }
-  }
 
   function rememberControlPaths(nodes: FormNodePayload[]): void {
     visitControls(nodes, (control) =>

--- a/resources/js/modules/forms/runtime.ts
+++ b/resources/js/modules/forms/runtime.ts
@@ -3,6 +3,8 @@ import type {InjectionKey, Ref, Slots} from 'vue';
 import type {
   CanonicalFormValue,
   FormChange,
+  FormControlPayload,
+  FormNodePayload,
   FormValue,
   FormValues,
 } from './types';
@@ -131,6 +133,22 @@ export function unsetValue(source: FormValue, path: string[]): void {
 
   if (isRecord(parent)) {
     delete parent[path.at(-1)!];
+  }
+}
+
+export function visitControls(
+  nodes: FormNodePayload[],
+  visit: (control: FormControlPayload) => void
+): void {
+  for (const node of nodes) {
+    if (node.control) {
+      visit(node.control);
+      node.control.forms?.forEach((form) => visitControls(form.nodes, visit));
+    }
+
+    if (node.children) {
+      visitControls(node.children, visit);
+    }
   }
 }
 

--- a/resources/js/modules/forms/useInertiaFormRenderer.test.ts
+++ b/resources/js/modules/forms/useInertiaFormRenderer.test.ts
@@ -204,6 +204,45 @@ describe('useInertiaFormRenderer', () => {
     ]);
   });
 
+  it('resolves an error key through structural children and Control-owned Forms', async () => {
+    const ownerPath = ['settings', 'matrix', 'entries', 'block-a', 'heading'];
+    const nestedPayload: FormPayload = {
+      ...payload,
+      nodes: [
+        {
+          children: [
+            {
+              control: {
+                path: ['settings', 'matrix'],
+                forms: [
+                  {
+                    nodes: [{children: [{control: {path: ownerPath}}]}],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ] as unknown as FormPayload['nodes'],
+    };
+    let form!: InertiaForm<{settings: TestSettings}>;
+    let integration!: TestIntegration;
+
+    mount(() => {
+      form = useForm({settings: {}});
+      integration = useInertiaFormRenderer(form, nestedPayload, {
+        mutationKey: 'settings',
+      });
+    });
+
+    form.setError({heading: 'A heading is required.'} as never);
+    await nextTick();
+
+    expect(integration.errors.value).toEqual([
+      {path: ownerPath, messages: ['A heading is required.']},
+    ]);
+  });
+
   it('leaves an unowned error key alone, so it stays global', async () => {
     const layoutPayload: FormPayload = {
       ...rootPayload,

--- a/resources/js/modules/forms/useInertiaFormRenderer.ts
+++ b/resources/js/modules/forms/useInertiaFormRenderer.ts
@@ -7,13 +7,8 @@ import {
   watch,
   type MaybeRefOrGetter,
 } from 'vue';
-import type {
-  FormChangeKind,
-  FormNodePayload,
-  FormPayload,
-  FormValue,
-} from './types';
-import {pathsMatch} from './runtime';
+import type {FormChangeKind, FormPayload, FormValue} from './types';
+import {pathsMatch, visitControls} from './runtime';
 
 interface FormRendererInstance {
   advanceBaseline(): void;
@@ -150,7 +145,8 @@ function defaultErrorPath(
   const withinScope = scope.every(
     (segment, index) => segments[index] === segment
   );
-  const paths = controlPaths(payload?.nodes);
+  const paths: string[][] = [];
+  visitControls(payload?.nodes ?? [], (control) => paths.push(control.path));
 
   if (
     withinScope &&
@@ -178,14 +174,6 @@ function defaultErrorPath(
   // Unowned keys stay as they are, so they surface as global errors rather
   // than being dropped.
   return withinScope ? segments : null;
-}
-
-/** Every control path in a payload, nested ones included. */
-function controlPaths(nodes: FormNodePayload[] | undefined): string[][] {
-  return (nodes ?? []).flatMap((node) => [
-    ...(node.control ? [node.control.path] : []),
-    ...controlPaths(node.children),
-  ]);
 }
 
 function clone<T>(value: T): T {


### PR DESCRIPTION
### Description

Save errors using shortened field paths could miss controls inside nested Forms because the Inertia form bridge only traversed structural children. Share the renderer's existing Control traversal with error lookup so both follow structural children and Control-owned Forms.

Adds regression coverage for a nested heading error that was previously dropped.
