### PR TITLE
[6.x] Keep shared Craft data reactive across Inertia navigation

### DIFF
--- a/resources/js/common/components/CurrentUser.vue
+++ b/resources/js/common/components/CurrentUser.vue
@@ -7,19 +7,19 @@
   const {currentUser} = useCraftData();
 
   const primaryText = computed(() => {
-    if (currentUser!.name !== currentUser!.username) {
-      return currentUser!.name;
+    if (currentUser.value!.name !== currentUser.value!.username) {
+      return currentUser.value!.name;
     }
 
-    return currentUser!.username;
+    return currentUser.value!.username;
   });
 
   const secondaryText = computed(() => {
-    if (currentUser!.username === currentUser!.name) {
-      return currentUser!.email;
+    if (currentUser.value!.username === currentUser.value!.name) {
+      return currentUser.value!.email;
     }
 
-    return currentUser!.username;
+    return currentUser.value!.username;
   });
 </script>
 

--- a/resources/js/common/components/EditionInfo.vue
+++ b/resources/js/common/components/EditionInfo.vue
@@ -5,7 +5,7 @@
   const {app, cpUrl} = useCraftData();
 
   const fullEditionName = computed(() => {
-    return `${app.edition.name} Edition`;
+    return `${app.value.edition.name} Edition`;
   });
 </script>
 

--- a/resources/js/common/components/MainNav.test.ts
+++ b/resources/js/common/components/MainNav.test.ts
@@ -2,12 +2,7 @@ import {expect, it, vi} from 'vite-plus/test';
 import {createApp, nextTick, reactive} from 'vue';
 
 const state = vi.hoisted(() => ({
-  craftData: null as any,
   page: null as any,
-}));
-
-vi.mock('@/common/composables/useCraftData', () => ({
-  default: () => state.craftData,
 }));
 
 vi.mock('@inertiajs/vue3', async () => ({
@@ -17,7 +12,7 @@ vi.mock('@inertiajs/vue3', async () => ({
 
 it('updates the active item when the shared navigation changes', async () => {
   const {default: MainNav} = await import('./MainNav.vue');
-  state.craftData = reactive({
+  const craftData = {
     nav: [
       {
         label: 'Entries',
@@ -38,9 +33,10 @@ it('updates the active item when the shared navigation changes', async () => {
         subnav: false,
       },
     ],
-  });
+  };
   state.page = reactive({
     props: {
+      craft: craftData,
       queue: {
         displayedJob: null,
         hasReservedJobs: false,
@@ -55,10 +51,16 @@ it('updates the active item when the shared navigation changes', async () => {
   app.mount(container);
   await nextTick();
 
-  state.craftData.nav = state.craftData.nav.map((item: any) => ({
-    ...item,
-    selected: item.url === '/assets',
-  }));
+  state.page.props = {
+    ...state.page.props,
+    craft: {
+      ...craftData,
+      nav: craftData.nav.map((item) => ({
+        ...item,
+        selected: item.url === '/assets',
+      })),
+    },
+  };
   await nextTick();
 
   const items = Array.from(container.querySelectorAll('craft-nav-item'));

--- a/resources/js/common/components/MainNav.vue
+++ b/resources/js/common/components/MainNav.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-  import {type CraftData} from '@/common/composables/useCraftData';
+  import useCraftData from '@/common/composables/useCraftData';
   import CpLink from '@/common/components/CpLink.vue';
   import {computed} from 'vue';
   import {usePage} from '@inertiajs/vue3';
 
   const page = usePage<{
-    craft: CraftData;
     queue: {
       enabled: boolean;
       displayedJob: any;
@@ -13,7 +12,7 @@
       hasWaitingJobs: boolean;
     };
   }>();
-  const nav = computed(() => page.props.craft.nav);
+  const {nav} = useCraftData();
 
   // Renders the nav as a rail: labels drop to tooltips, and subnavs move into
   // a flyout on hover or focus, since there's no room to indent them.

--- a/resources/js/common/components/MainNav.vue
+++ b/resources/js/common/components/MainNav.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-  import useCraftData from '@/common/composables/useCraftData';
+  import {type CraftData} from '@/common/composables/useCraftData';
   import CpLink from '@/common/components/CpLink.vue';
   import {computed} from 'vue';
   import {usePage} from '@inertiajs/vue3';
 
   const page = usePage<{
+    craft: CraftData;
     queue: {
       enabled: boolean;
       displayedJob: any;
@@ -12,8 +13,7 @@
       hasWaitingJobs: boolean;
     };
   }>();
-  const craftData = useCraftData();
-  const nav = computed(() => craftData.nav);
+  const nav = computed(() => page.props.craft.nav);
 
   // Renders the nav as a rail: labels drop to tooltips, and subnavs move into
   // a flyout on hover or focus, since there's no room to indent them.

--- a/resources/js/common/components/SystemInfo.vue
+++ b/resources/js/common/components/SystemInfo.vue
@@ -5,9 +5,7 @@
 
   const {iconOnly = false} = defineProps<{iconOnly?: boolean}>();
 
-  const craftData = useCraftData();
-  const system = computed(() => craftData.system);
-  const site = computed(() => craftData.site);
+  const {system, site} = useCraftData();
   const tag = computed(() => (site.value?.url ? 'a' : 'div'));
 </script>
 

--- a/resources/js/common/components/UserMenu.vue
+++ b/resources/js/common/components/UserMenu.vue
@@ -12,7 +12,7 @@
   import UserThumbnail from '@/common/components/UserThumbnail.vue';
   import PasswordController from '@actions/Users/PasswordController';
 
-  const {currentUser, csrfTokenName, csrfTokenValue} = useCraftData();
+  const {csrfTokenName, csrfTokenValue, currentUser} = useCraftData();
   const logoutForm = useTemplateRef('logoutForm');
 
   const menuItems = computed((): ActionItem[] => {

--- a/resources/js/common/composables/useCraftData.test.ts
+++ b/resources/js/common/composables/useCraftData.test.ts
@@ -1,0 +1,70 @@
+import {expect, it, vi} from 'vite-plus/test';
+import {computed, reactive} from 'vue';
+import useCraftData, {useHelpers} from './useCraftData';
+
+const state = vi.hoisted(() => ({page: null as any}));
+
+vi.mock('@inertiajs/vue3', () => ({usePage: () => state.page}));
+
+it('updates primitive, nested, and nullable props when Inertia replaces page props', () => {
+  state.page = reactive({
+    props: {
+      craft: {
+        readOnly: false,
+        site: {handle: 'english'},
+        csrfTokenValue: null,
+        csrfTokenName: null,
+      },
+    },
+  });
+  const {site, readOnly, csrfTokenValue, csrfTokenName} = useCraftData();
+  const selectedSite = computed(() => site.value?.handle);
+
+  expect(readOnly.value).toBe(false);
+  expect(selectedSite.value).toBe('english');
+  expect(csrfTokenValue.value).toBeNull();
+  expect(csrfTokenName.value).toBeNull();
+
+  state.page.props = {
+    craft: {
+      readOnly: true,
+      site: {handle: 'french'},
+      csrfTokenValue: 'replacement-token',
+      csrfTokenName: '_token',
+    },
+  };
+
+  expect(readOnly.value).toBe(true);
+  expect(selectedSite.value).toBe('french');
+  expect(csrfTokenValue.value).toBe('replacement-token');
+  expect(csrfTokenName.value).toBe('_token');
+});
+
+it('builds URLs from the current Craft data after navigation', () => {
+  state.page = reactive({
+    props: {
+      craft: {
+        actionUrl: 'https://example.test/actions',
+        cpUrl: 'https://example.test/admin/',
+        baseApiUrl: 'https://example.test/api',
+      },
+    },
+  });
+  const helpers = useHelpers();
+
+  expect(helpers.getCpUrl('entries')).toBe(
+    'https://example.test/admin/entries'
+  );
+
+  state.page.props.craft = {
+    actionUrl: 'https://other.test/actions',
+    cpUrl: 'https://other.test/control/',
+    baseApiUrl: 'https://other.test/api',
+  };
+
+  expect(helpers.getActionUrl('save')).toBe('https://other.test/actions/save');
+  expect(helpers.getCpUrl('entries')).toBe(
+    'https://other.test/control/entries'
+  );
+  expect(helpers.getApiUrl('entries')).toBe('https://other.test/api/entries');
+});

--- a/resources/js/common/composables/useCraftData.ts
+++ b/resources/js/common/composables/useCraftData.ts
@@ -1,3 +1,5 @@
+import {computed, type Ref} from 'vue';
+import {toRefs} from '@vueuse/core';
 import {usePage} from '@inertiajs/vue3';
 
 export interface CpUser {
@@ -9,8 +11,8 @@ export interface CpUser {
 }
 
 export interface CraftData {
-  csrfTokenValue?: string | null;
-  csrfTokenName?: string | null;
+  csrfTokenValue: string | null;
+  csrfTokenName: string | null;
   system: {
     name: string;
     icon: string | null;
@@ -60,28 +62,29 @@ function getUrl(baseUrl: string, path: string) {
  * @TODO move to NPM package
  */
 export function useHelpers() {
-  const craftData = useCraftData();
+  const {actionUrl, cpUrl, baseApiUrl} = useCraftData();
 
   return {
     // @TODO move to NPM package
     getActionUrl(action: string) {
-      //return `${craftData.actionUrl}${action}`;
-      return getUrl(craftData.actionUrl, action);
+      return getUrl(actionUrl.value, action);
     },
     // @TODO move to NPM package
     getCpUrl(action: string) {
-      return `${craftData.cpUrl}${action}`;
+      return `${cpUrl.value}${action}`;
     },
     getApiUrl(path: string) {
-      return getUrl(craftData.baseApiUrl, path);
+      return getUrl(baseApiUrl.value, path);
     },
   };
 }
 
-export default function useCraftData(): CraftData {
+export default function useCraftData(): {
+  [Key in keyof CraftData]-?: Readonly<Ref<CraftData[Key]>>;
+} {
   const page = usePage<{
     craft: CraftData;
   }>();
 
-  return page.props.craft;
+  return toRefs(computed(() => page.props.craft));
 }

--- a/resources/js/common/layouts/screens/PageScreen.vue
+++ b/resources/js/common/layouts/screens/PageScreen.vue
@@ -70,7 +70,7 @@
 
   const registry = provideLayoutSlotRegistry();
   provideScreenContext('page');
-  const craftData = useCraftData();
+  const {general} = useCraftData();
 
   // A page rendering `<AppLayout>` inline inside this shell shouldn't stack a
   // second one — it renders transparently instead.
@@ -281,7 +281,7 @@
                   <craft-icon name="search" :label="t('Search')"></craft-icon>
                 </craft-button>
                 <cp-notification-center
-                  :notifications.prop="craftData.general.notifications"
+                  :notifications.prop="general.notifications"
                 ></cp-notification-center>
                 <UserMenu />
               </div>

--- a/resources/js/modules/admin-table/composables/useEditableTable.ts
+++ b/resources/js/modules/admin-table/composables/useEditableTable.ts
@@ -172,7 +172,7 @@ export function useEditableTable<T extends object>(
       value = disabled(row);
     }
 
-    return readOnly ? true : Boolean(value);
+    return readOnly.value ? true : Boolean(value);
   }
 
   function textInputCell(

--- a/resources/js/modules/elements/ElementSources.test.ts
+++ b/resources/js/modules/elements/ElementSources.test.ts
@@ -1,4 +1,4 @@
-import {createApp, defineComponent, h, nextTick} from 'vue';
+import {computed, createApp, defineComponent, h, nextTick} from 'vue';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vite-plus/test';
 import type {Source} from '@/modules/elements/types/sources';
 
@@ -10,7 +10,7 @@ const router = vi.hoisted(() => ({
 vi.mock('@inertiajs/vue3', () => ({router}));
 
 vi.mock('@/common/composables/useCraftData', () => ({
-  default: () => ({site: {handle: 'default'}}),
+  default: () => ({site: computed(() => ({handle: 'default'}))}),
 }));
 
 const SOURCES: Source[] = [

--- a/resources/js/modules/elements/ElementSources.vue
+++ b/resources/js/modules/elements/ElementSources.vue
@@ -55,7 +55,7 @@
   function sourceUrl(key: string) {
     return props.route.url({
       source: key,
-      site: site?.handle,
+      site: site.value?.handle,
       viewMode: props.viewMode || undefined,
     });
   }

--- a/resources/js/modules/elements/components/NewEntryButton.vue
+++ b/resources/js/modules/elements/components/NewEntryButton.vue
@@ -47,7 +47,10 @@
       .filter((handle): handle is string => !!handle);
 
     return props.publishableSections
-      .filter((section) => site?.id != null && section.sites.includes(site.id))
+      .filter(
+        (section) =>
+          site.value?.id != null && section.sites.includes(site.value.id)
+      )
       .filter((section) => sourceHandles.includes(section.handle));
   });
 
@@ -76,8 +79,8 @@
     if (entryTypeHandle) {
       query.type = entryTypeHandle;
     }
-    if (site?.id != null) {
-      query.siteId = String(site.id);
+    if (site.value?.id != null) {
+      query.siteId = String(site.value.id);
     }
 
     return CreateEntryController['/{cpTrigger?}/entries/{section}/new'].url(

--- a/resources/js/modules/entry-types/components/EntryTypeSelect.test.ts
+++ b/resources/js/modules/entry-types/components/EntryTypeSelect.test.ts
@@ -1,5 +1,5 @@
 import type {EntryType} from '@/common/types';
-import {createApp, nextTick} from 'vue';
+import {computed, createApp, nextTick} from 'vue';
 import {afterEach, expect, it, vi} from 'vite-plus/test';
 import EntryTypeSelect from './EntryTypeSelect.vue';
 
@@ -23,7 +23,7 @@ vi.mock('@actions/Settings/EntryTypesController', () => ({
   renderOverrideSettings: () => ({url: '/render'}),
 }));
 vi.mock('@/common/composables/useCraftData', () => ({
-  default: () => ({readOnly: state.readOnly}),
+  default: () => ({readOnly: computed(() => state.readOnly)}),
 }));
 vi.mock('@/common/composables/useReorderableItems', () => ({
   useReorderableItems: () => ({

--- a/resources/js/modules/utilities/components/DatabaseBackup.vue
+++ b/resources/js/modules/utilities/components/DatabaseBackup.vue
@@ -10,7 +10,7 @@
     downloadBackup: true,
   });
 
-  const {csrfTokenValue, csrfTokenName} = useCraftData();
+  const {csrfTokenName, csrfTokenValue} = useCraftData();
   const formRef = useTemplateRef('formRef');
 
   function handleSubmit() {

--- a/resources/js/pages/settings/sections/Index.vue
+++ b/resources/js/pages/settings/sections/Index.vue
@@ -119,7 +119,7 @@
       },
       get columnVisibility() {
         return {
-          actions: !readOnly,
+          actions: !readOnly.value,
         };
       },
     },

--- a/resources/js/pages/settings/sites/Index.vue
+++ b/resources/js/pages/settings/sites/Index.vue
@@ -179,7 +179,7 @@
     state: {
       get columnVisibility() {
         return {
-          actions: !readOnly,
+          actions: !readOnly.value,
         };
       },
     },


### PR DESCRIPTION
### Description

Shared Craft data was captured when components mounted, leaving the sidebar active item and other persistent UI stale after Inertia navigation.

Use VueUse's `toRefs()` with computed page data in `useCraftData()` so callers can destructure its properties while tracking replacement page props. 