### PR TITLE
[6.x] Migrate core modals to the Form API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574) and [#19563](https://github.com/craftcms/cms/pull/19563) for details.
 
+- Migrated the reassign entries, replace relations, and replace references modals to the Form API. ([#19589](https://github.com/craftcms/cms/pull/19589))
 - Added support for refreshable standard plugin settings forms and conditional configuration of core form nodes. ([#19545](https://github.com/craftcms/cms/pull/19545))
 - Added support for sending queued Laravel notifications to `CraftCms\Cms\User\Elements\User` elements. ([#19541](https://github.com/craftcms/cms/pull/19541))
 - Added Markdown comments to element activity timelines, with support for editing, removing, structured user mentions, and email notifications.

--- a/packages/craftcms-ui/src/core/element-selector/element-selector-controller.test.ts
+++ b/packages/craftcms-ui/src/core/element-selector/element-selector-controller.test.ts
@@ -74,13 +74,18 @@ describe('options', () => {
 
 describe('indexParams', () => {
   it('identifies the index', () => {
-    const controller = create({sources: ['section:a'], condition: {x: 1}});
+    const controller = create({
+      sources: ['section:a'],
+      condition: {x: 1},
+      criteria: {id: ['not', 12, 34]},
+    });
 
     expect(controller.indexParams()).toEqual({
       context: 'modal',
       elementType: ENTRY,
       sources: ['section:a'],
       condition: {x: 1},
+      criteria: {id: ['not', 12, 34]},
     });
   });
 
@@ -437,6 +442,7 @@ describe('open and close', () => {
       loadIndexBody,
       bodyAction: 'custom/body',
       sources: ['section:a'],
+      criteria: {id: ['not', 12, 34]},
     });
 
     await controller.open();
@@ -446,6 +452,7 @@ describe('open and close', () => {
       elementType: ENTRY,
       sources: ['section:a'],
       condition: undefined,
+      criteria: {id: ['not', 12, 34]},
     });
   });
 

--- a/packages/craftcms-ui/src/core/element-selector/element-selector-controller.ts
+++ b/packages/craftcms-ui/src/core/element-selector/element-selector-controller.ts
@@ -299,6 +299,7 @@ export class ElementSelectorController<
       elementType: this.elementType,
       sources: options.sources,
       condition: options.condition,
+      criteria: {...options.criteria},
     };
 
     // `null` and `'auto'` both mean "server decides", so the key is omitted.

--- a/resources/js/modules/cp-modal/cp-modal.ts
+++ b/resources/js/modules/cp-modal/cp-modal.ts
@@ -1,5 +1,6 @@
 import {Modal, ESC_KEY, S_KEY, isMobileBrowser} from '@craftcms/garnish';
 import {uiLayerManager} from '@/modules/slideout/slideout';
+import {inputName} from '@/modules/forms/runtime';
 import type {FormValues} from '@/modules/forms/types';
 import type {AxiosRequestConfig} from 'axios';
 
@@ -354,7 +355,7 @@ export class CpModal extends Modal {
     if (
       !error.isAxiosError ||
       !error.response ||
-      error.response.status !== 400
+      ![400, 422].includes(error.response.status ?? 0)
     ) {
       Craft.cp.displayError();
       throw error;
@@ -371,9 +372,25 @@ export class CpModal extends Modal {
     this.clearErrors();
 
     Object.entries(errors).forEach(([name, fieldErrors]) => {
-      const $field = this.#$container.find(`[data-attribute="${name}"]`);
+      const path = [
+        ...(this.namespace ? [this.namespace] : []),
+        ...name.split('.'),
+      ];
+      const $field = this.#$container
+        .find(
+          `[data-attribute="${CSS.escape(name)}"], [data-error-key="${CSS.escape(name)}"]`
+        )
+        .add(
+          this.#$container
+            .find(`[name="${CSS.escape(inputName(path))}"]`)
+            .closest('craft-field')
+        );
       if ($field.length) {
         Craft.ui.addErrorsToField($field, fieldErrors);
+        $field
+          .filter('craft-field')
+          .children('ul.errors')
+          .attr('slot', 'feedback');
         this.#fieldsWithErrors.push($field);
       }
     });

--- a/resources/js/modules/element-select-input/base-element-select-input.test.ts
+++ b/resources/js/modules/element-select-input/base-element-select-input.test.ts
@@ -215,3 +215,17 @@ it('frees the replaced chip’s slot before applying the limit', async () => {
     expect.objectContaining({id: 7}),
   ]);
 });
+
+it.each([
+  '<button class="btn add">Choose</button>',
+  '<button command="--add-element">Choose</button>',
+])('finds the add button in supported element picker markup', (html) => {
+  const {input} = chipActionInput();
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  input.$container = {
+    find: (selector: string) => container.querySelectorAll(selector),
+  };
+
+  expect([...input.getAddElementsBtn()]).toEqual([container.firstElementChild]);
+});

--- a/resources/js/modules/element-select-input/base-element-select-input.ts
+++ b/resources/js/modules/element-select-input/base-element-select-input.ts
@@ -363,7 +363,7 @@ export class BaseElementSelectInput extends Base<BaseElementSelectInputSettings>
   }
 
   getAddElementsBtn(): any {
-    return this.$container.find('[command="--add-element"]');
+    return this.$container.find('[command="--add-element"], .btn.add');
   }
 
   getSpinner(): any {

--- a/resources/js/modules/forms/ElementSelectControl.test.ts
+++ b/resources/js/modules/forms/ElementSelectControl.test.ts
@@ -95,13 +95,13 @@ describe('ElementSelectControl', () => {
     stub.destroy.mockClear();
   });
 
-  let updates: Array<Array<number>>;
+  let updates: Array<number[] | number | null>;
 
   async function mount(
     options: {
       props?: Record<string, unknown>;
       editable?: boolean;
-      value?: number[];
+      value?: number[] | number | null;
     } = {}
   ): Promise<HTMLElement> {
     updates = [];
@@ -111,9 +111,10 @@ describe('ElementSelectControl', () => {
       render: () =>
         h(ElementSelectControl, {
           control: control(options.props),
-          value: options.value ?? [5],
+          value: options.value === undefined ? [5] : options.value,
           editable: options.editable ?? true,
-          'onUpdate:value': (value: number[]) => updates.push(value),
+          'onUpdate:value': (value: number[] | number | null) =>
+            updates.push(value),
         }),
     });
     app.mount(container);
@@ -138,6 +139,40 @@ describe('ElementSelectControl', () => {
       ...root.querySelectorAll('craft-chip [slot="suffix"] craft-action-menu'),
     ];
   }
+
+  it('renders scalar values with a scalar input name', async () => {
+    const root = await mount({props: {single: true, limit: 1}, value: 5});
+
+    expect(root.querySelectorAll('craft-chip')).toHaveLength(1);
+    expect(root.querySelector<HTMLInputElement>('craft-chip input')?.name).toBe(
+      'related'
+    );
+    expect(
+      root.querySelector<HTMLInputElement>('craft-chip input')?.value
+    ).toBe('5');
+    expect(addButton(root)).toBeNull();
+  });
+
+  it('emits a scalar ID when selecting one element', async () => {
+    const root = await mount({props: {single: true, limit: 1}, value: null});
+    addButton(root)!.click();
+    await flushSelector();
+
+    const [, settings] = stub.createElementSelectorModal.mock.calls[0]!;
+    expect(settings.multiSelect).toBe(false);
+    settings.onSelect([{id: 9, label: 'Replacement', siteId: 1}]);
+
+    expect(updates).toEqual([9]);
+  });
+
+  it('clears a scalar selection to null', async () => {
+    const root = await mount({props: {single: true, limit: 1}, value: 5});
+    menus(root)[0]
+      .actions.find((action: any) => action.label === 'Remove')
+      .onClick();
+
+    expect(updates).toEqual([null]);
+  });
 
   it('renders exactly one action menu per chip, with Replace and Remove', async () => {
     const root = await mount();

--- a/resources/js/modules/forms/ElementSelectControl.vue
+++ b/resources/js/modules/forms/ElementSelectControl.vue
@@ -83,6 +83,7 @@
     criteria: FormProperties;
     selectionLabel: string;
     limit: number | null;
+    single?: boolean;
     showSiteMenu: boolean;
     viewMode: ElementSelectViewMode;
     /** Lower-cased, for "Edit entry" / "Copy entry". */
@@ -94,11 +95,15 @@
   };
   const props = defineProps<{
     control: FormControlPayload<ElementSelectProps>;
-    value: Array<number | string>;
+    value: Array<number | string> | number | string | null;
     editable: boolean;
   }>();
   const emit = defineEmits<{
-    (event: 'update:value', value: number[], kind: FormChangeKind): void;
+    (
+      event: 'update:value',
+      value: number[] | number | null,
+      kind: FormChangeKind
+    ): void;
   }>();
 
   const presentations = reactive(new Map<number, ElementPresentation>());
@@ -120,7 +125,22 @@
     () => props.editable && props.control.props.canUpload === true
   );
 
-  const ids = computed(() => props.value.map(elementId));
+  const ids = computed(() =>
+    (Array.isArray(props.value)
+      ? props.value
+      : props.value === null || props.value === ''
+        ? []
+        : [props.value]
+    ).map(elementId)
+  );
+
+  function updateValue(ids: number[]): void {
+    emit(
+      'update:value',
+      props.control.props.single ? (ids[0] ?? null) : ids,
+      'discrete'
+    );
+  }
 
   /** One relation can't be reordered, and a read-only field can't be either. */
   const sortable = computed(() => props.editable && ids.value.length > 1);
@@ -180,7 +200,7 @@
    * next round-trip.
    */
   const listData = computed(() =>
-    props.value.map((selectedValue) => ({
+    ids.value.map((selectedValue) => ({
       ...presentation(selectedValue),
       id: elementId(selectedValue),
     }))
@@ -238,7 +258,7 @@
     }
 
     next.splice(finishIndex, 0, moved);
-    emit('update:value', next, 'discrete');
+    updateValue(next);
   }
 
   // ───────────────────────────── selection modal ─────────────────────────────
@@ -316,12 +336,10 @@
               ? [...ids.value, ...chosen]
               : ids.value.flatMap((id) => (id === replacing ? chosen : [id]));
 
-          emit(
-            'update:value',
+          updateValue(
             limit.value === null
               ? next
-              : next.slice(0, Math.max(limit.value, 1)),
-            'discrete'
+              : next.slice(0, Math.max(limit.value, 1))
           );
         },
       }
@@ -336,7 +354,7 @@
   function removeIds(remove: Set<number>): void {
     const next = ids.value.filter((id) => !remove.has(id));
     pruneSelection(next);
-    emit('update:value', next, 'discrete');
+    updateValue(next);
   }
 
   /** One dispatcher for every chip's menu, rather than one per element. */
@@ -565,11 +583,7 @@
     const limit = props.control.props.limit;
     const next = [...ids.value, asset.id];
 
-    emit(
-      'update:value',
-      limit === null ? next : next.slice(-Math.max(limit, 1)),
-      'discrete'
-    );
+    updateValue(limit === null ? next : next.slice(-Math.max(limit, 1)));
   }
 
   /**
@@ -627,7 +641,7 @@
 
       <div
         class="border border-(--c-color-neutral-border-quiet) rounded-sm inset-shadow-sm bg-(--c-color-neutral-fill-quiet) relative"
-        v-if="value.length > 0"
+        v-if="ids.length > 0"
       >
         <!--
           Selection toolbar. The whole bar is selection-only, so a field that
@@ -688,7 +702,7 @@
               <input
                 v-if="editable"
                 type="hidden"
-                :name="`${inputName(control.path)}[]`"
+                :name="`${inputName(control.path)}${control.props.single ? '' : '[]'}`"
                 :value="String(element.id)"
               />
             </template>
@@ -715,7 +729,7 @@
         </div>
         <div class="absolute inset-e-1 inset-be-1" v-if="limit && limit > 1">
           <craft-badge size="small" no-prefix
-            >{{ value.length }}/{{ limit }}</craft-badge
+            >{{ ids.length }}/{{ limit }}</craft-badge
           >
         </div>
       </div>

--- a/src/Form/Controls/ElementSelect.php
+++ b/src/Form/Controls/ElementSelect.php
@@ -15,6 +15,7 @@ use CraftCms\Cms\Form\ControlPayload;
 use CraftCms\Cms\Form\FormHtmlRenderer;
 use CraftCms\Cms\Image\Enums\ImageTransformMode;
 use CraftCms\Cms\Shared\Enums\Color;
+use CraftCms\Cms\Support\Html;
 use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 
@@ -40,6 +41,8 @@ class ElementSelect extends Control
     private ?string $selectionLabel = null;
 
     private ?int $limit = null;
+
+    private bool $single = false;
 
     private bool $showSiteMenu = false;
 
@@ -67,7 +70,7 @@ class ElementSelect extends Control
     {
         $editable = $attributes['name'] !== null;
 
-        return FormFields::elementSelectHtml([
+        return Html::tag('div', FormFields::elementSelectHtml([
             'id' => $attributes['id'],
             'name' => $attributes['name'],
             'elements' => self::elements($control->props['elementType'], $value),
@@ -76,6 +79,7 @@ class ElementSelect extends Control
             'criteria' => $control->props['criteria'],
             'selectionLabel' => $control->props['selectionLabel'],
             'limit' => $control->props['limit'],
+            'single' => $control->props['single'] ?? false,
             'showSiteMenu' => $control->props['showSiteMenu'],
             'allowAdd' => $editable,
             'allowRemove' => $editable,
@@ -83,7 +87,7 @@ class ElementSelect extends Control
             'disabled' => ! $editable,
             'useCustomElement' => true,
             'customElement' => $control->props['customElement'],
-        ]);
+        ]));
     }
 
     public function component(): string
@@ -141,6 +145,17 @@ class ElementSelect extends Control
         return $this;
     }
 
+    /** Selects and submits one scalar element ID instead of an ID list. */
+    public function single(bool $single = true): static
+    {
+        $this->single = $single;
+        if ($this->value === [] || $this->value === null) {
+            $this->value = $single ? null : [];
+        }
+
+        return $this;
+    }
+
     public function showSiteMenu(bool $showSiteMenu = true): static
     {
         $this->showSiteMenu = $showSiteMenu;
@@ -191,7 +206,8 @@ class ElementSelect extends Control
             'sources' => $this->sources,
             'criteria' => $this->criteria,
             'selectionLabel' => $this->selectionLabel ?? t('Choose'),
-            'limit' => $this->limit,
+            'limit' => $this->single ? 1 : $this->limit,
+            'single' => $this->single,
             'showSiteMenu' => $this->showSiteMenu,
             'viewMode' => $this->viewMode,
         ];
@@ -329,6 +345,10 @@ class ElementSelect extends Control
      */
     private static function elements(string $elementType, mixed $value): array
     {
+        if (is_int($value) || is_string($value) && $value !== '') {
+            $value = [$value];
+        }
+
         if (! is_array($value) || $value === []) {
             return [];
         }

--- a/src/Http/Controllers/Elements/DeleteElementsController.php
+++ b/src/Http/Controllers/Elements/DeleteElementsController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http\Controllers\Elements;
 
-use CraftCms\Cms\Cp\FormFields;
 use CraftCms\Cms\Cp\Html\PreviewHtml;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
@@ -18,11 +17,14 @@ use CraftCms\Cms\Element\Jobs\ReplaceRelations;
 use CraftCms\Cms\Element\Queries\Contracts\NestedElementQueryInterface;
 use CraftCms\Cms\Element\Validation\Rules\ElementTypeRule;
 use CraftCms\Cms\Field\FieldReferences;
+use CraftCms\Cms\Form\Controls\ElementSelect;
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\Nodes\Field;
+use CraftCms\Cms\Form\Nodes\HiddenField;
 use CraftCms\Cms\Http\Requests\ElementRequest;
 use CraftCms\Cms\Http\RespondsWithFlash;
 use CraftCms\Cms\Http\Responses\CpModalResponse;
 use CraftCms\Cms\Support\Facades\HtmlStack;
-use CraftCms\Cms\Support\Html;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
@@ -143,22 +145,23 @@ readonly class DeleteElementsController
 
         return new CpModalResponse()
             ->action('delete-elements/replace-relations')
-            ->contentHtml(fn () => FormFields::elementSelectFieldHtml([
-                'label' => t('Choose a new {type}', [
+            ->form(Form::make([
+                Field::make(t('Choose a new {type}', [
                     'type' => $this->elementType::lowerDisplayName(),
-                ]),
-                'name' => 'newTargetId',
+                ]), ElementSelect::make('newTargetId')
+                    ->elementType($this->elementType)
+                    ->criteria(['id' => ['not', ...$targetElementIds->all()]])
+                    ->single()),
+                HiddenField::make('elementType'),
+                ...$targetElementIds->keys()->map(fn (int $index) => HiddenField::make(['elementIds', (string) $index]))->all(),
+                HiddenField::make('hardDelete'),
+                HiddenField::make('sourceElementType'),
+            ]), [
                 'elementType' => $this->elementType,
-                'criteria' => [
-                    'id' => $targetElementIds->map(fn (int $id) => "not $id")->all(),
-                ],
-                'single' => true,
-            ]).
-                Html::hiddenInput('elementType', $this->elementType).
-                $targetElementIds->map(fn (int $id) => (string) Html::hiddenInput('elementIds[]', (string) $id))->join('').
-                Html::hiddenInput('hardDelete', $this->hardDelete ? '1' : '0').
-                Html::hiddenInput('sourceElementType', $sourceElementType)
-            )
+                'elementIds' => $targetElementIds->all(),
+                'hardDelete' => $this->hardDelete ? '1' : '0',
+                'sourceElementType' => $sourceElementType,
+            ])
             ->submitButtonLabel(t('Replace'));
     }
 
@@ -209,21 +212,21 @@ readonly class DeleteElementsController
 
         return new CpModalResponse()
             ->action('delete-elements/replace-references')
-            ->contentHtml(fn () => FormFields::elementSelectFieldHtml([
-                'label' => t('Choose a new {type}', [
+            ->form(Form::make([
+                Field::make(t('Choose a new {type}', [
                     'type' => $this->elementType::lowerDisplayName(),
-                ]),
-                'name' => 'newTargetId',
+                ]), ElementSelect::make('newTargetId')
+                    ->elementType($this->elementType)
+                    ->criteria(['id' => ['not', ...$targetElementIds->all()]])
+                    ->single()),
+                HiddenField::make('elementType'),
+                ...$targetElementIds->keys()->map(fn (int $index) => HiddenField::make(['elementIds', (string) $index]))->all(),
+                HiddenField::make('hardDelete'),
+            ]), [
                 'elementType' => $this->elementType,
-                'criteria' => [
-                    'id' => $targetElementIds->map(fn (int $id) => "not $id")->all(),
-                ],
-                'single' => true,
-            ]).
-                Html::hiddenInput('elementType', $this->elementType).
-                $targetElementIds->map(fn (int $id) => (string) Html::hiddenInput('elementIds[]', (string) $id))->join('').
-                Html::hiddenInput('hardDelete', $this->hardDelete ? '1' : '0')
-            )
+                'elementIds' => $targetElementIds->all(),
+                'hardDelete' => $this->hardDelete ? '1' : '0',
+            ])
             ->submitButtonLabel(t('Replace'));
     }
 

--- a/src/Http/Controllers/Entries/ReassignEntriesModalController.php
+++ b/src/Http/Controllers/Entries/ReassignEntriesModalController.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Http\Controllers\Entries;
 
 use CraftCms\Cms\Auth\Concerns\EnforcesPermissions;
-use CraftCms\Cms\Cp\FormFields;
 use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Entry\Entries;
+use CraftCms\Cms\Form\Controls\ElementSelect;
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\Nodes\Field;
+use CraftCms\Cms\Form\Nodes\HiddenField;
 use CraftCms\Cms\Http\RespondsWithFlash;
 use CraftCms\Cms\Http\Responses\CpModalResponse;
-use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,17 +35,13 @@ readonly class ReassignEntriesModalController
 
         return new CpModalResponse()
             ->action('entries/reassign')
-            ->contentHtml(fn () => FormFields::elementSelectFieldHtml([
-                'label' => t('Choose a new author'),
-                'name' => 'newUserId',
-                'elementType' => User::class,
-                'criteria' => [
-                    'id' => array_map(fn ($id) => "not $id", $oldUserIds),
-                ],
-                'single' => true,
-            ]).
-                implode('', array_map(fn ($id) => Html::hiddenInput('oldUserIds[]', $id), $oldUserIds)),
-            )
+            ->form(Form::make([
+                Field::make(t('Choose a new author'), ElementSelect::make('newUserId')
+                    ->elementType(User::class)
+                    ->criteria(['id' => ['not', ...$oldUserIds]])
+                    ->single()),
+                ...array_map(fn ($index) => HiddenField::make(['oldUserIds', (string) $index]), array_keys($oldUserIds)),
+            ]), ['oldUserIds' => $oldUserIds])
             ->submitButtonLabel(t('Reassign'));
     }
 

--- a/src/Http/Responses/CpModalResponse.php
+++ b/src/Http/Responses/CpModalResponse.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http\Responses;
 
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\FormHtmlRenderer;
+use CraftCms\Cms\Form\FormResolver;
 use CraftCms\Cms\Support\Facades\DeltaRegistry;
 use CraftCms\Cms\Support\Facades\HtmlStack;
 use CraftCms\Cms\Support\Facades\InputNamespace;
@@ -60,6 +64,11 @@ class CpModalResponse implements Responsable
      * @see contentTemplate()
      */
     public $contentHtml;
+
+    public ?Form $form = null;
+
+    /** @var array<string, mixed> */
+    public array $formValues = [];
 
     /**
      * @var string|Stringable|callable|null The errors summary HTML (DEV-212).
@@ -123,6 +132,19 @@ class CpModalResponse implements Responsable
     }
 
     /**
+     * Sets a Form to render alongside any legacy content HTML.
+     *
+     * @param  array<string, mixed>  $values
+     */
+    public function form(?Form $form, array $values = []): self
+    {
+        $this->form = $form;
+        $this->formValues = $values;
+
+        return $this;
+    }
+
+    /**
      * Sets a template that should be used to render the content HTML.
      */
     /** @param array<string, mixed> $variables */
@@ -172,6 +194,11 @@ class CpModalResponse implements Responsable
             $components = [];
             if ($this->contentHtml) {
                 $components[] = is_callable($this->contentHtml) ? call_user_func($this->contentHtml) : $this->contentHtml;
+            }
+            if ($this->form !== null) {
+                $components[] = app(FormHtmlRenderer::class)->render(
+                    app(FormResolver::class)->resolve($this->form, new FormContext(values: $this->formValues)),
+                );
             }
             if ($this->action) {
                 $components[] = Html::actionInput($this->action, [

--- a/src/Http/ViewModels/ContentIndexViewModel.php
+++ b/src/Http/ViewModels/ContentIndexViewModel.php
@@ -558,6 +558,7 @@ abstract class ContentIndexViewModel extends ViewModel
             elementType: $this->elementType,
             source: $this->sourceState()[1],
             condition: $this->request->condition(),
+            criteria: static::RENDER_CONTEXT === ElementSources::CONTEXT_MODAL ? $this->request->criteria() : [],
         )['query'];
 
         $query->status($this->status() ?: ($this->sourceState()[1]['criteria']['status'] ?? null));

--- a/tests/Feature/Form/ElementSelectControlTest.php
+++ b/tests/Feature/Form/ElementSelectControlTest.php
@@ -158,3 +158,25 @@ it('resolves JSON-safe props for every element type', function (Closure $createE
     'entries' => fn () => EntryElement::find()->id(Entry::factory()->create()->id)->one(),
     'users' => fn () => UserModel::factory()->createElement(),
 ]);
+
+it('renders a scalar element selection without changing list selection semantics', function (bool $single) {
+    $entry = Entry::factory()->createElement();
+    $control = ElementSelect::make('replacement')->elementType(EntryElement::class)->limit(1);
+    if ($single) {
+        $control->single();
+    }
+
+    $value = $single ? $entry->id : [$entry->id];
+    $payload = app(FormResolver::class)->resolve(Form::make([
+        Field::make('Replacement', $control),
+    ]), new FormContext(values: ['replacement' => $value]));
+    $crawler = new Crawler(app(FormHtmlRenderer::class)->render($payload));
+    $settings = json_decode($crawler->filter('craft-entry-select-input')->attr('settings'), true);
+    $name = $single ? 'replacement' : 'replacement[]';
+
+    expect($payload->values['replacement'])->toBe($value)
+        ->and($settings['single'])->toBe($single)
+        ->and($settings['limit'])->toBe(1)
+        ->and($crawler->filter('craft-field > [slot="input"] craft-entry-select-input'))->toHaveCount(1)
+        ->and($crawler->filter("craft-chip input[name=\"{$name}\"]")->attr('value'))->toBe((string) $entry->id);
+})->with([false, true]);

--- a/tests/Feature/Http/Controllers/Elements/DeleteElementsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/DeleteElementsControllerTest.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Queue;
+use Symfony\Component\DomCrawler\Crawler;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\post;
@@ -275,6 +276,45 @@ describe('replaceReferencesModal', function () {
         );
     });
 });
+
+it('preserves replacement Form settings and hidden values', function (string $method, string $action, bool $hardDelete) {
+    $first = EntryModel::factory()->createElement();
+    $second = EntryModel::factory()->createElement();
+    $response = postJson(action([DeleteElementsController::class, $method]), [
+        'elementType' => Entry::class,
+        'elementIds' => [$first->id, $second->id],
+        'hardDelete' => $hardDelete,
+        'sourceElementType' => Entry::class,
+    ])->assertOk();
+
+    $namespace = $response->json('namespace');
+    $crawler = new Crawler('<form>'.$response->json('content').'</form>', 'http://localhost');
+    $settings = json_decode($crawler->filter('craft-entry-select-input')->attr('settings'), true);
+
+    expect($settings['name'])->toBe("{$namespace}[newTargetId]")
+        ->and($settings['single'])->toBeTrue()
+        ->and($settings['limit'])->toBe(1)
+        ->and($settings['criteria']['id'])->toEqualCanonicalizing(['not', $first->id, $second->id]);
+
+    $values = [
+        'newTargetId' => '',
+        'elementType' => Entry::class,
+        'elementIds' => [(string) $first->id, (string) $second->id],
+        'hardDelete' => $hardDelete ? '1' : '0',
+    ];
+    if ($method === 'replaceRelationsModal') {
+        $values['sourceElementType'] = Entry::class;
+    }
+    $values['action'] = $action;
+
+    $submitted = $crawler->filter('form')->form()->getPhpValues();
+    sort($submitted[$namespace]['elementIds']);
+
+    expect($submitted)->toBe([$namespace => $values]);
+})->with([
+    ['replaceRelationsModal', 'delete-elements/replace-relations'],
+    ['replaceReferencesModal', 'delete-elements/replace-references'],
+])->with([false, true]);
 
 describe('replaceRelations', function () {
     it('requires a source element type and new target id', function () {

--- a/tests/Feature/Http/Controllers/Elements/ElementSelectorModalControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/ElementSelectorModalControllerTest.php
@@ -121,3 +121,15 @@ describe('titles are not links', function () {
         $thumbs->each(fn (array $thumb) => expect($thumb['url'])->toBeNull());
     });
 });
+
+it('excludes the target IDs supplied by replacement modals', function () {
+    $first = EntryModel::factory()->createElement();
+    $second = EntryModel::factory()->createElement();
+    $replacement = EntryModel::factory()->createElement();
+
+    $response = ($this->postBody)([
+        'criteria' => ['id' => ['not', $first->id, $second->id]],
+    ])->assertOk();
+
+    expect(array_column($response->json('props.data'), 'id'))->toBe([$replacement->id]);
+});

--- a/tests/Feature/Http/Controllers/Entries/ReassignEntriesModalControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/ReassignEntriesModalControllerTest.php
@@ -7,6 +7,7 @@ use CraftCms\Cms\Http\Controllers\Entries\ReassignEntriesModalController;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
+use Symfony\Component\DomCrawler\Crawler;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\postJson;
@@ -111,3 +112,35 @@ it('reassigns entries to the selected author', function (int $count, string $mes
     'single entry' => [1, 'Entry reassigned.'],
     'multiple entries' => [2, 'Entries reassigned.'],
 ]);
+
+it('submits the rendered reassignment Form through its namespace', function () {
+    $response = postJson(action([ReassignEntriesModalController::class, 'show']), [
+        'oldUserIds' => [12, 34],
+    ])->assertOk();
+
+    $namespace = $response->json('namespace');
+    $crawler = new Crawler('<form>'.$response->json('content').'</form>', 'http://localhost');
+    $settings = json_decode($crawler->filter('craft-element-select-input')->attr('settings'), true);
+
+    expect($settings['name'])->toBe("{$namespace}[newUserId]")
+        ->and($settings['single'])->toBeTrue()
+        ->and($settings['limit'])->toBe(1)
+        ->and($settings['criteria']['id'])->toBe(['not', 12, 34]);
+
+    $form = $crawler->filter('form')->form();
+    $form->setValues(["{$namespace}[newUserId]" => '56']);
+
+    expect($form->getPhpValues())->toBe([$namespace => [
+        'newUserId' => '56',
+        'oldUserIds' => ['12', '34'],
+        'action' => 'entries/reassign',
+    ]]);
+
+    $entries = Mockery::mock(Entries::class);
+    $entries->shouldReceive('reassignEntries')->once()->with([12, 34], 56)->andReturn(2);
+    app()->instance(Entries::class, $entries);
+
+    postJson(action([ReassignEntriesModalController::class, 'store']), $form->getPhpValues(), [
+        'X-Craft-Namespace' => $namespace,
+    ])->assertOk()->assertJsonPath('message', 'Entries reassigned.');
+});

--- a/tests/Unit/Http/Responses/CpModalResponseTest.php
+++ b/tests/Unit/Http/Responses/CpModalResponseTest.php
@@ -2,7 +2,12 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\Nodes\HiddenField;
 use CraftCms\Cms\Http\Responses\CpModalResponse;
+use CraftCms\Cms\Support\Facades\InputNamespace;
+use Illuminate\Http\Request;
+use Symfony\Component\DomCrawler\Crawler;
 use Twig\Markup;
 
 it('accepts markup for html sections', function (string $method, string $property) {
@@ -15,3 +20,40 @@ it('accepts markup for html sections', function (string $method, string $propert
     ['contentHtml', 'contentHtml'],
     ['errorSummary', 'errorSummary'],
 ]);
+
+it('renders Forms and legacy HTML under the same modal namespace', function () {
+    InputNamespace::set('outer');
+
+    $response = new CpModalResponse()
+        ->action('entries/reassign')
+        ->contentHtml(fn () => '<input name="legacy" value="kept">')
+        ->form(Form::make([
+            HiddenField::make('hardDelete'),
+            HiddenField::make(['oldUserIds', '0']),
+            HiddenField::make(['oldUserIds', '1']),
+        ]), ['hardDelete' => '0', 'oldUserIds' => [12, 34]]);
+
+    $data = $response->toResponse(Request::create('/'))->getData(true);
+    $form = new Crawler('<form>'.$data['content'].'</form>', 'http://localhost')->filter('form')->form();
+
+    expect($form->getPhpValues())->toBe([
+        $data['namespace'] => [
+            'legacy' => 'kept',
+            'hardDelete' => '0',
+            'oldUserIds' => ['12', '34'],
+            'action' => 'entries/reassign',
+        ],
+    ])->and(InputNamespace::get())->toBe('outer');
+});
+
+it('allows a Form to be configured during modal preparation', function () {
+    $request = Request::create('/', server: ['HTTP_X_CRAFT_CONTAINER_ID' => 'modal']);
+    $response = new CpModalResponse()->prepareModal(function (CpModalResponse $response) {
+        $response->form(Form::make([HiddenField::make('token')]), ['token' => 'prepared']);
+    });
+
+    $data = $response->toResponse($request)->getData(true);
+    $form = new Crawler('<form>'.$data['content'].'</form>', 'http://localhost')->filter('form')->form();
+
+    expect($form->getPhpValues())->toBe([$data['namespace'] => ['token' => 'prepared']]);
+});


### PR DESCRIPTION
### Description

Migrate the reassign entries, replace relations, and replace references modals to the Craft Form API while preserving their actions, submitted values, authorization, and success behavior. Add Form rendering to `CpModalResponse` alongside its existing HTML content API.

Support scalar element selections and namespaced validation feedback in these forms. Ensure the element picker opens correctly and carries exclusion criteria through to the modal query so users cannot select an element being replaced.
