### PR TITLE
Avoid locale-aware project config sorting on PostgreSQL

### DIFF
--- a/src/services/ProjectConfig.php
+++ b/src/services/ProjectConfig.php
@@ -36,6 +36,7 @@ use yii\base\InvalidArgumentException;
 use yii\base\InvalidConfigException;
 use yii\base\NotSupportedException;
 use yii\caching\ExpressionDependency;
+use yii\db\Expression;
 use yii\web\ServerErrorHttpException;
 
 /**
@@ -1872,7 +1873,9 @@ class ProjectConfig extends Component
         $data = Craft::$app->getCache()->getOrSet(self::STORED_CACHE_KEY, function() {
             $data = [];
             // Load the project config data
-            $rows = $this->_createProjectConfigQuery()->orderBy('path')->pairs();
+            // Paths only need parent-before-child ordering, not locale-aware sorting.
+            $orderBy = Craft::$app->getDb()->getIsPgsql() ? new Expression('[[path]] COLLATE "C"') : 'path';
+            $rows = $this->_createProjectConfigQuery()->orderBy($orderBy)->pairs();
             foreach ($rows as $path => $value) {
                 $current = &$data;
                 $segments = ProjectConfigHelper::pathSegments($path);


### PR DESCRIPTION
### Description

Reloading project config on an internal config cache miss orders all stored paths using the database’s default collation. On PostgreSQL with a locale-aware collation, this sort can dominate the reload time and delay both control panel and frontend requests.

On an affected production database containing 38,633 project-config rows, the normal query took approximately 790 ms, compared with 55 ms for the same query ordered by `path COLLATE "C"`. Most of the original query time was spent sorting.

Use PostgreSQL’s bytewise `C` collation specifically when ordering paths in `_loadInternalConfig()`. This preserves the parent-before-child ordering needed to reconstruct nested config without paying for language-aware sorting of machine identifiers. The existing config cleanup still applies its natural key sorting afterward.

The change requires no schema migration and leaves MySQL ordering unchanged. It targets config-cache misses; it does not imply that every slow request reloads project config.

### Related issues

No existing GitHub issue.
