### PR TITLE
[6.x] Fix relation field option serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed an error that could occur when creating relation fields. ([#19567](https://github.com/craftcms/cms/issues/19567))
+- Fixed an error that could occur when creating relation fields. ([#19571](https://github.com/craftcms/cms/pull/19571))
 - Fixed a bug where failed structure moves could leave locks held and block subsequent operations. ([#19568](https://github.com/craftcms/cms/pull/19568))
 - Fixed a bug where structure repair previews could differ from the repairs that would be applied. ([#19568](https://github.com/craftcms/cms/pull/19568))
 - Fixed database errors and incorrect ordering when repairing structures. ([#19568](https://github.com/craftcms/cms/pull/19568))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed an error that could occur when creating relation fields. ([#19567](https://github.com/craftcms/cms/issues/19567))
 - Fixed a bug where failed structure moves could leave locks held and block subsequent operations. ([#19568](https://github.com/craftcms/cms/pull/19568))
 - Fixed a bug where structure repair previews could differ from the repairs that would be applied. ([#19568](https://github.com/craftcms/cms/pull/19568))
 - Fixed database errors and incorrect ordering when repairing structures. ([#19568](https://github.com/craftcms/cms/pull/19568))

--- a/src/Field/BaseRelationField.php
+++ b/src/Field/BaseRelationField.php
@@ -1613,6 +1613,7 @@ abstract class BaseRelationField extends Field implements CrossSiteCopyableField
                 ],
             ])
             ->sortBy(fn ($option) => $option['value'] === '*' ? 0 : $option['label'], SORT_NATURAL | SORT_FLAG_CASE)
+            ->values()
             ->all();
     }
 

--- a/src/Form/Controls/Choice.php
+++ b/src/Form/Controls/Choice.php
@@ -83,7 +83,7 @@ class Choice extends Control
      */
     public function options(array $options): static
     {
-        $this->options = $options;
+        $this->options = array_values($options);
 
         return $this;
     }

--- a/tests/Unit/Form/ChoiceBlankOptionTest.php
+++ b/tests/Unit/Form/ChoiceBlankOptionTest.php
@@ -51,6 +51,16 @@ function volumeChoice(): Choice
     ]);
 }
 
+it('serializes keyed options as a JSON list', function () {
+    $options = [
+        1 => ['label' => 'Images', 'value' => 'volume:images'],
+        3 => ['label' => 'Documents', 'value' => 'volume:docs'],
+    ];
+
+    expect(Choice::make('volume')->options($options)->props()['options'])
+        ->toBe(array_values($options));
+});
+
 it('offers a blank option so an unset value is visible as unset', function () {
     $crawler = choiceCrawler(volumeChoice());
 


### PR DESCRIPTION
### Description

Normalizes Choice control options as lists before payload serialization, preventing keyed relation field options from being encoded as JSON objects and crashing the Vue Choice control. Relation source options are also reindexed after sorting to preserve their list contract.

### Related issues

- #19567