### PR TITLE
[6.x] Update Larastan and use table constants in migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "driftingly/rector-laravel": "^2.1",
     "fakerphp/faker": "^1.19.0",
     "intervention/image-driver-vips": "^4.1",
-    "larastan/larastan": "^3.4",
+    "larastan/larastan": "^3.12",
     "laravel/boost": "^2.6",
     "laravel/pao": "^1.0",
     "laravel/pint": "^1.22",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89fdea3686e8bb00dc45b6ac82752187",
+    "content-hash": "824e50baf364e6501ba1aecc26be633b",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -10791,16 +10791,16 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v3.11.0",
+            "version": "v3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "9baa74074f17cc70feaef31616a06ea0faeebba5"
+                "reference": "ab26fdf90d84877061388109e1e251f67ca3ff7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/9baa74074f17cc70feaef31616a06ea0faeebba5",
-                "reference": "9baa74074f17cc70feaef31616a06ea0faeebba5",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/ab26fdf90d84877061388109e1e251f67ca3ff7a",
+                "reference": "ab26fdf90d84877061388109e1e251f67ca3ff7a",
                 "shasum": ""
             },
             "require": {
@@ -10868,7 +10868,7 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v3.11.0"
+                "source": "https://github.com/larastan/larastan/tree/v3.12.0"
             },
             "funding": [
                 {
@@ -10876,7 +10876,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-09-01T16:35:48+00:00"
+            "time": "2026-09-10T09:06:54+00:00"
         },
         {
             "name": "laravel/agent-detector",

--- a/src/Database/Migrations/0000_00_00_000005_rename_tokens_to_routetokens.php
+++ b/src/Database/Migrations/0000_00_00_000005_rename_tokens_to_routetokens.php
@@ -3,23 +3,24 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Database\Migration;
+use CraftCms\Cms\Database\Table;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('routetokens')) {
+        if (Schema::hasTable(Table::ROUTETOKENS)) {
             Schema::dropIfExists('tokens');
 
             return;
         }
 
-        Schema::rename('tokens', 'routetokens');
+        Schema::rename('tokens', Table::ROUTETOKENS);
     }
 
     public function down(): void
     {
-        Schema::rename('routetokens', 'tokens');
+        Schema::rename(Table::ROUTETOKENS, 'tokens');
     }
 };

