### PR TITLE
[6.x] Fix field type combobox icons and selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574), [#19563](https://github.com/craftcms/cms/pull/19563), [#19588](https://github.com/craftcms/cms/pull/19588), and [#19585](https://github.com/craftcms/cms/pull/19585) for details.
 
+- Fixed a bug where field types could remain unchanged or switch to an unintended option when their combobox query was submitted with <kbd>Return</kbd>. ([#19614](https://github.com/craftcms/cms/pull/19614))
+- Fixed a bug where brand icons, including the Markdown field type icon, were not displayed in combobox options. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder. ([#19603](https://github.com/craftcms/cms/pull/19603))
 - Added support for nested condition groups. ([#19587](https://github.com/craftcms/cms/pull/19587))
 - Moved legacy relation-field settings HTML and entry-title input HTML into the Yii adapter. ([#19591](https://github.com/craftcms/cms/pull/19591))

--- a/packages/craftcms-ui/src/components/combobox/combobox.test.ts
+++ b/packages/craftcms-ui/src/components/combobox/combobox.test.ts
@@ -153,6 +153,41 @@ describe('craft-combobox', () => {
     expect(emitted).toBe(true);
   });
 
+  it.each(['Mark', 'Markdown'])(
+    'selects the filtered option when Enter is pressed for %s',
+    async (query) => {
+      const combobox = await createFixture((c) => {
+        c.requireOptionMatch = true;
+        c.options = [
+          {label: 'Addresses', value: 'addresses'},
+          {label: 'Markdown', value: 'markdown'},
+          {label: 'Plain Text', value: 'plain-text'},
+        ];
+        c.modelValue = 'plain-text';
+      });
+      let emitted = false;
+      combobox.addEventListener('model-value-changed', () => {
+        emitted = true;
+      });
+
+      const input = combobox.querySelector('input')!;
+      input.focus();
+      await typeQuery(combobox, query);
+      expect(combobox.activeIndex).toBe(0);
+      expect(String(combobox.formElements[0]?.choiceValue)).toBe('markdown');
+      emitted = false;
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', {key: 'Enter', bubbles: true})
+      );
+      await combobox.updateComplete;
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(combobox.modelValue).toBe('markdown');
+      expect(input.value).toBe('Markdown');
+      expect(emitted).toBe(true);
+    }
+  );
+
   it('shows the selected option’s icon in the textbox', async () => {
     const combobox = await createFixture((c) => {
       c.options = [

--- a/packages/craftcms-ui/src/components/combobox/combobox.test.ts
+++ b/packages/craftcms-ui/src/components/combobox/combobox.test.ts
@@ -87,7 +87,7 @@ describe('craft-combobox', () => {
     // Regression: Lion's match-highlighting used to mutate option DOM and
     // collide with our lit-html render, producing e.g. "Option 000Option 300".
     const combobox = await createFixture((c) => {
-      c.options = makeOptions(400);
+      c.options = makeOptions(301);
     });
     for (const q of ['O', 'Op', 'Option 3', 'Option 30', 'Option 300']) {
       await typeQuery(combobox, q);

--- a/packages/craftcms-ui/src/components/combobox/combobox.ts
+++ b/packages/craftcms-ui/src/components/combobox/combobox.ts
@@ -1,7 +1,6 @@
 import {LionCombobox} from '@lion/ui/combobox.js';
 import {html, nothing, render} from 'lit';
 import {property} from 'lit/decorators.js';
-import {keyed} from 'lit/directives/keyed.js';
 import {repeat} from 'lit/directives/repeat.js';
 import styles from './combobox.styles.js';
 import type CraftOption from '../option/option.js';
@@ -133,6 +132,7 @@ export default class CraftCombobox extends LionCombobox {
     // We own filtering (see `matchCondition`), so keep Lion in list mode and
     // avoid its inline-autofill, which would fight our pre-filtered set.
     this.autocomplete = 'list';
+    this.selectionFollowsFocus = false;
 
     // Lion announces while it still holds the previous value: a requested value
     // is only adopted once the option naming it registers, so until then
@@ -156,15 +156,19 @@ export default class CraftCombobox extends LionCombobox {
         return;
       }
       if (
-        this.multipleChoice &&
         event.target === this &&
         (event as CustomEvent).detail?.isTriggeredByUser
       ) {
-        this.pendingModelValue = [...this.selectedValues];
-        this.syncInputs();
-        this.dispatchEvent(
-          new Event('change', {bubbles: true, composed: true})
-        );
+        this.pendingModelValue = this.multipleChoice
+          ? [...this.selectedValues]
+          : this.modelValue;
+
+        if (this.multipleChoice) {
+          this.syncInputs();
+          this.dispatchEvent(
+            new Event('change', {bubbles: true, composed: true})
+          );
+        }
       }
     });
     this.addEventListener('focusout', (event) => {
@@ -276,7 +280,7 @@ export default class CraftCombobox extends LionCombobox {
   #onInput = () => {
     this.#filtering = true;
     this.#renderOptions();
-    if (!this.multipleChoice) {
+    if (!this.multipleChoice && !this.requireOptionMatch) {
       this.#syncModelFromInput();
     }
   };
@@ -334,6 +338,10 @@ export default class CraftCombobox extends LionCombobox {
    */
   override matchCondition(option: CraftOption) {
     return !this.multipleChoice || !option.hidden;
+  }
+
+  override _autoSelectCondition() {
+    return !this.multipleChoice;
   }
 
   /**
@@ -459,37 +467,14 @@ export default class CraftCombobox extends LionCombobox {
 
     // Retain selected option elements while filtering: Lion derives checked
     // values from registered options, including selections outside the limit.
-    const content = html`${this.multipleChoice
-      ? repeat(
-          rows,
-          (row) => row.value,
-          (row) => row.template
-        )
-      : rows.map((row) => row.template)}${footer}`;
-    // Single selection keys the whole option set so replaced options disconnect
-    // and register with Lion again. Otherwise Lion keeps the old choice values
-    // and can reject the new model value. Filtering keeps the same key.
     render(
-      this.multipleChoice ? content : keyed(this.#optionSetKey(), content),
+      html`${repeat(
+        rows,
+        (row) => row.value,
+        (row) => row.template
+      )}${footer}`,
       node
     );
-  }
-
-  /** Identifies the current option set, so a changed one rebuilds the list. */
-  #optionSetKey(): string {
-    const values: string[] = [];
-
-    for (const item of this.options) {
-      if (this.#isGroup(item)) {
-        for (const option of item.options) {
-          values.push(String(option.value));
-        }
-      } else {
-        values.push(String(item.value));
-      }
-    }
-
-    return values.join('\u0000');
   }
 
   #optionTemplate(option: ComboboxOption, selected = false) {

--- a/packages/craftcms-ui/src/components/nav-item/nav-item.test.ts
+++ b/packages/craftcms-ui/src/components/nav-item/nav-item.test.ts
@@ -186,4 +186,3 @@ describe('craft-nav-item flyout', () => {
     ]);
   });
 });
-

--- a/packages/craftcms-ui/src/utilities/icons.test.ts
+++ b/packages/craftcms-ui/src/utilities/icons.test.ts
@@ -4,6 +4,7 @@ import {getIconUrl} from './icons.js';
 describe('getIconUrl', () => {
   test.for([
     ['custom-icons/graphql', '/vendor/craft/icons/custom-icons/graphql.svg'],
+    ['brands/markdown', '/vendor/craft/icons/brands/markdown.svg'],
     ['light/sliders', '/vendor/craft/icons/light/sliders.svg'],
     ['x', '/vendor/craft/icons/regular/x.svg'],
     ['newstamp', '/vendor/craft/icons/regular/newstamp.svg'],

--- a/packages/craftcms-ui/src/utilities/icons.ts
+++ b/packages/craftcms-ui/src/utilities/icons.ts
@@ -99,7 +99,7 @@ export function getIconUrl(
   }
 
   // Brands
-  if (family === 'brands') {
+  if (family === 'brands' || resolvedVariant === 'brands') {
     folder = 'brands';
   }
 

--- a/src/Http/ViewModels/FieldEditViewModel.php
+++ b/src/Http/ViewModels/FieldEditViewModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http\ViewModels;
 
+use CraftCms\Cms\Cp\Icons;
 use CraftCms\Cms\Cp\SelectOptions;
 use CraftCms\Cms\Field\Contracts\FieldInterface;
 use CraftCms\Cms\Field\Enums\TranslationMethod;
@@ -74,6 +75,7 @@ class FieldEditViewModel extends ViewModel
         ];
         $typeField = FormField::make(t('Field Type'), Combobox::make('type')
             ->options($this->fieldTypeOptions())
+            ->requireOptionMatch()
             ->reactive())
             ->instructions(t('What type of field is this?'))
             ->required();
@@ -213,12 +215,17 @@ class FieldEditViewModel extends ViewModel
             ))
             ->map(function (string $class) use ($compatibleFieldTypes, $currentType): array {
                 $name = $class::displayName();
+                $icon = Icons::resolveIconData(
+                    $class === $currentType && ! $this->field instanceof MissingField
+                        ? $this->field->getIcon()
+                        : $class::icon(),
+                );
 
                 return [
                     'data' => [
-                        'icon' => $class === $currentType && ! $this->field instanceof MissingField
-                            ? $this->field->getIcon()
-                            : $class::icon(),
+                        'icon' => $icon['family'] === 'solid'
+                            ? $icon['name']
+                            : "{$icon['family']}/{$icon['name']}",
                     ],
                     'value' => $class,
                     'label' => $class === $currentType || $compatibleFieldTypes->contains($class)


### PR DESCRIPTION
### Description

Fixes field type selection when typing a query and pressing Return, and restores brand icons such as the Markdown field icon in the field type combobox.