### PR TITLE
[6.x] Fix user-photo selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## Unreleased
 
-- Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder.
-
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574), [#19563](https://github.com/craftcms/cms/pull/19563), [#19588](https://github.com/craftcms/cms/pull/19588), and [#19585](https://github.com/craftcms/cms/pull/19585) for details.
 
+- Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder. ([#19603](https://github.com/craftcms/cms/pull/19603))
 - Added support for nested condition groups. ([#19587](https://github.com/craftcms/cms/pull/19587))
 - Moved legacy relation-field settings HTML and entry-title input HTML into the Yii adapter. ([#19591](https://github.com/craftcms/cms/pull/19591))
 - Migrated the reassign entries, replace relations, and replace references modals to the Form API. ([#19589](https://github.com/craftcms/cms/pull/19589))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder.
+
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574), [#19563](https://github.com/craftcms/cms/pull/19563), [#19588](https://github.com/craftcms/cms/pull/19588), and [#19585](https://github.com/craftcms/cms/pull/19585) for details.
 

--- a/packages/craftcms-ui/src/core/element-selector/element-selector-controller.test.ts
+++ b/packages/craftcms-ui/src/core/element-selector/element-selector-controller.test.ts
@@ -73,6 +73,23 @@ describe('options', () => {
 });
 
 describe('indexParams', () => {
+  it('sends asset location criteria and folder visibility when loading the index', async () => {
+    const loadIndexBody = vi.fn(async () => body());
+    const criteria = {volumeId: 2, folderId: 7, kind: 'image'};
+    const controller = create({
+      criteria,
+      indexSettings: {showFolders: false},
+      loadIndexBody,
+    });
+
+    await controller.open();
+
+    expect(loadIndexBody).toHaveBeenCalledWith(
+      'element-selector-modals/body',
+      expect.objectContaining({criteria, showFolders: false})
+    );
+  });
+
   it('identifies the index', () => {
     const controller = create({
       sources: ['section:a'],

--- a/packages/craftcms-ui/src/core/element-selector/element-selector-controller.ts
+++ b/packages/craftcms-ui/src/core/element-selector/element-selector-controller.ts
@@ -311,6 +311,14 @@ export class ElementSelectorController<
       params.siteIds = options.siteIds;
     }
 
+    if (options.criteria) {
+      params.criteria = {...options.criteria};
+    }
+
+    if (typeof options.indexSettings.showFolders === 'boolean') {
+      params.showFolders = options.indexSettings.showFolders;
+    }
+
     return params;
   }
 

--- a/resources/js/modules/forms/ElementSelectControl.test.ts
+++ b/resources/js/modules/forms/ElementSelectControl.test.ts
@@ -224,6 +224,27 @@ describe('ElementSelectControl', () => {
     expect(updates).toEqual([[5, 9]]);
   });
 
+  it('opens a photo selector with its folder restrictions', async () => {
+    await mount({
+      value: [],
+      props: {
+        sources: ['volume:photos/folder:avatars'],
+        criteria: {volumeId: 2, folderId: 7, kind: 'image'},
+        showFolders: false,
+      },
+    });
+
+    (container!.querySelector('craft-button') as HTMLElement).click();
+    await flushSelector();
+
+    const [, settings] = stub.createElementSelectorModal.mock.calls[0]!;
+    expect(settings).toMatchObject({
+      sources: ['volume:photos/folder:avatars'],
+      criteria: {volumeId: 2, folderId: 7, kind: 'image'},
+      indexSettings: {showFolders: false},
+    });
+  });
+
   it('drops Replace when there is no element type to pick from', async () => {
     const root = await mount({props: {elementType: null}});
 

--- a/resources/js/modules/forms/ElementSelectControl.vue
+++ b/resources/js/modules/forms/ElementSelectControl.vue
@@ -93,6 +93,7 @@
     canUpload?: boolean;
     uploadFolderId?: number | null;
     fsType?: string | null;
+    showFolders?: boolean;
   };
   const props = defineProps<{
     control: FormControlPayload<ElementSelectProps>;
@@ -317,6 +318,7 @@
         criteria: props.control.props.criteria as Record<string, unknown>,
         condition: props.control.props.selectionCondition,
         showSiteMenu: props.control.props.showSiteMenu,
+        indexSettings: {showFolders: props.control.props.showFolders ?? true},
         multiSelect: replacing === null && remaining !== 1,
         // Already-related elements can't be picked again — except the one being
         // replaced, which would otherwise disable the obvious no-op choice.

--- a/src/FieldLayout/LayoutElements/Users/PhotoField.php
+++ b/src/FieldLayout/LayoutElements/Users/PhotoField.php
@@ -9,13 +9,14 @@ use CraftCms\Cms\Element\Contracts\ElementInterface;
 use CraftCms\Cms\FieldLayout\FieldLayoutElementContext;
 use CraftCms\Cms\FieldLayout\LayoutElements\BaseNativeField;
 use CraftCms\Cms\Form\Contracts\Control;
-use CraftCms\Cms\Form\Controls\ElementSelect;
+use CraftCms\Cms\Form\Controls\AssetSelect;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\HtmlStack;
 use CraftCms\Cms\Support\Facades\InputNamespace;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
 use CraftCms\Cms\Support\Facades\Volumes;
 use CraftCms\Cms\User\Elements\User;
+use CraftCms\Cms\User\Users;
 use CraftCms\Cms\View\LegacyAssets\InternalAssetRegistry;
 use CraftCms\Cms\View\LegacyAssets\UserPhotoAsset;
 use InvalidArgumentException;
@@ -71,8 +72,18 @@ class PhotoField extends BaseNativeField
             return null;
         }
 
-        return ElementSelect::make($this->attribute())
+        $folder = app(Users::class)->userPhotoFolder($context->element);
+        $source = 'volume:'.$folder->getVolume()->uid;
+
+        if ($folder->parentId) {
+            $source .= '/folder:'.$folder->uid;
+        }
+
+        return AssetSelect::make($this->attribute())
             ->elementType(Asset::class)
+            ->sources([$source])
+            ->criteria(['volumeId' => $folder->volumeId, 'folderId' => $folder->id, 'kind' => 'image'])
+            ->showFolders(false)
             ->limit(1)
             ->value($context->element->photoId ? [$context->element->photoId] : []);
     }

--- a/src/Form/Controls/AssetSelect.php
+++ b/src/Form/Controls/AssetSelect.php
@@ -26,6 +26,15 @@ class AssetSelect extends ElementSelect
 
     private ?string $fsType = null;
 
+    private bool $showFolders = true;
+
+    public function showFolders(bool $showFolders = true): static
+    {
+        $this->showFolders = $showFolders;
+
+        return $this;
+    }
+
     public function canUpload(bool $canUpload = true): static
     {
         $this->canUpload = $canUpload;
@@ -56,6 +65,7 @@ class AssetSelect extends ElementSelect
             'canUpload' => $this->canUpload,
             'uploadFolderId' => $this->uploadFolderId,
             'fsType' => $this->fsType,
+            'showFolders' => $this->showFolders,
         ];
     }
 }

--- a/src/Http/Controllers/Users/SaveUserController.php
+++ b/src/Http/Controllers/Users/SaveUserController.php
@@ -255,8 +255,21 @@ readonly class SaveUserController
         // Validate and save!
         // ---------------------------------------------------------------------
 
-        $selectedPhoto = $this->validateSelectedPhoto($request, $user);
-        $decodedUserPhoto = $this->validateUserPhoto($request, $user);
+        $selection = $request->input('photo');
+        $selectedPhoto = null;
+
+        if (is_array($selection) && array_is_list($selection)) {
+            $validated = $request->validate([
+                'photo' => ['array', 'max:1'],
+                'photo.*' => ['required', 'integer'],
+            ]);
+
+            if ($validated['photo'] !== []) {
+                $selectedPhoto = $this->validateSelectedPhoto((int) $validated['photo'][0], $user);
+            }
+        }
+
+        $decodedUserPhoto = $this->validateUploadedPhoto($request, $user);
 
         // Don't validate required custom fields if it's public registration
         if (! $isPublicRegistration || ($userSettings['validateOnPublicRegistration'] ?? false)) {
@@ -428,24 +441,9 @@ readonly class SaveUserController
         }
     }
 
-    private function validateSelectedPhoto(Request $request, User $user): ?Asset
+    private function validateSelectedPhoto(int $photoId, User $user): ?Asset
     {
-        $selection = $request->input('photo');
-
-        if (! is_array($selection) || ! array_is_list($selection)) {
-            return null;
-        }
-
-        $request->validate([
-            'photo' => ['array', 'max:1'],
-            'photo.*' => ['required', 'integer'],
-        ]);
-
-        if ($selection === []) {
-            return null;
-        }
-
-        $photo = Asset::findOne((int) $selection[0]);
+        $photo = Asset::findOne($photoId);
 
         if ($photo === null || ! ImageHelper::canManipulateAsImage($photo->getExtension())) {
             $user->errors()->add('photo', t('The user photo provided is not an image.'));
@@ -468,7 +466,7 @@ readonly class SaveUserController
         return $photo;
     }
 
-    private function validateUserPhoto(Request $request, User $user): ?string
+    private function validateUploadedPhoto(Request $request, User $user): ?string
     {
         $maxUploadSize = AssetsHelper::getMaxUploadSize();
         $uploadedPhoto = $request->file('photo');

--- a/src/Http/Controllers/Users/SaveUserController.php
+++ b/src/Http/Controllers/Users/SaveUserController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Http\Controllers\Users;
 
 use CraftCms\Cms\Asset\AssetsHelper;
+use CraftCms\Cms\Asset\Elements\Asset;
 use CraftCms\Cms\Auth\AuthMethods;
 use CraftCms\Cms\Auth\Concerns\ConfirmsPasswords;
 use CraftCms\Cms\Config\GeneralConfig;
@@ -254,6 +255,7 @@ readonly class SaveUserController
         // Validate and save!
         // ---------------------------------------------------------------------
 
+        $selectedPhoto = $this->validateSelectedPhoto($request, $user);
         $decodedUserPhoto = $this->validateUserPhoto($request, $user);
 
         // Don't validate required custom fields if it's public registration
@@ -303,7 +305,7 @@ readonly class SaveUserController
         }
 
         // Save the user’s photo, if it was submitted
-        $this->processUserPhoto($request, app(Elements::class), $user, $decodedUserPhoto);
+        $this->processUserPhoto($request, app(Elements::class), $user, $decodedUserPhoto, $selectedPhoto);
 
         // If this is public registration, assign the user to the default user group
         if (Edition::isAtLeast(Edition::Pro) && $isPublicRegistration) {
@@ -361,10 +363,10 @@ readonly class SaveUserController
             : null);
     }
 
-    private function processUserPhoto(Request $request, Elements $elements, User $user, ?string $decodedUserPhoto): void
+    private function processUserPhoto(Request $request, Elements $elements, User $user, ?string $decodedUserPhoto, ?Asset $selectedPhoto): void
     {
         // Delete their photo?
-        if ($request->input('deletePhoto')) {
+        if ($user->photoId && ($request->input('deletePhoto') || $request->input('photo') === [])) {
             $this->users->deleteUserPhoto($user);
             $user->photoId = null;
             $elements->saveElement($user);
@@ -376,7 +378,12 @@ readonly class SaveUserController
         $mimeType = null;
 
         // Did they upload a new one?
-        if ($photo = $request->file('photo')) {
+        if ($selectedPhoto !== null && $selectedPhoto->id !== $user->photoId) {
+            $fileLocation = $selectedPhoto->getCopyOfFile();
+            $filename = $selectedPhoto->getFilename();
+            $mimeType = $selectedPhoto->getMimeType();
+            $newPhoto = true;
+        } elseif ($photo = $request->file('photo')) {
             $fileLocation = AssetsHelper::tempFilePath($photo->extension());
             $photo->move(dirname($fileLocation), basename($fileLocation));
             $filename = $photo->getClientOriginalName();
@@ -419,6 +426,46 @@ readonly class SaveUserController
                 throw $e;
             }
         }
+    }
+
+    private function validateSelectedPhoto(Request $request, User $user): ?Asset
+    {
+        $selection = $request->input('photo');
+
+        if (! is_array($selection) || ! array_is_list($selection)) {
+            return null;
+        }
+
+        $request->validate([
+            'photo' => ['array', 'max:1'],
+            'photo.*' => ['required', 'integer'],
+        ]);
+
+        if ($selection === []) {
+            return null;
+        }
+
+        $photo = Asset::findOne((int) $selection[0]);
+
+        if ($photo === null || ! ImageHelper::canManipulateAsImage($photo->getExtension())) {
+            $user->errors()->add('photo', t('The user photo provided is not an image.'));
+
+            return null;
+        }
+
+        if ($photo->id !== $user->photoId) {
+            Gate::authorize('view', $photo);
+
+            $folder = $this->users->userPhotoFolder($user);
+
+            if ($photo->volumeId !== $folder->volumeId || $photo->folderId !== $folder->id) {
+                $user->errors()->add('photo', t('The user photo provided is not valid.'));
+
+                return null;
+            }
+        }
+
+        return $photo;
     }
 
     private function validateUserPhoto(Request $request, User $user): ?string

--- a/src/User/Users.php
+++ b/src/User/Users.php
@@ -6,6 +6,7 @@ namespace CraftCms\Cms\User;
 
 use CraftCms\Cms\Asset\AssetsHelper;
 use CraftCms\Cms\Asset\Data\Volume;
+use CraftCms\Cms\Asset\Data\VolumeFolder;
 use CraftCms\Cms\Asset\Elements\Asset;
 use CraftCms\Cms\Asset\Exceptions\ImageException;
 use CraftCms\Cms\Asset\Exceptions\VolumeException;
@@ -395,8 +396,9 @@ class Users
         if ($event->photoId && ($photo = AssetsService::getAssetById($event->photoId)) !== null) {
             AssetsService::replaceAssetFile($photo, $fileLocation, $filename, $mimeType);
         } else {
-            $volume = $this->userPhotoVolume();
-            $folderId = $this->userPhotoFolderId($user, $volume);
+            $folder = $this->userPhotoFolder($user);
+            $volume = $folder->getVolume();
+            $folderId = $folder->id;
             $filename = AssetsService::getNameReplacementInFolder($filename, $folderId);
 
             $photo = new Asset;
@@ -426,8 +428,7 @@ class Users
             return;
         }
 
-        $volume = $this->userPhotoVolume();
-        $folderId = $this->userPhotoFolderId($user, $volume);
+        $folderId = $this->userPhotoFolder($user)->id;
 
         if ($photo->folderId === $folderId) {
             return;
@@ -463,13 +464,12 @@ class Users
     /**
      * Returns the folder that a user’s photo should be stored.
      *
-     * @param  Volume  $volume  The user photo volume
-     *
      * @throws VolumeException if the user photo volume doesn’t exist
      * @throws InvalidSubpathException if the user photo subpath can’t be resolved
      */
-    private function userPhotoFolderId(User $user, Volume $volume): int
+    public function userPhotoFolder(User $user): VolumeFolder
     {
+        $volume = $this->userPhotoVolume();
         $subpath = (string) app(ProjectConfig::class)->get('users.photoSubpath');
 
         if ($subpath !== '') {
@@ -480,7 +480,11 @@ class Users
             }
         }
 
-        return Folders::ensureFolderByFullPathAndVolume($subpath, $volume)->id;
+        if (array_intersect(explode('/', str_replace('\\', '/', $subpath)), ['.', '..'])) {
+            throw new InvalidSubpathException($subpath);
+        }
+
+        return Folders::ensureFolderByFullPathAndVolume($subpath, $volume, justRecord: false);
     }
 
     /**

--- a/tests/Feature/Http/Controllers/User/SaveUserController/ProfileEditTest.php
+++ b/tests/Feature/Http/Controllers/User/SaveUserController/ProfileEditTest.php
@@ -2,17 +2,29 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Asset\Elements\Asset;
+use CraftCms\Cms\Asset\Folders;
+use CraftCms\Cms\Asset\Models\Volume;
+use CraftCms\Cms\Database\Factories\AssetFactory;
 use CraftCms\Cms\Database\Factories\UserFactory;
 use CraftCms\Cms\Edition;
+use CraftCms\Cms\Filesystem\Exceptions\InvalidSubpathException;
+use CraftCms\Cms\Http\Controllers\Elements\ElementSelectorModalController;
 use CraftCms\Cms\Http\Controllers\Users\SaveUserController;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
+use CraftCms\Cms\Support\Facades\Volumes;
 use CraftCms\Cms\User\Elements\User;
+use CraftCms\Cms\User\Users;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Testing\AssertableInertia;
 
 use function CraftCms\Cms\cp_url;
 use function CraftCms\Cms\t;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\postJson;
 
 beforeEach(function () {
     Edition::set(Edition::Team);
@@ -33,6 +45,177 @@ it('succeeds when user edits their own profile without changing email or passwor
     expect($updatedUser)->not->toBeNull();
     expect($updatedUser->firstName)->toBe('Updated');
     expect($updatedUser->lastName)->toBe('User');
+});
+
+describe('photo selection', function () {
+    beforeEach(function () {
+        $this->user = User::findOne();
+        config()->set('filesystems.disks.profile-photos', [
+            'driver' => 'local',
+            'root' => storage_path('framework/testing/profile-photos'),
+        ]);
+        $this->disk = Storage::fake('profile-photos');
+        $this->volume = Volume::factory()->create(['fs' => 'disk:profile-photos']);
+        ProjectConfig::set('users.photoVolumeUid', $this->volume->uid);
+        ProjectConfig::set('users.photoSubpath', 'profiles/{id}');
+        $this->folder = app(Users::class)->userPhotoFolder($this->user);
+        $this->photo = AssetFactory::new()->createElement([
+            'volumeId' => $this->volume->id,
+            'folderId' => $this->folder->id,
+            'filename' => 'avatar.png',
+        ]);
+        $this->bytes = UploadedFile::fake()->image('avatar.png', 20, 20)->getContent();
+        $this->disk->put($this->photo->getPath(), $this->bytes);
+        actingAs($this->user);
+    });
+
+    it('saves an asset selected as the user photo without changing the source', function () {
+        post(action(SaveUserController::class), [
+            'userId' => $this->user->id,
+            'photo' => [$this->photo->id],
+        ])->assertRedirect()->assertSessionHasNoErrors();
+
+        $saved = User::findOne($this->user->id)->getPhoto();
+        expect($saved)->not->toBeNull()
+            ->and($saved->id)->not->toBe($this->photo->id)
+            ->and($saved->folderId)->toBe($this->folder->id)
+            ->and($this->disk->get($this->photo->getPath()))->toBe($this->bytes);
+
+        post(action(SaveUserController::class), [
+            'userId' => $this->user->id,
+            'photo' => [$saved->id],
+        ])->assertRedirect()->assertSessionHasNoErrors();
+
+        expect(User::findOne($this->user->id)->photoId)->toBe($saved->id);
+
+        post(action(SaveUserController::class), [
+            'userId' => $this->user->id,
+            'photo' => [],
+        ])->assertRedirect()->assertSessionHasNoErrors();
+
+        expect(User::findOne($this->user->id)->photoId)->toBeNull()
+            ->and(Asset::findOne($this->photo->id))->not->toBeNull()
+            ->and($this->disk->get($this->photo->getPath()))->toBe($this->bytes);
+    });
+
+    it('rejects assets outside the configured photo folder', function (string $location) {
+        $volume = $location === 'other volume'
+            ? Volume::factory()->create(['fs' => 'disk:profile-photos'])
+            : $this->volume;
+        Volumes::reset();
+        $path = match ($location) {
+            'parent' => 'profiles',
+            'sibling' => 'profiles/another-user',
+            'child' => $this->folder->path.'child',
+            default => $this->folder->path,
+        };
+        $folder = app(Folders::class)->ensureFolderByFullPathAndVolume($path, Volumes::getVolumeById($volume->id));
+        $photo = AssetFactory::new()->createElement(['volumeId' => $volume->id, 'folderId' => $folder->id]);
+
+        post(action(SaveUserController::class), [
+            'userId' => $this->user->id,
+            'firstName' => 'Should not save',
+            'photo' => [$photo->id],
+        ])->assertRedirect()->assertSessionHasErrors('photo');
+
+        expect(User::findOne($this->user->id)->photoId)->toBeNull()
+            ->and(User::findOne($this->user->id)->firstName)->toBe($this->user->firstName);
+    })->with(['parent', 'sibling', 'child', 'other volume']);
+
+    it('rejects invalid photo selections', function (array $selection) {
+        post(action(SaveUserController::class), [
+            'userId' => $this->user->id,
+            'photo' => $selection,
+        ])->assertRedirect()->assertSessionHasErrors();
+
+        expect(User::findOne($this->user->id)->photoId)->toBeNull();
+    })->with([
+        'missing asset' => [[999999]],
+        'non-integer' => [['invalid']],
+        'multiple assets' => [[1, 2]],
+    ]);
+
+    it('saves an empty photo selection when the user has no photo', function () {
+        post(action(SaveUserController::class), [
+            'userId' => $this->user->id,
+            'photo' => [],
+        ])->assertRedirect()->assertSessionHasNoErrors();
+
+        expect(User::findOne($this->user->id)->photoId)->toBeNull();
+    });
+
+    it('rejects a non-image asset', function () {
+        $photo = AssetFactory::new()->createElement([
+            'volumeId' => $this->volume->id,
+            'folderId' => $this->folder->id,
+            'filename' => 'document.txt',
+            'kind' => 'text',
+        ]);
+
+        post(action(SaveUserController::class), [
+            'userId' => $this->user->id,
+            'photo' => [$photo->id],
+        ])->assertRedirect()->assertSessionHasErrors('photo');
+
+        expect(User::findOne($this->user->id)->photoId)->toBeNull();
+    });
+
+    it('rejects an image the user cannot view', function () {
+        $user = UserFactory::new()->createElement();
+        ProjectConfig::set('users.photoSubpath', $this->folder->path);
+
+        actingAs($user)->post(action(SaveUserController::class), [
+            'userId' => $user->id,
+            'photo' => [$this->photo->id],
+        ])->assertForbidden();
+
+        expect(User::findOne($user->id)->photoId)->toBeNull();
+    });
+
+    it('creates the configured folder and restricts the photo selector to it', function () {
+        ProjectConfig::set('users.photoSubpath', 'new-photos/{id}');
+        $path = "new-photos/{$this->user->id}";
+        $this->disk->assertMissing($path);
+
+        get(cp_url('myaccount'))->assertOk()->assertInertia(function (AssertableInertia $page) {
+            $nodes = flattenFormNodes($page->toArray()['props']['form']['nodes']);
+            $control = collect($nodes)->firstWhere('control.path', ['photo'])['control'];
+            $folder = app(Users::class)->userPhotoFolder($this->user);
+
+            expect($control['props']['sources'])->toBe(["volume:{$this->volume->uid}/folder:{$folder->uid}"])
+                ->and($control['props']['criteria'])->toBe(['volumeId' => $this->volume->id, 'folderId' => $folder->id, 'kind' => 'image'])
+                ->and($control['props']['showFolders'])->toBeFalse();
+        });
+
+        $this->disk->assertExists($path);
+    });
+
+    it('only lists images in the photo folder without child folders', function () {
+        AssetFactory::new()->createElement([
+            'volumeId' => $this->volume->id,
+            'folderId' => $this->folder->id,
+            'filename' => 'document.txt',
+            'kind' => 'text',
+        ]);
+        app(Folders::class)->ensureFolderByFullPathAndVolume($this->folder->path.'child', $this->folder->getVolume());
+
+        $response = postJson(action(ElementSelectorModalController::class), [
+            'context' => 'modal',
+            'elementType' => Asset::class,
+            'sources' => ["volume:{$this->volume->uid}/folder:{$this->folder->uid}"],
+            'criteria' => ['volumeId' => $this->volume->id, 'folderId' => $this->folder->id, 'kind' => 'image'],
+            'showFolders' => false,
+        ])->assertOk();
+
+        expect(array_column($response->json('props.data'), 'id'))->toBe([$this->photo->id]);
+    });
+
+    it('rejects traversal in the rendered photo subpath', function (string $subpath) {
+        ProjectConfig::set('users.photoSubpath', $subpath);
+
+        expect(fn () => app(Users::class)->userPhotoFolder($this->user))
+            ->toThrow(InvalidSubpathException::class);
+    })->with(['../outside', 'profiles/../outside', 'profiles\\..\\outside']);
 });
 
 it('succeeds when user changes their email with correct current password', function () {


### PR DESCRIPTION
### Description

Saves and clears assets selected as user photos, restricts the selector to images in the configured volume and subfolder, and validates the selected asset when saving the user. Folder visibility is passed through the asset selector controls.