--- a/src/Database/Migrations/0000_00_00_000007_migrate_to_laravel_queue.php
+++ b/src/Database/Migrations/0000_00_00_000007_migrate_to_laravel_queue.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Database\Migration;
+use CraftCms\Cms\Database\Table;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -19,8 +20,8 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (! Schema::hasTable('jobprogress')) {
-            Schema::create('jobprogress', function (Blueprint $table) {
+        if (! Schema::hasTable(Table::JOBPROGRESS)) {
+            Schema::create(Table::JOBPROGRESS, function (Blueprint $table) {
                 $table->string('uid')->primary();
                 $table->string('description')->nullable();
                 $table->unsignedTinyInteger('status')->default(1); // JobStatus::Pending
@@ -35,13 +36,13 @@ return new class extends Migration
             });
         }
 
-        Schema::dropIfExists('queue');
+        Schema::dropIfExists(Table::QUEUE);
     }
 
     public function down(): void
     {
-        if (! Schema::hasTable('queue')) {
-            Schema::create('queue', function (Blueprint $table) {
+        if (! Schema::hasTable(Table::QUEUE)) {
+            Schema::create(Table::QUEUE, function (Blueprint $table) {
                 $table->integer('id', true);
                 $table->string('channel')->default('queue');
                 $table->binary('job');
@@ -60,10 +61,10 @@ return new class extends Migration
                 $table->text('error')->nullable();
             });
 
-            Schema::createIndex('queue', ['channel', 'fail', 'timeUpdated', 'timePushed']);
-            Schema::createIndex('queue', ['channel', 'fail', 'timeUpdated', 'delay']);
+            Schema::createIndex(Table::QUEUE, ['channel', 'fail', 'timeUpdated', 'timePushed']);
+            Schema::createIndex(Table::QUEUE, ['channel', 'fail', 'timeUpdated', 'delay']);
         }
 
-        Schema::dropIfExists('jobprogress');
+        Schema::dropIfExists(Table::JOBPROGRESS);
     }
 };

--- a/src/Database/Migrations/0000_00_00_000008_remove_field_version.php
+++ b/src/Database/Migrations/0000_00_00_000008_remove_field_version.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Database\Migration;
+use CraftCms\Cms\Database\Table;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -10,18 +11,18 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (! Schema::hasColumn('info', 'fieldVersion')) {
+        if (! Schema::hasColumn(Table::INFO, 'fieldVersion')) {
             return;
         }
 
-        Schema::table('info', function (Blueprint $table) {
+        Schema::table(Table::INFO, function (Blueprint $table) {
             $table->dropColumn('fieldVersion');
         });
     }
 
     public function down(): void
     {
-        Schema::table('info', function (Blueprint $table) {
+        Schema::table(Table::INFO, function (Blueprint $table) {
             $table->char('fieldVersion', 12)->default('000000000000')->after('configVersion');
         });
     }

--- a/src/Database/Migrations/0000_00_00_000009_remove_maintenance_from_info.php
+++ b/src/Database/Migrations/0000_00_00_000009_remove_maintenance_from_info.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CraftCms\Cms\Database\Migration;
+use CraftCms\Cms\Database\Table;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -10,18 +11,18 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (! Schema::hasColumn('info', 'maintenance')) {
+        if (! Schema::hasColumn(Table::INFO, 'maintenance')) {
             return;
         }
 
-        Schema::table('info', function (Blueprint $table) {
+        Schema::table(Table::INFO, function (Blueprint $table) {
             $table->dropColumn('maintenance');
         });
     }
 
     public function down(): void
     {
-        Schema::table('info', function (Blueprint $table) {
+        Schema::table(Table::INFO, function (Blueprint $table) {
             $table->boolean('maintenance')->default(false)->after('schemaVersion');
         });
     }

--- a/src/Database/Migrations/2026_08_18_165555_add_date_columns_to_jobprogress.php
+++ b/src/Database/Migrations/2026_08_18_165555_add_date_columns_to_jobprogress.php
@@ -9,7 +9,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('jobprogress', function (Blueprint $table) {
+        Schema::table(Table::JOBPROGRESS, function (Blueprint $table) {
             if (! Schema::hasColumn(Table::JOBPROGRESS, 'dateCompleted')) {
                 $table->dateTime('dateCompleted')->nullable()->after('error');
             }

--- a/src/Database/Migrations/2026_09_01_160000_replace_announcements_with_notifications.php
+++ b/src/Database/Migrations/2026_09_01_160000_replace_announcements_with_notifications.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use CraftCms\Cms\Cp\Notifications\CpNotification;
 use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migration;
+use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Support\Json;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder;
@@ -29,7 +30,7 @@ return new class extends Migration
         $notifiableType = (new $authModel)->getMorphClass();
 
         DB::table('announcements')
-            ->leftJoin('plugins', 'announcements.pluginId', '=', 'plugins.id')
+            ->leftJoin(Table::PLUGINS, 'announcements.pluginId', '=', 'plugins.id')
             ->select([
                 'announcements.id',
                 'announcements.userId',

--- a/src/Database/Migrations/Install.php
+++ b/src/Database/Migrations/Install.php
@@ -130,16 +130,16 @@ class Install extends Migration
      */
     public function createLaravelTables(): void
     {
-        if (! Schema::hasTable('password_reset_tokens')) {
-            Schema::create('password_reset_tokens', function (Blueprint $table) {
+        if (! Schema::hasTable(Table::PASSWORD_RESET_TOKENS)) {
+            Schema::create(Table::PASSWORD_RESET_TOKENS, function (Blueprint $table) {
                 $table->string('email')->primary();
                 $table->string('token');
                 $table->timestamp('created_at')->nullable();
             });
         }
 
-        if (! Schema::hasTable('cache')) {
-            Schema::create('cache', function (Blueprint $table) {
+        if (! Schema::hasTable(Table::CACHE)) {
+            Schema::create(Table::CACHE, function (Blueprint $table) {
                 $table->string('key')->primary();
                 $table->mediumText('value');
                 $table->bigInteger('expiration')->index();
@@ -193,8 +193,8 @@ class Install extends Migration
             });
         }
 
-        if (! Schema::hasTable('sessions')) {
-            Schema::create('sessions', function (Blueprint $table) {
+        if (! Schema::hasTable(Table::SESSIONS)) {
+            Schema::create(Table::SESSIONS, function (Blueprint $table) {
                 $table->string('id')->primary();
                 $table->foreignId('user_id')->nullable()->index();
                 $table->string('ip_address', 45)->nullable();
@@ -230,7 +230,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('addresses');
-        Schema::create('addresses', function (Blueprint $table) {
+        Schema::create(Table::ADDRESSES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('primaryOwnerId')->nullable();
             $table->integer('fieldId')->nullable();
@@ -255,7 +255,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('assetindexdata');
-        Schema::create('assetindexdata', function (Blueprint $table) {
+        Schema::create(Table::ASSETINDEXDATA, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('sessionId');
             $table->integer('volumeId');
@@ -271,7 +271,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('assetindexingsessions');
-        Schema::create('assetindexingsessions', function (Blueprint $table) {
+        Schema::create(Table::ASSETINDEXINGSESSIONS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->text('indexedVolumes')->nullable();
             $table->integer('totalEntries')->nullable();
@@ -287,7 +287,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('assets');
-        Schema::create('assets', function (Blueprint $table) {
+        Schema::create(Table::ASSETS, function (Blueprint $table) {
             $table->integer('id')->primary();
             $table->integer('volumeId')->nullable();
             $table->integer('folderId');
@@ -307,7 +307,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('assets_sites');
-        Schema::create('assets_sites', function (Blueprint $table) {
+        Schema::create(Table::ASSETS_SITES, function (Blueprint $table) {
             $table->integer('assetId');
             $table->integer('siteId');
             $table->text('alt')->nullable();
@@ -315,7 +315,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('imagetransformindex');
-        Schema::create('imagetransformindex', function (Blueprint $table) {
+        Schema::create(Table::IMAGETRANSFORMINDEX, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('assetId');
             $table->string('transformer')->default(null)->nullable();
@@ -332,7 +332,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('imagetransforms');
-        Schema::create('imagetransforms', function (Blueprint $table) {
+        Schema::create(Table::IMAGETRANSFORMS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('name');
             $table->string('handle');
@@ -353,7 +353,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('authenticator');
-        Schema::create('authenticator', function (Blueprint $table) {
+        Schema::create(Table::AUTHENTICATOR, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('userId');
             $table->string('auth2faSecret')->default(null)->nullable();
@@ -363,7 +363,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('bulkopevents');
-        Schema::create('bulkopevents', function (Blueprint $table) {
+        Schema::create(Table::BULKOPEVENTS, function (Blueprint $table) {
             $table->char('key', 10);
             $table->string('senderClass');
             $table->string('eventName');
@@ -372,7 +372,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('changedattributes');
-        Schema::create('changedattributes', function (Blueprint $table) {
+        Schema::create(Table::CHANGEDATTRIBUTES, function (Blueprint $table) {
             $table->integer('elementId');
             $table->integer('siteId');
             $table->string('attribute');
@@ -383,7 +383,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('changedfields');
-        Schema::create('changedfields', function (Blueprint $table) {
+        Schema::create(Table::CHANGEDFIELDS, function (Blueprint $table) {
             $table->integer('elementId');
             $table->integer('siteId');
             $table->integer('fieldId');
@@ -395,7 +395,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('contentblocks');
-        Schema::create('contentblocks', function (Blueprint $table) {
+        Schema::create(Table::CONTENTBLOCKS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('primaryOwnerId')->nullable();
             $table->integer('fieldId')->nullable();
@@ -403,7 +403,7 @@ class Install extends Migration
 
         /** @todo change back to Table::DEPRECATIONERRORS once larastan is updated */
         $logger?->subLabel('deprecationerrors');
-        Schema::create('deprecationerrors', function (Blueprint $table) {
+        Schema::create(Table::DEPRECATIONERRORS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('key');
             $table->string('fingerprint');
@@ -418,7 +418,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('drafts');
-        Schema::create('drafts', function (Blueprint $table) {
+        Schema::create(Table::DRAFTS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('canonicalId')->nullable();
             $table->integer('creatorId')->nullable();
@@ -431,7 +431,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('elementactivity');
-        Schema::create('elementactivity', function (Blueprint $table) {
+        Schema::create(Table::ELEMENTACTIVITY, function (Blueprint $table) {
             $table->integer('elementId');
             $table->integer('userId');
             $table->integer('siteId');
@@ -442,7 +442,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('elements');
-        Schema::create('elements', function (Blueprint $table) {
+        Schema::create(Table::ELEMENTS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('canonicalId')->nullable();
             $table->integer('draftId')->nullable();
@@ -460,7 +460,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('elements_bulkops');
-        Schema::create('elements_bulkops', function (Blueprint $table) {
+        Schema::create(Table::ELEMENTS_BULKOPS, function (Blueprint $table) {
             $table->integer('elementId');
             $table->char('key', 10);
             $table->dateTime('timestamp');
@@ -468,7 +468,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('elements_owners');
-        Schema::create('elements_owners', function (Blueprint $table) {
+        Schema::create(Table::ELEMENTS_OWNERS, function (Blueprint $table) {
             $table->integer('elementId');
             $table->integer('ownerId');
             $table->unsignedSmallInteger('sortOrder');
@@ -476,7 +476,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('elements_sites');
-        Schema::create('elements_sites', function (Blueprint $table) {
+        Schema::create(Table::ELEMENTS_SITES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('elementId');
             $table->integer('siteId');
@@ -491,14 +491,14 @@ class Install extends Migration
         });
 
         $logger?->subLabel('resourcepaths');
-        Schema::create('resourcepaths', function (Blueprint $table) {
+        Schema::create(Table::RESOURCEPATHS, function (Blueprint $table) {
             $table->string('hash');
             $table->string('path');
             $table->primary('hash');
         });
 
         $logger?->subLabel('revisions');
-        Schema::create('revisions', function (Blueprint $table) {
+        Schema::create(Table::REVISIONS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('canonicalId');
             $table->integer('creatorId')->nullable();
@@ -507,7 +507,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('sequences');
-        Schema::create('sequences', function (Blueprint $table) {
+        Schema::create(Table::SEQUENCES, function (Blueprint $table) {
             $table->string('name');
             $table->unsignedInteger('next')->default(1);
             $table->primary('name');
@@ -515,7 +515,7 @@ class Install extends Migration
 
         /** @todo Change when Larastan is updated */
         $logger?->subLabel('systemmessages');
-        Schema::create('systemmessages', function (Blueprint $table) {
+        Schema::create(Table::SYSTEMMESSAGES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('language');
             $table->string('key');
@@ -527,7 +527,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('entries');
-        Schema::create('entries', function (Blueprint $table) {
+        Schema::create(Table::ENTRIES, function (Blueprint $table) {
             $table->integer('id');
             $table->integer('sectionId')->nullable();
             $table->integer('parentId')->nullable();
@@ -549,7 +549,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('entries_authors');
-        Schema::create('entries_authors', function (Blueprint $table) {
+        Schema::create(Table::ENTRIES_AUTHORS, function (Blueprint $table) {
             $table->integer('entryId');
             $table->integer('authorId');
             $table->unsignedSmallInteger('sortOrder');
@@ -557,7 +557,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('entrytypes');
-        Schema::create('entrytypes', function (Blueprint $table) {
+        Schema::create(Table::ENTRYTYPES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('fieldLayoutId')->nullable();
             $table->string('name');
@@ -582,7 +582,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('fieldlayouts');
-        Schema::create('fieldlayouts', function (Blueprint $table) {
+        Schema::create(Table::FIELDLAYOUTS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('type');
             $table->jsonb('config')->nullable();
@@ -593,7 +593,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('fields');
-        Schema::create('fields', function (Blueprint $table) {
+        Schema::create(Table::FIELDS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->text('name');
             $table->string('handle', 64);
@@ -621,7 +621,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('gqltokens');
-        Schema::create('gqltokens', function (Blueprint $table) {
+        Schema::create(Table::GQLTOKENS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('name');
             $table->string('accessToken');
@@ -635,7 +635,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('gqlschemas');
-        Schema::create('gqlschemas', function (Blueprint $table) {
+        Schema::create(Table::GQLSCHEMAS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('name');
             $table->jsonb('scope')->nullable();
@@ -647,7 +647,7 @@ class Install extends Migration
 
         /** @todo Change when Larastan is updated */
         $logger?->subLabel('info');
-        Schema::create('info', function (Blueprint $table) {
+        Schema::create(Table::INFO, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('version', 50);
             $table->string('schemaVersion', 15);
@@ -668,7 +668,7 @@ class Install extends Migration
         }
 
         $logger?->subLabel('plugins');
-        Schema::create('plugins', function (Blueprint $table) {
+        Schema::create(Table::PLUGINS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('handle');
             $table->string('version');
@@ -680,13 +680,13 @@ class Install extends Migration
         });
 
         $logger?->subLabel('projectconfig');
-        Schema::create('projectconfig', function (Blueprint $table) {
+        Schema::create(Table::PROJECTCONFIG, function (Blueprint $table) {
             $table->string('path')->primary();
             $table->text('value');
         });
 
         $logger?->subLabel('jobprogress');
-        Schema::create('jobprogress', function (Blueprint $table) {
+        Schema::create(Table::JOBPROGRESS, function (Blueprint $table) {
             $table->string('uid')->primary();
             $table->string('description')->nullable();
             $table->unsignedTinyInteger('status')->default(1); // JobStatus::Pending
@@ -701,7 +701,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('recoverycodes');
-        Schema::create('recoverycodes', function (Blueprint $table) {
+        Schema::create(Table::RECOVERYCODES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('userId');
             $table->text('recoveryCodes')->nullable();
@@ -710,7 +710,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('relations');
-        Schema::create('relations', function (Blueprint $table) {
+        Schema::create(Table::RELATIONS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('fieldId');
             $table->integer('sourceId');
@@ -723,7 +723,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('routetokens');
-        Schema::create('routetokens', function (Blueprint $table) {
+        Schema::create(Table::ROUTETOKENS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->char('token', 32);
             $table->text('route')->nullable();
@@ -736,7 +736,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('searchindexqueue');
-        Schema::create('searchindexqueue', function (Blueprint $table) {
+        Schema::create(Table::SEARCHINDEXQUEUE, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('elementId');
             $table->integer('siteId');
@@ -744,7 +744,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('searchindexqueue_fields');
-        Schema::create('searchindexqueue_fields', function (Blueprint $table) {
+        Schema::create(Table::SEARCHINDEXQUEUE_FIELDS, function (Blueprint $table) {
             $table->integer('jobId');
             $table->string('fieldHandle');
 
@@ -752,7 +752,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('sections');
-        Schema::create('sections', function (Blueprint $table) {
+        Schema::create(Table::SECTIONS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('structureId')->nullable();
             $table->string('name');
@@ -778,7 +778,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('sections_entrytypes');
-        Schema::create('sections_entrytypes', function (Blueprint $table) {
+        Schema::create(Table::SECTIONS_ENTRYTYPES, function (Blueprint $table) {
             $table->integer('sectionId');
             $table->integer('typeId');
             $table->unsignedSmallInteger('sortOrder');
@@ -790,7 +790,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('sections_sites');
-        Schema::create('sections_sites', function (Blueprint $table) {
+        Schema::create(Table::SECTIONS_SITES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('sectionId');
             $table->integer('siteId');
@@ -804,7 +804,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('shunnedmessages');
-        Schema::create('shunnedmessages', function (Blueprint $table) {
+        Schema::create(Table::SHUNNEDMESSAGES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('userId');
             $table->string('message');
@@ -815,7 +815,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('sites');
-        Schema::create('sites', function (Blueprint $table) {
+        Schema::create(Table::SITES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('groupId');
             $table->boolean('primary');
@@ -833,7 +833,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('sitegroups');
-        Schema::create('sitegroups', function (Blueprint $table) {
+        Schema::create(Table::SITEGROUPS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('name');
             $table->dateTime('dateCreated');
@@ -843,7 +843,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('sso_identities');
-        Schema::create('sso_identities', function (Blueprint $table) {
+        Schema::create(Table::SSO_IDENTITIES, function (Blueprint $table) {
             $table->string('provider');
             $table->string('identityId');
             $table->integer('userId');
@@ -854,7 +854,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('structureelements');
-        Schema::create('structureelements', function (Blueprint $table) {
+        Schema::create(Table::STRUCTUREELEMENTS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('structureId');
             $table->integer('elementId')->nullable();
@@ -868,7 +868,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('structures');
-        Schema::create('structures', function (Blueprint $table) {
+        Schema::create(Table::STRUCTURES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->unsignedSmallInteger('maxLevels')->nullable();
             $table->dateTime('dateCreated');
@@ -878,7 +878,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('usergroups');
-        Schema::create('usergroups', function (Blueprint $table) {
+        Schema::create(Table::USERGROUPS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('name');
             $table->string('handle');
@@ -889,7 +889,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('usergroups_users');
-        Schema::create('usergroups_users', function (Blueprint $table) {
+        Schema::create(Table::USERGROUPS_USERS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('groupId');
             $table->integer('userId');
@@ -899,7 +899,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('userpermissions');
-        Schema::create('userpermissions', function (Blueprint $table) {
+        Schema::create(Table::USERPERMISSIONS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->string('name');
             $table->dateTime('dateCreated');
@@ -908,7 +908,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('userpermissions_usergroups');
-        Schema::create('userpermissions_usergroups', function (Blueprint $table) {
+        Schema::create(Table::USERPERMISSIONS_USERGROUPS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('permissionId');
             $table->integer('groupId');
@@ -918,7 +918,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('userpermissions_users');
-        Schema::create('userpermissions_users', function (Blueprint $table) {
+        Schema::create(Table::USERPERMISSIONS_USERS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('permissionId');
             $table->integer('userId');
@@ -928,13 +928,13 @@ class Install extends Migration
         });
 
         $logger?->subLabel('userpreferences');
-        Schema::create('userpreferences', function (Blueprint $table) {
+        Schema::create(Table::USERPREFERENCES, function (Blueprint $table) {
             $table->integer('userId')->primary();
             $table->jsonb('preferences')->nullable();
         });
 
         $logger?->subLabel('users');
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create(Table::USERS, function (Blueprint $table) {
             $table->integer('id');
             $table->integer('photoId')->nullable();
             $table->integer('affiliatedSiteId')->nullable();
@@ -967,7 +967,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('volumefolders');
-        Schema::create('volumefolders', function (Blueprint $table) {
+        Schema::create(Table::VOLUMEFOLDERS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('parentId')->nullable();
             $table->integer('volumeId')->nullable();
@@ -979,7 +979,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('volumes');
-        Schema::create('volumes', function (Blueprint $table) {
+        Schema::create(Table::VOLUMES, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('fieldLayoutId')->nullable();
             $table->string('name');
@@ -999,7 +999,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('webauthn');
-        Schema::create('webauthn', function (Blueprint $table) {
+        Schema::create(Table::WEBAUTHN, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('userId');
             $table->string('credentialId')->default(null)->nullable();
@@ -1012,7 +1012,7 @@ class Install extends Migration
         });
 
         $logger?->subLabel('widgets');
-        Schema::create('widgets', function (Blueprint $table) {
+        Schema::create(Table::WIDGETS, function (Blueprint $table) {
             $table->integer('id', true);
             $table->integer('userId');
             $table->string('type');

--- a/yii2-adapter/composer.json
+++ b/yii2-adapter/composer.json
@@ -56,7 +56,7 @@
     "codeception/module-yii2": "^1.1.9",
     "craftcms/ecs": "dev-main",
     "dg/bypass-finals": "^1.9",
-    "larastan/larastan": "^3.7",
+    "larastan/larastan": "^3.12",
     "laravel/socialite": "^5.25",
     "league/factory-muffin": "^3.3.0",
     "orchestra/testbench": "^11.0",

--- a/yii2-adapter/composer.lock
+++ b/yii2-adapter/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cbc75dfba221e3fc791d08652e2b08b",
+    "content-hash": "9a8774429f940b079aca332eeb71dafc",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -476,7 +476,7 @@
             "dist": {
                 "type": "path",
                 "url": "..",
-                "reference": "b10f5e610ee0f146eb164995a34a379b352dfd93"
+                "reference": "69502271cd43bb9e4da546c818528c2ed78430fd"
             },
             "require": {
                 "bacon/bacon-qr-code": "^3.0",
@@ -490,7 +490,7 @@
                 "craftcms/server-check": "~6.0.0",
                 "craftcms/url-validator": "^1.0",
                 "elvanto/litemoji": "^5.2.0",
-                "enshrined/svg-sanitize": "~0.22.0",
+                "enshrined/svg-sanitize": "^1.0.0",
                 "ext-bcmath": "*",
                 "ext-curl": "*",
                 "ext-dom": "*",
@@ -522,7 +522,7 @@
                 "symfony/yaml": "^7.0|^8.0",
                 "theiconic/name-parser": "^1.2",
                 "tpetry/laravel-query-expressions": "^1.5",
-                "twig/twig": "~3.27.0",
+                "twig/twig": "~3.28.0",
                 "voku/portable-ascii": "^2.0",
                 "web-auth/webauthn-lib": "~5.3.5",
                 "webonyx/graphql-php": "~15.33.1",
@@ -538,13 +538,14 @@
                 "driftingly/rector-laravel": "^2.1",
                 "fakerphp/faker": "^1.19.0",
                 "intervention/image-driver-vips": "^4.1",
-                "larastan/larastan": "^3.4",
+                "larastan/larastan": "^3.12",
                 "laravel/boost": "^2.6",
                 "laravel/pao": "^1.0",
                 "laravel/pint": "^1.22",
                 "laravel/socialite": "^5.23",
                 "orchestra/testbench": "^11.0",
                 "pestphp/pest": "^5.0",
+                "pestphp/pest-plugin-agent": "^5.0",
                 "pestphp/pest-plugin-arch": "^5.0",
                 "pestphp/pest-plugin-laravel": "^5.0",
                 "phpstan/phpstan": "^2.1",
@@ -565,8 +566,8 @@
                         "CraftCms\\Cms\\Providers\\CraftServiceProvider"
                     ],
                     "aliases": {
+                        "Activities": "CraftCms\\Cms\\Support\\Facades\\Activities",
                         "Addresses": "CraftCms\\Cms\\Support\\Facades\\Addresses",
-                        "Announcements": "CraftCms\\Cms\\Support\\Facades\\Announcements",
                         "AssetIndexer": "CraftCms\\Cms\\Support\\Facades\\AssetIndexer",
                         "Assets": "CraftCms\\Cms\\Support\\Facades\\Assets",
                         "AuthMethods": "CraftCms\\Cms\\Support\\Facades\\AuthMethods",
@@ -651,7 +652,7 @@
                 ],
                 "tests": [
                     "Composer\\Config::disableProcessTimeout",
-                    "./vendor/bin/pest --compact"
+                    "./vendor/bin/pest --parallel --compact"
                 ],
                 "tests-adapter": [
                     "./yii2-adapter/vendor/bin/pest --configuration ./yii2-adapter/phpunit.xml.dist --test-directory ./tests-laravel"
@@ -1730,16 +1731,16 @@
         },
         {
             "name": "enshrined/svg-sanitize",
-            "version": "0.22.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/darylldoyle/svg-sanitizer.git",
-                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500"
+                "reference": "f3300fcd1bbf67d205b52217c75d0f7d6a8c47ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/0afa95ea74be155a7bcd6c6fb60c276c39984500",
-                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/f3300fcd1bbf67d205b52217c75d0f7d6a8c47ff",
+                "reference": "f3300fcd1bbf67d205b52217c75d0f7d6a8c47ff",
                 "shasum": ""
             },
             "require": {
@@ -1769,9 +1770,9 @@
             "description": "An SVG sanitizer for PHP",
             "support": {
                 "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
-                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.22.0"
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/1.0.0"
             },
-            "time": "2025-08-12T10:13:48+00:00"
+            "time": "2026-09-01T09:35:47+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -9450,16 +9451,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.27.1",
+            "version": "v3.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "ae2071bffb38f04847fc0864d730c94b9cb8ab74"
+                "reference": "597c12ed286fb9d1701a36684ce6e0cbe28ebc8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ae2071bffb38f04847fc0864d730c94b9cb8ab74",
-                "reference": "ae2071bffb38f04847fc0864d730c94b9cb8ab74",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/597c12ed286fb9d1701a36684ce6e0cbe28ebc8b",
+                "reference": "597c12ed286fb9d1701a36684ce6e0cbe28ebc8b",
                 "shasum": ""
             },
             "require": {
@@ -9514,7 +9515,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.27.1"
+                "source": "https://github.com/twigphp/Twig/tree/v3.28.0"
             },
             "funding": [
                 {
@@ -9526,7 +9527,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-30T17:09:26+00:00"
+            "time": "2026-07-03T20:44:34+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -12609,20 +12610,19 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v3.10.0",
+            "version": "v3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "2970f83398154178a739609c244577267c7ee8eb"
+                "reference": "ab26fdf90d84877061388109e1e251f67ca3ff7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/2970f83398154178a739609c244577267c7ee8eb",
-                "reference": "2970f83398154178a739609c244577267c7ee8eb",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/ab26fdf90d84877061388109e1e251f67ca3ff7a",
+                "reference": "ab26fdf90d84877061388109e1e251f67ca3ff7a",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
                 "iamcal/sql-parser": "^0.7.0",
                 "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
                 "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
@@ -12632,7 +12632,7 @@
                 "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
                 "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
                 "php": "^8.2",
-                "phpstan/phpstan": "^2.2.0"
+                "phpstan/phpstan": "^2.2.2"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^14",
@@ -12642,7 +12642,7 @@
                 "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
                 "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
                 "phpstan/phpstan-deprecation-rules": "^2.0.1",
-                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.1.8"
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.3.0"
             },
             "suggest": {
                 "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
@@ -12687,7 +12687,7 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v3.10.0"
+                "source": "https://github.com/larastan/larastan/tree/v3.12.0"
             },
             "funding": [
                 {
@@ -12695,7 +12695,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-28T08:00:58+00:00"
+            "time": "2026-09-10T09:06:54+00:00"
         },
         {
             "name": "laravel/pail",


### PR DESCRIPTION
### Description

Update Larastan to 3.12.0 in both core and the Yii2 adapter so their static analysis can resolve typed table constants. 
