### PR TITLE
[6.x] Keep plugin action errors readable until the next action

### DIFF
--- a/resources/js/modules/plugin-manager/components/PluginsList.stories.ts
+++ b/resources/js/modules/plugin-manager/components/PluginsList.stories.ts
@@ -3,7 +3,11 @@ import type {
   Meta,
   StoryObj,
 } from '@storybook/vue3-vite';
-import {pluginInfo} from '@/modules/plugin-manager/fixtures/plugins';
+import {
+  createPlugin,
+  pluginInfo,
+} from '@/modules/plugin-manager/fixtures/plugins';
+import {nextTick, onMounted, useTemplateRef} from 'vue';
 
 import PluginsList from './PluginsList.vue';
 
@@ -34,4 +38,66 @@ export const Default: Story = {
   args: {
     pluginInfo,
   },
+};
+
+function failureStory(messages: string[]): Story {
+  return {
+    args: {
+      pluginInfo: Object.fromEntries(
+        messages.map((_, index) => {
+          const handle = `example-${index + 1}`;
+          return [
+            handle,
+            createPlugin({
+              handle,
+              name: `Example Plugin ${index + 1}`,
+              isInstalled: false,
+              isEnabled: false,
+            }),
+          ];
+        })
+      ),
+    },
+    render(args) {
+      return {
+        components: {PluginsList},
+        setup() {
+          const harness = useTemplateRef<HTMLElement>('harness');
+          onMounted(async () => {
+            await nextTick();
+            const table = harness.value!.querySelector('.element-index')!;
+            messages.forEach((message) => {
+              table.dispatchEvent(
+                new CustomEvent('action:change-state', {
+                  bubbles: true,
+                  composed: true,
+                  detail: {state: 'error', actionType: 'http', message},
+                })
+              );
+            });
+          });
+          return {args, harness};
+        },
+        template: '<div ref="harness"><PluginsList v-bind="args" /></div>',
+      };
+    },
+  };
+}
+
+export const ShortFailure: Story = {...failureStory(['Server Error'])};
+
+export const LargeMultilineFailure: Story = {
+  ...failureStory([
+    'Migration failed.\n\n<img src="example" onerror="alert(1)">\n' +
+      'UnbrokenDiagnostic'.repeat(100) +
+      '\n' +
+      'Additional diagnostic line.\n'.repeat(200),
+  ]),
+};
+
+export const MultipleFailures: Story = {
+  ...failureStory([
+    'A plugin action raised an error.',
+    'Migration failed.\nReview the application logs for more information.',
+  ]),
 };

--- a/resources/js/modules/plugin-manager/components/PluginsList.test.ts
+++ b/resources/js/modules/plugin-manager/components/PluginsList.test.ts
@@ -1,0 +1,187 @@
+import {createApp, nextTick} from 'vue';
+import {
+  afterEach,
+  beforeEach,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vite-plus/test';
+import {router} from '@inertiajs/vue3';
+import {index, install} from '@actions/PluginsController';
+import {useAnnouncer} from '@/common/composables/useAnnouncer';
+import {createPlugin} from '../fixtures/plugins';
+import PluginsList from './PluginsList.vue';
+
+vi.mock('@inertiajs/vue3', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@inertiajs/vue3')>()),
+  usePage: () => ({props: {readOnly: false}}),
+}));
+
+let app: ReturnType<typeof createApp>;
+let container: HTMLElement;
+let visit: MockInstance<typeof router.visit>;
+
+async function settle() {
+  await nextTick();
+  for (const element of container.querySelectorAll('*')) {
+    if ('updateComplete' in element) {
+      await element.updateComplete;
+    }
+  }
+  await nextTick();
+}
+
+async function mount() {
+  const pluginInfo = Object.fromEntries(
+    ['alpha', 'beta'].map((handle) => [
+      handle,
+      createPlugin({
+        handle,
+        name: handle,
+        isInstalled: false,
+        isEnabled: false,
+      }),
+    ])
+  );
+  container = document.createElement('div');
+  document.body.append(container);
+  app = createApp(PluginsList, {pluginInfo});
+  app.mount(container);
+  await settle();
+}
+
+function installItem(handle = 'alpha') {
+  return [...container.querySelectorAll('craft-action-item')].find((item) => {
+    const action = item.action;
+    return (
+      action &&
+      typeof action === 'object' &&
+      action.type === 'http' &&
+      action.url === install({handle}).url
+    );
+  })!;
+}
+
+async function state(handle: string, state: string, message?: string) {
+  installItem(handle).dispatchEvent(
+    new CustomEvent('action:change-state', {
+      bubbles: true,
+      composed: true,
+      detail: {state, actionType: 'http', message},
+    })
+  );
+  await settle();
+}
+
+function messages() {
+  return [...container.querySelectorAll('[role="region"]')].map(
+    (element) => element.textContent
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () => new Response('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+    )
+  );
+  visit = vi.spyOn(router, 'visit').mockImplementation(() => {});
+  useAnnouncer().announcement.value = null;
+});
+
+afterEach(() => {
+  app?.unmount();
+  container?.remove();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it('shows complete, safe, accessible diagnostics after the real install menu closes', async () => {
+  await mount();
+  const item = installItem();
+  const menu = item.closest('craft-action-menu')!;
+  menu.querySelector('craft-button')!.click();
+  await settle();
+  expect(menu.opened).toBe(true);
+  let resolveRequest!: (response: Response) => void;
+  const request = new Promise<Response>((resolve) => {
+    resolveRequest = resolve;
+  });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => request)
+  );
+  item.shadowRoot!.querySelector('button')!.click();
+  await settle();
+  expect(menu.opened).toBe(false);
+  const message =
+    '<img src=x onerror=alert(1)>\n\n' +
+    'x'.repeat(2000) +
+    '\nline'.repeat(10000);
+  resolveRequest(new Response(JSON.stringify({message}), {status: 500}));
+  await vi.waitFor(() => expect(messages()).toEqual([message]));
+  const region = container.querySelector('[role="region"]')!;
+  expect(region.querySelector('img')).toBeNull();
+  expect(region.getAttribute('tabindex')).toBe('0');
+  expect(region.getAttribute('aria-label')).toBe('An error occurred.');
+  expect(useAnnouncer().announcement.value).toBe('An error occurred.');
+  expect(visit).not.toHaveBeenCalled();
+});
+
+it('keeps accumulated failures through idle and timeouts until another action starts', async () => {
+  await mount();
+  vi.useFakeTimers();
+  await state('alpha', 'error', 'First');
+  await state('beta', 'error', 'Other');
+  await state('alpha', 'error', 'Latest');
+  await state('alpha', 'idle');
+  await vi.advanceTimersByTimeAsync(6000);
+  expect(messages()).toEqual(['First', 'Other', 'Latest']);
+  expect(visit).not.toHaveBeenCalled();
+  await state('beta', 'loading');
+  expect(messages()).toEqual([]);
+  await state('beta', 'error', 'New failure');
+  expect(messages()).toEqual(['New failure']);
+});
+
+it('refreshes only pluginInfo on HTTP success but not clipboard success', async () => {
+  await mount();
+  const clipboardItem = [
+    ...container.querySelectorAll('craft-action-item'),
+  ].find(
+    (item) =>
+      typeof item.action === 'object' && item.action?.type === 'clipboard'
+  )!;
+  clipboardItem.dispatchEvent(
+    new CustomEvent('action:change-state', {
+      bubbles: true,
+      detail: {state: 'success', actionType: 'clipboard'},
+    })
+  );
+  await settle();
+  expect(visit).not.toHaveBeenCalled();
+  await state('alpha', 'success');
+  expect(visit).toHaveBeenCalledExactlyOnceWith(index(), {
+    only: ['pluginInfo'],
+  });
+});
+
+it('uses a fallback when an error has no message', async () => {
+  await mount();
+  await state('alpha', 'error');
+  expect(messages()).toEqual(['Request failed']);
+});
+
+it('does not steal focus on failure', async () => {
+  await mount();
+  const invoker = installItem('beta')
+    .closest('craft-action-menu')!
+    .querySelector('craft-button')!;
+  invoker.focus();
+  await state('alpha', 'error', 'Details');
+  expect(document.activeElement).toBe(invoker);
+});

