### PR TITLE
[6.x] Render inline element editing with Form controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Removed `CraftCms\Cms\Element\Conditions\ElementCondition::$queryParams`. ([#19563](https://github.com/craftcms/cms/pull/19563))
 - Remove `CraftCms\Cms\Contracts\PluginInterface::createSettingsModel()`. Plugins must now declare `createSettings()`. ([#19574](https://github.com/craftcms/cms/pull/19574))
 - Replaced the project config implementation with separate change handling, storage, and rebuild components.
+- Replaced core inline element editing inputs with Form API controls rendered by Vue, with plugin field HTML compatibility handled by the Yii adapter. ([#19590](https://github.com/craftcms/cms/pull/19590))
 - Added `CraftCms\Cms\ProjectConfig\ProjectConfig::getPendingChanges()`.
 - Fixed a bug where removing false, zero, or empty-string project config values could leave their database rows behind.
 - Fixed an error that could occur when creating relation fields. ([#19571](https://github.com/craftcms/cms/pull/19571))

--- a/packages/craftcms-legacy/cp/src/js/TableElementIndexView.js
+++ b/packages/craftcms-legacy/cp/src/js/TableElementIndexView.js
@@ -1,5 +1,6 @@
 /** global: Craft */
 /** global: Garnish */
+import {serializeFormInputs} from '@craftcms/ui/utilities/dom';
 /**
  * Table Element Index View
  */
@@ -130,7 +131,18 @@ Craft.TableElementIndexView = Craft.BaseElementIndexView.extend({
   initForInlineEditing: function () {
     if (this.elementIndex.inlineEditing) {
       Craft.initUiElements(this.$elementContainer);
-      this.initialSerializedValue = this.serializeInputs();
+      this.inlineInputsReady = Promise.all(
+        [
+          ...this.$elementContainer[0].querySelectorAll(
+            'craft-inline-attribute-form'
+          ),
+        ].map(async (form) => {
+          await customElements.whenDefined('craft-inline-attribute-form');
+          await form.ready;
+        })
+      ).then(() => {
+        this.initialSerializedValue = this.serializeInputs();
+      });
 
       this.$saveBtn = Craft.ui
         .createSubmitButton({
@@ -157,9 +169,12 @@ Craft.TableElementIndexView = Craft.BaseElementIndexView.extend({
                   const $row = this.$elementContainer.children(
                     `[data-id="${elementId}"]`
                   );
+                  $row.find('craft-inline-attribute-form').each((i, form) => {
+                    form.errors = data.errors[elementId];
+                  });
                   for (const attribute in data.errors[elementId]) {
                     $row
-                      .find(`[name*="${attribute}"]`)
+                      .find(`[name*="${attribute.replace(/^field:/, '')}"]`)
                       .closest('td')
                       .addClass('errors');
                   }
@@ -188,7 +203,8 @@ Craft.TableElementIndexView = Craft.BaseElementIndexView.extend({
           });
       });
 
-      this.addListener(this.$cancelBtn, 'activate', () => {
+      this.addListener(this.$cancelBtn, 'activate', async () => {
+        await this.inlineInputsReady;
         if (
           !this.getDeltaInputChanges() ||
           confirm(
@@ -252,12 +268,7 @@ Craft.TableElementIndexView = Craft.BaseElementIndexView.extend({
   },
 
   serializeInputs: function () {
-    const data = Garnish.getPostData(this.$elementContainer);
-    const serialized = [];
-    for (const i in data) {
-      serialized.push(encodeURIComponent(`${i}=${data[i]}`));
-    }
-    return serialized.join('&');
+    return serializeFormInputs(this.$elementContainer[0]);
   },
 
   getDeltaInputChanges: function () {
@@ -278,10 +289,25 @@ Craft.TableElementIndexView = Craft.BaseElementIndexView.extend({
   },
 
   haveInputsChanged: function () {
-    return this.serializeInputs() !== this.initialSerializedValue;
+    return (
+      this.initialSerializedValue !== null &&
+      this.serializeInputs() !== this.initialSerializedValue
+    );
   },
 
   saveChanges: async function () {
+    await this.inlineInputsReady;
+
+    if (
+      [
+        ...this.$elementContainer[0].querySelectorAll(
+          'craft-inline-attribute-form'
+        ),
+      ].some((form) => !form.canSubmit())
+    ) {
+      throw new Error('Cannot save inline inputs that failed to render.');
+    }
+
     let data = this.getDeltaInputChanges();
     if (!data) {
       return {};

--- a/packages/craftcms-legacy/cpcompat/src/legacy-html-control.js
+++ b/packages/craftcms-legacy/cpcompat/src/legacy-html-control.js
@@ -29,6 +29,7 @@ import {
     _form = null;
     _error = null;
     _errors = [];
+    ready = Promise.resolve();
 
     set node(node) {
       this.control = node?.control ?? null;
@@ -62,7 +63,7 @@ import {
       this._fragmentKey = fragmentKey;
 
       if (this.isConnected) {
-        void this.mount();
+        this.ready = this.mount();
       }
     }
 
@@ -100,7 +101,7 @@ import {
       this._form?.addEventListener('submit', this.handleSubmit, true);
       this.addEventListener('input', this.handleInput);
       this.addEventListener('change', this.handleInput);
-      void this.mount();
+      this.ready = this.mount();
     }
 
     disconnectedCallback() {

--- a/resources/js/cp.ts
+++ b/resources/js/cp.ts
@@ -2,6 +2,7 @@ import '@craftcms/ui';
 import '../../packages/craftcms-legacy/cp/src/js/UI.js';
 import Cp from './bootstrap/cp.js';
 import {defineEntryFieldLayoutFormHost} from './modules/forms/entry-field-layout-form-host';
+import {defineInlineAttributeFormHost} from './modules/forms/inline-attribute-form-host';
 import {defineLayoutComponentSettingsFormHost} from './modules/forms/layout-component-settings-form-host';
 import './modules/navigation/components/cp-global-sidebar.js';
 import './modules/navigation/components/cp-queue-indicator.js';
@@ -54,4 +55,5 @@ import './modules/ui';
 
 window.Cp = Cp;
 defineEntryFieldLayoutFormHost(Cp.$components);
+defineInlineAttributeFormHost(Cp.$components);
 defineLayoutComponentSettingsFormHost(Cp.$components);

--- a/resources/js/legacy.ts
+++ b/resources/js/legacy.ts
@@ -24,6 +24,7 @@ import './modules/auth/components/recovery-codes/recovery-code-form.js';
 import {mountElevatedSessionHost} from './modules/auth/elevated-session';
 import {defineDashboardWidgetSettingsFormHost} from './modules/forms/dashboard-widget-settings-form-host';
 import {defineEntryFieldLayoutFormHost} from './modules/forms/entry-field-layout-form-host';
+import {defineInlineAttributeFormHost} from './modules/forms/inline-attribute-form-host';
 import {defineLayoutComponentSettingsFormHost} from './modules/forms/layout-component-settings-form-host';
 
 import './modules/listbox/index';
@@ -78,6 +79,7 @@ Cp.init();
 
 defineDashboardWidgetSettingsFormHost(Cp.$components);
 defineEntryFieldLayoutFormHost(Cp.$components);
+defineInlineAttributeFormHost(Cp.$components);
 defineLayoutComponentSettingsFormHost(Cp.$components);
 
 mountElevatedSessionHost();

--- a/resources/js/modules/forms/FormRenderer.vue
+++ b/resources/js/modules/forms/FormRenderer.vue
@@ -375,7 +375,13 @@
     recordChange({kind, path});
   }
 
-  defineExpose({advanceBaseline, currentValues, resetValues, setValue});
+  defineExpose({
+    advanceBaseline,
+    currentValues,
+    resetValues,
+    setValue,
+    canSubmit: () => !renderError.value,
+  });
 
   function rememberControlPaths(nodes: FormNodePayload[]): void {
     visitControls(nodes, (control) =>

--- a/resources/js/modules/forms/inline-attribute-form-host.test.ts
+++ b/resources/js/modules/forms/inline-attribute-form-host.test.ts
@@ -1,0 +1,177 @@
+import {afterEach, expect, it, vi} from 'vite-plus/test';
+import {nextTick} from 'vue';
+import {serializeFormInputs} from '@craftcms/ui/utilities/dom';
+import {createCpComponentRegistry} from '@/bootstrap/components';
+import FieldNode from './FieldNode.vue';
+import TextControl from './TextControl.vue';
+import DateTimeControl from './DateTimeControl.vue';
+import {
+  defineInlineAttributeFormHost,
+  type InlineAttributeFormHost,
+} from './inline-attribute-form-host';
+import type {FormPayload} from './types';
+
+const components = createCpComponentRegistry();
+components.register('craft:field', FieldNode);
+components.register('craft:text', TextControl);
+components.register('craft:date-time', DateTimeControl);
+defineInlineAttributeFormHost(components);
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+function mountInput(payload: FormPayload): InlineAttributeFormHost {
+  const host = document.createElement(
+    'craft-inline-attribute-form'
+  ) as InlineAttributeFormHost;
+  host.dataset.payload = JSON.stringify(payload);
+  document.body.append(host);
+
+  return host;
+}
+
+function textPayload(mode: 'editable' | 'disabled' = 'editable'): FormPayload {
+  return {
+    scope: ['index', 'element-42', 'fields'],
+    refreshable: false,
+    nodes: [
+      {
+        type: 'Field',
+        component: 'craft:field',
+        props: {},
+        control: {
+          type: 'Text',
+          component: 'craft:text',
+          path: ['index', 'element-42', 'fields', 'summary'],
+          deltaGroup: ['index', 'element-42', 'fields', 'summary'],
+          mode,
+          props: {},
+        },
+      },
+    ],
+    values: {index: {'element-42': {fields: {summary: 'Original & value=1'}}}},
+    errors: [],
+    globalErrors: [],
+  };
+}
+
+it('waits for posting inputs before capturing the baseline and serializes edits', async () => {
+  const host = mountInput(textPayload());
+  await host.ready;
+  const baseline = serializeFormInputs(host);
+
+  expect(
+    new URLSearchParams(baseline).get('index[element-42][fields][summary]')
+  ).toBe('Original & value=1');
+
+  const input = host.querySelector('craft-input');
+  if (!input) throw new Error('Expected the Form text control.');
+  input.modelValue = 'Edited & value=2';
+  input.dispatchEvent(new CustomEvent('model-value-changed', {bubbles: true}));
+  await nextTick();
+  await input.updateComplete;
+
+  expect(
+    new URLSearchParams(serializeFormInputs(host)).get(
+      'index[element-42][fields][summary]'
+    )
+  ).toBe('Edited & value=2');
+  expect(serializeFormInputs(host)).not.toBe(baseline);
+});
+
+it('omits disabled controls from row submissions', async () => {
+  const host = mountInput(textPayload('disabled'));
+  await host.ready;
+
+  expect(serializeFormInputs(host)).toBe('');
+});
+
+it('prevents submission when a Form control cannot be rendered', async () => {
+  const payload = textPayload();
+  const host = mountInput({
+    ...payload,
+    nodes: [
+      {
+        ...payload.nodes[0]!,
+        control: {...payload.nodes[0]!.control!, component: 'missing:control'},
+      },
+    ],
+  });
+  await host.ready;
+
+  expect(host.canSubmit()).toBe(false);
+  expect(host.textContent).toContain('missing:control');
+});
+
+it('shows field validation errors without discarding edits', async () => {
+  const host = mountInput(textPayload());
+  await host.ready;
+  host.errors = {'field:summary': ['Summary is invalid.']};
+  await nextTick();
+
+  expect(host.textContent).toContain('Summary is invalid.');
+  expect(
+    new URLSearchParams(serializeFormInputs(host)).get(
+      'index[element-42][fields][summary]'
+    )
+  ).toBe('Original & value=1');
+});
+
+it('posts empty dates and retains their timezone', async () => {
+  const payload: FormPayload = {
+    scope: ['index', 'element-42'],
+    refreshable: false,
+    nodes: [
+      {
+        type: 'Field',
+        component: 'craft:field',
+        props: {},
+        control: {
+          type: 'DateTime',
+          component: 'craft:date-time',
+          path: ['index', 'element-42', 'expiryDate'],
+          deltaGroup: ['index', 'element-42', 'expiryDate'],
+          mode: 'editable',
+          props: {
+            showDate: true,
+            showTime: true,
+            showTimeZone: false,
+            locale: 'en-US',
+            minuteIncrement: 1,
+          },
+        },
+      },
+    ],
+    values: {
+      index: {
+        'element-42': {
+          expiryDate: {date: '', time: '', timezone: 'Europe/Brussels'},
+        },
+      },
+    },
+    errors: [],
+    globalErrors: [],
+  };
+  const host = mountInput(payload);
+  await host.ready;
+
+  expect(
+    Object.fromEntries(new URLSearchParams(serializeFormInputs(host)))
+  ).toMatchObject({
+    'index[element-42][expiryDate][date]': '',
+    'index[element-42][expiryDate][time]': '',
+    'index[element-42][expiryDate][timezone]': 'Europe/Brussels',
+  });
+});
+
+it('unmounts the Vue app when a row is removed', async () => {
+  const uninstall = vi.spyOn(components, 'uninstall');
+  const host = mountInput(textPayload());
+  await host.ready;
+  host.remove();
+
+  expect(uninstall).toHaveBeenCalledOnce();
+  expect(host.childElementCount).toBe(0);
+});

--- a/resources/js/modules/forms/inline-attribute-form-host.ts
+++ b/resources/js/modules/forms/inline-attribute-form-host.ts
@@ -1,0 +1,98 @@
+import type {CpComponentRegistry} from '@/bootstrap/components';
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  shallowRef,
+  type App,
+} from 'vue';
+import FormRenderer from './FormRenderer.vue';
+import type {FormPayload} from './types';
+
+export interface InlineAttributeFormHost extends HTMLElement {
+  ready: Promise<void>;
+  errors: Record<string, string[]>;
+  canSubmit(): boolean;
+}
+
+/** Mounts Form controls in the legacy table without changing its row save contract. */
+export function defineInlineAttributeFormHost(
+  components: CpComponentRegistry
+): void {
+  if (customElements.get('craft-inline-attribute-form')) {
+    return;
+  }
+
+  customElements.define(
+    'craft-inline-attribute-form',
+    class extends HTMLElement {
+      #app: App | null = null;
+      #payload: FormPayload | null = null;
+      readonly #errors = shallowRef<FormPayload['errors']>([]);
+      readonly #renderer = shallowRef<{canSubmit(): boolean} | null>(null);
+      ready: Promise<void> = Promise.resolve();
+
+      set errors(errors: Record<string, string[]>) {
+        const scope = this.#payload?.scope ?? [];
+        this.#errors.value = Object.entries(errors).map(
+          ([attribute, messages]) => ({
+            path: [...scope, ...attribute.replace(/^field:/, '').split('.')],
+            messages,
+          })
+        );
+      }
+
+      connectedCallback(): void {
+        if (this.#app) {
+          return;
+        }
+
+        const payload: FormPayload = JSON.parse(this.dataset.payload!);
+        this.#payload = payload;
+        this.#errors.value = payload.errors;
+        this.#app = createApp(
+          defineComponent({
+            setup: () => () =>
+              h(FormRenderer, {
+                payload,
+                ref: this.#renderer,
+                errors: this.#errors.value,
+              }),
+          })
+        );
+        this.#app.config.compilerOptions.isCustomElement = (tag) =>
+          tag.includes('-');
+        components.install(this.#app);
+        this.#app.mount(this);
+        this.ready = this.#whenReady();
+      }
+
+      async #whenReady(): Promise<void> {
+        await nextTick();
+
+        for (const element of this.querySelectorAll('*')) {
+          if ('updateComplete' in element) {
+            await element.updateComplete;
+          }
+
+          if ('ready' in element) {
+            await element.ready;
+          }
+        }
+      }
+
+      canSubmit(): boolean {
+        return this.#renderer.value?.canSubmit() ?? false;
+      }
+
+      disconnectedCallback(): void {
+        if (this.#app) {
+          components.uninstall(this.#app);
+          this.#app.unmount();
+          this.#app = null;
+        }
+      }
+    }
+  );
+}

--- a/src/Asset/Elements/Asset.php
+++ b/src/Asset/Elements/Asset.php
@@ -58,7 +58,9 @@ use CraftCms\Cms\Filesystem\Exceptions\FilesystemException;
 use CraftCms\Cms\Filesystem\Filesystems\Filesystem;
 use CraftCms\Cms\Form\Contracts\Node;
 use CraftCms\Cms\Form\Controls\Text;
+use CraftCms\Cms\Form\Controls\Textarea;
 use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Form\Form;
 use CraftCms\Cms\Form\Nodes\Field;
 use CraftCms\Cms\Gql\Interfaces\Elements\Asset as AssetInterface;
 use CraftCms\Cms\Http\Requests\ElementRequest;
@@ -2569,15 +2571,11 @@ JS, [
     }
 
     #[Override]
-    protected function inlineAttributeInputHtml(string $attribute): string
+    protected function inlineAttributeInputForm(string $attribute): ?Form
     {
-        return match ($attribute) {
-            'alt' => FormFields::textareaHtml([
-                'name' => 'alt',
-                'value' => $this->alt,
-            ]),
-            default => parent::inlineAttributeInputHtml($attribute),
-        };
+        return $attribute === 'alt'
+            ? Form::make([Field::make(control: Textarea::make('alt')->value($this->alt))])
+            : parent::inlineAttributeInputForm($attribute);
     }
 
     /**

--- a/src/Element/Concerns/HasControlPanelUI.php
+++ b/src/Element/Concerns/HasControlPanelUI.php
@@ -728,7 +728,22 @@ JS,
      */
     protected function inlineAttributeInputHtml(string $attribute): string|Stringable
     {
-        return app(ElementAttributeRenderer::class)->renderInlineInput($this, $attribute);
+        $renderer = app(ElementAttributeRenderer::class);
+        $form = $this->inlineAttributeInputForm($attribute);
+
+        return $form === null
+            ? $renderer->renderInlineInput($this, $attribute)
+            : $renderer->renderInlineForm($form, $this->errors()->getMessages());
+    }
+
+    /**
+     * Defines a native attribute's inline controls. Custom fields are resolved by
+     * ElementAttributeRenderer. HTML overrides and the resolving event still run
+     * through getInlineAttributeInputHtml() before this default implementation.
+     */
+    protected function inlineAttributeInputForm(string $attribute): ?Form
+    {
+        return null;
     }
 
     public function getSidebarHtml(bool $static): string|Stringable

--- a/src/Element/ElementAttributeRenderer.php
+++ b/src/Element/ElementAttributeRenderer.php
@@ -17,10 +17,17 @@ use CraftCms\Cms\Field\Contracts\InlineEditableFieldInterface;
 use CraftCms\Cms\Field\Contracts\PreviewableFieldInterface;
 use CraftCms\Cms\Field\Exceptions\FieldNotFoundException;
 use CraftCms\Cms\Field\Exceptions\InvalidFieldException;
+use CraftCms\Cms\Field\FieldContext;
 use CraftCms\Cms\Field\Fields;
 use CraftCms\Cms\FieldLayout\LayoutElements\CustomField;
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\FormResolver;
+use CraftCms\Cms\Form\Nodes\Field as FormField;
 use CraftCms\Cms\Support\Facades\I18N;
+use CraftCms\Cms\Support\Facades\InputNamespace;
 use CraftCms\Cms\Support\Html;
+use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Translation\Locale;
 use DateTimeInterface;
@@ -113,7 +120,18 @@ readonly class ElementAttributeRenderer
                         }
                     }
 
-                    return $field->getInlineInputHtml($value, $element);
+                    $context = $this->inlineFormContext([
+                        $field->handle => $element->errors()->get("field:$field->handle"),
+                    ]);
+                    $control = InputNamespace::with(null, fn () => $field->formControl(new FieldContext(
+                        path: $field->handle,
+                        value: $value,
+                        element: $element,
+                        form: $context,
+                        inline: true,
+                    )));
+
+                    return $this->renderInlineForm(Form::make([FormField::make(control: $control)]), context: $context);
                 }
             }
 
@@ -121,6 +139,31 @@ readonly class ElementAttributeRenderer
         }
 
         return $this->render($element, $attribute);
+    }
+
+    /**
+     * The table's HTML transport carries Form data, not generated inputs. The
+     * active Twig namespace is resolved now because Vue mounts after that scope
+     * has ended. Plugin HTML continues through the existing HTML hook chain.
+     *
+     * @param  array<string, list<string>>  $errors
+     */
+    public function renderInlineForm(Form $form, array $errors = [], ?FormContext $context = null): string
+    {
+        $payload = app(FormResolver::class)->resolve($form, $context ?? $this->inlineFormContext($errors));
+
+        return Html::tag('craft-inline-attribute-form', '', [
+            'data-payload' => Json::encode($payload),
+        ]);
+    }
+
+    /** @param array<string, list<string>> $errors */
+    private function inlineFormContext(array $errors): FormContext
+    {
+        return new FormContext(
+            namespace: preg_split('/[\[\]]+/', InputNamespace::get() ?? '', flags: PREG_SPLIT_NO_EMPTY),
+            errors: $errors,
+        );
     }
 
     public function attributeHtml(mixed $value): string

--- a/src/Entry/Elements/Entry.php
+++ b/src/Entry/Elements/Entry.php
@@ -61,6 +61,7 @@ use CraftCms\Cms\Form\Controls\DateTime;
 use CraftCms\Cms\Form\Controls\ElementSelect;
 use CraftCms\Cms\Form\Controls\Text;
 use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Form\Form;
 use CraftCms\Cms\Form\Nodes\Field;
 use CraftCms\Cms\Gql\Interfaces\Elements\Entry as EntryInterface;
 use CraftCms\Cms\Http\Requests\ElementRequest;
@@ -2049,49 +2050,40 @@ JS, [
     }
 
     #[Override]
-    protected function inlineAttributeInputHtml(string $attribute): string
+    protected function inlineAttributeInputForm(string $attribute): ?Form
     {
-        switch ($attribute) {
-            case 'postDate':
-                return FormFields::dateTimeFieldHtml([
-                    'name' => 'postDate',
-                    'value' => $this->postDate,
-                ]);
-            case 'expiryDate':
-                return FormFields::dateTimeFieldHtml([
-                    'name' => 'expiryDate',
-                    'value' => $this->expiryDate,
-                ]);
-            case 'slug':
-                return FormFields::textHtml([
-                    'name' => 'slug',
-                    'value' => $this->slug,
-                ]);
-            case 'authors':
-                $authors = $this->getAuthors();
-                $section = $this->getSection();
+        if ($attribute === 'authors') {
+            $section = $this->getSection();
+            $status = $this->getAttributeStatus('authorIds');
 
-                return FormFields::elementSelectHtml([
-                    'status' => $this->getAttributeStatus('authorIds'),
-                    'label' => t('{max, plural, =1{Author} other {Authors}}', [
-                        'max' => $section->maxAuthors ?? PHP_INT_MAX,
-                    ]),
-                    'id' => 'authorIds',
-                    'name' => 'authorIds',
-                    'elementType' => User::class,
-                    'selectionLabel' => t('Choose'),
-                    'criteria' => [
-                        'can' => "viewEntries:$section->uid",
-                    ],
-                    'single' => false,
-                    'elements' => $authors ?: null,
-                    'disabled' => ! $this->canChangeAuthor(),
-                    'errors' => $this->errors()->get('authorIds'),
-                    'limit' => $section->maxAuthors,
-                ]);
-            default:
-                return parent::inlineAttributeInputHtml($attribute);
+            return Form::make([
+                Field::make(t('{max, plural, =1{Author} other {Authors}}', [
+                    'max' => $section->maxAuthors ?? PHP_INT_MAX,
+                ]), ElementSelect::make('authorIds')
+                    ->elementType(User::class)
+                    ->criteria(['can' => "viewEntries:$section->uid"])
+                    ->selectionLabel(t('Choose'))
+                    ->limit($section->maxAuthors)
+                    ->value($this->getAuthorIds())
+                    ->mode($this->canChangeAuthor() ? ControlMode::Editable : ControlMode::Disabled))
+                    ->status($status[0]->value ?? null, $status[1] ?? null),
+            ]);
         }
+
+        $control = match ($attribute) {
+            'postDate', 'expiryDate' => DateTime::make($attribute)
+                ->showTime()
+                ->minuteIncrement(1)
+                ->value(self::dateTimeControlValue($this->$attribute === null
+                    ? null
+                    : Date::instance($this->$attribute)->setTimezone(Cms::timezone()))),
+            'slug' => Text::make('slug')->value($this->slug),
+            default => null,
+        };
+
+        return $control === null
+            ? parent::inlineAttributeInputForm($attribute)
+            : Form::make([Field::make(control: $control)]);
     }
 
     /** @return array<string, array<string, scalar>> */

--- a/src/Field/FieldContext.php
+++ b/src/Field/FieldContext.php
@@ -23,5 +23,6 @@ readonly class FieldContext
         public ?ElementInterface $element = null,
         public FormContext $form = new FormContext,
         public ControlMode $mode = ControlMode::Editable,
+        public bool $inline = false,
     ) {}
 }

--- a/tests/Feature/Element/InlineAttributeFormTest.php
+++ b/tests/Feature/Element/InlineAttributeFormTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Asset\Models\Asset;
+use CraftCms\Cms\Cms;
+use CraftCms\Cms\Element\Events\ElementInlineAttributeInputHtmlResolving;
+use CraftCms\Cms\Entry\Elements\Entry;
+use CraftCms\Cms\Entry\Models\Entry as EntryModel;
+use CraftCms\Cms\Field\FieldContext;
+use CraftCms\Cms\Field\Models\Field;
+use CraftCms\Cms\Field\PlainText;
+use CraftCms\Cms\FieldLayout\Events\FieldLayoutComponentShowInFormResolving;
+use CraftCms\Cms\FieldLayout\LayoutElements\CustomField;
+use CraftCms\Cms\FieldLayout\Models\FieldLayout;
+use CraftCms\Cms\Support\Facades\InputNamespace;
+use CraftCms\Cms\User\Elements\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Gate;
+use Symfony\Component\DomCrawler\Crawler;
+
+use function Pest\Laravel\actingAs;
+
+beforeEach(function () {
+    actingAs(User::findOne());
+});
+
+function inlineAttributePayload(string $html): array
+{
+    $crawler = new Crawler($html);
+
+    expect($crawler->filter('input, textarea, select')->count())->toBe(0);
+
+    return json_decode($crawler->filter('craft-inline-attribute-form')->attr('data-payload'), true, flags: JSON_THROW_ON_ERROR);
+}
+
+it('renders entry dates and slug as namespaced Form controls', function (string $attribute, string $component) {
+    $entry = EntryModel::factory()->createElement();
+    $entry->postDate = new DateTimeImmutable('2026-05-03 09:17:00', new DateTimeZone(Cms::timezone()));
+    $entry->expiryDate = null;
+    $entry->slug = 'a&b="quoted"';
+
+    $payload = inlineAttributePayload(InputNamespace::namespaceInputs(
+        fn () => $entry->getInlineAttributeInputHtml($attribute),
+        'index[element-42]',
+    ));
+
+    expect($payload['nodes'][0]['control']['component'])->toBe($component)
+        ->and($payload['nodes'][0]['control']['path'])->toBe(['index', 'element-42', $attribute])
+        ->and($payload['values']['index']['element-42'][$attribute])->toBe(match ($attribute) {
+            'slug' => 'a&b="quoted"',
+            'postDate' => ['date' => '2026-05-03', 'time' => '09:17', 'timezone' => Cms::timezone()],
+            'expiryDate' => ['date' => '', 'time' => '', 'timezone' => Cms::timezone()],
+        });
+})->with([
+    ['postDate', 'craft:date-time'],
+    ['expiryDate', 'craft:date-time'],
+    ['slug', 'craft:text'],
+]);
+
+it('retains the system timezone when displaying entry dates', function () {
+    $entry = EntryModel::factory()->createElement();
+    $entry->postDate = new DateTimeImmutable('2026-05-03 09:17:00', new DateTimeZone('+05:00'));
+    $expected = $entry->postDate->setTimezone(new DateTimeZone(Cms::timezone()));
+
+    $payload = inlineAttributePayload($entry->getInlineAttributeInputHtml('postDate'));
+
+    expect($payload['values']['postDate'])->toBe([
+        'date' => $expected->format('Y-m-d'),
+        'time' => $expected->format('H:i'),
+        'timezone' => Cms::timezone(),
+    ])->and($entry->postDate->getTimezone()->getName())->toBe('+05:00');
+});
+
+it('uses the author selector criteria limit and IDs', function () {
+    $entry = EntryModel::factory()->createElement();
+    $payload = inlineAttributePayload($entry->getInlineAttributeInputHtml('authors'));
+
+    expect($payload['nodes'][0]['control']['component'])->toBe('craft:element-select')
+        ->and($payload['nodes'][0]['control']['path'])->toBe(['authorIds'])
+        ->and($payload['nodes'][0]['control']['props']['criteria']['can'])->toBe('viewEntries:'.$entry->getSection()->uid)
+        ->and($payload['nodes'][0]['control']['props']['limit'])->toBe($entry->getSection()->maxAuthors)
+        ->and($payload['values']['authorIds'])->toBe($entry->getAuthorIds());
+});
+
+it('disables author controls when the author cannot be changed', function () {
+    $entry = EntryModel::factory()->createElement();
+    Gate::before(fn ($user, $ability) => $ability === 'changeAuthor' ? false : null);
+
+    $payload = inlineAttributePayload($entry->getInlineAttributeInputHtml('authors'));
+
+    expect($payload['nodes'][0]['control']['mode'])->toBe('disabled');
+});
+
+it('renders asset alt text and keeps folders without inline inputs', function () {
+    $asset = Asset::factory()->createElement();
+    $asset->alt = "First line\nSecond & <line>";
+    $payload = inlineAttributePayload($asset->getInlineAttributeInputHtml('alt'));
+
+    expect($payload['nodes'][0]['control']['component'])->toBe('craft:textarea')
+        ->and($payload['values']['alt'])->toBe("First line\nSecond & <line>");
+
+    $asset->isFolder = true;
+
+    expect($asset->getInlineAttributeInputHtml('alt'))->toBe('');
+});
+
+it('reuses field configuration and the field instance handle', function () {
+    $field = Field::factory()->create([
+        'type' => PlainText::class,
+        'handle' => 'body',
+        'settings' => ['multiline' => true, 'initialRows' => 3, 'charLimit' => 80],
+    ]);
+    $entry = EntryModel::factory()
+        ->withFieldLayout(FieldLayout::factory()->withContentTab([
+            new CustomField(config: ['fieldUid' => $field->uid, 'handle' => 'summary']),
+        ]))
+        ->createElement();
+    $layoutElement = $entry->getFieldLayout()->getCustomFields()[0]->layoutElement;
+    $entry->setFieldValue('summary', 'Existing text');
+    $nativeControl = $layoutElement->getField()->formControl(new FieldContext('summary', 'Existing text', $entry));
+
+    $payload = inlineAttributePayload(InputNamespace::namespaceInputs(
+        fn () => $entry->getInlineAttributeInputHtml("fieldInstance:$layoutElement->uid"),
+        'index[element-42][fields]',
+    ));
+
+    expect($payload['nodes'][0]['control']['component'])->toBe($nativeControl->component())
+        ->and($payload['nodes'][0]['control']['props'])->toBe($nativeControl->props())
+        ->and($payload['nodes'][0]['control']['path'])->toBe(['index', 'element-42', 'fields', 'summary'])
+        ->and($payload['values']['index']['element-42']['fields']['summary'])->toBe('Existing text');
+});
+
+it('keeps HTML event overrides authoritative for native controls', function () {
+    $entry = EntryModel::factory()->createElement();
+    $calls = 0;
+    Event::listen(ElementInlineAttributeInputHtmlResolving::class, function ($event) use (&$calls) {
+        $calls++;
+        $event->html = '<input name="slug" value="Plugin">';
+    });
+
+    expect($entry->getInlineAttributeInputHtml('slug'))->toBe('<input name="slug" value="Plugin">')
+        ->and($calls)->toBe(1);
+});
+
+it('does not create controls for fields hidden by their layout', function () {
+    $field = Field::factory()->create(['type' => PlainText::class, 'handle' => 'body']);
+    $entry = EntryModel::factory()->withFieldLayout(FieldLayout::factory()->forField($field))->createElement();
+    $entry->setFieldValue('body', 'Visible preview');
+    Event::listen(FieldLayoutComponentShowInFormResolving::class, function ($event) {
+        $event->showInForm = false;
+    });
+
+    expect($entry->getInlineAttributeInputHtml("field:$field->uid"))->toBe($entry->getAttributeHtml("field:$field->uid"));
+});
+
+it('allows inherited protected HTML overrides to call the native parent', function () {
+    $entry = EntryModel::factory()->createElement();
+    $plugin = new class(['slug' => $entry->slug]) extends Entry
+    {
+        protected function inlineAttributeInputHtml(string $attribute): string
+        {
+            return '<span data-plugin></span>'.parent::inlineAttributeInputHtml($attribute);
+        }
+    };
+
+    $html = $plugin->getInlineAttributeInputHtml('slug');
+
+    expect(new Crawler($html)->filter('[data-plugin]')->count())->toBe(1)
+        ->and(inlineAttributePayload($html)['values']['slug'])->toBe($entry->slug);
+});

--- a/tests/Feature/Http/Controllers/Elements/SaveElementIndexElementsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Elements/SaveElementIndexElementsControllerTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Asset\Elements\Asset;
+use CraftCms\Cms\Asset\Models\Asset as AssetModel;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
@@ -19,6 +21,7 @@ use CraftCms\Cms\Support\Facades\Fields as FieldsFacade;
 use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\User\Models\User as UserModel;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\postJson;
@@ -123,6 +126,58 @@ it('saves inline-edited elements in a batch', function () {
 
     expect(Entry::find()->id($firstEntry->id)->status(null)->one()?->title)->toBe('First After Save')
         ->and(Entry::find()->id($secondEntry->id)->status(null)->one()?->title)->toBe('Second After Save');
+});
+
+it('saves structured entry dates author IDs and cleared values', function () {
+    $entry = EntryModel::factory()->createElement();
+    $author = UserModel::factory()->admin()->createElement();
+
+    ($this->postSaveElements)([
+        'siteId' => $entry->siteId,
+        'namespace' => 'elementindex-test',
+        'elementindex-test' => [
+            "element-$entry->id" => [
+                'postDate' => ['date' => '2026-05-03', 'time' => '09:17', 'timezone' => 'Europe/Brussels'],
+                'expiryDate' => ['date' => '', 'time' => '', 'timezone' => 'Europe/Brussels'],
+                'authorIds' => [$author->id],
+            ],
+        ],
+    ])->assertOk()->assertJsonMissingPath('errors');
+
+    $saved = Entry::find()->id($entry->id)->status(null)->one();
+
+    expect($saved->postDate->getTimestamp())->toBe(new DateTimeImmutable('2026-05-03T07:17:00+00:00')->getTimestamp())
+        ->and($saved->expiryDate)->toBeNull()
+        ->and($saved->getAuthorIds())->toBe([$author->id]);
+});
+
+it('saves and clears inline asset alt text', function () {
+    $asset = AssetModel::factory()->createElement();
+
+    foreach (["Description & <text>\nNext line", ''] as $alt) {
+        postJson(action(SaveElementIndexElementsController::class), [
+            'elementType' => Asset::class,
+            'siteId' => $asset->siteId,
+            'namespace' => 'elementindex-test',
+            'elementindex-test' => ["element-$asset->id" => ['alt' => $alt]],
+        ])->assertOk()->assertJsonMissingPath('errors');
+
+        expect(Asset::find()->id($asset->id)->one()->alt)->toBe($alt === '' ? null : $alt);
+    }
+});
+
+it('still authorizes saves before applying structured values', function () {
+    $entry = EntryModel::factory()->createElement();
+    $originalSlug = $entry->slug;
+    Gate::before(fn ($user, $ability) => $ability === 'save' ? false : null);
+
+    ($this->postSaveElements)([
+        'siteId' => $entry->siteId,
+        'namespace' => 'elementindex-test',
+        'elementindex-test' => ["element-$entry->id" => ['slug' => 'changed']],
+    ])->assertForbidden();
+
+    expect(Entry::find()->id($entry->id)->status(null)->one()->slug)->toBe($originalSlug);
 });
 
 it('ignores sensitive attributes when saving user elements in a batch', function () {

--- a/yii2-adapter/src/Field/Concerns/LegacyFieldControl.php
+++ b/yii2-adapter/src/Field/Concerns/LegacyFieldControl.php
@@ -38,6 +38,7 @@ trait LegacyFieldControl
                 ControlMode::Disabled => LegacyHtmlMode::Disabled,
             },
             deltaGroup: $path,
+            inline: $context->inline,
         );
 
         return $node?->getControl()->expandValues() ?? throw new RuntimeException(sprintf(

--- a/yii2-adapter/src/Form/LegacyHtml.php
+++ b/yii2-adapter/src/Form/LegacyHtml.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Yii2Adapter\Form;
 
 use CraftCms\Cms\Element\Contracts\ElementInterface;
+use CraftCms\Cms\Field\Contracts\InlineEditableFieldInterface;
 use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\View\HtmlStack;
 use CraftCms\Cms\View\InputNamespace;
@@ -56,17 +57,22 @@ class LegacyHtml
         ?string $namespace = null,
         LegacyHtmlMode $mode = LegacyHtmlMode::Editable,
         string|array|null $deltaGroup = null,
+        bool $inline = false,
     ): ?LegacyHtmlField {
+        $input = $inline
+            ? ($field instanceof InlineEditableFieldInterface
+                ? fn(): string => $field->getInlineInputHtml($value, $element)
+                : throw new InvalidArgumentException('Inline legacy fields must support inline editing.'))
+            : fn(): string => $field->getInputHtml($value, $element);
+
         return $this->capture(
             $path,
             match ($mode) {
-                LegacyHtmlMode::Editable => fn(): string => $field->getInputHtml($value, $element),
+                LegacyHtmlMode::Editable => $input,
                 LegacyHtmlMode::Static => fn(): string => $element === null
                     ? throw new InvalidArgumentException('Static legacy fields require an element.')
                     : $field->getStaticHtml($value, $element),
-                LegacyHtmlMode::ReadOnly, LegacyHtmlMode::Disabled => fn(): string => Html::disableInputs(
-                    fn(): string => $field->getInputHtml($value, $element),
-                ),
+                LegacyHtmlMode::ReadOnly, LegacyHtmlMode::Disabled => fn(): string => Html::disableInputs($input),
             },
             $namespace,
             $mode,

--- a/yii2-adapter/tests-laravel/Legacy/LegacyHtmlFormTest.php
+++ b/yii2-adapter/tests-laravel/Legacy/LegacyHtmlFormTest.php
@@ -49,6 +49,7 @@ use CraftCms\Cms\Field\FieldContext;
 use CraftCms\Cms\FieldLayout\FieldLayout;
 use CraftCms\Cms\FieldLayout\FieldLayoutCompiler;
 use CraftCms\Cms\FieldLayout\FieldLayoutTab;
+use CraftCms\Cms\FieldLayout\LayoutElements\CustomField;
 use CraftCms\Cms\Form\Enums\ControlMode;
 use CraftCms\Cms\Form\Form;
 use CraftCms\Cms\Form\FormContext;
@@ -81,6 +82,32 @@ class LegacyHookField extends LegacyField
     public function getStaticHtml(mixed $value, ElementInterface $element): string
     {
         return '<span data-static>static</span>';
+    }
+}
+
+class LegacyInlineHookField extends PlainText
+{
+    protected function inputHtml(mixed $value, ?ElementInterface $element, bool $inline): string
+    {
+        HtmlStack::js('window.inlineHookLoaded = true;');
+
+        return '<input name="body" value="' . ($inline ? 'Inline editor' : 'Full editor') . '">';
+    }
+}
+
+class InlineHtmlOverrideField extends PlainText
+{
+    public function getInlineInputHtml(mixed $value, ?ElementInterface $element): string
+    {
+        return '<input name="body" value="Plugin inline">';
+    }
+}
+
+class InlineProtectedHtmlOverrideField extends PlainText
+{
+    protected function inputHtml(mixed $value, ?ElementInterface $element, bool $inline): string
+    {
+        return '<input name="body" value="' . ($inline ? 'Plugin inline' : 'Full editor') . '">';
     }
 }
 
@@ -135,6 +162,47 @@ it('registers its private Form types', function() {
     expect(app(FormNodeTypes::class)->types()->contains(LegacyHtmlField::class))->toBeTrue()
         ->and(app(FormControlTypes::class)->types()->contains(LegacyHtmlControl::class))->toBeTrue();
 });
+
+it('captures inline field hooks with their namespace and assets', function() {
+    $field = new LegacyInlineHookField(['handle' => 'body']);
+    $control = $field->formControl(new FieldContext(
+        path: 'body',
+        form: new FormContext(namespace: ['index', 'element-42', 'fields']),
+        inline: true,
+    ));
+    $props = $control->props();
+    $input = new Crawler($props['fragment']['html'])->filter('input');
+
+    expect($control)->toBeInstanceOf(LegacyHtmlControl::class)
+        ->and($input->attr('name'))->toBe('index[element-42][fields][body]')
+        ->and($input->attr('value'))->toBe('Inline editor')
+        ->and($props['fragment']['bodyHtml'])->toContain('window.inlineHookLoaded = true;');
+});
+
+it('preserves public and protected custom field HTML hooks through inline Form rendering', function(string $type) {
+    $field = new $type(['handle' => 'body', 'uid' => 'inline-field']);
+    $layoutElement = Mockery::mock(CustomField::class);
+    $layoutElement->shouldReceive('showInForm', 'editable')->andReturn(true);
+    $field->layoutElement = $layoutElement;
+    $layout = Mockery::mock(FieldLayout::class);
+    $layout->shouldReceive('getFieldByUid')->with('inline-field')->andReturn($field);
+    $entry = Mockery::mock(Entry::class)->makePartial();
+    $entry->shouldReceive('getFieldLayout')->andReturn($layout);
+    $entry->shouldReceive('getFieldValue')->with('body')->andReturn('Original');
+
+    $html = InputNamespace::namespaceInputs(
+        fn() => $entry->getInlineAttributeInputHtml('field:inline-field'),
+        'index[element-42][fields]',
+    );
+    $payload = json_decode(new Crawler($html)->filter('craft-inline-attribute-form')->attr('data-payload'), true, flags: JSON_THROW_ON_ERROR);
+    $input = new Crawler($payload['nodes'][0]['control']['props']['fragment']['html'])->filter('input');
+
+    expect($input->attr('name'))->toBe('index[element-42][fields][body]')
+        ->and($input->attr('value'))->toBe('Plugin inline');
+})->with([
+    'public hook' => [InlineHtmlOverrideField::class],
+    'protected hook' => [InlineProtectedHtmlOverrideField::class],
+]);
 
 it('eagerly captures namespaced HTML and assets into a JSON-safe payload', function() {
     $component = Mockery::mock(LegacySettingsContract::class);


### PR DESCRIPTION
### Description

Render inline element edits with structured Form API controls mounted by Vue. Entry dates, authors, and slugs, asset alt text, and editable custom fields reuse the existing controls while preserving namespaced values, row saving, validation errors, and permissions.

Keep the public element HTML hooks and resolving event available. Field HTML compatibility is handled by the Yii adapter, and the table waits for controls to initialize before capturing changes or saving.
