### PR TITLE
[6.x] Restore focus when the global sidebar collapses or expands

### DIFF
--- a/.ai/guidelines/craft.md
+++ b/.ai/guidelines/craft.md
@@ -37,3 +37,7 @@ Some files contain Unicode characters in comments and strings. If a text edit fa
 - Prefix the title with the origin version branch, such as `[6.x]` or `[5.x]`.
 - Use a `### Description` section and add `### Related issues` only when applicable. Do not add validation summaries.
 - When the branch already identifies a Linear issue, reference the related GitHub issue instead of repeating the Linear identifier.
+
+## Regression tests
+
+- After a bug fix or behavior change is verified working, propose adding a test that covers it — don't leave that as an unprompted afterthought.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ Some files contain Unicode characters in comments and strings. If a text edit fa
 
 - When the branch already identifies a Linear issue, reference the related GitHub issue instead of repeating the Linear identifier.
 
+## Regression tests
+
+- After a bug fix or behavior change is verified working, propose adding a test that covers it — don't leave that as an unprompted afterthought.
+
 === foundation rules ===
 
 # Laravel Boost Guidelines

--- a/resources/js/common/components/CpSidebar.test.ts
+++ b/resources/js/common/components/CpSidebar.test.ts
@@ -1,0 +1,117 @@
+import {expect, it, vi} from 'vite-plus/test';
+import {computed, createApp, nextTick, reactive} from 'vue';
+
+const state = vi.hoisted(() => ({
+  page: null as any,
+  sidebar: null as unknown as {
+    mode: 'docked' | 'floating';
+    visibility: 'visible' | 'hidden';
+  },
+  toggle: vi.fn(),
+}));
+state.sidebar = reactive({mode: 'docked', visibility: 'visible'});
+
+vi.mock('@inertiajs/vue3', async () => ({
+  ...(await vi.importActual('@inertiajs/vue3')),
+  usePage: () => state.page,
+}));
+
+vi.mock('@/common/composables/useGlobalSidebar', () => ({
+  useGlobalSidebar: () => ({
+    sidebar: state.sidebar,
+    collapsed: computed(
+      () =>
+        state.sidebar.mode === 'docked' && state.sidebar.visibility === 'hidden'
+    ),
+    toggle: state.toggle,
+    icon: computed(() => 'arrow-left-to-line'),
+  }),
+}));
+
+async function mountSidebar(
+  mode: 'docked' | 'floating',
+  visibility: 'visible' | 'hidden'
+) {
+  state.sidebar = reactive({mode, visibility});
+  state.toggle = vi.fn(() => {
+    state.sidebar.visibility =
+      state.sidebar.visibility === 'visible' ? 'hidden' : 'visible';
+  });
+  state.page = reactive({
+    props: {
+      craft: {
+        maintenanceMode: false,
+        system: {name: 'Craft CMS', icon: null},
+        site: null,
+        app: {version: '6.0.0', edition: {name: 'Pro'}},
+        general: {cpTrigger: 'admin'},
+        nav: [],
+      },
+      queue: {
+        displayedJob: null,
+        hasReservedJobs: false,
+        hasWaitingJobs: false,
+      },
+    },
+  });
+
+  const {default: CpSidebar} = await import('./CpSidebar.vue');
+  const container = document.createElement('div');
+  document.body.append(container);
+  const app = createApp(CpSidebar);
+
+  app.mount(container);
+  await nextTick();
+
+  return {
+    container,
+    unmount: () => {
+      app.unmount();
+      container.remove();
+    },
+  };
+}
+
+it('returns focus to the relocated toggle when the docked sidebar expands', async () => {
+  const {container, unmount} = await mountSidebar('docked', 'hidden');
+
+  container.querySelector<HTMLElement>('#sidebar-toggle')!.click();
+  await nextTick();
+  await nextTick();
+
+  expect(state.sidebar.visibility).toBe('visible');
+  expect(document.activeElement).toBe(
+    container.querySelector('#sidebar-toggle')
+  );
+
+  unmount();
+});
+
+it('moves focus to the nav body instead of the toggle when the docked sidebar collapses', async () => {
+  const {container, unmount} = await mountSidebar('docked', 'visible');
+
+  container.querySelector<HTMLElement>('#sidebar-toggle')!.click();
+  await nextTick();
+  await nextTick();
+
+  expect(state.sidebar.visibility).toBe('hidden');
+  expect(document.activeElement).toBe(
+    container.querySelector('.cp-sidebar__body')
+  );
+
+  unmount();
+});
+
+it('leaves focus on the toggle when a floating sidebar opens or closes', async () => {
+  const {container, unmount} = await mountSidebar('floating', 'hidden');
+  const toggleButton = container.querySelector<HTMLElement>('#sidebar-toggle')!;
+
+  toggleButton.click();
+  await nextTick();
+  await nextTick();
+
+  expect(state.sidebar.visibility).toBe('visible');
+  expect(document.activeElement).toBe(toggleButton);
+
+  unmount();
+});