--- a/resources/js/modules/plugin-manager/components/PluginsList.vue
+++ b/resources/js/modules/plugin-manager/components/PluginsList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import {t} from '@craftcms/ui';
-  import {computed, h} from 'vue';
+  import {computed, h, shallowReactive} from 'vue';
   import AdminTable from '@/modules/admin-table/components/AdminTable.vue';
   import Empty from '@/common/components/Empty.vue';
   import type {PluginInfo} from '@/modules/plugin-manager/types/plugins';
@@ -11,11 +11,16 @@
   import PluginActionMenu from '@/modules/plugin-manager/components/PluginActionMenu.vue';
   import {router} from '@inertiajs/vue3';
   import {index} from '@actions/PluginsController';
+  import {useAnnouncer} from '@/common/composables/useAnnouncer';
 
   const props = defineProps<{
     pluginInfo: Record<string, PluginInfo>;
     readOnly?: boolean;
   }>();
+
+  const {announce} = useAnnouncer();
+  const errors = shallowReactive<string[]>([]);
+  const errorSummary = t('An error occurred.');
 
   const plugins = computed(() => {
     return Object.entries(props.pluginInfo).map(([handle, value]) => {
@@ -76,6 +81,15 @@
    * an http action is successful
    */
   function handleStateChange(event: CustomEvent) {
+    if (event.detail?.state === 'loading') {
+      errors.length = 0;
+    }
+
+    if (event.detail?.state === 'error') {
+      errors.push(event.detail.message ?? t('Request failed'));
+      announce(errorSummary);
+    }
+
     if (
       event.detail?.state === 'success' &&
       event.detail?.actionType === 'http'
@@ -89,6 +103,23 @@
 
 <template>
   <craft-pane appearance="raised" padding="0">
+    <div v-if="errors.length" class="action-errors">
+      <craft-callout
+        v-for="(error, index) in errors"
+        :key="index"
+        variant="danger"
+      >
+        <strong>{{ errorSummary }}</strong>
+        <div
+          class="action-error-message"
+          role="region"
+          tabindex="0"
+          :aria-label="errorSummary"
+        >
+          {{ error }}
+        </div>
+      </craft-callout>
+    </div>
     <AdminTable :table="table" @action:change-state="handleStateChange">
       <template #empty-row>
         <Empty
@@ -100,4 +131,26 @@
   </craft-pane>
 </template>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+  craft-pane,
+  .action-errors,
+  .action-error-message {
+    min-inline-size: 0;
+  }
+
+  .action-errors {
+    display: grid;
+    gap: var(--c-spacing-md);
+    padding: var(--c-spacing-md);
+    overflow-wrap: anywhere;
+  }
+
+  .action-error-message {
+    margin-block-start: var(--c-spacing-sm);
+    max-block-size: min(200px, 40dvh);
+    overflow: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    user-select: text;
+  }
+</style>


### PR DESCRIPTION
### Description

Plugin action failures can disappear inside a closed menu before users can read them, so Settings → Plugins now displays the available error messages in readable callouts above the table until another action starts.

<img width="1025" height="238" alt="image" src="https://github.com/user-attachments/assets/059504f7-f502-4e8a-8db9-bca2eebb22eb" />
