### PR TITLE
[6.x] Preserve the selected source when applying element index filters

### DIFF
--- a/resources/js/modules/elements/composables/useElementIndexFilters.test.ts
+++ b/resources/js/modules/elements/composables/useElementIndexFilters.test.ts
@@ -1,11 +1,13 @@
 import {beforeEach, describe, expect, it, vi} from 'vite-plus/test';
-import {shallowRef} from 'vue';
+import {reactive, shallowRef} from 'vue';
 import {useElementIndexFilters} from './useElementIndexFilters';
 import type {ConditionConfig} from './useConditionBuilder';
 import type {ViewState} from '@/modules/elements/types/view-state';
 import type {IndexQueryParams} from './useElementIndexVisits';
+import type {SourceItem} from '@/modules/elements/types/sources';
 
 interface FilterData {
+  source?: string;
   search?: string;
   status?: string | null;
   condition?: ConditionConfig;
@@ -61,6 +63,31 @@ function makeViewState(): ViewState {
 describe('useElementIndexFilters', () => {
   beforeEach(() => {
     submitSpy.mockClear();
+  });
+
+  it('applies condition rules to the currently selected source', () => {
+    const props = reactive<{status: null; source: SourceItem}>({
+      status: null,
+      source: {type: 'native', key: '*', label: 'All entries'},
+    });
+    const condition: ConditionConfig = {
+      class: 'EntryCondition',
+      conditionRules: [{class: 'TitleConditionRule', value: 'foo'}],
+    };
+    const {submit} = useElementIndexFilters(
+      props,
+      shallowRef<ViewState>(makeViewState()),
+      stubRoute,
+      shallowRef(condition)
+    );
+
+    props.source = {type: 'native', key: 'section:news', label: 'News'};
+    submit();
+
+    expect(transformState.callback({search: '', status: ''})).toMatchObject({
+      source: 'section:news',
+      condition,
+    });
   });
 
   it('submits the filter condition intact alongside the other filters', () => {

--- a/resources/js/modules/elements/composables/useElementIndexFilters.ts
+++ b/resources/js/modules/elements/composables/useElementIndexFilters.ts
@@ -35,6 +35,7 @@ export function useElementIndexFilters(
     form
       .transform((data) => ({
         ...data,
+        source: props.source?.key,
         sort: viewState.value.sources?.[sourceKey]?.sort,
         viewMode: viewState.value.mode,
         condition: conditions?.value ?? undefined,


### PR DESCRIPTION
### Description

Applying filter HUD condition rules after switching sources reset the element index to its initial source because the filter submission omitted the source key. 