--- a/resources/js/common/components/CpSidebar.test.ts
+++ b/resources/js/common/components/CpSidebar.test.ts
@@ -1,5 +1,5 @@
-import {expect, it, vi} from 'vite-plus/test';
-import {computed, createApp, nextTick, reactive} from 'vue';
+import {afterEach, expect, it, vi} from 'vite-plus/test';
+import {computed, createApp, nextTick, reactive, type App} from 'vue';
 
 const state = vi.hoisted(() => ({
   page: null as any,
@@ -27,6 +27,21 @@ vi.mock('@/common/composables/useGlobalSidebar', () => ({
     icon: computed(() => 'arrow-left-to-line'),
   }),
 }));
+
+let app: App | null = null;
+const extraElements: HTMLElement[] = [];
+
+afterEach(() => {
+  app?.unmount();
+  app = null;
+  extraElements.splice(0).forEach((el) => el.remove());
+});
+
+function appendElement<T extends HTMLElement>(el: T): T {
+  document.body.append(el);
+  extraElements.push(el);
+  return el;
+}
 
 async function mountSidebar(
   mode: 'docked' | 'floating',
@@ -56,62 +71,50 @@ async function mountSidebar(
   });
 
   const {default: CpSidebar} = await import('./CpSidebar.vue');
-  const container = document.createElement('div');
-  document.body.append(container);
-  const app = createApp(CpSidebar);
+  const container = appendElement(document.createElement('div'));
+  app = createApp(CpSidebar);
 
   app.mount(container);
   await nextTick();
 
-  return {
-    container,
-    unmount: () => {
-      app.unmount();
-      container.remove();
-    },
-  };
+  return container;
 }
 
 it('returns focus to the relocated toggle when the docked sidebar expands', async () => {
-  const {container, unmount} = await mountSidebar('docked', 'hidden');
+  const container = await mountSidebar('docked', 'hidden');
 
   container.querySelector<HTMLElement>('#sidebar-toggle')!.click();
-  await nextTick();
-  await nextTick();
 
   expect(state.sidebar.visibility).toBe('visible');
-  expect(document.activeElement).toBe(
-    container.querySelector('#sidebar-toggle')
+  await vi.waitFor(() =>
+    expect(document.activeElement).toBe(
+      container.querySelector('#sidebar-toggle')
+    )
   );
-
-  unmount();
 });
 
 it('moves focus to the nav body instead of the toggle when the docked sidebar collapses', async () => {
-  const {container, unmount} = await mountSidebar('docked', 'visible');
+  const container = await mountSidebar('docked', 'visible');
 
   container.querySelector<HTMLElement>('#sidebar-toggle')!.click();
-  await nextTick();
-  await nextTick();
 
   expect(state.sidebar.visibility).toBe('hidden');
-  expect(document.activeElement).toBe(
-    container.querySelector('.cp-sidebar__body')
+  await vi.waitFor(() =>
+    expect(document.activeElement).toBe(
+      container.querySelector('.cp-sidebar__body')
+    )
   );
-
-  unmount();
 });
 
-it('leaves focus on the toggle when a floating sidebar opens or closes', async () => {
-  const {container, unmount} = await mountSidebar('floating', 'hidden');
-  const toggleButton = container.querySelector<HTMLElement>('#sidebar-toggle')!;
+it('moves focus into the sidebar when it becomes visible while focus was on an external control', async () => {
+  const container = await mountSidebar('floating', 'hidden');
+  const externalControl = appendElement(document.createElement('button'));
+  externalControl.focus();
 
-  toggleButton.click();
-  await nextTick();
-  await nextTick();
-
-  expect(state.sidebar.visibility).toBe('visible');
-  expect(document.activeElement).toBe(toggleButton);
-
-  unmount();
+  state.sidebar.visibility = 'visible';
+  await vi.waitFor(() =>
+    expect(document.activeElement).toBe(
+      container.querySelector('#sidebar-toggle')
+    )
+  );
 });

--- a/resources/js/common/components/CpSidebar.vue
+++ b/resources/js/common/components/CpSidebar.vue
@@ -5,7 +5,7 @@
   import EditionInfo from '@/common/components/EditionInfo.vue';
   import CpLink from '@/common/components/CpLink.vue';
   import DevModeIndicator from '@/common/components/DevModeIndicator.vue';
-  import {computed, nextTick, watch} from 'vue';
+  import {computed, nextTick, useTemplateRef, watch} from 'vue';
   import {useGlobalSidebar} from '@/common/composables/useGlobalSidebar';
   import {type CraftData} from '@/common/composables/useCraftData';
   import {index as generalSettings} from '@/routes/craft/cp/settings/general';
@@ -16,6 +16,7 @@
   // would give the same state two sources of truth.
   const {sidebar, collapsed, toggle, icon} = useGlobalSidebar();
   const page = usePage<{craft: CraftData}>();
+  const sidebarBody = useTemplateRef<HTMLElement>('sidebarBody');
 
   const shouldManageFocus = computed(() => sidebar.mode === 'floating');
   const maintenanceMode = computed(() => page.props.craft.maintenanceMode);
@@ -36,6 +37,27 @@
       }
     }
   );
+
+  async function toggleAndRestoreFocus() {
+    const wasDocked = sidebar.mode === 'docked';
+    const wasCollapsed = collapsed.value;
+    toggle();
+
+    if (!wasDocked) {
+      return;
+    }
+
+    await nextTick();
+
+    if (wasCollapsed) {
+      document.getElementById('sidebar-toggle')?.focus();
+      return;
+    }
+
+    // Focusing the relocated toggle here would skip past the whole nav for
+    // keyboard and screen reader users, so focus the nav list instead.
+    sidebarBody.value?.focus();
+  }
 </script>
 
 <template>
@@ -57,13 +79,13 @@
           size="small"
           :icon="icon"
           :variant="ButtonVariant.Outline"
-          @click="toggle"
+          @click="toggleAndRestoreFocus"
           :aria-label="t('Toggle menu')"
         >
         </craft-button>
       </div>
     </div>
-    <div class="cp-sidebar__body">
+    <div class="cp-sidebar__body" tabindex="-1" ref="sidebarBody">
       <MainNav :icon-only="collapsed" />
     </div>
     <div class="cp-sidebar__footer">
@@ -77,7 +99,7 @@
           size="small"
           :icon="icon"
           :variant="ButtonVariant.Outline"
-          @click="toggle"
+          @click="toggleAndRestoreFocus"
           :aria-label="t('Toggle menu')"
         >
         </craft-button>

--- a/resources/js/common/composables/useGlobalSidebar.test.ts
+++ b/resources/js/common/composables/useGlobalSidebar.test.ts
@@ -1,0 +1,57 @@
+import {afterEach, beforeEach, expect, it, vi} from 'vite-plus/test';
+import {nextTick} from 'vue';
+
+const extraElements: HTMLElement[] = [];
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  extraElements.splice(0).forEach((el) => el.remove());
+});
+
+function appendElement<T extends HTMLElement>(el: T): T {
+  document.body.append(el);
+  extraElements.push(el);
+  return el;
+}
+
+it('returns focus to the registered toggle when the sidebar hides while focus was inside it', async () => {
+  vi.stubGlobal('Craft', {systemUid: 'test'});
+  const {useGlobalSidebar} = await import('./useGlobalSidebar');
+  const {sidebar, toggleButton} = useGlobalSidebar();
+
+  const externalToggle = appendElement(document.createElement('button'));
+  toggleButton.value = externalToggle;
+
+  const sidebarEl = appendElement(document.createElement('div'));
+  sidebarEl.className = 'cp-sidebar';
+  const innerControl = document.createElement('button');
+  sidebarEl.append(innerControl);
+
+  sidebar.visibility = 'visible';
+  await nextTick();
+  innerControl.focus();
+
+  sidebar.visibility = 'hidden';
+  await vi.waitFor(() => expect(document.activeElement).toBe(externalToggle));
+});
+
+it('leaves focus alone when the sidebar hides while focus was already elsewhere', async () => {
+  vi.stubGlobal('Craft', {systemUid: 'test'});
+  const {useGlobalSidebar} = await import('./useGlobalSidebar');
+  const {sidebar, toggleButton} = useGlobalSidebar();
+
+  const externalToggle = appendElement(document.createElement('button'));
+  toggleButton.value = externalToggle;
+
+  const unrelatedField = appendElement(document.createElement('input'));
+  unrelatedField.focus();
+
+  sidebar.visibility = 'visible';
+  await nextTick();
+  sidebar.visibility = 'hidden';
+  await vi.waitFor(() => expect(document.activeElement).toBe(unrelatedField));
+});


### PR DESCRIPTION
### Description
Toggling the docked sidebar swaps `#sidebar-toggle` between header and footer (v-if), destroying the button that was just clicked and dropping focus to `<body>` (WCAG 2.4.3 Focus Order).

Fix refocuses deliberately, direction-aware:
- Expand: focus the relocated toggle.
- Collapse: focus the nav list instead. Refocusing the toggle here would skip screen reader/keyboard users past the whole nav, since the toggle sits below it in the footer.

Scoped to docked mode only — floating (mobile) mode never destroys its toggle, so it already keeps focus correctly and needs no change.

**This PR also adds agent instructions to recommend writing tests to prevent regressions.**

### Testing
`CpSidebar.test.ts` covers both directions plus floating mode (no regression).


### Related issues
ACC-261
