### PR TITLE
[6.x] Restore Inertia navigation for internal control panel links

### DIFF
--- a/resources/js/pages/settings/fields/Index.vue
+++ b/resources/js/pages/settings/fields/Index.vue
@@ -64,11 +64,7 @@
         trackSize: '1.5fr',
       },
       cell: ({row, getValue}) =>
-        h(
-          CpLink,
-          {href: row.original.url, inertia: false, class: 'font-bold'},
-          getValue
-        ),
+        h(CpLink, {href: row.original.url, class: 'font-bold'}, getValue),
     }),
     columnHelper.accessor('searchable', {
       header: t('Searchable'),
@@ -207,13 +203,7 @@
 
 <template>
   <LayoutSlot name="actions">
-    <CpLink
-      :inertia="false"
-      appearance="button"
-      variant="accent"
-      :href="create()"
-      icon="plus"
-    >
+    <CpLink appearance="button" variant="accent" :href="create()" icon="plus">
       {{ t('New field') }}
     </CpLink>
   </LayoutSlot>

--- a/resources/js/pages/settings/filesystems/Index.vue
+++ b/resources/js/pages/settings/filesystems/Index.vue
@@ -51,7 +51,6 @@
         href: edit['/{cpTrigger?}/settings/filesystems/{handle}/edit']({
           handle: row.original.handle,
         }).url,
-        inertia: false,
       }),
     }),
     columnHelper.handle('handle'),
@@ -104,20 +103,16 @@
 
 <template>
   <LayoutSlot name="actions">
-    <CpLink
-      variant="accent"
-      appearance="button"
-      :href="create().url"
-      :inertia="false"
-      >{{ t('New filesystem') }}</CpLink
-    >
+    <CpLink variant="accent" appearance="button" :href="create().url">{{
+      t('New filesystem')
+    }}</CpLink>
   </LayoutSlot>
 
   <craft-pane padding="0" appearance="raised">
     <AdminTable :table="table" :reorderable="false">
       <template #empty-row>
         <Empty :label="t('No filesystems exist yet.')" icon="light/folder-open">
-          <CpLink appearance="button" :href="create().url" :inertia="false">{{
+          <CpLink appearance="button" :href="create().url">{{
             t('New filesystem')
           }}</CpLink>
         </Empty>

--- a/resources/js/pages/settings/users/groups/Index.vue
+++ b/resources/js/pages/settings/users/groups/Index.vue
@@ -58,7 +58,6 @@
 <template>
   <LayoutSlot name="actions">
     <CpLink
-      :inertia="false"
       :href="create().url"
       class="btn submit add icon"
       icon="plus"
@@ -73,7 +72,6 @@
       <template #empty-row>
         <Empty icon="users" :label="t('No groups exist yet.')">
           <CpLink
-            :inertia="false"
             :href="create().url"
             class="btn submit add icon"
             icon="plus"

--- a/resources/js/pages/users/Index.vue
+++ b/resources/js/pages/users/Index.vue
@@ -66,7 +66,6 @@
     <template #actions>
       <CpLink
         v-if="page.props.canRegisterUsers"
-        :inertia="false"
         :href="create().url"
         class="btn submit add icon"
         icon="plus"

--- a/resources/js/pages/users/Permissions.vue
+++ b/resources/js/pages/users/Permissions.vue
@@ -115,10 +115,7 @@
       >
         <template v-if="props.teamPermissionsNotice.allowAdminChanges">
           {{ t('Team permissions can be managed from') }}
-          <CpLink
-            :href="props.teamPermissionsNotice.settingsUrl"
-            :inertia="false"
-          >
+          <CpLink :href="props.teamPermissionsNotice.settingsUrl">
             {{ t('User Permissions') }}
           </CpLink>
         </template>

--- a/src/Http/ViewModels/ContentIndexViewModel.php
+++ b/src/Http/ViewModels/ContentIndexViewModel.php
@@ -733,12 +733,7 @@ abstract class ContentIndexViewModel extends ViewModel
             return $chip;
         }
 
-        // `:inertia`, bound — a plain `inertia => false` renders nothing at all
-        // (Html::tag drops false attributes), so the prop falls back to its
-        // `true` default and the title becomes an Inertia <Link> that navigates
-        // on click. The element edit screen isn't an Inertia page, so that
-        // visit only ends in a hard redirect anyway.
-        return Html::tag('CpLink', $chip, ['href' => $editUrl, ':inertia' => 'false']);
+        return Html::tag('CpLink', $chip, ['href' => $editUrl]);
     }
 
     /**


### PR DESCRIPTION
### Description

Entry titles in the element index explicitly disabled Inertia, causing a full page reload when opening an entry. Remove that opt-out and the stale opt-outs on internal field, filesystem, user group, registration, and user permissions links so they use the control panel's default Inertia navigation.
