### PR TITLE
[6.x] Performance tweaks & test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `CraftCms\Cms\Element\Conditions\ElementCondition::$forQuery`. ([#19563](https://github.com/craftcms/cms/pull/19563))
 - Removed `CraftCms\Cms\Element\Conditions\Contracts\ElementConditionRuleInterface::getExclusiveQueryParams()` and `modifyQuery()`. `ElementQueryConditionRuleInterface::modifyQuery()` should be implemented instead, which now accepts the underlying query builder directly. ([#19563](https://github.com/craftcms/cms/pull/19563))
 - Removed `CraftCms\Cms\Element\Conditions\ElementCondition::$queryParams`. ([#19563](https://github.com/craftcms/cms/pull/19563))
+- Improved performance of element queries, Control Panel rendering, asset transforms, date formatting, and queue status checks, and fixed related SQLite index and timezone issues.
 - Fixed an error that could occur when creating relation fields. ([#19571](https://github.com/craftcms/cms/pull/19571))
 - Fixed a bug where failed structure moves could leave locks held and block subsequent operations. ([#19568](https://github.com/craftcms/cms/pull/19568))
 - Fixed a bug where structure repair previews could differ from the repairs that would be applied. ([#19568](https://github.com/craftcms/cms/pull/19568))

--- a/src/Asset/AssetTransformers.php
+++ b/src/Asset/AssetTransformers.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Asset;
 
+use Closure;
+use CraftCms\Cms\Asset\Contracts\AssetTransformDriver;
 use CraftCms\Cms\Asset\Contracts\PreloadsAssetTransforms;
 use CraftCms\Cms\Asset\Data\AssetTransformer;
 use CraftCms\Cms\Asset\Data\AssetTransformRequest;
@@ -36,6 +38,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use InvalidArgumentException;
 use Stringable;
+use WeakMap;
 
 use function CraftCms\Cms\t;
 
@@ -50,10 +53,15 @@ class AssetTransformers
     /** @var Collection<string, AssetTransformer>|null */
     private ?Collection $transformers = null;
 
+    /** @var WeakMap<AssetTransformDriver, array<string, array<string, mixed>>> */
+    private WeakMap $validatedParameters;
+
     public function __construct(
         private readonly ProjectConfig $projectConfig,
         private readonly AssetTransformDrivers $transformDrivers,
     ) {
+        $this->validatedParameters = new WeakMap;
+
         $this->parameterRules = [
             'fill' => ['string'],
             'format' => ['string', Rule::enum(ImageTransformFormat::class)],
@@ -268,14 +276,16 @@ class AssetTransformers
 
     /**
      * @param  list<Asset>  $assets
-     * @param  list<mixed>  $definitions
+     * @param  list<mixed>|(Closure(Asset): list<mixed>)  $definitions
      */
-    public function preload(array $assets, #[\SensitiveParameter] array $definitions): void
+    public function preload(array $assets, #[\SensitiveParameter] array|Closure $definitions): void
     {
         $requestsByDriver = [];
 
         foreach ($assets as $asset) {
-            foreach ($this->preloadRequests($asset, $definitions) as $request) {
+            $assetDefinitions = $definitions instanceof Closure ? $definitions($asset) : $definitions;
+
+            foreach ($this->preloadRequests($asset, $assetDefinitions) as $request) {
                 $requestsByDriver[$request->transformer->driver][] = $request;
             }
         }
@@ -293,8 +303,10 @@ class AssetTransformers
     public function parameterRules(AssetTransformer $transformer): array
     {
         $parameterRules = $this->parameterRules;
+        $driver = $this->transformDrivers->driver($transformer->driver);
+        $driverRules = $driver->definition()->parameterRules;
 
-        foreach ($this->transformDrivers->driver($transformer->driver)->definition()->parameterRules as $handle => $rules) {
+        foreach ($driverRules as $handle => $rules) {
             if (! is_string($handle) || $handle === '') {
                 throw new InvalidAssetTransformException('Asset Transform parameter handles must be non-empty strings.');
             }
@@ -351,6 +363,7 @@ class AssetTransformers
     public function reset(): void
     {
         $this->transformers = null;
+        $this->validatedParameters = new WeakMap;
     }
 
     /** @return Collection<string, AssetTransformer> */
@@ -532,10 +545,22 @@ class AssetTransformers
             throw new InvalidAssetTransformException($exception->getMessage(), previous: $exception);
         }
 
+        ksort($parameters);
+
+        if (array_all($parameters, fn (mixed $value): bool => is_scalar($value) || $value === null)) {
+            $driver = $this->transformDrivers->driver($transformer->driver);
+            $key = serialize($parameters);
+            $this->validatedParameters[$driver] ??= [];
+            $parameters = $this->validatedParameters[$driver][$key]
+                ??= $this->validateParameters($transformer, $parameters);
+        } else {
+            $parameters = $this->validateParameters($transformer, $parameters);
+        }
+
         return new AssetTransformRequest(
             asset: $asset,
             transformer: $transformer,
-            parameters: $this->validateParameters($transformer, $parameters),
+            parameters: $parameters,
         );
     }
 

--- a/src/Asset/Assets.php
+++ b/src/Asset/Assets.php
@@ -40,6 +40,7 @@ use CraftCms\Cms\User\Elements\User;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use InvalidArgumentException;
 use RuntimeException;
 use Throwable;
@@ -127,6 +128,37 @@ class Assets
         }
 
         return $this->elements->saveElement($asset);
+    }
+
+    /**
+     * @param  list<Asset>  $assets
+     * @param  list<int>  $sizes
+     */
+    public function preloadThumbs(array $assets, array $sizes): void
+    {
+        if (Event::hasListeners(ThumbUrlResolving::class)) {
+            return;
+        }
+
+        $assets = array_values(array_filter($assets, fn (Asset $asset): bool => $asset::class === Asset::class
+            && ! $asset->isFolder
+            && ! $asset->getFieldLayout()?->thumbFieldKey));
+
+        $this->assetTransformers->preload($assets, fn (Asset $asset): array => array_map(function (int $size) use ($asset): array {
+            [$width, $height] = $this->getThumbDimensions($asset, $size);
+
+            return ['width' => $width, 'height' => $height, 'mode' => 'crop'];
+        }, $sizes));
+    }
+
+    /** @return array{int, int} */
+    public function getThumbDimensions(Asset $asset, int $size): array
+    {
+        if ($size % 128 !== 0 && $asset->getWidth() && $asset->getHeight()) {
+            return AssetsHelper::scaledDimensions((int) $asset->getWidth(), (int) $asset->getHeight(), $size, $size);
+        }
+
+        return [$size, $size];
     }
 
     public function getThumbUrl(Asset $asset, int $width, ?int $height = null, bool $iconFallback = true): ?string

--- a/src/Asset/Elements/Asset.php
+++ b/src/Asset/Elements/Asset.php
@@ -2067,13 +2067,7 @@ JS, [
             return null;
         }
 
-        $forCard = $size % 128 === 0;
-
-        if (! $forCard && $this->getWidth() && $this->getHeight()) {
-            [$width, $height] = AssetsHelper::scaledDimensions((int) $this->getWidth(), (int) $this->getHeight(), $size, $size);
-        } else {
-            $width = $height = $size;
-        }
+        [$width, $height] = AssetsService::getThumbDimensions($this, $size);
 
         return AssetsService::getThumbUrl($this, $width, $height, false);
     }

--- a/src/Auth/OAuth/OAuth.php
+++ b/src/Auth/OAuth/OAuth.php
@@ -314,6 +314,8 @@ class OAuth
             ->where('userId', $user->id)
             ->where('provider', $provider->handle)
             ->delete();
+
+        $user->setHasSsoIdentity(null);
     }
 
     /**
@@ -370,6 +372,8 @@ class OAuth
                 'dateUpdated' => $now,
             ]);
         });
+
+        $user->setHasSsoIdentity(null);
     }
 
     private function normalizeProvider(string $handle, mixed $config): ?ProviderDefinition

--- a/src/Cms.php
+++ b/src/Cms.php
@@ -92,6 +92,9 @@ readonly class Cms
 
     private static function validatedTimezone(?string $timezone): string
     {
+        static $validatedTimezone = null;
+        static $validatedLocale = null;
+
         $timezone = Env::parse($timezone);
 
         if (! $timezone) {
@@ -99,11 +102,20 @@ readonly class Cms
         }
 
         if ($timezone !== 'UTC') {
+            $locale = app()->getLocale();
+
+            if ($timezone === $validatedTimezone && $locale === $validatedLocale) {
+                return $timezone;
+            }
+
             // Make sure that ICU supports this timezone
             try {
-                $formatter = new IntlDateFormatter(app()->getLocale(), IntlDateFormatter::NONE, IntlDateFormatter::NONE);
+                $formatter = new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE);
                 if (! $formatter->setTimeZone($timezone)) {
                     $timezone = 'UTC';
+                } else {
+                    $validatedTimezone = $timezone;
+                    $validatedLocale = $locale;
                 }
             } catch (IntlException) {
                 Log::warning("Time zone “{$timezone}” does not appear to be supported by ICU: ".intl_get_error_message());

--- a/src/Database/Migrations/Install.php
+++ b/src/Database/Migrations/Install.php
@@ -105,6 +105,11 @@ class Install extends Migration
             $logger?->subLabel('Adding foreign keys...');
             $this->addForeignKeys();
             $logger?->success('Foreign keys added.');
+
+            // SQLite rebuilds tables for foreign keys without preserving expression indexes.
+            if (DB::isSqlite()) {
+                Schema::table(Table::ELEMENTS_SITES, fn (Blueprint $table) => $table->rawIndex('lower("uri"), "siteId"', 'sites_uri_siteid_index'));
+            }
         });
 
         event(new TablesCreated);
@@ -1058,11 +1063,12 @@ class Install extends Migration
         Schema::createIndex(Table::ELEMENTS, ['fieldLayoutId']);
         Schema::createIndex(Table::ELEMENTS, ['type']);
         Schema::createIndex(Table::ELEMENTS, ['enabled']);
-        Schema::createIndex(Table::ELEMENTS, ['canonicalId']);
+        Schema::createIndex(Table::ELEMENTS, ['canonicalId', 'dateCreated']);
         Schema::createIndex(Table::ELEMENTS, ['archived', 'dateCreated']);
         Schema::createIndex(Table::ELEMENTS, ['archived', 'dateDeleted', 'draftId', 'revisionId', 'canonicalId']);
         Schema::createIndex(Table::ELEMENTS, ['archived', 'dateDeleted', 'draftId', 'revisionId', 'canonicalId', 'enabled']);
         Schema::createIndex(Table::ELEMENTS_BULKOPS, ['timestamp']);
+        Schema::createIndex(Table::ELEMENTS_OWNERS, ['ownerId']);
         Schema::createIndex(Table::ELEMENTS_OWNERS, ['sortOrder']);
         Schema::createIndex(Table::ELEMENTS_SITES, ['elementId', 'siteId'], unique: true);
         Schema::createIndex(Table::ELEMENTS_SITES, ['siteId']);
@@ -1074,7 +1080,7 @@ class Install extends Migration
         Schema::createIndex(Table::ENTRIES, ['postDate']);
         Schema::createIndex(Table::ENTRIES, ['expiryDate']);
         Schema::createIndex(Table::ENTRIES, ['status']);
-        Schema::createIndex(Table::ENTRIES, ['sectionId']);
+        Schema::createIndex(Table::ENTRIES, ['sectionId', 'postDate']);
         Schema::createIndex(Table::ENTRIES, ['typeId']);
         Schema::createIndex(Table::ENTRIES_AUTHORS, ['authorId']);
         Schema::createIndex(Table::ENTRIES_AUTHORS, ['entryId', 'sortOrder']);
@@ -1176,7 +1182,6 @@ class Install extends Migration
             DB::statement('CREATE INDEX keywords_index ON '.DB::getTablePrefix().Table::SEARCHINDEX.' USING btree(keywords)');
         } else {
             // SQLite: basic indexes only, no full-text or tsvector
-            DB::statement('CREATE INDEX sites_uri_siteid_index ON '.DB::getTablePrefix().Table::ELEMENTS_SITES.' (lower(uri), "siteId")');
             Schema::createIndex(Table::USERS, ['email']);
             Schema::createIndex(Table::USERS, ['username']);
         }

--- a/src/Element/Operations/ElementEagerLoader.php
+++ b/src/Element/Operations/ElementEagerLoader.php
@@ -396,6 +396,7 @@ readonly class ElementEagerLoader
                         $eagerLoadResult = new EagerLoadInfo($plan, $filteredElements);
                         foreach ($flatTargetElements as $element) {
                             $element->eagerLoadInfo = $eagerLoadResult;
+                            $element->elementQueryResult = $flatTargetElements;
                         }
 
                         // Pass the instantiated elements to afterPopulate()

--- a/src/Element/Queries/Concerns/QueriesNestedElements.php
+++ b/src/Element/Queries/Concerns/QueriesNestedElements.php
@@ -116,6 +116,13 @@ trait QueriesNestedElements
 
             self::prepForNestedElementParams($elementQuery);
 
+            if ($elementQuery->ownerId) {
+                // Restrict candidates before the other joins when the query planner starts with the elements table.
+                $elementQuery->whereIn('elements.id', DB::table(Table::ELEMENTS_OWNERS)
+                    ->select('elementId')
+                    ->whereIn('ownerId', $elementQuery->ownerId));
+            }
+
             if (isset($elementQuery->fieldId)) {
                 self::applyFieldIdInternal($elementQuery, $elementQuery->fieldId, $elementQuery);
             }

--- a/src/Element/Queries/Concerns/SearchesElements.php
+++ b/src/Element/Queries/Concerns/SearchesElements.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Element\Queries\Concerns;
 
+use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Queries\ElementQuery;
 use CraftCms\Cms\Element\Queries\Exceptions\QueryAbortedException;
 use CraftCms\Cms\Support\Arr;
@@ -110,7 +111,7 @@ trait SearchesElements
             throw new QueryAbortedException;
         }
 
-        $elementQuery->whereIn('elements.id', $searchQuery->pluck('elementId'));
+        $elementQuery->whereExists($searchQuery->whereColumn(Table::SEARCHINDEX.'.elementId', 'elements_sites.elementId'));
     }
 
     /**

--- a/src/Element/Queries/ElementQuery.php
+++ b/src/Element/Queries/ElementQuery.php
@@ -1282,7 +1282,9 @@ class ElementQuery extends Component implements \Illuminate\Contracts\Database\Q
 
         foreach ($this->query->columns as $column) {
             if ($column instanceof Expression) {
-                $column = $column->getValue($this->query->getGrammar());
+                $select[] = $column;
+
+                continue;
             }
 
             [$column, $alias] = explode(' as ', $column, 2) + [1 => null];

--- a/src/Element/Queries/UserQuery.php
+++ b/src/Element/Queries/UserQuery.php
@@ -17,6 +17,7 @@ use CraftCms\Cms\Element\Queries\Concerns\User\QueriesUserProperties;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Facades\DB;
 use Override;
 
 /**
@@ -71,6 +72,15 @@ class UserQuery extends ElementQuery
             'users.fullName',
             'users.rememberToken',
         ]);
+
+        $identities = DB::table(Table::SSO_IDENTITIES)
+            ->selectRaw('1')
+            ->whereColumn('userId', 'users.id');
+
+        $this->query->selectRaw(
+            sprintf('exists(%s) as %s', $identities->toSql(), $this->query->getGrammar()->wrap('hasSsoIdentity')),
+            $identities->getBindings(),
+        );
 
         $this->beforeQuery(static function (self $userQuery) {
             $orders = $userQuery->query->orders;

--- a/src/Field/Matrix.php
+++ b/src/Field/Matrix.php
@@ -74,7 +74,6 @@ use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use CraftCms\Cms\View\LegacyAssets\MatrixAsset;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Contracts\Database\Query\Builder;
-use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -1339,16 +1338,17 @@ class Matrix extends Field implements EagerLoadingFieldInterface, ElementContain
         }
 
         // Return any relation data on these elements, defined with this field
-        $map = DB::table(Table::ENTRIES, 'entries')
+        $map = DB::table(Table::ELEMENTS_OWNERS, 'elements_owners')
             ->select([
                 'elements_owners.ownerId as source',
-                'entries.id as target',
+                'elements_owners.elementId as target',
             ])
-            ->join(new Alias(Table::ELEMENTS_OWNERS, 'elements_owners'), function (JoinClause $join) use ($sourceElementIds) {
-                $join->whereColumn('elements_owners.elementId', 'entries.id')
-                    ->whereIn('elements_owners.ownerId', $sourceElementIds);
-            })
-            ->where('entries.fieldId', $this->id)
+            ->whereIn('elements_owners.ownerId', $sourceElementIds)
+            ->whereExists(fn (Builder $query) => $query
+                ->selectRaw('1')
+                ->from(Table::ENTRIES, 'entries')
+                ->whereColumn('entries.id', 'elements_owners.elementId')
+                ->where('entries.fieldId', $this->id))
             ->orderBy('elements_owners.sortOrder')
             ->get()
             ->map(fn (object $row) => (array) $row)

--- a/src/Http/Controllers/Assets/IndexController.php
+++ b/src/Http/Controllers/Assets/IndexController.php
@@ -22,9 +22,11 @@ readonly class IndexController
         // global request, which is a separate instance from this FormRequest.
         request()->merge(['showFolders' => true]);
 
-        return Inertia::render('assets/Index', new AssetIndexViewModel(
-            $request,
-            defaultSource: $request->input('defaultSource', $defaultSource),
-        ));
+        return Inertia::render('assets/Index', [
+            new AssetIndexViewModel(
+                $request,
+                defaultSource: $request->input('defaultSource', $defaultSource),
+            ),
+        ]);
     }
 }

--- a/src/Http/Controllers/ContentIndexController.php
+++ b/src/Http/Controllers/ContentIndexController.php
@@ -13,10 +13,12 @@ readonly class ContentIndexController
 {
     public function __invoke(ElementIndexRequest $request, string $page, ?string $sectionHandle = null): Response
     {
-        return Inertia::render('content/Index', new EntryIndexViewModel(
-            request: $request,
-            page: $page,
-            sectionHandle: $sectionHandle,
-        ));
+        return Inertia::render('content/Index', [
+            new EntryIndexViewModel(
+                request: $request,
+                page: $page,
+                sectionHandle: $sectionHandle,
+            ),
+        ]);
     }
 }

--- a/src/Http/Controllers/Users/IndexController.php
+++ b/src/Http/Controllers/Users/IndexController.php
@@ -21,9 +21,11 @@ readonly class IndexController
 
         Edition::require(Edition::Team);
 
-        return Inertia::render('users/Index', new UserIndexViewModel(
-            $request,
-            slug: $slug,
-        ));
+        return Inertia::render('users/Index', [
+            new UserIndexViewModel(
+                $request,
+                slug: $slug,
+            ),
+        ]);
     }
 }

--- a/src/Http/Middleware/HandleInertiaRequests.php
+++ b/src/Http/Middleware/HandleInertiaRequests.php
@@ -13,8 +13,8 @@ use CraftCms\Cms\Cp\Icons;
 use CraftCms\Cms\Cp\Navigation;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Edition;
-use CraftCms\Cms\Queue\Enums\JobStatus;
 use CraftCms\Cms\Queue\JobProgress;
+use CraftCms\Cms\Queue\QueueState;
 use CraftCms\Cms\Support\Api;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Flash;
@@ -133,11 +133,7 @@ class HandleInertiaRequests extends Middleware
                 'success' => Flash::getSuccess(),
                 'error' => Flash::getError(),
             ],
-            'queue' => fn () => Schema::hasTable(Table::JOBPROGRESS) ? [
-                'displayedJob' => $progressService->getDisplayedJob(),
-                'hasReservedJobs' => $progressService->getByStatus(JobStatus::Reserved)->count() > 0,
-                'hasWaitingJobs' => $progressService->getByStatus(JobStatus::Pending)->count() > 0,
-            ] : [
+            'queue' => fn () => Schema::hasTable(Table::JOBPROGRESS) ? new QueueState($progressService) : [
                 'displayedJob' => null,
                 'hasReservedJobs' => false,
                 'hasWaitingJobs' => false,

--- a/src/Http/Mixins/RequestMixin.php
+++ b/src/Http/Mixins/RequestMixin.php
@@ -116,8 +116,6 @@ class RequestMixin
              * @phpstan-ignore-next-line
              */
             $request = $this;
-            $cpTrigger = trim((string) Cms::config()->cpTrigger, '/');
-
             if ($request->attributes->has('isCpRequest')) {
                 return (bool) $request->attributes->get('isCpRequest');
             }
@@ -125,6 +123,8 @@ class RequestMixin
             if ($request->routeIs('craft.cp.*')) {
                 return true;
             }
+
+            $cpTrigger = trim((string) Cms::config()->cpTrigger, '/');
 
             if ($cpTrigger === '') {
                 return true;

--- a/src/Http/ViewModels/AssetIndexViewModel.php
+++ b/src/Http/ViewModels/AssetIndexViewModel.php
@@ -8,11 +8,14 @@ use CraftCms\Cms\Asset\Data\Volume;
 use CraftCms\Cms\Asset\Data\VolumeFolder;
 use CraftCms\Cms\Asset\Elements\Asset;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
+use CraftCms\Cms\Element\Enums\ElementIndexViewMode;
 use CraftCms\Cms\Http\Requests\ElementIndexRequest;
 use CraftCms\Cms\Support\Arr;
+use CraftCms\Cms\Support\Facades\Assets;
 use CraftCms\Cms\Support\Facades\Folders;
 use CraftCms\Cms\Support\Facades\Volumes;
 use CraftCms\Cms\Support\Url;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Override;
 
@@ -56,6 +59,18 @@ class AssetIndexViewModel extends ContentIndexViewModel
     public function defaultSource(): ?string
     {
         return $this->defaultSource;
+    }
+
+    #[Override]
+    protected function prepareElements(array $elements): void
+    {
+        if ($this->viewState()['mode'] !== ElementIndexViewMode::Table->value) {
+            return;
+        }
+
+        $assets = array_values(array_filter($elements, fn (mixed $element): bool => $element instanceof Asset));
+
+        Assets::preloadThumbs($assets, [30, 60]);
     }
 
     /**

--- a/src/Http/ViewModels/ContentIndexViewModel.php
+++ b/src/Http/ViewModels/ContentIndexViewModel.php
@@ -362,6 +362,7 @@ abstract class ContentIndexViewModel extends ViewModel
         }
 
         $elements = $this->resolvePaginator()->items();
+        $this->prepareElements($elements);
 
         return match ($this->mode()) {
             ElementIndexViewMode::Cards->value => $this->cardData($elements),
@@ -369,6 +370,9 @@ abstract class ContentIndexViewModel extends ViewModel
             default => $this->tableRows($elements),
         };
     }
+
+    /** @param list<ElementInterface|array<string, mixed>> $elements */
+    protected function prepareElements(array $elements): void {}
 
     /** @return array<int, array<string, mixed>>|null */
     public function actions(): ?array

--- a/src/Http/ViewModels/ViewModel.php
+++ b/src/Http/ViewModels/ViewModel.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http\ViewModels;
 
+use Closure;
 use CraftCms\Cms\Support\Utils;
 use Illuminate\Contracts\Support\Arrayable;
+use Inertia\ProvidesInertiaProperties;
+use Inertia\RenderContext;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -13,25 +16,35 @@ use ReflectionMethod;
  * Base class for Inertia page payloads.
  *
  * Public properties are returned as-is. Public zero-argument instance methods on
- * concrete view models are called and returned under their method name, which
+ * concrete view models are returned under their method name, which
  * keeps constructors focused on required dependencies and lets view models expose
  * derived payload data without storing duplicate properties. Methods that take
  * arguments are skipped, so a view model can expose fluent setters alongside
- * its payload.
+ * its payload. Array conversion evaluates methods immediately. Passing the view
+ * model as an Inertia property provider lets Inertia evaluate only requested props.
  */
 /** @implements Arrayable<string, mixed> */
-abstract class ViewModel implements Arrayable
+abstract class ViewModel implements Arrayable, ProvidesInertiaProperties
 {
     public function toArray(): array
     {
         return [
             ...Utils::getPublicProperties($this),
-            ...$this->publicMethodValues(),
+            ...array_map(fn (Closure $method): mixed => $method(), $this->publicMethodClosures()),
         ];
     }
 
     /** @return array<string, mixed> */
-    private function publicMethodValues(): array
+    public function toInertiaProperties(RenderContext $context): array
+    {
+        return [
+            ...Utils::getPublicProperties($this),
+            ...$this->publicMethodClosures(),
+        ];
+    }
+
+    /** @return array<string, Closure> */
+    private function publicMethodClosures(): array
     {
         return collect(new ReflectionClass($this)->getMethods(ReflectionMethod::IS_PUBLIC))
             ->filter(fn (ReflectionMethod $method): bool => $method->getDeclaringClass()->getName() !== self::class
@@ -42,7 +55,7 @@ abstract class ViewModel implements Arrayable
                 // invoked — argument-less — as payload.
                 && $method->getNumberOfParameters() === 0)
             ->mapWithKeys(fn (ReflectionMethod $method): array => [
-                $method->getName() => $method->invoke($this),
+                $method->getName() => $method->getClosure($this),
             ])
             ->all();
     }

--- a/src/Image/ImageTransformer.php
+++ b/src/Image/ImageTransformer.php
@@ -38,6 +38,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Filesystem\LocalFilesystemAdapter;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Sleep;
 use RuntimeException;
@@ -337,7 +338,12 @@ class ImageTransformer
 
             if ($this->validateTransformIndexResult($index, $transform, $asset)) {
                 $indexFingerprint = $assetTransformer->uid.':'.$result->assetId.':'.$transformFingerprint;
-                $this->eagerLoadedTransformIndexes[$indexFingerprint] = (array) $result;
+                $this->eagerLoadedTransformIndexes[$indexFingerprint] = [
+                    ...(array) $result,
+                    'dateIndexed' => $index->dateIndexed,
+                    'dateCreated' => $index->dateCreated,
+                    'dateUpdated' => $index->dateUpdated,
+                ];
             } else {
                 $invalidIndexIds[] = $result->id;
             }
@@ -528,8 +534,16 @@ class ImageTransformer
 
         if (isset($this->eagerLoadedTransformIndexes[$fingerprint])) {
             $result = $this->eagerLoadedTransformIndexes[$fingerprint];
+            $timeZone = null;
 
-            return new ImageTransformIndex((array) $result);
+            foreach (['dateIndexed', 'dateCreated', 'dateUpdated'] as $attribute) {
+                if ($result[$attribute] instanceof DateTimeInterface) {
+                    $timeZone ??= Cms::timezone();
+                    $result[$attribute] = Date::instance($result[$attribute])->setTimezone($timeZone);
+                }
+            }
+
+            return new ImageTransformIndex($result);
         }
 
         // Check if an entry exists already
@@ -623,7 +637,7 @@ class ImageTransformer
                 'dateIndexed',
             ], [], false)
         );
-        $now = now();
+        $now = Query::prepareDateForDb(now());
 
         if ($index->id !== null) {
             $this->createTransformIndexQuery()

--- a/src/Image/Images.php
+++ b/src/Image/Images.php
@@ -22,6 +22,7 @@ use Intervention\Image\Exceptions\MissingDependencyException;
 use Intervention\Image\FileExtension;
 use Intervention\Image\Format;
 use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\DriverInterface;
 use Jcupitt\Vips\Image as VipsImage;
 use Throwable;
 
@@ -32,6 +33,11 @@ class Images
 {
     /** @var string[] */
     private array $supportedImageFormats = ['jpg', 'jpeg', 'gif', 'png'];
+
+    /** @var string[]|null */
+    private ?array $additionalImageFormats = null;
+
+    private ?DriverInterface $supportedFormatsDriver = null;
 
     private ImageDriver $driver;
 
@@ -116,15 +122,19 @@ class Images
      */
     public function getSupportedImageFormats(): array
     {
-        $additionalFormats = array_filter(
-            FileExtension::cases(),
-            fn (FileExtension $extension) => ! in_array($extension->format(), [Format::JPEG, Format::GIF, Format::PNG], true)
-                && $this->canDecodeFormat($extension),
-        );
+        if ($this->additionalImageFormats === null || $this->supportedFormatsDriver !== $this->manager->driver) {
+            $additionalFormats = array_filter(
+                FileExtension::cases(),
+                fn (FileExtension $extension) => ! in_array($extension->format(), [Format::JPEG, Format::GIF, Format::PNG], true)
+                    && $this->canDecodeFormat($extension),
+            );
+            $this->additionalImageFormats = array_map(fn (FileExtension $extension) => $extension->value, $additionalFormats);
+            $this->supportedFormatsDriver = $this->manager->driver;
+        }
 
         return array_values(array_unique([
             ...$this->supportedImageFormats,
-            ...array_map(fn (FileExtension $extension) => $extension->value, $additionalFormats),
+            ...$this->additionalImageFormats,
         ]));
     }
 

--- a/src/Queue/JobProgress.php
+++ b/src/Queue/JobProgress.php
@@ -193,12 +193,12 @@ readonly class JobProgress
 
     public function hasReservedJobs(): bool
     {
-        return $this->getByStatus(JobStatus::Reserved)->isNotEmpty();
+        return JobProgressModel::query()->where('status', JobStatus::Reserved)->exists();
     }
 
     public function hasPendingJobs(): bool
     {
-        return $this->getByStatus(JobStatus::Pending)->isNotEmpty();
+        return JobProgressModel::query()->where('status', JobStatus::Pending)->exists();
     }
 
     public function delete(string $uid): void

--- a/src/Queue/QueueState.php
+++ b/src/Queue/QueueState.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Queue;
+
+use CraftCms\Cms\Queue\Models\JobProgress as JobProgressModel;
+
+/**
+ * Queue properties are read during JSON encoding, after page props can enqueue jobs.
+ * Inertia would resolve Arrayable or JsonSerializable implementations too early.
+ */
+class QueueState
+{
+    public ?JobProgressModel $displayedJob {
+        get => $this->state()['displayedJob'];
+    }
+
+    public bool $hasReservedJobs {
+        get => $this->state()['hasReservedJobs'];
+    }
+
+    public bool $hasWaitingJobs {
+        get => $this->state()['hasWaitingJobs'];
+    }
+
+    /** @var array{displayedJob: ?JobProgressModel, hasReservedJobs: bool, hasWaitingJobs: bool}|null */
+    private ?array $state = null;
+
+    public function __construct(private readonly JobProgress $progress) {}
+
+    /** @return array{displayedJob: ?JobProgressModel, hasReservedJobs: bool, hasWaitingJobs: bool} */
+    private function state(): array
+    {
+        return $this->state ??= [
+            'displayedJob' => $this->progress->getDisplayedJob(),
+            'hasReservedJobs' => $this->progress->hasReservedJobs(),
+            'hasWaitingJobs' => $this->progress->hasPendingJobs(),
+        ];
+    }
+}

--- a/src/Site/Sites.php
+++ b/src/Site/Sites.php
@@ -364,6 +364,12 @@ class Sites
 
     public function getSiteById(int $siteId, ?bool $withDisabled = null): ?Site
     {
+        $site = $this->allSitesById[$siteId] ?? null;
+
+        if ($site === ($this->enabledSitesById[$siteId] ?? null)) {
+            return $site;
+        }
+
         return $this->allSites($withDisabled)[$siteId] ?? null;
     }
 

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -624,9 +624,15 @@ class Html
                     $normalized[$name] = self::explodeStyle($value);
                     break;
                 default:
+                    if (! is_array($value)) {
+                        $normalized[$name] = $value;
+
+                        break;
+                    }
+
                     // See if it's a data attribute
                     foreach (self::_sortedDataAttributes() as $dataAttribute) {
-                        if (is_array($value) && str_starts_with((string) $name, (string) $dataAttribute)) {
+                        if (str_starts_with((string) $name, (string) $dataAttribute)) {
                             foreach ($value as $n => $v) {
                                 $normalized[$name.'-'.$n] = $v;
                             }

--- a/src/Translation/Formatter.php
+++ b/src/Translation/Formatter.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Date;
 use IntlDateFormatter;
 use IntlTimeZone;
 use InvalidArgumentException;
+use Locale as IntlLocale;
 use NumberFormatter;
 use RoundingMode;
 use Throwable;
@@ -61,6 +62,9 @@ class Formatter
         'full' => IntlDateFormatter::FULL,
     ];
 
+    /** @var array<string, IntlDateFormatter> */
+    private array $dateFormatters = [];
+
     public function asCurrency(mixed $value, ?string $currency = null, bool $stripZeros = false): string
     {
         $value = $this->normalizeNumericValue($value);
@@ -96,17 +100,13 @@ class Formatter
         $format = $this->dateTimeFormats[$format]['date'] ?? $format;
 
         if (isset($this->defaultDateFormats[$format])) {
-            return new IntlDateFormatter(
-                locale: $this->locale,
+            return $this->dateFormatter(
                 dateType: $this->defaultDateFormats[$format] ?? IntlDateFormatter::NONE,
                 timeType: IntlDateFormatter::NONE,
-                timezone: $this->timeZone,
             )->format($value->toDateTime());
         }
 
-        return new IntlDateFormatter(
-            locale: $this->locale,
-            timezone: $this->timeZone,
+        return $this->dateFormatter(
             pattern: $format,
         )->format($value->toDateTime());
     }
@@ -129,17 +129,13 @@ class Formatter
         $format = $this->dateTimeFormats[$format]['datetime'] ?? $format;
 
         if (isset($this->defaultDateFormats[$format])) {
-            return new IntlDateFormatter(
-                locale: $this->locale,
+            return $this->dateFormatter(
                 dateType: $this->defaultDateFormats[$format] ?? IntlDateFormatter::NONE,
                 timeType: $this->defaultDateFormats[$format] ?? IntlDateFormatter::NONE,
-                timezone: $this->timeZone,
             )->format($value->toDateTime());
         }
 
-        return new IntlDateFormatter(
-            locale: $this->locale,
-            timezone: $this->timeZone,
+        return $this->dateFormatter(
             pattern: $format,
         )->format($value->toDateTime());
     }
@@ -412,19 +408,33 @@ class Formatter
         $format = $this->dateTimeFormats[$format]['time'] ?? $format;
 
         if (isset($this->defaultDateFormats[$format])) {
-            return new IntlDateFormatter(
-                locale: $this->locale,
+            return $this->dateFormatter(
                 dateType: IntlDateFormatter::NONE,
                 timeType: $this->defaultDateFormats[$format] ?? IntlDateFormatter::NONE,
-                timezone: $this->timeZone,
             )->format($value->toDateTime());
         }
 
-        return new IntlDateFormatter(
-            locale: $this->locale,
-            timezone: $this->timeZone,
+        return $this->dateFormatter(
             pattern: $format,
         )->format($value->toDateTime());
+    }
+
+    private function dateFormatter(
+        int $dateType = IntlDateFormatter::FULL,
+        int $timeType = IntlDateFormatter::FULL,
+        ?string $pattern = null,
+    ): IntlDateFormatter {
+        $locale = $this->locale;
+        $timeZone = $this->timeZone;
+        $key = serialize([$locale, IntlLocale::getDefault(), $timeZone, $dateType, $timeType, $pattern]);
+
+        return $this->dateFormatters[$key] ??= new IntlDateFormatter(
+            locale: $locale,
+            dateType: $dateType,
+            timeType: $timeType,
+            timezone: $timeZone,
+            pattern: $pattern,
+        );
     }
 
     public function asTimestamp(int|string|DateTimeInterface $value, ?string $format = null, bool $withPreposition = false): string

--- a/src/Translation/Locale.php
+++ b/src/Translation/Locale.php
@@ -9,6 +9,7 @@ use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use IntlDateFormatter;
+use Locale as IntlLocale;
 use NumberFormatter;
 use RuntimeException;
 use Stringable;
@@ -230,7 +231,7 @@ class Locale implements Stringable
         // If no target locale is specified, default to this locale
         $inLocale ??= $this->id;
 
-        return \Locale::getDisplayName($this->id, $inLocale);
+        return IntlLocale::getDisplayName($this->id, $inLocale);
     }
 
     public function setDisplayName(?string $displayName): self
@@ -575,6 +576,9 @@ class Locale implements Stringable
      */
     private function _getDateTimeIcuFormat(string $length, bool $withDate, bool $withTime): string
     {
+        static $context = null;
+        static $patterns = [];
+
         // Convert length to IntlDateFormatter constants
         $length = match ($length) {
             self::LENGTH_FULL => IntlDateFormatter::FULL,
@@ -586,11 +590,23 @@ class Locale implements Stringable
 
         $dateType = ($withDate ? $length : IntlDateFormatter::NONE);
         $timeType = ($withTime ? $length : IntlDateFormatter::NONE);
-        $formatter = new IntlDateFormatter($this->aliasOf ?? $this->id, $dateType, $timeType);
+        $locale = $this->aliasOf ?? $this->id;
+        $currentContext = [$locale, IntlLocale::getDefault(), date_default_timezone_get()];
+
+        if ($context !== $currentContext) {
+            $context = $currentContext;
+            $patterns = [];
+        }
+
+        if (isset($patterns[$dateType][$timeType])) {
+            return $patterns[$dateType][$timeType];
+        }
+
+        $formatter = new IntlDateFormatter($locale, $dateType, $timeType);
         $pattern = $formatter->getPattern();
 
         // Use 4-digit years
-        return strtr($pattern, [
+        return $patterns[$dateType][$timeType] = strtr($pattern, [
             'yyyy' => 'yyyy',
             'yy' => 'yyyy',
         ]);

--- a/src/User/Elements/User.php
+++ b/src/User/Elements/User.php
@@ -340,6 +340,8 @@ class User extends Element implements AuthenticatableContract, AuthorizableContr
      */
     private ?array $_groups = null;
 
+    private ?bool $_hasSsoIdentity = null;
+
     /**
      * @see setAttributesFromRequest()
      * @see afterSave()
@@ -416,7 +418,7 @@ class User extends Element implements AuthenticatableContract, AuthorizableContr
         return $this->id;
     }
 
-    /** @return MorphMany<DatabaseNotification, Model> */
+    /** @return MorphMany<DatabaseNotification, Model&AuthenticatableContract> */
     public function notifications(): MorphMany
     {
         $user = Auth::getProvider()->retrieveById($this->getAuthIdentifier());
@@ -934,6 +936,7 @@ class User extends Element implements AuthenticatableContract, AuthorizableContr
     public function setAttributesFromRequest(array $values): void
     {
         unset(
+            $values['hasSsoIdentity'],
             $values['invalidLoginCount'],
             $values['lastInvalidLoginDate'],
             $values['lastLoginAttemptIp'],
@@ -1021,7 +1024,12 @@ class User extends Element implements AuthenticatableContract, AuthorizableContr
     #[AllowedInSandbox]
     public function getHasSsoIdentity(): bool
     {
-        return $this->id !== null && app(OAuth::class)->hasIdentity($this->id);
+        return $this->id !== null && ($this->_hasSsoIdentity ?? app(OAuth::class)->hasIdentity($this->id));
+    }
+
+    public function setHasSsoIdentity(?bool $hasSsoIdentity): void
+    {
+        $this->_hasSsoIdentity = $hasSsoIdentity;
     }
 
     #[Override]

--- a/tests/Feature/Asset/AssetTransformersTest.php
+++ b/tests/Feature/Asset/AssetTransformersTest.php
@@ -11,6 +11,7 @@ use CraftCms\Cms\Asset\Data\AssetTransformer;
 use CraftCms\Cms\Asset\Data\AssetTransformRequest;
 use CraftCms\Cms\Asset\Data\AssetTransformResult;
 use CraftCms\Cms\Asset\Data\Volume as VolumeData;
+use CraftCms\Cms\Asset\Elements\Asset as AssetElement;
 use CraftCms\Cms\Asset\Exceptions\AssetTransformerNotFoundException;
 use CraftCms\Cms\Asset\Exceptions\AssetTransformException;
 use CraftCms\Cms\Asset\Exceptions\InvalidAssetTransformException;
@@ -26,6 +27,7 @@ use CraftCms\Cms\ProjectConfig\ProjectConfig;
 use CraftCms\Cms\Support\Facades\Deprecator;
 use CraftCms\Cms\Support\Str;
 use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 
 it('resolves the Craft transformer without writing project config', function () {
@@ -251,6 +253,91 @@ it('uses driver rules in place of conflicting core rules', function () {
         ))->toThrow(InvalidAssetTransformException::class);
 });
 
+it('passes complex custom parameters through without serializing or reusing them', function () {
+    $driver = registerTransformer('remote');
+    $asset = Asset::factory()->createElement();
+    $transformers = app(AssetTransformers::class);
+    $first = fn () => 'first';
+    $second = fn () => 'second';
+
+    $transformers->transform($asset, ['callback' => $first], transformer: 'remote');
+    expect($driver->request->parameters['callback'])->toBe($first);
+
+    $transformers->transform($asset, ['callback' => $second], transformer: 'remote');
+    expect($driver->request->parameters['callback'])->toBe($second);
+});
+
+it('reuses validated Craft transform definitions across assets', function () {
+    $transformers = app(AssetTransformers::class);
+    $assets = [Asset::factory()->createElement(), Asset::factory()->createElement()];
+    $driver = Mockery::mock(CraftAssetTransformDriver::class);
+    $driver->shouldReceive('definition')->once()->andReturn(new AssetTransformDriverDefinition('Craft'));
+    $driver->shouldReceive('transform')->twice()->andReturn(new AssetTransformResult('/thumbnail.jpg', 'image/jpeg'));
+    app(AssetTransformDrivers::class)->extend('craft', fn () => $driver);
+
+    $transformers->transform($assets[0], ['width' => 24, 'height' => 24, 'mode' => 'crop']);
+    $transformers->transform($assets[1], ['mode' => 'crop', 'height' => 24, 'width' => 24]);
+});
+
+it('validates each normalized definition once across preloading and rendering', function () {
+    $driver = new TestPreloadingAssetTransformDriver;
+    registerTransformer('remote', driver: $driver);
+    Cms::config()->defaultAssetTransformer('remote');
+    $assets = [Asset::factory()->createElement(), Asset::factory()->createElement()];
+    $transformers = app(AssetTransformers::class);
+    $validator = Validator::getFacadeRoot();
+    Validator::shouldReceive('make')->twice()->andReturnUsing($validator->make(...));
+
+    $transformers->preload($assets, [['width' => 100], '2x']);
+
+    foreach ($assets as $asset) {
+        $transformers->transform($asset, ['width' => 100]);
+        $transformers->transform($asset, ['width' => 200]);
+    }
+
+    expect($driver->requests)->toHaveCount(4)
+        ->and($driver->request->parameters)->toBe(['width' => 200]);
+});
+
+it('revalidates definitions after resetting transformers or replacing a driver', function () {
+    registerTransformer('remote');
+    $asset = Asset::factory()->createElement();
+    $transformers = app(AssetTransformers::class);
+    $validator = Validator::getFacadeRoot();
+    Validator::shouldReceive('make')->times(3)->andReturnUsing($validator->make(...));
+
+    $transformers->transform($asset, ['width' => 100], transformer: 'remote');
+    $transformers->reset();
+    $transformers->transform($asset, ['width' => 100], transformer: 'remote');
+
+    app(AssetTransformDrivers::class)->forgetDrivers()->extend('remote', fn () => new TestAssetTransformDriver(
+        new AssetTransformDriverDefinition('Remote', parameterRules: ['width' => ['integer', 'max:50']]),
+    ));
+
+    expect(fn () => $transformers->transform($asset, ['width' => 100], transformer: 'remote'))
+        ->toThrow(InvalidAssetTransformException::class);
+});
+
+it('preserves parameter rules declared by a custom Craft driver definition', function () {
+    $driver = new class(new ImageTransformer) extends CraftAssetTransformDriver
+    {
+        public function definition(): AssetTransformDriverDefinition
+        {
+            return new AssetTransformDriverDefinition('Custom Craft', parameterRules: [
+                'width' => [Rule::in(['auto'])],
+            ]);
+        }
+    };
+    app(AssetTransformDrivers::class)->extend('custom-craft', fn () => $driver);
+    $transformer = new AssetTransformer(['driver' => 'custom-craft']);
+    $transformers = app(AssetTransformers::class);
+
+    expect($transformers->validateParameters($transformer, ['width' => 'auto']))
+        ->toBe(['width' => 'auto'])
+        ->and(fn () => $transformers->validateParameters($transformer, ['width' => 24]))
+        ->toThrow(InvalidAssetTransformException::class);
+});
+
 it('rejects invalid parameters and missing transformer handles', function () {
     registerTransformer('remote');
     $asset = Asset::factory()->createElement();
@@ -267,7 +354,7 @@ it('rejects invalid parameters and missing transformer handles', function () {
         ))->toThrow(AssetTransformerNotFoundException::class);
 });
 
-it('preloads requests grouped by driver', function () {
+it('preloads requests grouped by driver', function (bool $perAsset) {
     $firstDriver = new TestPreloadingAssetTransformDriver;
     $secondDriver = new TestPreloadingAssetTransformDriver;
     registerTransformer('first', driver: $firstDriver);
@@ -282,18 +369,28 @@ it('preloads requests grouped by driver', function () {
             'assetTransformer' => $handle,
         ]);
 
-        return Asset::factory()->createElement(['volumeId' => $volume->id]);
+        return Asset::factory()->createElement([
+            'volumeId' => $volume->id,
+            'filename' => 'source.jpg',
+            'kind' => 'image',
+            'width' => $handle === 'first' ? 320 : 640,
+            'height' => 200,
+        ]);
     })->all();
 
-    app(AssetTransformers::class)->preload($assets, [['width' => 320]]);
+    app(AssetTransformers::class)->preload($assets, $perAsset
+        ? fn (AssetElement $asset): array => [['width' => $asset->getWidth()]]
+        : [['width' => 320]]);
 
     expect($firstDriver->requests)->toHaveCount(1)
         ->and($firstDriver->requests[0]->asset)->toBe($assets[0])
         ->and($firstDriver->requests[0]->transformer->handle)->toBe('first')
+        ->and($firstDriver->requests[0]->parameters)->toBe(['width' => 320])
         ->and($secondDriver->requests)->toHaveCount(1)
         ->and($secondDriver->requests[0]->asset)->toBe($assets[1])
-        ->and($secondDriver->requests[0]->transformer->handle)->toBe('second');
-});
+        ->and($secondDriver->requests[0]->transformer->handle)->toBe('second')
+        ->and($secondDriver->requests[0]->parameters)->toBe(['width' => $perAsset ? 640 : 320]);
+})->with(['shared definitions' => false, 'asset-specific definitions' => true]);
 
 it('redacts transformer settings from debug output', function () {
     $request = new AssetTransformRequest(

--- a/tests/Feature/Asset/AssetsTest.php
+++ b/tests/Feature/Asset/AssetsTest.php
@@ -76,6 +76,17 @@ it('can get total assets', function () {
     expect($this->assets->getTotalAssets())->toBe(3);
 });
 
+it('resolves thumbnail dimensions for table and card sizes', function (?int $width, ?int $height, int $size, array $expected) {
+    $asset = AssetModel::factory()->createElement(['width' => $width, 'height' => $height]);
+
+    expect($this->assets->getThumbDimensions($asset, $size))->toBe($expected);
+})->with([
+    'landscape' => [800, 400, 30, [30, 15]],
+    'portrait' => [400, 600, 60, [40, 60]],
+    'card' => [800, 400, 128, [128, 128]],
+    'missing dimensions' => [null, null, 30, [30, 30]],
+]);
+
 it('dispatches ThumbUrlResolving event in getThumbUrl', function () {
     Event::fake([ThumbUrlResolving::class]);
 

--- a/tests/Feature/Auth/OAuth/OAuthIdentityPresenceTest.php
+++ b/tests/Feature/Auth/OAuth/OAuthIdentityPresenceTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Auth\Models\SsoIdentity;
+use CraftCms\Cms\Auth\OAuth\Data\ProviderDefinition;
+use CraftCms\Cms\Auth\OAuth\OAuth;
+use CraftCms\Cms\Database\Table;
+use CraftCms\Cms\User\Elements\User;
+use CraftCms\Cms\User\Models\User as UserModel;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach(function () {
+    $this->provider = new ProviderDefinition(
+        handle: 'test',
+        driver: 'test',
+        providerClass: null,
+        name: 'Test',
+        label: 'Test',
+        clientId: null,
+        clientSecret: null,
+    );
+});
+
+it('selects identity presence with users without additional lookups', function () {
+    $models = UserModel::factory()->count(3)->active()->create();
+    app(OAuth::class)->linkIdentity($models[0]->asElement(), $this->provider, 'linked-identity');
+
+    DB::enableQueryLog();
+    $users = User::find()->id($models->modelKeys())->orderBy('id')->all();
+
+    expect($users[0]->getHasSsoIdentity())->toBeTrue()
+        ->and($users[1]->getHasSsoIdentity())->toBeFalse()
+        ->and($users[2]->getHasSsoIdentity())->toBeFalse()
+        ->and($users[0]->getHasSsoIdentity())->toBeTrue()
+        ->and($users[1]->getHasSsoIdentity())->toBeFalse();
+
+    $queries = array_filter(DB::getQueryLog(), fn (array $query): bool => str_contains($query['query'], Table::SSO_IDENTITIES));
+    DB::disableQueryLog();
+
+    expect($queries)->toHaveCount(1);
+});
+
+it('reuses selected identity presence on clones and queries detached and scalar users', function () {
+    $model = UserModel::factory()->active()->create();
+    app(OAuth::class)->linkIdentity($model->asElement(), $this->provider, 'linked-identity');
+    $user = User::find()->id($model->id)->one();
+    $clone = clone $user;
+    $detached = $model->asElement();
+
+    DB::enableQueryLog();
+
+    expect($user->getHasSsoIdentity())->toBeTrue()
+        ->and($clone->getHasSsoIdentity())->toBeTrue()
+        ->and($detached->getHasSsoIdentity())->toBeTrue()
+        ->and(app(OAuth::class)->hasIdentity($user->id))->toBeTrue();
+
+    $queries = array_filter(DB::getQueryLog(), fn (array $query): bool => str_contains($query['query'], Table::SSO_IDENTITIES));
+    DB::disableQueryLog();
+
+    expect($queries)->toHaveCount(2);
+});
+
+it('looks up identities for users created without a query result', function () {
+    $user = UserModel::factory()->active()->create()->asElement();
+    app(OAuth::class)->linkIdentity($user, $this->provider, 'linked-identity');
+
+    expect($user->elementQueryResult)->toBeNull()
+        ->and($user->getHasSsoIdentity())->toBeTrue();
+});
+
+it('does not query identity presence for unsaved users', function () {
+    DB::enableQueryLog();
+
+    expect(UserModel::factory()->make()->asElement()->getHasSsoIdentity())->toBeFalse();
+
+    $queries = array_filter(DB::getQueryLog(), fn (array $query): bool => str_contains($query['query'], Table::SSO_IDENTITIES));
+    DB::disableQueryLog();
+
+    expect($queries)->toBe([]);
+});
+
+it('looks up identity presence when it was omitted from the user query', function () {
+    $model = UserModel::factory()->active()->create();
+    app(OAuth::class)->linkIdentity($model->asElement(), $this->provider, 'linked-identity');
+    $user = User::find()->select('id')->id($model->id)->one();
+
+    expect($user->getHasSsoIdentity())->toBeTrue();
+});
+
+it('refreshes a selected identity snapshot when the user is queried again', function () {
+    $model = UserModel::factory()->active()->create();
+    $user = User::find()->id($model->id)->one();
+    $clone = clone $user;
+    app(OAuth::class)->linkIdentity($model->asElement(), $this->provider, 'linked-identity');
+
+    expect($user->getHasSsoIdentity())->toBeFalse()
+        ->and($clone->getHasSsoIdentity())->toBeFalse()
+        ->and(User::find()->id($model->id)->one()->getHasSsoIdentity())->toBeTrue()
+        ->and(app(OAuth::class)->hasIdentity($model->id))->toBeTrue();
+});
+
+it('does not accept identity presence from request attributes', function () {
+    $model = UserModel::factory()->active()->create();
+    $user = User::find()->id($model->id)->one();
+
+    $user->setAttributesFromRequest(['hasSsoIdentity' => true]);
+
+    expect($user->getHasSsoIdentity())->toBeFalse();
+});
+
+it('refreshes identity presence in a new request or job scope', function () {
+    $user = UserModel::factory()->active()->createElement();
+    $oauth = app(OAuth::class);
+
+    expect($user->getHasSsoIdentity())->toBeFalse();
+
+    DB::table(Table::SSO_IDENTITIES)->insert([
+        'provider' => 'test',
+        'identityId' => 'identity-linked-in-another-process',
+        'userId' => $user->id,
+        'dateCreated' => now('UTC'),
+        'dateUpdated' => now('UTC'),
+    ]);
+    app()->forgetScopedInstances();
+
+    expect(app(OAuth::class))->not()->toBe($oauth)
+        ->and($user->getHasSsoIdentity())->toBeTrue();
+});
+
+it('updates identity presence and suspension permissions after linking and unlinking', function () {
+    $operator = UserModel::factory()->create(['admin' => true]);
+    $model = UserModel::factory()->active()->create();
+    $user = User::find()->id($model->id)->one();
+    $oauth = app(OAuth::class);
+
+    expect($user->getHasSsoIdentity())->toBeFalse()
+        ->and(Gate::forUser($operator)->allows('suspend', $user))->toBeTrue();
+
+    $oauth->linkIdentity($user, $this->provider, 'linked-identity');
+
+    expect($user->getHasSsoIdentity())->toBeTrue()
+        ->and(Gate::forUser($operator)->allows('suspend', $user))->toBeFalse();
+
+    $oauth->unlinkIdentity($user, $this->provider);
+
+    expect($user->getHasSsoIdentity())->toBeFalse()
+        ->and(Gate::forUser($operator)->allows('suspend', $user))->toBeTrue();
+});
+
+it('refreshes both users when an identity moves to a different user', function () {
+    $previousUser = UserModel::factory()->active()->createElement();
+    $nextUser = UserModel::factory()->active()->createElement();
+    $oauth = app(OAuth::class);
+    $oauth->linkIdentity($previousUser, $this->provider, 'shared-identity');
+
+    expect($previousUser->getHasSsoIdentity())->toBeTrue()
+        ->and($nextUser->getHasSsoIdentity())->toBeFalse();
+
+    $oauth->linkIdentity($nextUser, $this->provider, 'shared-identity');
+
+    expect($previousUser->getHasSsoIdentity())->toBeFalse()
+        ->and($nextUser->getHasSsoIdentity())->toBeTrue();
+});
+
+it('refreshes identity presence when identities are saved or deleted through the model', function () {
+    $user = UserModel::factory()->active()->createElement();
+    $nextUser = UserModel::factory()->active()->createElement();
+    $clone = clone $user;
+
+    expect($user->getHasSsoIdentity())->toBeFalse()
+        ->and($nextUser->getHasSsoIdentity())->toBeFalse();
+
+    $identity = SsoIdentity::query()->firstOrNew([
+        'provider' => 'test',
+        'identityId' => 'directly-linked-identity',
+    ]);
+    $identity->userId = $user->id;
+    $identity->save();
+
+    expect($clone->getHasSsoIdentity())->toBeTrue()
+        ->and(app(OAuth::class)->hasIdentity($user->id))->toBeTrue();
+
+    $identity = SsoIdentity::query()->where('userId', $user->id)->firstOrFail();
+    $identity->setKeyName('identityId');
+    $identity->userId = $nextUser->id;
+    $identity->save();
+
+    expect($user->getHasSsoIdentity())->toBeFalse()
+        ->and($clone->getHasSsoIdentity())->toBeFalse()
+        ->and($nextUser->getHasSsoIdentity())->toBeTrue();
+
+    $identity->delete();
+
+    expect($nextUser->getHasSsoIdentity())->toBeFalse();
+});
+
+it('keeps identity presence when another provider is still linked', function () {
+    $user = UserModel::factory()->active()->createElement();
+    $otherProvider = new ProviderDefinition(
+        handle: 'other',
+        driver: 'test',
+        providerClass: null,
+        name: 'Other',
+        label: 'Other',
+        clientId: null,
+        clientSecret: null,
+    );
+    $oauth = app(OAuth::class);
+    $oauth->linkIdentity($user, $this->provider, 'test-identity');
+    $oauth->linkIdentity($user, $otherProvider, 'other-identity');
+
+    expect($user->getHasSsoIdentity())->toBeTrue();
+
+    $oauth->unlinkIdentity($user, $this->provider);
+
+    expect($user->getHasSsoIdentity())->toBeTrue();
+
+    $oauth->unlinkIdentity($user, $otherProvider);
+
+    expect($user->getHasSsoIdentity())->toBeFalse();
+});
+
+it('restores identity presence after an outer transaction rolls back', function (bool $linked) {
+    $user = UserModel::factory()->active()->createElement();
+    $oauth = app(OAuth::class);
+    if ($linked) {
+        $oauth->linkIdentity($user, $this->provider, 'linked-identity');
+    }
+
+    expect($user->getHasSsoIdentity())->toBe($linked);
+
+    DB::beginTransaction();
+    try {
+        if ($linked) {
+            $oauth->unlinkIdentity($user, $this->provider);
+        } else {
+            $oauth->linkIdentity($user, $this->provider, 'linked-identity');
+        }
+
+        expect($user->getHasSsoIdentity())->toBe(! $linked);
+    } finally {
+        DB::rollBack();
+    }
+
+    expect($user->getHasSsoIdentity())->toBe($linked);
+})->with(['link rollback' => false, 'unlink rollback' => true]);

--- a/tests/Feature/Database/Migrations/ElementLookupIndexesTest.php
+++ b/tests/Feature/Database/Migrations/ElementLookupIndexesTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+it('preserves the SQLite URI expression index through installation', function () {
+    $columns = DB::select('PRAGMA index_info("sites_uri_siteid_index")');
+    $plan = DB::select('EXPLAIN QUERY PLAN SELECT "elementId" FROM "elements_sites" WHERE lower("uri") = ? AND "siteId" = ?', ['missing-page', 1]);
+
+    expect(array_column($columns, 'cid'))->toBe([-2, 2])
+        ->and($plan[0]->detail)->toContain('sites_uri_siteid_index');
+})->skip(fn () => ! DB::isSqlite(), 'SQLite expression index regression.');

--- a/tests/Feature/Element/ElementEagerLoaderTest.php
+++ b/tests/Feature/Element/ElementEagerLoaderTest.php
@@ -217,6 +217,8 @@ it('eager loads nested elements per site and collects cache expiry data', functi
         ->and($relatedForSourceA?->last()?->getEagerLoadedElements('child')?->pluck('id')->all())->toBe([401])
         ->and($relatedForSourceC?->first()?->getEagerLoadedElements('child')?->pluck('id')->all())->toBe([402])
         ->and($relatedForSourceA?->first()?->eagerLoadInfo?->plan->handle)->toBe('related')
+        ->and(array_column($relatedForSourceA?->first()?->elementQueryResult ?? [], 'id'))->toBe([201, 202])
+        ->and(array_column($relatedForSourceC?->first()?->elementQueryResult ?? [], 'id'))->toBe([301])
         ->and(array_merge(...TestElementEagerLoaderQuery::$afterHydrateCalls[TestElementEagerLoaderExpirableTargetElement::class]))->toBe([201, 202, 301])
         ->and(array_merge(...TestElementEagerLoaderQuery::$afterHydrateCalls[TestElementEagerLoaderNestedTargetElement::class]))->toBe([401, 402])
         ->and($duration)->toBeInt()

--- a/tests/Feature/Element/NestedElementManagerTest.php
+++ b/tests/Feature/Element/NestedElementManagerTest.php
@@ -30,6 +30,7 @@ use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\User\Models\User as UserModel;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Symfony\Component\DomCrawler\Crawler;
 
 use function Pest\Laravel\actingAs;
@@ -617,6 +618,39 @@ it('eager-loads matrix entries for the requested source owner', function () {
     expect($eagerLoaded)->toHaveCount(1)
         ->and($eagerLoaded[0]->id)->toBe($firstNested->id)
         ->and($eagerLoaded[0]->getPrimaryOwnerId())->toBe($owner->id);
+});
+
+it('maps Matrix entries by owner while preserving field boundaries and sort order', function () {
+    ['owner' => $owner, 'field' => $field, 'entryType' => $entryType, 'ownerType' => $ownerType, 'section' => $section] = createMatrixOwnerFixture();
+
+    $last = createMatrixNestedEntry($owner, $field, $entryType, 2, 'Last block');
+    $first = createMatrixNestedEntry($owner, $field, $entryType, 1, 'First block');
+    $otherField = Field::factory()->create(['type' => Matrix::class, 'settings' => ['entryTypes' => [$entryType->id]]]);
+    Fields::refreshFields();
+    createMatrixNestedEntry($owner, Fields::getFieldById($otherField->id), $entryType, 3, 'Other field block');
+    $otherOwner = EntryModel::factory()->forSection($section)->forEntryType($ownerType)->createElement();
+    createMatrixNestedEntry($otherOwner, $field, $entryType, 1, 'Other owner block');
+    $emptyOwners = EntryModel::factory()->forSection($section)->forEntryType($ownerType)->count(49)->create();
+    $sourceElements = EntryElement::find()->id([$owner->id, ...$emptyOwners->modelKeys()])->all();
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    $map = $field->getEagerLoadingMap($sourceElements);
+    $query = DB::getQueryLog()[0];
+
+    DB::disableQueryLog();
+
+    expect($map['map'])->toBe([
+        ['source' => $owner->id, 'target' => $first->id],
+        ['source' => $owner->id, 'target' => $last->id],
+    ])->and($field->getEagerLoadingMap([])['map'])->toBe([]);
+
+    if (DB::isSqlite()) {
+        $plan = DB::select('EXPLAIN QUERY PLAN '.$query['query'], $query['bindings']);
+
+        expect($plan[0]->detail)->toContain(Schema::indexName(Table::ELEMENTS_OWNERS, ['ownerId']));
+    }
 });
 
 it('creates eager-loaded field addresses with the requested source owner', function () {

--- a/tests/Feature/Element/Queries/Concerns/QueriesNestedElementsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/QueriesNestedElementsTest.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Entry\Models\Entry;
 use CraftCms\Cms\Field\ContentBlock;
 use CraftCms\Cms\Field\Models\Field;
+use CraftCms\Cms\Site\Models\Site;
 use CraftCms\Cms\Support\Facades\ElementCaches;
 use CraftCms\Cms\Support\Facades\Elements;
 use CraftCms\Cms\Support\Facades\Fields;
+use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\DependencyAwareCache\Dependency\TagDependency;
 use Illuminate\Support\Facades\DB;
 
@@ -127,4 +131,40 @@ test('field(false) only returns entries with no field', function () {
         ]);
 
     expect(entryQuery()->field(false)->ids())->toEqualCanonicalizing([$topLevelEntry->id, $owner->id]);
+});
+
+test('owner filters preserve shared nested entries and the selected owners sort order', function () {
+    $field = Field::factory()->create(['type' => ContentBlock::class]);
+    Fields::refreshFields();
+
+    $primaryOwner = Entry::factory()->create();
+    $secondaryOwner = Entry::factory()->create();
+    $first = Entry::factory()->create(['primaryOwnerId' => $primaryOwner->id, 'fieldId' => $field->id]);
+    $second = Entry::factory()->create(['primaryOwnerId' => $primaryOwner->id, 'fieldId' => $field->id]);
+
+    DB::table(Table::ELEMENTS_OWNERS)->insert([
+        ['elementId' => $first->id, 'ownerId' => $primaryOwner->id, 'sortOrder' => 1],
+        ['elementId' => $second->id, 'ownerId' => $primaryOwner->id, 'sortOrder' => 2],
+        ['elementId' => $first->id, 'ownerId' => $secondaryOwner->id, 'sortOrder' => 2],
+        ['elementId' => $second->id, 'ownerId' => $secondaryOwner->id, 'sortOrder' => 1],
+    ]);
+
+    $query = entryQuery()->fieldId($field->id)->ownerId($secondaryOwner->id);
+
+    expect($query->ids())->toBe([$second->id, $first->id]);
+    expect($query->count())->toBe(2);
+    expect(collect($query->all())->pluck('ownerId')->all())->toBe([$secondaryOwner->id, $secondaryOwner->id]);
+    expect((clone $query)->ownerId($primaryOwner->id)->ids())->toBe([$first->id, $second->id]);
+    expect(entryQuery()->ownerId([$primaryOwner->id, $secondaryOwner->id])->count())->toBe(4);
+    expect(entryQuery()->ownerId([$primaryOwner->id, $secondaryOwner->id])->ids())->toEqualCanonicalizing([$first->id, $first->id, $second->id, $second->id]);
+    expect(entryQuery()->ownerId([])->ids())->toEqualCanonicalizing([$primaryOwner->id, $secondaryOwner->id, $first->id, $second->id]);
+    expect(entryQuery()->ownerId(-1)->count())->toBe(0);
+    expect(entryQuery()->ownerId(false)->ids())->toEqualCanonicalizing([$primaryOwner->id, $secondaryOwner->id, $first->id, $second->id]);
+
+    $secondSite = Site::factory()->create();
+    $first->element->siteSettings->first()->update(['siteId' => $secondSite->id]);
+    Sites::refreshSites();
+
+    expect(entryQuery()->ownerId($secondaryOwner->id)->ids())->toBe([$second->id]);
+    expect(entryQuery()->ownerId($secondaryOwner->id)->siteId($secondSite->id)->ids())->toBe([$first->id]);
 });

--- a/tests/Feature/Element/Queries/Concerns/SearchesElementsTest.php
+++ b/tests/Feature/Element/Queries/Concerns/SearchesElementsTest.php
@@ -1,9 +1,95 @@
 <?php
 
+declare(strict_types=1);
+
 use CraftCms\Cms\Asset\Elements\Asset as AssetElement;
 use CraftCms\Cms\Asset\Models\Asset as AssetModel;
+use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Site\Models\Site;
 use CraftCms\Cms\Support\Facades\Search;
+use CraftCms\Cms\Support\Facades\Sites;
+use Illuminate\Support\Facades\DB;
+
+test('unscored search filters candidates without materializing matching index rows', function () {
+    $entry = EntryModel::factory()->title('Orchard')->slug('orchard')->indexed()->create();
+    EntryModel::factory()->title('Orchard elsewhere')->indexed()->create();
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    $results = entryQuery()->id($entry->id)->search('orchard')->ids();
+    $queries = collect(DB::getQueryLog())->filter(fn (array $query) => str_contains($query['query'], 'searchindex'));
+
+    DB::disableQueryLog();
+
+    expect($results)->toBe([$entry->id]);
+    expect($queries)->toHaveCount(1);
+    expect($queries->first()['query'])->toContain('exists');
+});
+
+test('unscored search retains site filters and observes index changes', function () {
+    $entry = EntryModel::factory()->title('Orchard')->indexed()->create();
+    $siteId = Sites::getCurrentSite()->id;
+    $otherSite = Site::factory()->create();
+    Sites::refreshSites();
+
+    DB::table(Table::SEARCHINDEX)->insert([
+        'elementId' => $entry->id,
+        'siteId' => $otherSite->id,
+        'attribute' => 'title',
+        'fieldId' => '0',
+        'keywords' => ' berry ',
+        ...(DB::isPgsql() ? ['keywords_vector' => ' berry '] : []),
+    ]);
+
+    expect(entryQuery()->siteId($siteId)->search('berry')->count())->toBe(0);
+    expect(entryQuery()->siteId([$siteId, $otherSite->id])->search('berry')->ids())->toBe([$entry->id]);
+
+    DB::table(Table::SEARCHINDEX)->where('elementId', $entry->id)->update([
+        'keywords' => ' apple ',
+        ...(DB::isPgsql() ? ['keywords_vector' => ' apple '] : []),
+    ]);
+
+    expect(entryQuery()->search('orchard')->count())->toBe(0);
+    expect(entryQuery()->search('apple')->ids())->toBe([$entry->id]);
+});
+
+test('unscored search paginates unique matching elements', function () {
+    $entries = EntryModel::factory()->title('Orchard')->slug('orchard')->indexed()->count(3)->create();
+
+    $page = entryQuery()->search('orchard')->orderBy('id')->paginate(2, page: 2);
+
+    expect($page->total())->toBe(3);
+    expect($page->items())->toHaveCount(1);
+    expect($page->items()[0]->id)->toBe($entries->last()->id);
+});
+
+test('unscored candidate filtering preserves keyword conditions', function (string $term) {
+    EntryModel::factory()->title('Orchard apples')->slug('green-fruit')->indexed()->create();
+    EntryModel::factory()->title('Berry fruit')->slug('orchard')->indexed()->create();
+    EntryModel::factory()->title('Unrelated')->slug('other')->indexed()->create();
+
+    $query = entryQuery()->search($term);
+    $search = Search::createDbQuery($term, $query);
+    $expected = $search === false ? [] : $search->pluck('elementId')->unique()->sort()->values()->all();
+
+    expect($query->ids())->toEqualCanonicalizing($expected);
+    expect($query->count())->toBe(count($expected));
+})->with([
+    'word' => 'orchard',
+    'prefix' => 'orch*',
+    'substring' => '*chard*',
+    'phrase' => '"orchard apples"',
+    'conjunction' => 'orchard apples',
+    'disjunction' => 'orchard OR berry',
+    'exclusion' => 'fruit -berry',
+    'attribute' => 'title:orchard',
+    'exact attribute' => 'slug::orchard',
+    'attribute exclusion' => 'title:-orchard',
+    'attribute disjunction' => 'title:orchard OR slug:orchard',
+    'missing' => 'nomatchingword',
+]);
 
 test('search', function () {
     $entry1 = EntryModel::factory()->title('Foo')->indexed()->create();

--- a/tests/Feature/Element/Queries/ElementQueryTest.php
+++ b/tests/Feature/Element/Queries/ElementQueryTest.php
@@ -2,16 +2,63 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Address\Models\Address;
+use CraftCms\Cms\Asset\Models\Asset;
+use CraftCms\Cms\Database\Table;
+use CraftCms\Cms\Element\Models\Element as ElementModel;
 use CraftCms\Cms\Element\Queries\AddressQuery;
 use CraftCms\Cms\Element\Queries\ContentBlockQuery;
 use CraftCms\Cms\Element\Queries\ElementQuery;
 use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Field\ContentBlock as ContentBlockField;
+use CraftCms\Cms\Field\Elements\ContentBlock;
+use CraftCms\Cms\Field\Models\Field;
+use CraftCms\Cms\User\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Facades\DB;
 use Tpetry\QueryExpressions\Language\Alias;
+
+it('preserves select expressions bindings and mapped aliases across element types', function (Closure $factory) {
+    $element = $factory();
+    $query = $element::find()->id($element->id)
+        ->select(['id as selectedId', new Alias(new Expression('6 * 7'), 'computedValue')])
+        ->selectRaw('? + 22 as bound_value', [20])
+        ->selectRaw("'text as value' as text_value")
+        ->asArray();
+
+    $expected = [
+        'selectedId' => $element->id,
+        'computedValue' => 42,
+        'bound_value' => 42,
+        'text_value' => 'text as value',
+    ];
+
+    expect($query->one())->toMatchArray($expected)
+        ->and($query->one())->toMatchArray($expected);
+})->with([
+    'entries' => fn () => EntryModel::factory()->createElement(),
+    'assets' => fn () => Asset::factory()->createElement(),
+    'users' => fn () => User::factory()->createElement(),
+    'addresses' => fn () => Address::factory()->createElement(),
+    'content blocks' => function () {
+        $field = Field::factory()->create(['type' => ContentBlockField::class]);
+        $owner = EntryModel::factory()->create();
+        $element = ElementModel::factory()->create(['type' => ContentBlock::class]);
+
+        DB::table(Table::CONTENTBLOCKS)->insert([
+            'id' => $element->id,
+            'primaryOwnerId' => $owner->id,
+            'fieldId' => $field->id,
+        ]);
+
+        return ContentBlock::find()->id($element->id)->one();
+    },
+]);
 
 it('can run basic queries', function () {
     expect(entryQuery()->all())->toBeEmpty();

--- a/tests/Feature/Http/Controllers/Assets/IndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/Assets/IndexControllerTest.php
@@ -2,11 +2,22 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Asset\Elements\Asset as AssetElement;
+use CraftCms\Cms\Asset\Events\ThumbUrlResolving;
+use CraftCms\Cms\Asset\Models\Asset;
 use CraftCms\Cms\Asset\Models\Volume;
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Database\Table;
+use CraftCms\Cms\Element\Events\QueryForTableAttributePreparing;
+use CraftCms\Cms\Image\Data\ImageTransform;
+use CraftCms\Cms\Image\ImageTransformer;
 use CraftCms\Cms\Support\Facades\Folders;
 use CraftCms\Cms\Support\Facades\Volumes;
 use CraftCms\Cms\User\Elements\User;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia;
 
 use function Pest\Laravel\actingAs;
@@ -56,6 +67,165 @@ it('renders with a default source', function () {
 
     get("/{$cpTrigger}/assets", ['defaultSource' => $volume->handle])->assertOk();
 });
+
+it('preloads existing thumbnail indexes for the displayed assets', function (int $sourceWidth, int $sourceHeight, array $transforms) {
+    Queue::fake();
+    $volume = Volume::factory()->create(['fs' => 'disk:test-disk']);
+    $folder = Folders::getRootFolderByVolumeId($volume->id);
+    $imageTransformer = new ImageTransformer;
+
+    foreach (range(1, 3) as $number) {
+        $asset = Asset::factory()->createElement([
+            'volumeId' => $volume->id,
+            'folderId' => $folder->id,
+            'filename' => "image-{$number}.jpg",
+            'kind' => 'image',
+            'width' => $sourceWidth,
+            'height' => $sourceHeight,
+            'dateModified' => now()->subMinute(),
+        ]);
+
+        foreach ($transforms as [$width, $height]) {
+            $imageTransformer->getTransformIndex($asset, new ImageTransform([
+                'width' => $width,
+                'height' => $height,
+                'mode' => 'crop',
+            ]));
+        }
+    }
+
+    $queries = [];
+    DB::listen(function (QueryExecuted $query) use (&$queries): void {
+        if (str_starts_with($query->sql, 'select') && str_contains($query->sql, Table::IMAGETRANSFORMINDEX)) {
+            $queries[] = $query;
+        }
+    });
+
+    $response = get(route('craft.cp.assets.index', ['defaultSource' => $volume->handle, 'per_page' => 2]), ['X-Inertia' => 'true'])
+        ->assertOk()
+        ->assertJsonPath('component', 'assets/Index')
+        ->assertJsonCount(2, 'props.data');
+
+    expect($queries)->toHaveCount(2);
+
+    $displayedIds = array_column($response->json('props.data'), 'id');
+    sort($displayedIds);
+
+    foreach ($queries as $query) {
+        $queriedIds = array_values(array_filter($query->bindings, is_int(...)));
+        sort($queriedIds);
+
+        expect($queriedIds)->toBe($displayedIds);
+    }
+
+    expect(DB::table(Table::IMAGETRANSFORMINDEX)->count())->toBe(6);
+})->with([
+    'landscape' => [800, 400, [[30, 15], [60, 30]]],
+    'portrait' => [400, 600, [[20, 30], [40, 60]]],
+    'square' => [600, 600, [[30, 30], [60, 60]]],
+]);
+
+it('preserves custom thumbnail URLs without resolving the configured transformer', function () {
+    $volume = Volume::factory()->create(['fs' => 'disk:test-disk']);
+    $asset = Asset::factory()->createElement([
+        'volumeId' => $volume->id,
+        'folderId' => Folders::getRootFolderByVolumeId($volume->id)->id,
+        'filename' => 'image.jpg',
+        'kind' => 'image',
+        'width' => 800,
+        'height' => 400,
+    ]);
+    Cms::config()->defaultAssetTransformer('missing');
+    $requests = [];
+    Event::listen(ThumbUrlResolving::class, function (ThumbUrlResolving $event) use (&$requests): void {
+        $requests[] = [$event->asset->id, $event->width, $event->height];
+        $event->url = 'https://example.test/custom-thumb.jpg';
+    });
+
+    get(route('craft.cp.assets.index', ['defaultSource' => $volume->handle]), ['X-Inertia' => 'true'])
+        ->assertOk()
+        ->assertJsonPath('props.data.0.title', fn (string $html): bool => str_contains($html, 'https://example.test/custom-thumb.jpg'));
+
+    expect($requests)->toBe([[$asset->id, 30, 15], [$asset->id, 60, 30]]);
+});
+
+it('preserves thumbnail overrides on asset subclasses', function () {
+    $volume = Volume::factory()->create(['fs' => 'disk:test-disk']);
+    Asset::factory()->createElement([
+        'volumeId' => $volume->id,
+        'folderId' => Folders::getRootFolderByVolumeId($volume->id)->id,
+        'filename' => 'custom-thumbnail.jpg',
+        'kind' => 'image',
+        'width' => 800,
+        'height' => 400,
+    ]);
+    Cms::config()->defaultAssetTransformer('missing');
+    Event::listen(QueryForTableAttributePreparing::class, function (QueryForTableAttributePreparing $event): void {
+        if ($event->elementType === AssetElement::class) {
+            $event->query->elementType = CustomThumbnailIndexAsset::class;
+        }
+    });
+
+    get(route('craft.cp.assets.index', ['defaultSource' => $volume->handle]), ['X-Inertia' => 'true'])
+        ->assertOk()
+        ->assertJsonCount(1, 'props.data')
+        ->assertJsonPath('props.data.0.title', fn (string $html): bool => str_contains($html, 'https://example.test/subclass-thumbnail.jpg'));
+});
+
+it('reports thumbnail jobs created while rendering the requested page data', function (bool $inertia, bool $queueOnly) {
+    $volume = Volume::factory()->create(['fs' => 'disk:test-disk']);
+    Asset::factory()->createElement([
+        'volumeId' => $volume->id,
+        'folderId' => Folders::getRootFolderByVolumeId($volume->id)->id,
+        'filename' => 'missing-thumbnails.jpg',
+        'kind' => 'image',
+        'width' => 800,
+        'height' => 400,
+    ]);
+    config(['queue.default' => 'database']);
+
+    expect(DB::table(Table::JOBPROGRESS)->count())->toBe(0);
+
+    $headers = $inertia ? ['X-Inertia' => 'true'] : [];
+    if ($queueOnly) {
+        $headers += [
+            'X-Inertia-Partial-Component' => 'assets/Index',
+            'X-Inertia-Partial-Data' => 'queue',
+        ];
+    }
+
+    $response = get(route('craft.cp.assets.index', ['defaultSource' => $volume->handle]), $headers)->assertOk();
+
+    if (! $inertia) {
+        $response->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('queue.hasWaitingJobs', true)
+            ->where('queue.hasReservedJobs', false)
+            ->where('queue.displayedJob', fn ($job): bool => $job !== null)
+            ->has('data', 1));
+
+        expect(DB::table(Table::JOBPROGRESS)->count())->toBe(2);
+
+        return;
+    }
+
+    $response->assertJsonPath('props.queue.hasWaitingJobs', ! $queueOnly)
+        ->assertJsonPath('props.queue.hasReservedJobs', false);
+
+    if ($queueOnly) {
+        $response->assertJsonMissingPath('props.data')
+            ->assertJsonPath('props.queue.displayedJob', null);
+    } else {
+        $response->assertJsonCount(1, 'props.data');
+
+        expect($response->json('props.queue.displayedJob'))->not()->toBeNull();
+    }
+
+    expect(DB::table(Table::JOBPROGRESS)->count())->toBe($queueOnly ? 0 : 2);
+})->with([
+    'Inertia response' => [true, false],
+    'initial HTML' => [false, false],
+    'queue only' => [true, true],
+]);
 
 it('includes a volume’s subfolders in the index results', function () {
     $volumeModel = Volume::factory()->create([
@@ -121,3 +291,11 @@ it('passes the route path segment through as defaultSource', function () {
             ->where('source.key', "volume:{$volume->uid}")
         );
 });
+
+class CustomThumbnailIndexAsset extends AssetElement
+{
+    protected function thumbUrl(int $size): ?string
+    {
+        return 'https://example.test/subclass-thumbnail.jpg';
+    }
+}

--- a/tests/Feature/Http/Controllers/ContentIndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/ContentIndexControllerTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Cms;
+use CraftCms\Cms\Cp\Html\ElementHtml;
+use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\ElementSources;
 use CraftCms\Cms\Entry\Elements\Entry as EntryElement;
 use CraftCms\Cms\Entry\Models\Entry as EntryModel;
@@ -17,7 +19,10 @@ use CraftCms\Cms\Support\Facades\Sections as SectionsFacade;
 use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Facades\Structures;
 use CraftCms\Cms\User\Elements\User;
+use CraftCms\Cms\User\Models\User as UserModel;
+use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia;
+use Mockery\MockInterface;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
@@ -53,6 +58,61 @@ it('paginates elements via query params', function () {
             ->where('pagination.current_page', 1)
         );
 });
+
+it('does not render element chips when only pagination is requested', function () {
+    EntryModel::factory()->count(3)->create();
+
+    $this->partialMock(ElementHtml::class, fn (MockInterface $mock) => $mock
+        ->shouldReceive('elementChipHtml')->never());
+
+    get("/{$this->cpTrigger}/content/entries", [
+        'X-Inertia' => 'true',
+        'X-Inertia-Partial-Component' => 'content/Index',
+        'X-Inertia-Partial-Data' => 'pagination',
+    ])
+        ->assertOk()
+        ->assertJsonPath('props.pagination.total', 3)
+        ->assertJsonMissingPath('props.data');
+});
+
+it('selects identity presence with users without separate lookups when rendering entry pages', function (bool $showAuthors) {
+    $section = Section::factory()->create();
+    $type = EntryType::factory()->create();
+    $authors = UserModel::factory()->count(4)->active()->create();
+
+    foreach ([0, 1, 2, 0, 3] as $index => $authorIndex) {
+        EntryModel::factory()->forSection($section)->forEntryType($type)
+            ->title("Article $index")
+            ->create()
+            ->authors()->attach($authors[$authorIndex]->id, ['sortOrder' => 1]);
+    }
+
+    DB::enableQueryLog();
+
+    get(route('craft.cp.content.index', [
+        'page' => 'entries',
+        'sectionHandle' => $section->handle,
+        'columns' => [$showAuthors ? 'authors' : 'id'],
+        'sort' => [['field' => 'title', 'direction' => 'asc']],
+        'per_page' => 4,
+    ]), [
+        'X-Inertia' => 'true',
+        'X-Inertia-Partial-Component' => 'content/Index',
+        'X-Inertia-Partial-Data' => 'data,pagination',
+    ])
+        ->assertOk()
+        ->assertJsonCount(4, 'props.data');
+
+    $queries = array_values(array_filter(DB::getQueryLog(), fn (array $query): bool => str_contains($query['query'], Table::SSO_IDENTITIES)));
+    DB::disableQueryLog();
+
+    expect($queries)->toHaveCount(1)
+        ->and($queries[0]['query'])->toContain('hasSsoIdentity');
+
+    if ($showAuthors) {
+        expect($queries[0]['bindings'])->toEqualCanonicalizing($authors->take(3)->modelKeys());
+    }
+})->with(['visible authors' => true, 'hidden authors' => false]);
 
 it('accepts sort parameters', function () {
     EntryModel::factory()->createElement(['title' => 'Zebra']);

--- a/tests/Feature/Image/ImageTransformerTest.php
+++ b/tests/Feature/Image/ImageTransformerTest.php
@@ -511,3 +511,84 @@ it('rejects invalid Craft driver settings', function () {
         ['width' => 100],
     )))->toThrow(FilesystemException::class);
 });
+
+it('keeps eager loaded index dates independent and follows the current timezone', function () {
+    $asset = ($this->createImageAsset)();
+    $transform = new ImageTransform(['width' => 100]);
+    $original = $this->transformer->getTransformIndex($asset, $transform);
+    $this->transformer->eagerLoadTransforms([$transform], [$asset]);
+
+    $first = $this->transformer->getTransformIndex($asset, $transform);
+    $first->dateIndexed->modify('+1 year');
+    $first->dateCreated->modify('+1 year');
+    $first->dateUpdated->modify('+1 year');
+    $first->fileExists = true;
+    $first->transform->width = 999;
+    Cms::config()->timezone('Europe/Brussels');
+
+    $second = $this->transformer->getTransformIndex($asset, $transform);
+    $persisted = $this->transformer->getTransformIndexModelById($original->id);
+
+    expect($second->id)->toBe($original->id)
+        ->and($second->fileExists)->toBeFalse()
+        ->and($second->transform->width)->toBe(100);
+
+    foreach (['dateIndexed', 'dateCreated', 'dateUpdated'] as $attribute) {
+        expect($second->$attribute->getTimestamp())->toBe($persisted->$attribute->getTimestamp())
+            ->and($second->$attribute->getTimezone()->getName())->toBe('Europe/Brussels')
+            ->and($second->$attribute)->not->toBe($first->$attribute);
+    }
+});
+
+it('reevaluates stale generation state when retrieving an eager loaded index', function (string $timeZone) {
+    Cms::config()->timezone($timeZone);
+    Cms::setDefaultTimezone();
+    $this->freezeSecond();
+    $asset = ($this->createImageAsset)();
+    $asset->dateModified = now()->subMinute();
+    $transform = new ImageTransform(['width' => 100]);
+    $original = $this->transformer->getTransformIndex($asset, $transform);
+    $original->inProgress = true;
+    $this->transformer->storeTransformIndexData($original);
+    $this->transformer->eagerLoadTransforms([$transform], [$asset]);
+
+    expect($this->transformer->getTransformIndex($asset, $transform)->inProgress)->toBeTrue();
+
+    $this->travel(31)->seconds();
+
+    expect($this->transformer->getTransformIndex($asset, $transform)->inProgress)->toBeFalse();
+
+    $this->travelBack();
+
+    expect($this->transformer->getTransformIndex($asset, $transform)->inProgress)->toBeTrue();
+})->with(['UTC', 'America/Los_Angeles', 'Asia/Tokyo']);
+
+it('stores transform creation and update times in UTC', function (string $timeZone) {
+    Cms::config()->timezone($timeZone);
+    Cms::setDefaultTimezone();
+    $this->freezeSecond();
+    $createdAt = now()->utc()->format('Y-m-d H:i:s');
+    $asset = ($this->createImageAsset)();
+    $transform = new ImageTransform(['width' => 100]);
+    $index = $this->transformer->getTransformIndex($asset, $transform);
+
+    $this->assertDatabaseHas(Table::IMAGETRANSFORMINDEX, [
+        'id' => $index->id,
+        'dateCreated' => $createdAt,
+        'dateUpdated' => $createdAt,
+    ]);
+
+    $this->travel(10)->seconds();
+    $updatedAt = now()->utc()->format('Y-m-d H:i:s');
+    $index->inProgress = true;
+    $this->transformer->storeTransformIndexData($index);
+
+    $this->assertDatabaseHas(Table::IMAGETRANSFORMINDEX, [
+        'id' => $index->id,
+        'dateCreated' => $createdAt,
+        'dateUpdated' => $updatedAt,
+        'inProgress' => true,
+    ]);
+
+    expect($this->transformer->getTransformIndexModelById($index->id)->inProgress)->toBeTrue();
+})->with(['America/Los_Angeles', 'Asia/Tokyo']);

--- a/tests/Feature/Image/ImagesTest.php
+++ b/tests/Feature/Image/ImagesTest.php
@@ -9,6 +9,8 @@ use CraftCms\Cms\Image\Raster;
 use CraftCms\Cms\Image\Svg;
 use CraftCms\Cms\Support\Facades\Images as ImagesFacade;
 use Illuminate\Support\Facades\File;
+use Intervention\Image\FileExtension;
+use Intervention\Image\Interfaces\DriverInterface;
 
 beforeEach(function () {
     $this->service = app(Images::class);
@@ -121,6 +123,34 @@ it('includes baseline supported image formats', function () {
     if ($this->service->getSupportsHeic()) {
         expect($formats)->toContain('heic');
     }
+});
+
+it('discovers additional image formats once and preserves configured formats and driver changes', function () {
+    $driver = Mockery::mock(DriverInterface::class);
+    $calls = [];
+    $driver->shouldReceive('supports')->andReturnUsing(function (FileExtension $extension) use (&$calls): bool {
+        $calls[] = $extension->value;
+
+        return $extension === FileExtension::WEBP;
+    });
+    $this->service->getManager()->driver = $driver;
+
+    expect($this->service->getSupportedImageFormats())->toBe(['jpg', 'jpeg', 'gif', 'png', 'webp']);
+    $firstCalls = $calls;
+
+    expect($this->service->getSupportedImageFormats())->toBe(['jpg', 'jpeg', 'gif', 'png', 'webp'])
+        ->and($calls)->toBe($firstCalls);
+
+    $this->service->setSupportedImageFormats(['custom']);
+
+    expect($this->service->getSupportedImageFormats())->toBe(['custom', 'webp'])
+        ->and($calls)->toBe($firstCalls);
+
+    $replacement = Mockery::mock(DriverInterface::class);
+    $replacement->shouldReceive('supports')->andReturnUsing(fn (FileExtension $extension): bool => $extension === FileExtension::AVIF);
+    $this->service->getManager()->driver = $replacement;
+
+    expect($this->service->getSupportedImageFormats())->toBe(['custom', 'avif']);
 });
 
 it('returns true for memory checks on svg and empty files', function () {

--- a/tests/Feature/Queue/JobProgressServiceTest.php
+++ b/tests/Feature/Queue/JobProgressServiceTest.php
@@ -4,19 +4,68 @@ declare(strict_types=1);
 
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\Table;
+use CraftCms\Cms\Http\Middleware\HandleInertiaRequests;
 use CraftCms\Cms\Queue\Enums\JobStatus;
 use CraftCms\Cms\Queue\JobProgress;
 use CraftCms\Cms\Queue\Models\JobProgress as JobProgressModel;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 
 use function Pest\Laravel\freezeTime;
 
 beforeEach(function () {
     $this->service = app(JobProgress::class);
+});
+
+it('checks reserved and pending job presence without hydrating the backlog', function () {
+    expect($this->service->hasReservedJobs())->toBeFalse()
+        ->and($this->service->hasPendingJobs())->toBeFalse();
+
+    $this->service->queued('pending-one', 'First pending job');
+    $this->service->queued('pending-two', 'Second pending job');
+    $this->service->processing('reserved-one');
+    $this->service->processing('reserved-two');
+
+    $retrieved = 0;
+    Event::listen('eloquent.retrieved: '.JobProgressModel::class, function () use (&$retrieved): void {
+        $retrieved++;
+    });
+
+    expect($this->service->hasReservedJobs())->toBeTrue()
+        ->and($this->service->hasPendingJobs())->toBeTrue()
+        ->and($retrieved)->toBe(0);
+});
+
+it('shares queue status while loading only the displayed job', function () {
+    $this->service->queued('pending-one', 'First pending job');
+    $this->service->queued('pending-two', 'Second pending job');
+    $this->service->processing('reserved-one');
+    $this->service->processing('reserved-two');
+
+    $request = Request::create(route('craft.cp.dashboard'));
+    $request->setLaravelSession(session()->driver());
+    $queue = app(HandleInertiaRequests::class)->share($request)['queue'];
+    $retrieved = 0;
+    Event::listen('eloquent.retrieved: '.JobProgressModel::class, function () use (&$retrieved): void {
+        $retrieved++;
+    });
+
+    $state = $queue();
+    $status = json_decode(json_encode($state, JSON_THROW_ON_ERROR), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($status['displayedJob'])->not()->toBeNull()
+        ->and($status['hasReservedJobs'])->toBeTrue()
+        ->and($status['hasWaitingJobs'])->toBeTrue()
+        ->and($retrieved)->toBe(1);
+
+    json_encode($state, JSON_THROW_ON_ERROR);
+
+    expect($retrieved)->toBe(1);
 });
 
 it('can set and retrieve job progress', function () {

--- a/tests/Feature/Site/SitesTest.php
+++ b/tests/Feature/Site/SitesTest.php
@@ -178,6 +178,32 @@ it('can get sites by id', function () {
     expect($this->sites->getSiteById(999))->toBeNull();
 });
 
+it('respects disabled site visibility when looking up sites by id', function (bool $enabled, ?bool $withDisabled) {
+    $site = Site::factory()->create(['enabled' => $enabled, 'primary' => false]);
+    $this->sites->refreshSites();
+
+    expect($this->sites->getSiteById($site->id, $withDisabled)?->id)
+        ->toBe($enabled || $withDisabled !== false ? $site->id : null);
+})->with([true, false])->with([true, false, null]);
+
+it('refreshes site id lookups when a site is enabled or disabled', function () {
+    $site = Site::factory()->create(['enabled' => true, 'primary' => false]);
+    $this->sites->refreshSites();
+
+    expect($this->sites->getSiteById($site->id, false)?->id)->toBe($site->id);
+
+    $site->update(['enabled' => false]);
+    $this->sites->refreshSites();
+
+    expect($this->sites->getSiteById($site->id, false))->toBeNull()
+        ->and($this->sites->getSiteById($site->id, true)?->id)->toBe($site->id);
+
+    $site->update(['enabled' => true]);
+    $this->sites->refreshSites();
+
+    expect($this->sites->getSiteById($site->id, false)?->id)->toBe($site->id);
+});
+
 it('can get sites by handle', function () {
     $defaultSite = Site::firstOrFail();
 

--- a/tests/Unit/CmsTest.php
+++ b/tests/Unit/CmsTest.php
@@ -139,6 +139,42 @@ it('falls back to UTC when ICU rejects the timezone', function () {
     expect(Cms::timezone())->toBe('UTC');
 });
 
+it('resolves timezone changes after successful ICU validation', function () {
+    Cms::config()->timezone = '$CRAFT_TEST_TIMEZONE';
+
+    try {
+        foreach (['Europe/Paris', 'Asia/Tokyo', 'Not/A_Timezone', 'Europe/Paris'] as $timezone) {
+            $_SERVER['CRAFT_TEST_TIMEZONE'] = $timezone;
+
+            foreach (['en', 'nl-BE'] as $locale) {
+                app()->setLocale($locale);
+
+                expect(Cms::systemTimezone())->toBe($timezone === 'Not/A_Timezone' ? 'UTC' : $timezone);
+            }
+        }
+    } finally {
+        unset($_SERVER['CRAFT_TEST_TIMEZONE']);
+    }
+});
+
+it('resolves CP timezone preferences after switching users and request context', function () {
+    Cms::config()->cpTrigger = 'admin';
+    Cms::config()->timezone = 'Europe/Paris';
+    app()->instance('request', Request::create('/admin'));
+
+    Auth::shouldReceive('hasUser')->andReturnTrue();
+    Auth::shouldReceive('id')->twice()->andReturn(42, 43);
+    Users::shouldReceive('getUserPreference')->once()->with(42, 'timeZone')->andReturn('Asia/Tokyo');
+    Users::shouldReceive('getUserPreference')->once()->with(43, 'timeZone')->andReturn('America/New_York');
+
+    expect(Cms::timezone())->toBe('Asia/Tokyo')
+        ->and(Cms::timezone())->toBe('America/New_York');
+
+    app()->instance('request', Request::create('/site'));
+
+    expect(Cms::timezone())->toBe('Europe/Paris');
+});
+
 it('uses the accepted language while Craft is not installed', function () {
     Cms::setIsInstalled(false);
     I18N::shouldReceive('getAppLocaleIds')->once()->andReturn(collect(['fr', 'en']));

--- a/tests/Unit/Http/ViewModelTest.php
+++ b/tests/Unit/Http/ViewModelTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Http\ViewModels\ViewModel;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
 
 it('returns public properties and public method values', function () {
     $viewModel = new class extends ViewModel
@@ -34,3 +36,54 @@ it('returns public properties and public method values', function () {
         'status' => 'ready',
     ]);
 });
+
+it('evaluates only the view model methods requested by Inertia', function (array $headers, array $props, int $rowCalls, int $paginationCalls) {
+    $calls = (object) ['rows' => 0, 'pagination' => 0];
+    $viewModel = new class($calls) extends ViewModel
+    {
+        public string $name = 'Craft';
+
+        public function __construct(private readonly object $calls) {}
+
+        public function rows(): array
+        {
+            $this->calls->rows++;
+
+            return [['id' => 1]];
+        }
+
+        public function pagination(): array
+        {
+            $this->calls->pagination++;
+
+            return ['total' => 1];
+        }
+    };
+    $request = Request::create('/view-model');
+    $request->headers->add(['X-Inertia' => 'true', ...$headers]);
+    config(['inertia.pages.ensure_pages_exist' => false]);
+
+    $response = Inertia::render('performance/Test', [$viewModel])->toResponse($request);
+
+    expect($response->getData(true)['props'])->toBe($props)
+        ->and($calls->rows)->toBe($rowCalls)
+        ->and($calls->pagination)->toBe($paginationCalls);
+})->with([
+    'full response' => [[], ['name' => 'Craft', 'rows' => [['id' => 1]], 'pagination' => ['total' => 1]], 1, 1],
+    'pagination only' => [
+        ['X-Inertia-Partial-Component' => 'performance/Test', 'X-Inertia-Partial-Data' => 'pagination'],
+        ['pagination' => ['total' => 1]], 0, 1,
+    ],
+    'public property only' => [
+        ['X-Inertia-Partial-Component' => 'performance/Test', 'X-Inertia-Partial-Data' => 'name'],
+        ['name' => 'Craft'], 0, 0,
+    ],
+    'exclude rows' => [
+        ['X-Inertia-Partial-Component' => 'performance/Test', 'X-Inertia-Partial-Except' => 'rows'],
+        ['name' => 'Craft', 'pagination' => ['total' => 1]], 0, 1,
+    ],
+    'component changed' => [
+        ['X-Inertia-Partial-Component' => 'performance/Other', 'X-Inertia-Partial-Data' => 'pagination'],
+        ['name' => 'Craft', 'rows' => [['id' => 1]], 'pagination' => ['total' => 1]], 1, 1,
+    ],
+]);

--- a/tests/Unit/Translation/FormatterTest.php
+++ b/tests/Unit/Translation/FormatterTest.php
@@ -7,6 +7,7 @@ use CraftCms\Cms\Support\Facades\I18N;
 use CraftCms\Cms\Translation\Formatter;
 use CraftCms\Cms\Translation\Locale;
 use Illuminate\Support\Facades\Date;
+use Locale as IntlLocale;
 
 beforeEach(function () {
     $this->formatter = app(Formatter::class);
@@ -485,3 +486,58 @@ test('willBeMisrepresented', function (mixed $input, bool $output, ?string $loca
     ['9.00', false],
     ['87654321098765436', true],
 ]);
+
+test('date formatting follows locale timezone and pattern changes on the same formatter', function () {
+    $date = Date::parse('2026-01-15 14:15:16', 'UTC');
+    $this->formatter->locale = 'en-US';
+    $this->formatter->timeZone = 'UTC';
+
+    expect($this->formatter->asDateTime($date, 'yyyy-MM-dd HH:mm'))->toBe('2026-01-15 14:15');
+
+    $this->formatter->timeZone = 'America/New_York';
+
+    expect($this->formatter->asDateTime($date, 'yyyy-MM-dd HH:mm'))->toBe('2026-01-15 09:15');
+
+    $this->formatter->locale = 'nl';
+
+    expect($this->formatter->asDate($date, 'MMMM'))->toBe('januari');
+
+    $this->formatter->locale = 'en-US';
+    $this->formatter->timeZone = 'UTC';
+
+    expect($this->formatter->asDateTime($date, 'yyyy-MM-dd HH:mm'))->toBe('2026-01-15 14:15')
+        ->and($this->formatter->asDate($date, 'MMMM'))->toBe('January');
+});
+
+test('date formatting keeps date and time styles separate across repeated values', function () {
+    $this->formatter->locale = 'en-US';
+    $this->formatter->timeZone = 'UTC';
+
+    foreach (['2026-01-15 14:15:16', '2026-02-16 14:15:16'] as $value) {
+        $date = Date::parse($value, 'UTC');
+        $expectedDate = $date->format('M j, Y');
+
+        expect($this->formatter->asDate($date))->toBe($expectedDate)
+            ->and($this->formatter->asTime($date))->toBe('2:15:16 PM')
+            ->and($this->formatter->asDateTime($date))->toBe("{$expectedDate}, 2:15:16 PM");
+    }
+});
+
+test('date formatting follows the ICU default locale when its locale is empty', function () {
+    $previousLocale = IntlLocale::getDefault();
+    $this->formatter->locale = '';
+    $this->formatter->timeZone = 'UTC';
+    $date = Date::parse('2026-01-15 14:15:16', 'UTC');
+
+    try {
+        IntlLocale::setDefault('en_US');
+
+        expect($this->formatter->asDate($date, 'MMMM'))->toBe('January');
+
+        IntlLocale::setDefault('nl_NL');
+
+        expect($this->formatter->asDate($date, 'MMMM'))->toBe('januari');
+    } finally {
+        IntlLocale::setDefault($previousLocale);
+    }
+});

--- a/tests/Unit/Translation/LocaleTest.php
+++ b/tests/Unit/Translation/LocaleTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Translation\I18N;
 use CraftCms\Cms\Translation\Locale;
 
 test('language id', function (string $expected, string $locale) {
@@ -17,3 +18,43 @@ test('language id', function (string $expected, string $locale) {
     ['', ''],
     ['pt', 'pt-BR'],
 ]);
+
+it('resolves ICU patterns after locale alias and timezone changes', function () {
+    $locale = new Locale('en-US');
+    $originalTimezone = date_default_timezone_get();
+
+    try {
+        foreach (['UTC', 'Asia/Tokyo'] as $timezone) {
+            date_default_timezone_set($timezone);
+
+            foreach (['en-US', 'nl-BE'] as $localeId) {
+                $locale->id = $localeId;
+
+                foreach ([null, 'fr-FR'] as $alias) {
+                    $locale->aliasOf = $alias;
+
+                    foreach (['short' => IntlDateFormatter::SHORT, 'full' => IntlDateFormatter::FULL] as $length => $style) {
+                        $expected = new IntlDateFormatter($alias ?? $localeId, $style, $style)->getPattern();
+
+                        expect($locale->getDateTimeFormat($length))->toBe(strtr($expected, ['yyyy' => 'yyyy', 'yy' => 'yyyy']));
+                    }
+                }
+            }
+        }
+    } finally {
+        date_default_timezone_set($originalTimezone);
+    }
+});
+
+it('keeps formatter customization local to each locale instance', function () {
+    $first = app(I18N::class)->getLocaleById('en-US')->getFormatter();
+    $originalFormats = $first->dateTimeFormats;
+    $first->dateTimeFormats['short']['date'] = 'yyyy';
+    $first->timeZone = 'Asia/Tokyo';
+
+    $second = app(I18N::class)->getLocaleById('en-US')->getFormatter();
+
+    expect($second)->not->toBe($first)
+        ->and($second->dateTimeFormats)->toBe($originalFormats)
+        ->and($second->timeZone)->not->toBe('Asia/Tokyo');
+});


### PR DESCRIPTION
The largest measured improvements were:

- **Asset index:** 70.2% faster in the initial pass, followed by another 21.0% at 5,000 articles.
- **Pagination-only responses:** 76.4% faster in the initial pass.
- **Lazy 50-article listing:** 59.4% faster in the larger dataset.
- **Eager 50-article listing:** 32.7% faster in the larger dataset.
- **CP search:** 35.2% faster in the larger dataset.

Did some changes since that measurement, but generally should be around those numbers.