### PR TITLE
[6.x] Restore plugin lifecycle cleanup and share settings forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug where failed plugin installation or uninstallation could leave project config writable.
+- Fixed a bug where failed plugin installation or uninstallation could leave project config writable. ([#19566](https://github.com/craftcms/cms/pull/19566))
 - Added support for refreshable standard plugin settings forms and conditional configuration of core form nodes. ([#19545](https://github.com/craftcms/cms/pull/19545))
 - Added support for sending queued Laravel notifications to `CraftCms\Cms\User\Elements\User` elements. ([#19541](https://github.com/craftcms/cms/pull/19541))
 - Improved the accessibility of element indexes. ([#19520](https://github.com/craftcms/cms/pull/19520))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where failed plugin installation or uninstallation could leave project config writable.
 - Added support for refreshable standard plugin settings forms and conditional configuration of core form nodes. ([#19545](https://github.com/craftcms/cms/pull/19545))
 - Added support for sending queued Laravel notifications to `CraftCms\Cms\User\Elements\User` elements. ([#19541](https://github.com/craftcms/cms/pull/19541))
 - Improved the accessibility of element indexes. ([#19520](https://github.com/craftcms/cms/pull/19520))

--- a/src/Http/Controllers/PluginsController.php
+++ b/src/Http/Controllers/PluginsController.php
@@ -5,19 +5,17 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Http\Controllers;
 
 use CraftCms\Cms\Config\GeneralConfig;
-use CraftCms\Cms\Form\FormContext;
-use CraftCms\Cms\Form\FormResolver;
 use CraftCms\Cms\Http\RespondsWithFlash;
 use CraftCms\Cms\Http\Responses\CpScreenResponse;
 use CraftCms\Cms\Plugin\Contracts\PluginInterface;
 use CraftCms\Cms\Plugin\Plugins;
+use CraftCms\Cms\Plugin\PluginSettingsForm;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use CraftCms\Cms\View\LegacyAssets\PluginsAsset;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use LogicException;
 use Symfony\Component\HttpFoundation\Response;
 
 use function CraftCms\Cms\t;
@@ -29,7 +27,7 @@ readonly class PluginsController
     public function __construct(
         private Plugins $plugins,
         private GeneralConfig $generalConfig,
-        private FormResolver $formResolver,
+        private PluginSettingsForm $settingsForm,
     ) {}
 
     public function index(): CpScreenResponse
@@ -163,25 +161,8 @@ readonly class PluginsController
 
         abort_if(is_null($plugin), 404, 'Plugin not found.');
 
-        $scope = $data['scope'];
-        $settings = $plugin->getSettings()?->validationData() ?? [];
-        $settings = $scope === ['settings']
-            ? $data['values']
-            : data_set($settings, array_slice($scope, 1), $data['values']);
-        $plugin->setSettings($settings);
-        $context = new FormContext(
-            namespace: 'settings',
-            values: ['settings' => $settings],
-            refreshable: true,
-        );
-        $form = $plugin->settingsForm($context);
-
-        if ($form === null) {
-            throw new LogicException("Plugin [{$plugin->handle}] must return a Form from settingsForm().");
-        }
-
         return new JsonResponse([
-            'form' => $this->formResolver->resolve($form, $context)->forScope($scope),
+            'form' => $this->settingsForm->refresh($plugin, $data['values'], $data['scope']),
         ]);
     }
 }

--- a/src/Plugin/Concerns/HasSettings.php
+++ b/src/Plugin/Concerns/HasSettings.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Plugin\Concerns;
 
-use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\Form;
 use CraftCms\Cms\Form\FormContext;
-use CraftCms\Cms\Form\FormResolver;
 use CraftCms\Cms\Http\Controllers\PluginsController;
 use CraftCms\Cms\Http\Responses\CpScreenResponse;
 use CraftCms\Cms\Plugin\Contracts\PluginInterface;
+use CraftCms\Cms\Plugin\PluginSettingsForm;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\Validation\Contracts\Validatable;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Log;
-use LogicException;
 
 use function CraftCms\Cms\t;
 
@@ -86,24 +84,7 @@ trait HasSettings
 
     private function settingsResponse(bool $readOnly): mixed
     {
-        $settings = $this->getSettings();
-
-        if (! $readOnly && $settings === null) {
-            throw new LogicException("Plugin [{$this->handle}] must provide a settings model when using the standard editable settings response.");
-        }
-
-        $context = new FormContext(
-            namespace: 'settings',
-            values: ['settings' => $settings?->validationData() ?? []],
-            errors: $settings?->errors()->getMessages() ?? [],
-            mode: $readOnly ? ControlMode::ReadOnly : ControlMode::Editable,
-            refreshable: ! $readOnly,
-        );
-        $form = $this->settingsForm($context);
-
-        if ($form === null) {
-            throw new LogicException("Plugin [{$this->handle}] must return a Form from settingsForm() when using the standard settings response.");
-        }
+        $form = app(PluginSettingsForm::class)->render($this, $readOnly);
 
         return new CpScreenResponse()
             ->title($this->name)
@@ -111,7 +92,7 @@ trait HasSettings
             ->addCrumb(t('Plugins'), 'settings/plugins')
             ->redirectUrl('settings')
             ->inertiaPage('Form', [
-                'form' => app(FormResolver::class)->resolve($form, $context),
+                'form' => $form,
                 'submit' => [
                     'method' => 'post',
                     'url' => Url::cpUrl("settings/plugins/{$this->handle}"),

--- a/src/Plugin/PluginSettingsForm.php
+++ b/src/Plugin/PluginSettingsForm.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Plugin;
+
+use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\FormPayload;
+use CraftCms\Cms\Form\FormResolver;
+use CraftCms\Cms\Plugin\Contracts\PluginInterface;
+use LogicException;
+
+/** @internal */
+readonly class PluginSettingsForm
+{
+    public function __construct(private FormResolver $formResolver) {}
+
+    public function render(PluginInterface $plugin, bool $readOnly = false): FormPayload
+    {
+        $settings = $plugin->getSettings();
+
+        if (! $readOnly && $settings === null) {
+            throw new LogicException("Plugin [{$plugin->handle}] must provide a settings model when using the standard editable settings response.");
+        }
+
+        return $this->resolve(
+            $plugin,
+            $settings?->validationData() ?? [],
+            $settings?->errors()->getMessages() ?? [],
+            $readOnly,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     * @param  list<string>  $scope
+     */
+    public function refresh(PluginInterface $plugin, array $values, array $scope): FormPayload
+    {
+        $settings = $plugin->getSettings()?->validationData() ?? [];
+        $settings = $scope === ['settings']
+            ? $values
+            : data_set($settings, array_slice($scope, 1), $values);
+        $plugin->setSettings($settings);
+
+        return $this->resolve($plugin, $settings)->forScope($scope);
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     * @param  array<string, string|list<string>>  $errors
+     */
+    private function resolve(PluginInterface $plugin, array $values, array $errors = [], bool $readOnly = false): FormPayload
+    {
+        $context = new FormContext(
+            namespace: 'settings',
+            values: ['settings' => $values],
+            errors: $errors,
+            mode: $readOnly ? ControlMode::ReadOnly : ControlMode::Editable,
+            refreshable: ! $readOnly,
+        );
+        $form = $plugin->settingsForm($context);
+
+        if ($form === null) {
+            throw new LogicException("Plugin [{$plugin->handle}] must return a Form from settingsForm().");
+        }
+
+        return $this->formResolver->resolve($form, $context);
+    }
+}

--- a/src/Plugin/Plugins.php
+++ b/src/Plugin/Plugins.php
@@ -475,93 +475,95 @@ class Plugins
         $readOnly = $projectConfig->readOnly;
         $projectConfig->readOnly = false;
 
-        $configKey = ProjectConfig::PATH_PLUGINS.'.'.$handle;
-
-        $plugin = $this->createPlugin($handle);
-
-        if ($plugin === null) {
-            throw new InvalidPluginException($handle);
-        }
-
-        // Set the edition
-        $edition ??= $projectConfig->get($configKey.'.edition');
-
-        $editions = $plugin::editions();
-
-        if ($edition === null || ! in_array($edition, $editions, true)) {
-            $edition = reset($editions);
-        }
-
-        $plugin->edition = $edition;
-
-        event(new PluginInstalling($plugin));
-
-        DB::beginTransaction();
-
         try {
-            // Make sure the plugin doesn't have a row in the `plugins` or `migrations` tables first, just in case
-            DB::table(Table::PLUGINS)->where('handle', $handle)->delete();
+            $configKey = ProjectConfig::PATH_PLUGINS.'.'.$handle;
 
-            DB::table(Table::MIGRATIONS)
-                ->where('track', "plugin:$handle")
-                ->delete();
+            $plugin = $this->createPlugin($handle);
 
-            $info['id'] = DB::table(Table::PLUGINS)->insertGetId([
-                'handle' => $handle,
-                'version' => $plugin->version,
-                'schemaVersion' => $plugin->schemaVersion,
-                'installDate' => $now = now(),
-                'dateCreated' => $now,
-                'dateUpdated' => $now,
-                'uid' => Str::uuid(),
-            ]);
-
-            $info['enabled'] = $projectConfig->get($configKey.'.enabled') ?? true;
-
-            $plugin->install();
-
-            try {
-                DB::commit();
-            } catch (PDOException $e) {
-                // The transaction could be implicitly committed by Mysql
-                if ($e->getMessage() !== 'There is no active transaction') {
-                    throw $e;
-                }
-            }
-        } catch (Throwable $e) {
-            try {
-                DB::rollBack();
-            } catch (PDOException $e) {
-                // Implicitly committed.
+            if ($plugin === null) {
+                throw new InvalidPluginException($handle);
             }
 
-            if (DB::isMysql()) {
-                // Explicitly remove the plugins row just in case the transaction was implicitly committed
+            // Set the edition
+            $edition ??= $projectConfig->get($configKey.'.edition');
+
+            $editions = $plugin::editions();
+
+            if ($edition === null || ! in_array($edition, $editions, true)) {
+                $edition = reset($editions);
+            }
+
+            $plugin->edition = $edition;
+
+            event(new PluginInstalling($plugin));
+
+            DB::beginTransaction();
+
+            try {
+                // Make sure the plugin doesn't have a row in the `plugins` or `migrations` tables first, just in case
                 DB::table(Table::PLUGINS)->where('handle', $handle)->delete();
+
+                DB::table(Table::MIGRATIONS)
+                    ->where('track', "plugin:$handle")
+                    ->delete();
+
+                $info['id'] = DB::table(Table::PLUGINS)->insertGetId([
+                    'handle' => $handle,
+                    'version' => $plugin->version,
+                    'schemaVersion' => $plugin->schemaVersion,
+                    'installDate' => $now = now(),
+                    'dateCreated' => $now,
+                    'dateUpdated' => $now,
+                    'uid' => Str::uuid(),
+                ]);
+
+                $info['enabled'] = $projectConfig->get($configKey.'.enabled') ?? true;
+
+                $plugin->install();
+
+                try {
+                    DB::commit();
+                } catch (PDOException $e) {
+                    // The transaction could be implicitly committed by Mysql
+                    if ($e->getMessage() !== 'There is no active transaction') {
+                        throw $e;
+                    }
+                }
+            } catch (Throwable $e) {
+                try {
+                    DB::rollBack();
+                } catch (PDOException $e) {
+                    // Implicitly committed.
+                }
+
+                if (DB::isMysql()) {
+                    // Explicitly remove the plugins row just in case the transaction was implicitly committed
+                    DB::table(Table::PLUGINS)->where('handle', $handle)->delete();
+                }
+
+                throw $e;
             }
 
-            throw $e;
+            // Add the plugin to the project config
+            $projectConfig->set(
+                path: $configKey,
+                value: [
+                    'edition' => $edition,
+                    'enabled' => true,
+                    'schemaVersion' => $plugin->schemaVersion,
+                ],
+                message: "Install plugin “{$handle}”",
+            );
+
+            $this->storedPluginInfo[$handle] = $info;
+            $plugin->publishAssets();
+
+            event(new PluginInstalled($plugin));
+
+            return true;
+        } finally {
+            $projectConfig->readOnly = $readOnly;
         }
-
-        // Add the plugin to the project config
-        $projectConfig->set(
-            path: $configKey,
-            value: [
-                'edition' => $edition,
-                'enabled' => true,
-                'schemaVersion' => $plugin->schemaVersion,
-            ],
-            message: "Install plugin “{$handle}”",
-        );
-
-        $this->storedPluginInfo[$handle] = $info;
-        $plugin->publishAssets();
-
-        event(new PluginInstalled($plugin));
-
-        $projectConfig->readOnly = $readOnly;
-
-        return true;
     }
 
     /**
@@ -597,64 +599,66 @@ class Plugins
         $readOnly = $projectConfig->readOnly;
         $projectConfig->readOnly = false;
 
-        if (($plugin = $this->getPlugin($handle)) === null && ! $force) {
-            throw new InvalidPluginException($handle);
-        }
-
-        event(new PluginUninstalling($plugin));
-
-        DB::beginTransaction();
         try {
-            // Let the plugin uninstall itself first
-            if ($plugin && $enabled) {
+            if (($plugin = $this->getPlugin($handle)) === null && ! $force) {
+                throw new InvalidPluginException($handle);
+            }
+
+            event(new PluginUninstalling($plugin));
+
+            DB::beginTransaction();
+            try {
+                // Let the plugin uninstall itself first
+                if ($plugin && $enabled) {
+                    try {
+                        $plugin->uninstall();
+                    } catch (Throwable $e) {
+                        if (! $force) {
+                            throw $e;
+                        }
+                    }
+                }
+
+                // Clean up the plugins and migrations tables
+                $info = $this->getStoredPluginInfo($handle);
+                if ($info !== null) {
+                    DB::table(Table::PLUGINS)->delete($info['id']);
+                }
+
+                DB::table(Table::MIGRATIONS)
+                    ->where('track', "plugin:$handle")
+                    ->delete();
+
                 try {
-                    $plugin->uninstall();
-                } catch (Throwable $e) {
-                    if (! $force) {
+                    DB::commit();
+                } catch (PDOException $e) {
+                    // The transaction could be implicitly committed by Mysql
+                    if ($e->getMessage() !== 'There is no active transaction') {
                         throw $e;
                     }
                 }
+            } catch (Throwable $e) {
+                DB::rollBack();
+                throw $e;
             }
 
-            // Clean up the plugins and migrations tables
-            $info = $this->getStoredPluginInfo($handle);
-            if ($info !== null) {
-                DB::table(Table::PLUGINS)->delete($info['id']);
+            // Remove the plugin from the project config
+            if ($projectConfig->get(ProjectConfig::PATH_PLUGINS.'.'.$handle, true)) {
+                $projectConfig->remove(ProjectConfig::PATH_PLUGINS.'.'.$handle, "Uninstall the “{$handle}” plugin");
             }
 
-            DB::table(Table::MIGRATIONS)
-                ->where('track', "plugin:$handle")
-                ->delete();
+            unset($this->storedPluginInfo[$handle]);
 
-            try {
-                DB::commit();
-            } catch (PDOException $e) {
-                // The transaction could be implicitly committed by Mysql
-                if ($e->getMessage() !== 'There is no active transaction') {
-                    throw $e;
-                }
+            if ($plugin) {
+                $plugin->removeAssets();
             }
-        } catch (Throwable $e) {
-            DB::rollBack();
-            throw $e;
+
+            event(new PluginUninstalled($plugin));
+
+            return true;
+        } finally {
+            $projectConfig->readOnly = $readOnly;
         }
-
-        // Remove the plugin from the project config
-        if ($projectConfig->get(ProjectConfig::PATH_PLUGINS.'.'.$handle, true)) {
-            $projectConfig->remove(ProjectConfig::PATH_PLUGINS.'.'.$handle, "Uninstall the “{$handle}” plugin");
-        }
-
-        unset($this->storedPluginInfo[$handle]);
-
-        if ($plugin) {
-            $plugin->removeAssets();
-        }
-
-        event(new PluginUninstalled($plugin));
-
-        $projectConfig->readOnly = $readOnly;
-
-        return true;
     }
 
     /**

--- a/tests/Feature/Plugin/PluginsTest.php
+++ b/tests/Feature/Plugin/PluginsTest.php
@@ -3,12 +3,17 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Plugin\Events\PluginInstalled;
+use CraftCms\Cms\Plugin\Events\PluginInstalling;
 use CraftCms\Cms\Plugin\Events\PluginSettingsSaved;
 use CraftCms\Cms\Plugin\Events\PluginsLoading;
 use CraftCms\Cms\Plugin\Events\PluginsRegistered;
+use CraftCms\Cms\Plugin\Events\PluginUninstalled;
+use CraftCms\Cms\Plugin\Events\PluginUninstalling;
 use CraftCms\Cms\Plugin\Events\SavingPluginSettings;
 use CraftCms\Cms\Plugin\Exceptions\InvalidPluginException;
 use CraftCms\Cms\Plugin\Plugins;
+use CraftCms\Cms\ProjectConfig\ProjectConfig;
 use CraftCms\Cms\Shared\Enums\LicenseKeyStatus;
 use CraftCms\Cms\Support\File;
 use CraftCms\Cms\Support\Str;
@@ -184,6 +189,35 @@ it('can uninstall and install a plugin', function () {
     expect($this->plugins->isPluginInstalled('test-plugin'))->toBeTrue();
     expect($this->plugins->isPluginEnabled('test-plugin'))->toBeTrue();
 });
+
+it('restores project config permissions after plugin lifecycle failures', function (string $operation, string $event, bool $installed, bool $readOnly) {
+    $this->plugins->enablePlugin('test-plugin');
+
+    if ($operation === 'installPlugin') {
+        $this->plugins->uninstallPlugin('test-plugin');
+    }
+
+    $failure = new RuntimeException('Plugin lifecycle failed.');
+    Event::listen($event, fn () => throw $failure);
+
+    $projectConfig = app(ProjectConfig::class);
+    $originalReadOnly = $projectConfig->readOnly;
+    $projectConfig->readOnly = $readOnly;
+
+    try {
+        expect(fn () => $this->plugins->{$operation}('test-plugin'))->toThrow($failure);
+
+        expect($projectConfig->readOnly)->toBe($readOnly)
+            ->and($this->plugins->isPluginInstalled('test-plugin'))->toBe($installed);
+    } finally {
+        $projectConfig->readOnly = $originalReadOnly;
+    }
+})->with([
+    'before installation' => ['installPlugin', PluginInstalling::class, false],
+    'after installation' => ['installPlugin', PluginInstalled::class, true],
+    'before uninstallation' => ['uninstallPlugin', PluginUninstalling::class, true],
+    'after uninstallation' => ['uninstallPlugin', PluginUninstalled::class, false],
+])->with([true, false]);
 
 it('publishes configured files when enabling a plugin', function () {
     $paths = configureTestPluginAssets();

--- a/tests/Unit/Plugin/PluginSettingsFormTest.php
+++ b/tests/Unit/Plugin/PluginSettingsFormTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Form\Controls\ContentBlock;
+use CraftCms\Cms\Form\Controls\Text;
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\Nodes\Field;
+use CraftCms\Cms\Plugin\Plugin;
+use CraftCms\Cms\Plugin\PluginSettings;
+use CraftCms\Cms\Plugin\PluginSettingsForm;
+
+it('refreshes nested settings without losing other values or replaying validation errors', function () {
+    $plugin = new class(app()) extends Plugin
+    {
+        public string $handle = 'nested-settings';
+
+        protected function createSettingsModel(): PluginSettings
+        {
+            return new class extends PluginSettings
+            {
+                public string $title = 'Saved title';
+
+                public array $content = ['body' => 'Saved body'];
+            };
+        }
+
+        public function settingsForm(FormContext $context = new FormContext): Form
+        {
+            return Form::make([
+                Field::make('Title', Text::make('title')),
+                Field::make('Content', ContentBlock::make('content')->form(Form::make([
+                    Field::make('Body', Text::make('body')),
+                ]))),
+            ]);
+        }
+    };
+    $plugin->getSettings()->errors()->add('content.body', 'Body is invalid.');
+    $settingsForm = app(PluginSettingsForm::class);
+
+    $initial = $settingsForm->render($plugin);
+
+    expect($initial->values['settings'])->toBe([
+        'title' => 'Saved title',
+        'content' => ['body' => 'Saved body'],
+    ])->and($initial->errors)->toBe([
+        ['path' => ['settings', 'content', 'body'], 'messages' => ['Body is invalid.']],
+    ]);
+
+    $refreshed = $settingsForm->refresh($plugin, ['body' => 'Edited body'], ['settings', 'content']);
+
+    expect($refreshed->scope)->toBe(['settings', 'content'])
+        ->and($refreshed->nodes)->toHaveCount(1)
+        ->and($refreshed->nodes[0]->control->path)->toBe(['settings', 'content', 'body'])
+        ->and($refreshed->values['settings'])->toBe([
+            'title' => 'Saved title',
+            'content' => ['body' => 'Edited body'],
+        ])
+        ->and($refreshed->errors)->toBe([])
+        ->and($plugin->getSettings()->content)->toBe(['body' => 'Edited body']);
+});


### PR DESCRIPTION
### Description

Restore project-config write protection when plugin installation or uninstallation throws, including failures before migration work and after persistence.

Share settings-form assembly between initial rendering and refresh requests while preserving nested scopes, validation errors, read-only forms, and existing plugin hooks.
