### PR TITLE
[6.x] Move legacy relation settings and entry title HTML into the adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574) and [#19563](https://github.com/craftcms/cms/pull/19563) for details.
 
+- Moved legacy relation-field settings HTML and entry-title input HTML into the Yii adapter. ([#19591](https://github.com/craftcms/cms/pull/19591))
 - Migrated the reassign entries, replace relations, and replace references modals to the Form API. ([#19589](https://github.com/craftcms/cms/pull/19589))
 - Added support for refreshable standard plugin settings forms and conditional configuration of core form nodes. ([#19545](https://github.com/craftcms/cms/pull/19545))
 - Added support for sending queued Laravel notifications to `CraftCms\Cms\User\Elements\User` elements. ([#19541](https://github.com/craftcms/cms/pull/19541))

--- a/src/Field/BaseRelationField.php
+++ b/src/Field/BaseRelationField.php
@@ -7,7 +7,6 @@ namespace CraftCms\Cms\Field;
 use Closure;
 use CraftCms\Cms\Condition\Contracts\ConditionInterface;
 use CraftCms\Cms\Cp\Cp;
-use CraftCms\Cms\Cp\FormFields;
 use CraftCms\Cms\Cp\Html\ElementHtml;
 use CraftCms\Cms\Cp\Html\PreviewHtml;
 use CraftCms\Cms\Database\ElementRelationParamFilter;
@@ -62,8 +61,6 @@ use CraftCms\Cms\Support\Html;
 use CraftCms\Cms\Support\Query;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\Support\Typecast;
-use CraftCms\Cms\View\LegacyAssets\CpAsset;
-use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Contracts\Database\Query\Builder as BuilderInterface;
@@ -79,7 +76,6 @@ use Override;
 use RuntimeException;
 use Tpetry\QueryExpressions\Language\Alias;
 
-use function CraftCms\Cms\craftAsset;
 use function CraftCms\Cms\t;
 use function CraftCms\Cms\template;
 
@@ -1618,174 +1614,10 @@ abstract class BaseRelationField extends Field implements CrossSiteCopyableField
             ->all();
     }
 
-    /**
-     * Returns the HTML for the Target Site setting.
-     */
-    public function getTargetSiteFieldHtml(): ?string
-    {
-        $class = static::elementType();
-
-        if (! Sites::isMultiSite() || ! $class::isLocalized()) {
-            return null;
-        }
-
-        $type = $class::lowerDisplayName();
-        $pluralType = $class::pluralLowerDisplayName();
-        $showTargetSite = ! empty($this->targetSiteId);
-        $siteOptions = [];
-
-        foreach (Sites::getAllSites() as $site) {
-            $siteOptions[] = [
-                'label' => t($site->getName(), category: 'site'),
-                'value' => $site->uid,
-            ];
-        }
-
-        $html =
-            FormFields::checkboxFieldHtml([
-                'checkboxLabel' => t('Relate {type} from a specific site?', ['type' => $pluralType]),
-                'name' => 'useTargetSite',
-                'checked' => $showTargetSite,
-                'toggle' => 'target-site-field',
-                'reverseToggle' => 'show-site-menu-field',
-            ]).
-            FormFields::selectFieldHtml([
-                'fieldClass' => ! $showTargetSite ? ['hidden'] : null,
-                'label' => t('Which site should {type} be related from?', ['type' => $pluralType]),
-                'id' => 'target-site',
-                'name' => 'targetSiteId',
-                'options' => $siteOptions,
-                'value' => $this->targetSiteId,
-            ]);
-
-        if (static::canShowSiteMenu()) {
-            $html .= FormFields::checkboxFieldHtml([
-                'fieldset' => true,
-                'fieldClass' => $showTargetSite ? ['hidden'] : null,
-                'checkboxLabel' => t('Show the site menu'),
-                'instructions' => t('Whether the site menu should be shown for {type} selection modals.',
-                    [
-                        'type' => $type,
-                    ]),
-                'warning' => t(
-                    'Relations don’t store the selected site, so this should only be enabled if some {type} aren’t propagated to all sites.',
-                    [
-                        'type' => $pluralType,
-                    ]),
-                'id' => 'show-site-menu',
-                'name' => 'showSiteMenu',
-                'checked' => $this->showSiteMenu,
-            ]);
-        }
-
-        return $html;
-    }
-
-    /**
-     * Returns the HTML for the View Mode setting.
-     */
-    public function getViewModeFieldHtml(): ?string
-    {
-        $supportedViewModes = $this->supportedViewModes();
-
-        if (count($supportedViewModes) === 1) {
-            return null;
-        }
-
-        if (empty(array_diff(array_keys($supportedViewModes), [
-            self::VIEW_MODE_LIST,
-            self::VIEW_MODE_LIST_INLINE,
-            self::VIEW_MODE_THUMBS,
-            self::VIEW_MODE_CARDS,
-            self::VIEW_MODE_CARDS_GRID,
-        ]))) {
-            $html = Html::beginTag('div', ['class' => ['flex', 'items-start', 'gap-l']]);
-            app(InternalAssetRegistry::class)->register(CpAsset::class);
-            $baseIconsUrl = craftAsset('legacy/cp/dist/images/view-modes');
-
-            foreach ($supportedViewModes as $key => $label) {
-                $html .= Html::beginTag('label', ['class' => 'nowrap']).
-                    Html::img("$baseIconsUrl/$key.svg", '', [
-                        'class' => 'mb-xs',
-                        'width' => $key === self::VIEW_MODE_LIST ? 48 : 80,
-                        'height' => 60,
-                    ]).
-                    Html::radio('viewMode', $key, [
-                        'value' => $key,
-                        'checked' => $this->viewMode === $key,
-                    ]).
-                    ' '.$label.
-                    Html::endTag('label');
-            }
-
-            $html .= Html::endTag('div');
-        } else {
-            $viewModeOptions = [];
-
-            foreach ($supportedViewModes as $key => $label) {
-                $viewModeOptions[] = ['label' => $label, 'value' => $key];
-            }
-
-            $html = FormFields::selectHtml([
-                'id' => 'viewMode',
-                'name' => 'viewMode',
-                'options' => $viewModeOptions,
-                'value' => $this->viewMode,
-            ]);
-        }
-
-        return FormFields::fieldHtml($html, [
-            'label' => t('View Mode'),
-            'instructions' => t('Choose how the field should look for authors.'),
-            'id' => 'viewMode',
-        ]);
-    }
-
     #[Override]
     public function useFieldset(): bool
     {
         return true;
-    }
-
-    /**
-     * Returns an array of variables that should be passed to the settings template.
-     *
-     * @return array{
-     *     field:static,
-     *     upperElementType:string,
-     *     elementType:string,
-     *     pluralElementType:string,
-     *     selectionCondition:string|null,
-     * }
-     */
-    protected function settingsTemplateVariables(): array
-    {
-        $elementType = static::elementType();
-
-        $selectionCondition = $this->getSelectionCondition() ?? $this->createSelectionCondition();
-        if ($selectionCondition) {
-            $selectionCondition->mainTag = 'div';
-            $selectionCondition->id = 'selection-condition';
-            $selectionCondition->name = 'selectionCondition';
-            $selectionCondition->forProjectConfig = true;
-
-            $selectionConditionHtml = FormFields::fieldHtml($selectionCondition->getBuilderHtml(), [
-                'label' => t('Selectable {type} Condition', [
-                    'type' => $elementType::pluralDisplayName(),
-                ]),
-                'instructions' => mb_ucfirst(t('Only allow {type} to be selected if they match the following rules:', [
-                    'type' => $elementType::pluralLowerDisplayName(),
-                ])),
-            ]);
-        }
-
-        return [
-            'field' => $this,
-            'upperElementType' => $elementType::displayName(),
-            'elementType' => $elementType::lowerDisplayName(),
-            'pluralElementType' => $elementType::pluralLowerDisplayName(),
-            'selectionCondition' => $selectionConditionHtml ?? null,
-        ];
     }
 
     /**

--- a/src/FieldLayout/LayoutElements/Entries/EntryTitleField.php
+++ b/src/FieldLayout/LayoutElements/Entries/EntryTitleField.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\FieldLayout\LayoutElements\Entries;
 
-use CraftCms\Cms\Cp\FormFields;
 use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\Entry\Elements\Entry;
 use CraftCms\Cms\Field\Enums\TranslationMethod;
@@ -87,39 +86,5 @@ class EntryTitleField extends TitleField
         }
 
         return $element->getType()->titleTranslationMethod->description();
-    }
-
-    #[Override]
-    public function inputHtml(?ElementInterface $element = null, bool $static = false): ?string
-    {
-        if (! $element instanceof Entry) {
-            throw new InvalidArgumentException(sprintf('%s can only be used in entry field layouts.', self::class));
-        }
-
-        $entryType = $element->getType();
-
-        if (! $entryType->hasTitleField) {
-            return null;
-        }
-
-        if ($entryType->allowLineBreaksInTitles) {
-            return FormFields::textareaHtml([
-                'class' => 'nicetext',
-                'id' => $this->id(),
-                'describedBy' => $this->describedBy($element, $static),
-                'rows' => 2,
-                'name' => $this->name ?? $this->attribute(),
-                'value' => $this->value($element),
-                'maxlength' => $this->maxlength,
-                'autofocus' => $this->autofocus,
-                'disabled' => $static || $this->disabled,
-                'readonly' => $this->readonly,
-                'required' => ! $static && $this->required,
-                'title' => $this->title,
-                'placeholder' => $this->placeholder,
-            ]);
-        }
-
-        return parent::inputHtml($element, $static);
     }
 }

--- a/yii2-adapter/legacy/fieldlayoutelements/entries/EntryTitleField.php
+++ b/yii2-adapter/legacy/fieldlayoutelements/entries/EntryTitleField.php
@@ -11,17 +11,74 @@ declare(strict_types=1);
 
 namespace craft\fieldlayoutelements\entries;
 
-/** @phpstan-ignore-next-line */
-if (false) {
-    /**
-     * EntryTitleField represents a Title field that can be included within an entry type's field layout designer.
-     *
-     * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
-     *
-     * @since 3.5.0
-     * @deprecated 6.0.0 use {@see \CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField} instead.
-     */
-    class EntryTitleField extends \CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField
+use CraftCms\Cms\Cp\FormFields;
+use CraftCms\Cms\Element\Contracts\ElementInterface;
+use CraftCms\Cms\Entry\Elements\Entry;
+use CraftCms\Cms\FieldLayout\FieldLayoutElementContext;
+use CraftCms\Cms\Form\Contracts\Control;
+use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Support\Html;
+use CraftCms\Yii2Adapter\Form\Enums\LegacyHtmlMode;
+use CraftCms\Yii2Adapter\Form\LegacyHtml;
+use InvalidArgumentException;
+use Override;
+
+/** @deprecated 6.0.0 use \CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField instead. */
+class EntryTitleField extends \CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField
+{
+    #[Override]
+    protected function formControl(FieldLayoutElementContext $context): ?Control
     {
+        $mode = $context->form->mode === ControlMode::Editable ? $context->mode : $context->form->mode;
+        $mode = $this->disabled ? ControlMode::Disabled : ($this->readonly && $mode === ControlMode::Editable ? ControlMode::ReadOnly : $mode);
+
+        $node = app(LegacyHtml::class)->capture(
+            path: $this->name ?? $this->attribute(),
+            hook: fn(): ?string => $mode === ControlMode::Disabled
+                ? Html::disableInputs(fn(): ?string => $this->inputHtml($context->element, true))
+                : $this->inputHtml($context->element, $mode !== ControlMode::Editable),
+            namespace: LegacyHtml::namespace($context->form->namespace),
+            mode: match ($mode) {
+                ControlMode::Editable => LegacyHtmlMode::Editable,
+                ControlMode::ReadOnly => LegacyHtmlMode::Static,
+                ControlMode::Disabled => LegacyHtmlMode::Disabled,
+            },
+        );
+
+        return $node?->getControl()->deltaGroupAtNamespace()->expandValues();
+    }
+
+    #[Override]
+    public function inputHtml(?ElementInterface $element = null, bool $static = false): ?string
+    {
+        if (!$element instanceof Entry) {
+            throw new InvalidArgumentException(sprintf('%s can only be used in entry field layouts.', self::class));
+        }
+
+        $entryType = $element->getType();
+
+        if (!$entryType->hasTitleField) {
+            return null;
+        }
+
+        if ($entryType->allowLineBreaksInTitles) {
+            return FormFields::textareaHtml([
+                'class' => 'nicetext',
+                'id' => $this->id(),
+                'describedBy' => $this->describedBy($element, $static),
+                'rows' => 2,
+                'name' => $this->name ?? $this->attribute(),
+                'value' => $this->value($element),
+                'maxlength' => $this->maxlength,
+                'autofocus' => $this->autofocus,
+                'disabled' => $static || $this->disabled,
+                'readonly' => $this->readonly,
+                'required' => !$static && $this->required,
+                'title' => $this->title,
+                'placeholder' => $this->placeholder,
+            ]);
+        }
+
+        return parent::inputHtml($element, $static);
     }
 }

--- a/yii2-adapter/legacy/fields/Assets.php
+++ b/yii2-adapter/legacy/fields/Assets.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace craft\fields;
 
 use CraftCms\Yii2Adapter\Field\Concerns\LegacyBuiltInField;
+use CraftCms\Yii2Adapter\Field\Concerns\LegacyRelationFieldSettings;
 use CraftCms\Yii2Adapter\Field\Contracts\LegacyField;
 
 /**
@@ -21,4 +22,7 @@ use CraftCms\Yii2Adapter\Field\Contracts\LegacyField;
 class Assets extends \CraftCms\Cms\Field\Assets implements LegacyField
 {
     use LegacyBuiltInField;
+    use LegacyRelationFieldSettings {
+        LegacyRelationFieldSettings::getSettingsHtml insteadof LegacyBuiltInField;
+    }
 }

--- a/yii2-adapter/legacy/fields/Entries.php
+++ b/yii2-adapter/legacy/fields/Entries.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace craft\fields;
 
 use CraftCms\Yii2Adapter\Field\Concerns\LegacyBuiltInField;
+use CraftCms\Yii2Adapter\Field\Concerns\LegacyRelationFieldSettings;
 use CraftCms\Yii2Adapter\Field\Contracts\LegacyField;
 
 /**
@@ -21,4 +22,7 @@ use CraftCms\Yii2Adapter\Field\Contracts\LegacyField;
 class Entries extends \CraftCms\Cms\Field\Entries implements LegacyField
 {
     use LegacyBuiltInField;
+    use LegacyRelationFieldSettings {
+        LegacyRelationFieldSettings::getSettingsHtml insteadof LegacyBuiltInField;
+    }
 }

--- a/yii2-adapter/legacy/fields/Users.php
+++ b/yii2-adapter/legacy/fields/Users.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace craft\fields;
 
 use CraftCms\Yii2Adapter\Field\Concerns\LegacyBuiltInField;
+use CraftCms\Yii2Adapter\Field\Concerns\LegacyRelationFieldSettings;
 use CraftCms\Yii2Adapter\Field\Contracts\LegacyField;
 
 /**
@@ -21,4 +22,7 @@ use CraftCms\Yii2Adapter\Field\Contracts\LegacyField;
 class Users extends \CraftCms\Cms\Field\Users implements LegacyField
 {
     use LegacyBuiltInField;
+    use LegacyRelationFieldSettings {
+        LegacyRelationFieldSettings::getSettingsHtml insteadof LegacyBuiltInField;
+    }
 }

--- a/yii2-adapter/src/ClassAliases.php
+++ b/yii2-adapter/src/ClassAliases.php
@@ -242,7 +242,6 @@ use craft\fieldlayoutelements\BaseField;
 use craft\fieldlayoutelements\BaseNativeField;
 use craft\fieldlayoutelements\BaseUiElement;
 use craft\fieldlayoutelements\CustomField;
-use craft\fieldlayoutelements\entries\EntryTitleField;
 use craft\fieldlayoutelements\Heading;
 use craft\fieldlayoutelements\HorizontalRule;
 use craft\fieldlayoutelements\Html;
@@ -622,7 +621,6 @@ class ClassAliases
         class_alias(\CraftCms\Cms\FieldLayout\LayoutElements\Addresses\OrganizationTaxIdField::class, OrganizationTaxIdField::class);
         class_alias(\CraftCms\Cms\FieldLayout\LayoutElements\Assets\AltField::class, AltField::class);
         class_alias(\CraftCms\Cms\FieldLayout\LayoutElements\Assets\AssetTitleField::class, AssetTitleField::class);
-        class_alias(\CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField::class, EntryTitleField::class);
         class_alias(\CraftCms\Cms\FieldLayout\LayoutElements\Users\AffiliatedSiteField::class, AffiliatedSiteField::class);
         class_alias(\CraftCms\Cms\FieldLayout\LayoutElements\Users\EmailField::class, EmailField::class);
         class_alias(\CraftCms\Cms\FieldLayout\LayoutElements\Users\FullNameField::class, FullNameField::class);

--- a/yii2-adapter/src/Field/BaseRelationField.php
+++ b/yii2-adapter/src/Field/BaseRelationField.php
@@ -7,21 +7,21 @@ namespace CraftCms\Yii2Adapter\Field;
 use CraftCms\Cms\Field\BaseRelationField as CoreBaseRelationField;
 use CraftCms\Cms\Form\Form;
 use CraftCms\Cms\Form\FormContext;
-use CraftCms\Cms\Support\Facades\HtmlStack;
-use CraftCms\Cms\Support\Facades\InputNamespace;
 use CraftCms\Cms\Support\Html;
 use CraftCms\Yii2Adapter\Field\Concerns\LegacyFieldControl;
 use CraftCms\Yii2Adapter\Field\Concerns\LegacyFieldHtml;
+use CraftCms\Yii2Adapter\Field\Concerns\LegacyRelationFieldSettings;
 use CraftCms\Yii2Adapter\Field\Contracts\LegacyField;
 use CraftCms\Yii2Adapter\Form\Concerns\LegacySettingsForm;
 use CraftCms\Yii2Adapter\Form\Contracts\LegacySettingsComponent;
-
-use function CraftCms\Cms\template;
 
 abstract class BaseRelationField extends CoreBaseRelationField implements LegacyField, LegacySettingsComponent
 {
     use LegacyFieldControl;
     use LegacyFieldHtml;
+    use LegacyRelationFieldSettings {
+        getSettingsHtml as private legacyRelationSettingsHtml;
+    }
     use LegacySettingsForm {
         settingsForm as private legacySettingsForm;
     }
@@ -33,24 +33,7 @@ abstract class BaseRelationField extends CoreBaseRelationField implements Legacy
 
     public function getSettingsHtml(): string
     {
-        $variables = $this->settingsTemplateVariables();
-
-        HtmlStack::jsWithVars(fn($args) => <<<JS
-new Craft.ElementFieldSettings(...$args)
-JS, [
-            [
-                $this->allowMultipleSources,
-                InputNamespace::namespaceId('maintain-hierarchy-field'),
-                InputNamespace::namespaceId($this->allowMultipleSources ? 'sources-field' : 'source-field'),
-                InputNamespace::namespaceId('branch-limit-field'),
-                InputNamespace::namespaceId('min-relations-field'),
-                InputNamespace::namespaceId('max-relations-field'),
-                InputNamespace::namespaceId('default-placement-field'),
-                InputNamespace::namespaceId('viewMode-field'),
-            ],
-        ]);
-
-        return template($this->settingsTemplate, $variables);
+        return $this->legacyRelationSettingsHtml();
     }
 
     public function getReadOnlySettingsHtml(): string

--- a/yii2-adapter/src/Field/Concerns/LegacyRelationFieldSettings.php
+++ b/yii2-adapter/src/Field/Concerns/LegacyRelationFieldSettings.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Yii2Adapter\Field\Concerns;
+
+use CraftCms\Cms\Cp\FormFields;
+use CraftCms\Cms\Field\BaseRelationField;
+use CraftCms\Cms\Support\Facades\HtmlStack;
+use CraftCms\Cms\Support\Facades\InputNamespace;
+use CraftCms\Cms\Support\Facades\Sites;
+use CraftCms\Cms\Support\Html;
+use CraftCms\Cms\View\LegacyAssets\CpAsset;
+use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
+
+use function CraftCms\Cms\craftAsset;
+use function CraftCms\Cms\t;
+use function CraftCms\Cms\template;
+
+/**
+ * @internal
+ * @phpstan-require-extends BaseRelationField
+ */
+trait LegacyRelationFieldSettings
+{
+    public function getSettingsHtml(): ?string
+    {
+        $variables = $this->settingsTemplateVariables();
+
+        HtmlStack::jsWithVars(fn($args) => <<<JS
+new Craft.ElementFieldSettings(...$args)
+JS, [
+            [
+                $this->allowMultipleSources,
+                InputNamespace::namespaceId('maintain-hierarchy-field'),
+                InputNamespace::namespaceId($this->allowMultipleSources ? 'sources-field' : 'source-field'),
+                InputNamespace::namespaceId('branch-limit-field'),
+                InputNamespace::namespaceId('min-relations-field'),
+                InputNamespace::namespaceId('max-relations-field'),
+                InputNamespace::namespaceId('default-placement-field'),
+                InputNamespace::namespaceId('viewMode-field'),
+            ],
+        ]);
+
+        return template($this->settingsTemplate, $variables);
+    }
+
+    /**
+     * Returns the HTML for the Target Site setting.
+     */
+    public function getTargetSiteFieldHtml(): ?string
+    {
+        $class = static::elementType();
+
+        if (!Sites::isMultiSite() || !$class::isLocalized()) {
+            return null;
+        }
+
+        $type = $class::lowerDisplayName();
+        $pluralType = $class::pluralLowerDisplayName();
+        $showTargetSite = !empty($this->targetSiteId);
+        $siteOptions = [];
+
+        foreach (Sites::getAllSites() as $site) {
+            $siteOptions[] = [
+                'label' => t($site->getName(), category: 'site'),
+                'value' => $site->uid,
+            ];
+        }
+
+        $html =
+            FormFields::checkboxFieldHtml([
+                'checkboxLabel' => t('Relate {type} from a specific site?', ['type' => $pluralType]),
+                'name' => 'useTargetSite',
+                'checked' => $showTargetSite,
+                'toggle' => 'target-site-field',
+                'reverseToggle' => 'show-site-menu-field',
+            ]) .
+            FormFields::selectFieldHtml([
+                'fieldClass' => !$showTargetSite ? ['hidden'] : null,
+                'label' => t('Which site should {type} be related from?', ['type' => $pluralType]),
+                'id' => 'target-site',
+                'name' => 'targetSiteId',
+                'options' => $siteOptions,
+                'value' => $this->targetSiteId,
+            ]);
+
+        if (static::canShowSiteMenu()) {
+            $html .= FormFields::checkboxFieldHtml([
+                'fieldset' => true,
+                'fieldClass' => $showTargetSite ? ['hidden'] : null,
+                'checkboxLabel' => t('Show the site menu'),
+                'instructions' => t('Whether the site menu should be shown for {type} selection modals.',
+                    [
+                        'type' => $type,
+                    ]),
+                'warning' => t(
+                    'Relations don’t store the selected site, so this should only be enabled if some {type} aren’t propagated to all sites.',
+                    [
+                        'type' => $pluralType,
+                    ]),
+                'id' => 'show-site-menu',
+                'name' => 'showSiteMenu',
+                'checked' => $this->showSiteMenu,
+            ]);
+        }
+
+        return $html;
+    }
+
+    /**
+     * Returns the HTML for the View Mode setting.
+     */
+    public function getViewModeFieldHtml(): ?string
+    {
+        $supportedViewModes = $this->supportedViewModes();
+
+        if (count($supportedViewModes) === 1) {
+            return null;
+        }
+
+        if (empty(array_diff(array_keys($supportedViewModes), [
+            self::VIEW_MODE_LIST,
+            self::VIEW_MODE_LIST_INLINE,
+            self::VIEW_MODE_THUMBS,
+            self::VIEW_MODE_CARDS,
+            self::VIEW_MODE_CARDS_GRID,
+        ]))) {
+            $html = Html::beginTag('div', ['class' => ['flex', 'items-start', 'gap-l']]);
+            app(InternalAssetRegistry::class)->register(CpAsset::class);
+            $baseIconsUrl = craftAsset('legacy/cp/dist/images/view-modes');
+
+            foreach ($supportedViewModes as $key => $label) {
+                $html .= Html::beginTag('label', ['class' => 'nowrap']) .
+                    Html::img("$baseIconsUrl/$key.svg", '', [
+                        'class' => 'mb-xs',
+                        'width' => $key === self::VIEW_MODE_LIST ? 48 : 80,
+                        'height' => 60,
+                    ]) .
+                    Html::radio('viewMode', $key, [
+                        'value' => $key,
+                        'checked' => $this->viewMode === $key,
+                    ]) .
+                    ' ' . $label .
+                    Html::endTag('label');
+            }
+
+            $html .= Html::endTag('div');
+        } else {
+            $viewModeOptions = [];
+
+            foreach ($supportedViewModes as $key => $label) {
+                $viewModeOptions[] = ['label' => $label, 'value' => $key];
+            }
+
+            $html = FormFields::selectHtml([
+                'id' => 'viewMode',
+                'name' => 'viewMode',
+                'options' => $viewModeOptions,
+                'value' => $this->viewMode,
+            ]);
+        }
+
+        return FormFields::fieldHtml($html, [
+            'label' => t('View Mode'),
+            'instructions' => t('Choose how the field should look for authors.'),
+            'id' => 'viewMode',
+        ]);
+    }
+
+    /**
+     * Returns an array of variables that should be passed to the settings template.
+     *
+     * @return array{
+     *     field:static,
+     *     upperElementType:string,
+     *     elementType:string,
+     *     pluralElementType:string,
+     *     selectionCondition:string|null,
+     * }
+     */
+    protected function settingsTemplateVariables(): array
+    {
+        $elementType = static::elementType();
+
+        $selectionCondition = $this->getSelectionCondition() ?? $this->createSelectionCondition();
+        $selectionConditionHtml = null;
+
+        if ($selectionCondition) {
+            $selectionCondition->mainTag = 'div';
+            $selectionCondition->id = 'selection-condition';
+            $selectionCondition->name = 'selectionCondition';
+            $selectionCondition->forProjectConfig = true;
+
+            $selectionConditionHtml = FormFields::fieldHtml($selectionCondition->getBuilderHtml(), [
+                'label' => t('Selectable {type} Condition', [
+                    'type' => $elementType::pluralDisplayName(),
+                ]),
+                'instructions' => mb_ucfirst(t('Only allow {type} to be selected if they match the following rules:', [
+                    'type' => $elementType::pluralLowerDisplayName(),
+                ])),
+            ]);
+        }
+
+        return [
+            'field' => $this,
+            'upperElementType' => $elementType::displayName(),
+            'elementType' => $elementType::lowerDisplayName(),
+            'pluralElementType' => $elementType::pluralLowerDisplayName(),
+            'selectionCondition' => $selectionConditionHtml,
+        ];
+    }
+}

--- a/yii2-adapter/tests-laravel/Legacy/LegacyCoreFormHtmlTest.php
+++ b/yii2-adapter/tests-laravel/Legacy/LegacyCoreFormHtmlTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Yii2Adapter\Tests\Legacy;
+
+use craft\fieldlayoutelements\entries\EntryTitleField as LegacyEntryTitleField;
+use craft\fields\Assets;
+use craft\fields\Entries;
+use craft\fields\Users;
+use CraftCms\Cms\Element\Conditions\ElementCondition;
+use CraftCms\Cms\Element\Contracts\ElementInterface;
+use CraftCms\Cms\Entry\Data\EntryType;
+use CraftCms\Cms\Entry\Elements\Entry;
+use CraftCms\Cms\FieldLayout\FieldLayoutElementContext;
+use CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField;
+use CraftCms\Cms\Form\Enums\ControlMode;
+use CraftCms\Cms\Form\Form;
+use CraftCms\Cms\Form\FormContext;
+use CraftCms\Cms\Form\FormResolver;
+use CraftCms\Cms\Support\Facades\HtmlStack;
+use CraftCms\Cms\Support\Facades\Sites;
+use CraftCms\Cms\Support\Facades\Template;
+use CraftCms\Cms\View\TemplateMode;
+use Mockery;
+use Symfony\Component\DomCrawler\Crawler;
+
+it('uses each built-in relation settings template through legacy parent hooks', function(string $class, string $template) {
+    $field = Mockery::mock($class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $condition = Mockery::mock(ElementCondition::class)->makePartial();
+    $condition->shouldReceive('getBuilderHtml')->andReturn('<div>Condition</div>');
+    $field->shouldReceive('getSelectionCondition')->andReturn($condition);
+    Template::shouldReceive('renderTemplate')->once()->withArgs(function($name, $variables) use ($template, $field) {
+        expect($name)->toBe($template)
+            ->and($variables['field'])->toBe($field);
+
+        return true;
+    })->andReturn('<input name="selectionLabel" value="Choose">');
+    $context = new FormContext(namespace: 'settings');
+
+    $payload = app(FormResolver::class)->resolve($field->settingsForm($context), $context);
+    $control = $payload->nodes[0]->control;
+    $html = new Crawler($control->props['fragment']['html']);
+
+    expect($html->filter('input')->attr('name'))->toBe('settings[selectionLabel]')
+        ->and($html->filter('input')->attr('value'))->toBe('Choose')
+        ->and($control->props['fragment']['bodyHtml'])->toContain('Craft.ElementFieldSettings');
+})->with([
+    'entries' => [Entries::class, '_components/fieldtypes/Entries/settings.twig'],
+    'assets' => [Assets::class, '_components/fieldtypes/Assets/settings.twig'],
+    'users' => [Users::class, '_components/fieldtypes/elementfieldsettings.twig'],
+]);
+
+it('preserves nullable settings overrides on built-in relation fields', function() {
+    $field = new class() extends Entries {
+        public function getSettingsHtml(): ?string
+        {
+            return null;
+        }
+    };
+
+    $payload = app(FormResolver::class)->resolve($field->settingsForm(), new FormContext());
+
+    expect($payload->nodes)->toBe([]);
+});
+
+it('renders the legacy relation templates with overridable settings HTML', function(string $class) {
+    TemplateMode::set(TemplateMode::Cp);
+    Sites::partialMock()->shouldReceive('isMultiSite')->andReturn(false);
+    Sites::shouldReceive('getEditableSiteIds')->andReturn(collect());
+    $condition = Mockery::mock(ElementCondition::class)->makePartial();
+    $condition->shouldReceive('getBuilderHtml')->andReturn('<div>Condition</div>');
+    $field = Mockery::mock($class)->makePartial();
+    $field->shouldReceive('getSelectionCondition')->andReturn($condition);
+    $field->shouldReceive('getSourceOptions')->andReturn([
+        ['label' => 'All sources', 'value' => '*', 'data' => ['structure-id' => null]],
+    ]);
+    $field->shouldReceive('getViewModeFieldHtml')->once()->andReturn('<input name="viewMode" value="plugin-view">');
+
+    $html = new Crawler($field->getSettingsHtml());
+
+    expect($html->filter('[name="viewMode"]')->attr('value'))->toBe('plugin-view')
+        ->and($html->filter('input[name="selectionLabel"]'))->toHaveCount(1);
+})->with([Entries::class, Assets::class, Users::class]);
+
+it('captures legacy entry title inputs while retaining the core title type', function(bool $multiline) {
+    $entry = Mockery::mock(Entry::class)->makePartial();
+    $entry->title = 'A title';
+    $entry->shouldReceive('getType')->andReturn(new EntryType([
+        'hasTitleField' => true,
+        'allowLineBreaksInTitles' => $multiline,
+    ]));
+    $entry->shouldReceive('getAttributeStatus')->andReturn(null);
+    $field = new LegacyEntryTitleField(['uid' => 'title', 'name' => 'headline']);
+    $context = new FormContext(namespace: ['nested']);
+    $node = $field->formNode(new FieldLayoutElementContext($entry, $context));
+    $payload = app(FormResolver::class)->resolve(Form::make([$node]), $context);
+    $html = new Crawler($payload->nodes[0]->control->props['fragment']['html']);
+
+    expect($field)->toBeInstanceOf(EntryTitleField::class)
+        ->and($field::class)->toBe(LegacyEntryTitleField::class)
+        ->and($html->filter($multiline ? 'textarea[name="nested[headline]"]' : 'input[name="nested[headline]"]'))->toHaveCount(1);
+})->with([false, true]);
+
+it('captures plugin title overrides once in every form mode', function(ControlMode $mode) {
+    $field = new class(['uid' => 'title', 'name' => 'headline']) extends LegacyEntryTitleField {
+        public int $calls = 0;
+
+        public function inputHtml(?ElementInterface $element = null, bool $static = false): ?string
+        {
+            $this->calls++;
+            HtmlStack::css('.plugin-title { color: red; }');
+
+            return '<input name="headline" data-static="' . ($static ? 'true' : 'false') . '">';
+        }
+    };
+    $context = new FormContext(namespace: ['nested'], mode: $mode);
+    $node = $field->formNode(new FieldLayoutElementContext(null, $context));
+    $payload = app(FormResolver::class)->resolve(Form::make([$node]), $context);
+    $control = $payload->nodes[0]->control;
+    $input = new Crawler($control->props['fragment']['html'])->filter('input');
+
+    expect($field->calls)->toBe(1)
+        ->and($control->mode)->toBe($mode)
+        ->and($control->props['fragment']['headHtml'])->toContain('.plugin-title')
+        ->and($input->attr('name'))->toBe('nested[headline]')
+        ->and($input->attr('data-static'))->toBe($mode === ControlMode::Editable ? 'false' : 'true');
+})->with(ControlMode::cases());
+
+it('serializes the adapter title class and omits titles disabled by the entry type', function() {
+    $field = new LegacyEntryTitleField(['uid' => 'title', 'name' => 'headline', 'required' => false]);
+    $layout = \CraftCms\Cms\FieldLayout\FieldLayout::make(Entry::class)
+        ->tab('Content', fn(\CraftCms\Cms\FieldLayout\FieldLayoutTab $tab) => $tab->add($field));
+    $entry = Mockery::mock(Entry::class)->makePartial();
+    $entry->shouldReceive('getType')->andReturn(new EntryType(['hasTitleField' => false]));
+
+    expect($layout->getConfig()['tabs'][0]['elements'][0])->toMatchArray([
+        'type' => LegacyEntryTitleField::class,
+        'uid' => 'title',
+        'name' => 'headline',
+        'required' => false,
+    ])->and($field->formNode(new FieldLayoutElementContext($entry, new FormContext())))->toBeNull();
+});


### PR DESCRIPTION
### Description

Moves legacy relation-field settings HTML into the Yii adapter while core retains its structured settings forms. Adapter relation fields preserve template and HTML overrides.

Replaces the legacy entry-title class alias with a subclass that owns `inputHtml()` and captures its output through `formControl()`. Core entry titles retain native controls, and legacy plugin overrides retain their HTML, namespaces, and registered assets.
