### PR TITLE
[6.x] Fix thumbnail initialization

### DIFF
--- a/packages/craftcms-legacy/cp/src/js/CP.js
+++ b/packages/craftcms-legacy/cp/src/js/CP.js
@@ -322,12 +322,18 @@ Craft.CP = Garnish.Base.extend(
         observer.observe(footer);
       }
 
-      // Load any element thumbs.
-      // (Deferred until after the Vite-side `modules/element-thumb-loader` shim
-      // has had a chance to load.)
-      setTimeout(() => {
+      const loadElementThumbs = () => {
         this.elementThumbLoader.load(this.$pageContainer);
-      }, 500);
+      };
+      if (Craft.ElementThumbLoader) {
+        loadElementThumbs();
+      } else {
+        window.addEventListener(
+          'craft:element-thumb-loader-ready',
+          loadElementThumbs,
+          {once: true}
+        );
+      }
 
       // Add notification close listeners
       this.on('notificationClose', () => {

--- a/resources/js/modules/element-thumb-loader/element-thumb-loader.test.ts
+++ b/resources/js/modules/element-thumb-loader/element-thumb-loader.test.ts
@@ -1,0 +1,80 @@
+import $ from 'jquery';
+import {afterEach, beforeEach, expect, it, vi} from 'vite-plus/test';
+
+const {load} = vi.hoisted(() => ({load: vi.fn()}));
+
+vi.mock('@craftcms/ui/utilities/thumbnail-loader', () => ({
+  ThumbnailLoader: class {
+    load(...args: unknown[]): void {
+      load(...args);
+    }
+  },
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  load.mockReset();
+  vi.stubGlobal('$', Object.assign($, {isTouchCapable: () => false}));
+  vi.stubGlobal('Craft', {
+    remainingSessionTime: 0,
+    AnimationBlocker: class {},
+    getLocalStorage: () => undefined,
+  });
+  const extend = (members: object): any => {
+    class LegacyClass {
+      addListener = vi.fn();
+      on = vi.fn();
+
+      constructor() {
+        (this as any).init?.();
+      }
+    }
+    Object.defineProperties(
+      LegacyClass.prototype,
+      Object.getOwnPropertyDescriptors(members)
+    );
+    return Object.assign(LegacyClass, {extend});
+  };
+  vi.stubGlobal('Garnish', {
+    Base: {extend},
+    $doc: {ready: vi.fn()},
+    isMobileBrowser: () => false,
+    uiLayerManager: {on: vi.fn()},
+  });
+  document.body.innerHTML = '<main id="page-container"></main>';
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  delete ($ as any).isTouchCapable;
+  document.body.replaceChildren();
+});
+
+async function initializeCp(): Promise<void> {
+  await import('../../../../packages/craftcms-legacy/cp/src/js/CP.js');
+}
+
+it('waits for the thumbnail module even when it loads after the old 500 ms deadline', async () => {
+  await initializeCp();
+  expect(() => vi.advanceTimersByTime(5_000)).not.toThrow();
+  expect(load).not.toHaveBeenCalled();
+
+  await import('./index');
+
+  expect(load).toHaveBeenCalledExactlyOnceWith(
+    document.querySelector('#page-container'),
+    '.thumb[data-sizes]'
+  );
+});
+
+it('loads thumbnails when the module is registered before CP initialization', async () => {
+  await import('./index');
+  await initializeCp();
+
+  expect(load).toHaveBeenCalledExactlyOnceWith(
+    document.querySelector('#page-container'),
+    '.thumb[data-sizes]'
+  );
+});

--- a/resources/js/modules/element-thumb-loader/index.ts
+++ b/resources/js/modules/element-thumb-loader/index.ts
@@ -24,5 +24,6 @@ class ElementThumbLoader extends ThumbnailLoader {
 }
 
 registerCraftGlobals({ElementThumbLoader});
+window.dispatchEvent(new Event('craft:element-thumb-loader-ready'));
 
 export {ElementThumbLoader};


### PR DESCRIPTION
### Description

Fixes thumbnail-loader initialization when the Control Panel starts before the loader module is ready. The loader's readiness event allows pending thumbnails to initialize once the module becomes available.

This fix is independent of the upload refactor. It is the first layer of a draft stack so the remaining changes can be reviewed incrementally.
