### PR TITLE
[6.x] Support dedicated Craft authentication guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574), [#19563](https://github.com/craftcms/cms/pull/19563), [#19588](https://github.com/craftcms/cms/pull/19588), and [#19585](https://github.com/craftcms/cms/pull/19585) for details.
 
+- Added the `authGuard` and `authPasswordBroker` general config settings, allowing Craft authentication to use a dedicated Laravel guard, provider, and password broker. ([#19598](https://github.com/craftcms/cms/issues/19598))
 - Fixed a bug where field types could remain unchanged or switch to an unintended option when their combobox query was submitted with <kbd>Return</kbd>. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed a bug where brand icons, including the Markdown field type icon, were not displayed in combobox options. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder. ([#19603](https://github.com/craftcms/cms/pull/19603))

--- a/routes/actions.php
+++ b/routes/actions.php
@@ -90,6 +90,7 @@ use CraftCms\Cms\Http\Controllers\Utilities\UtilitiesController;
 use CraftCms\Cms\Http\Middleware\EnsureTwoFactorChallengeIsRecent;
 use CraftCms\Cms\Http\Middleware\RequireAdmin;
 use CraftCms\Cms\Http\Middleware\RequireAdminChanges;
+use CraftCms\Cms\Http\Middleware\RequireConfirmedPassword;
 use CraftCms\Cms\Http\Middleware\RequireEdition;
 use CraftCms\Cms\Http\Middleware\RequireToken;
 use CraftCms\Cms\Http\Middleware\StartSessionWithoutPersistence;
@@ -376,12 +377,12 @@ Route::prefix($routes->cpActionTriggerRoutePrefix())->middleware(['craft.cp'])->
         Route::post('app/check-for-updates', [UpdatesController::class, 'check']);
         Route::post('app/cache-updates', [UpdatesController::class, 'cache']);
 
-        Route::middleware('password.confirm')->group(function () {
+        Route::middleware(RequireConfirmedPassword::class)->group(function () {
             Route::post('users/save-password', [PasswordController::class, 'store']);
         });
 
         Route::middleware([RequireEdition::class.':'.Edition::Team->value, 'can:editUsers'])->group(function () {
-            Route::middleware('password.confirm')->group(function () {
+            Route::middleware(RequireConfirmedPassword::class)->group(function () {
                 Route::post('users/impersonate', [ImpersonationController::class, 'impersonate']);
                 Route::post('users/get-impersonation-url', [ImpersonationController::class, 'getUrl']);
             });

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -70,6 +70,7 @@ use CraftCms\Cms\Http\Controllers\Utilities\UtilitiesController;
 use CraftCms\Cms\Http\Middleware\EnsureTwoFactorChallengeIsRecent;
 use CraftCms\Cms\Http\Middleware\RequireAdmin;
 use CraftCms\Cms\Http\Middleware\RequireAdminChanges;
+use CraftCms\Cms\Http\Middleware\RequireConfirmedPassword;
 use CraftCms\Cms\Http\Middleware\RequireEdition;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
@@ -327,7 +328,7 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
             Route::get('{tokenId}', [TokensController::class, 'edit'])->whereNumber('tokenId')->name('edit');
             Route::post('generate', [TokensController::class, 'generate'])->name('generate');
 
-            Route::middleware('password.confirm')->group(function () {
+            Route::middleware(RequireConfirmedPassword::class)->group(function () {
                 Route::post('/', [TokensController::class, 'store'])->name('store');
                 Route::patch('{tokenId}', [TokensController::class, 'update'])->whereNumber('tokenId')->name('update');
                 Route::post('{tokenId}/access-token', [TokensController::class, 'accessToken'])->whereNumber('tokenId')->name('accessToken');
@@ -341,7 +342,7 @@ Route::middleware(['auth', 'can:accessCp'])->group(function () {
                 Route::get('{schemaId}', [SchemasController::class, 'edit'])->where('schemaId', 'public|\d+')->name('edit');
                 Route::delete('{schemaId}', [SchemasController::class, 'destroy'])->whereNumber('schemaId')->name('destroy');
 
-                Route::middleware('password.confirm')->group(function () {
+                Route::middleware(RequireConfirmedPassword::class)->group(function () {
                     Route::post('/', [SchemasController::class, 'store'])->name('store');
                     Route::patch('{schemaId}', [SchemasController::class, 'update'])->where('schemaId', 'public|\d+')->name('update');
                 });

--- a/src/Asset/Elements/Asset.php
+++ b/src/Asset/Elements/Asset.php
@@ -105,7 +105,6 @@ use GraphQL\Type\Definition\Type;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Filesystem\LocalFilesystemAdapter;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
@@ -119,6 +118,7 @@ use Stringable;
 use Throwable;
 use Twig\Markup;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\currentUser;
 use function CraftCms\Cms\currentUserElement;
 use function CraftCms\Cms\t;
@@ -3195,7 +3195,7 @@ JS;
         $volume = $this->getVolume();
         $imageEditable = $context === ElementSources::CONTEXT_INDEX && $this->getSupportsImageEditor();
 
-        if ($volume->isTemporary() || Auth::id() === $this->uploaderId) {
+        if ($volume->isTemporary() || craftAuth()->id() === $this->uploaderId) {
             $attributes['data']['own-file'] = true;
             $movable = $replaceable = true;
         } else {

--- a/src/Auth/AuthMethods.php
+++ b/src/Auth/AuthMethods.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Facades\Session;
 use InvalidArgumentException;
 use SensitiveParameter;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\currentUserElement;
 use function CraftCms\Cms\t;
 
@@ -387,7 +388,7 @@ class AuthMethods
                     return false;
                 }
 
-                $authUser = auth()->getProvider()->retrieveById(Session::get('user.login_id', $user->id));
+                $authUser = craftAuth()->getProvider()->retrieveById(Session::get('user.login_id', $user->id));
                 $remember = (bool) Session::get('user.remember', false);
 
                 $this->setUser(null);
@@ -396,7 +397,7 @@ class AuthMethods
                     return false;
                 }
 
-                auth()->login($authUser, $remember);
+                craftAuth()->login($authUser, $remember);
             }
 
             return true;

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -35,6 +35,7 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\SendQueuedNotifications;
@@ -50,9 +51,21 @@ class AuthServiceProvider extends ServiceProvider
     #[Override]
     public function register(): void
     {
-        if (! class_exists($this->app->make(Repository::class)->get('auth.providers.users.model'))) {
-            $this->app->make(Repository::class)->set('auth.providers.users.model', User::class);
+        $config = $this->app->make(Repository::class);
+
+        if (! class_exists($config->get('auth.providers.users.model'))) {
+            $config->set('auth.providers.users.model', User::class);
         }
+
+        $config->set('auth.providers.craft', array_replace([
+            'driver' => 'eloquent',
+            'model' => User::class,
+        ], $config->get('auth.providers.craft', [])));
+        $config->set('auth.guards.craft', array_replace([
+            'driver' => 'session',
+            'provider' => 'craft',
+            'remember' => 20160,
+        ], $config->get('auth.guards.craft', [])));
 
         $this->app->bind(SendQueuedNotifications::class, SendQueuedUserNotifications::class);
 
@@ -85,7 +98,11 @@ class AuthServiceProvider extends ServiceProvider
          * This hooks our permission system into
          * Laravel's Gate authorization system
          */
-        Gate::after(function (CraftUser $user, string $ability, ?bool $result) {
+        Gate::after(function (Authenticatable $user, string $ability, ?bool $result) {
+            if (! $user instanceof CraftUser) {
+                return null;
+            }
+
             /**
              * Only check our permissions when the
              * result was not explicitly set.
@@ -118,11 +135,19 @@ class AuthServiceProvider extends ServiceProvider
     private function registerEvents(): void
     {
         Event::listen(function (Authenticated $event) {
+            if ($event->guard !== Cms::config()->getAuthGuard()) {
+                return;
+            }
+
             Sites::refreshSites();
             app(RequestedSite::class)->reset();
         });
 
         Event::listen(Login::class, function (Login $event) {
+            if ($event->guard !== Cms::config()->getAuthGuard()) {
+                return;
+            }
+
             $user = $event->user instanceof CraftUser ? $event->user->asElement() : null;
 
             if (! $user) {
@@ -133,10 +158,14 @@ class AuthServiceProvider extends ServiceProvider
 
             app(AuthMethods::class)->setRememberedUsername($user);
 
-            Session::passwordConfirmed();
+            Session::put(Cms::config()->getPasswordConfirmationKey(), now()->unix());
         });
 
         Event::listen(Failed::class, function (Failed $event) {
+            if ($event->guard !== Cms::config()->getAuthGuard()) {
+                return;
+            }
+
             $user = $event->user instanceof CraftUser ? $event->user->asElement() : null;
 
             if (! $user) {
@@ -146,7 +175,11 @@ class AuthServiceProvider extends ServiceProvider
             UsersFacade::handleInvalidLogin($user);
         });
 
-        Event::listen(Logout::class, function () {
+        Event::listen(Logout::class, function (Logout $event) {
+            if ($event->guard !== Cms::config()->getAuthGuard()) {
+                return;
+            }
+
             app(Impersonation::class)->setImpersonatorId(null);
         });
     }

--- a/src/Auth/Concerns/ConfirmsPasswords.php
+++ b/src/Auth/Concerns/ConfirmsPasswords.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Auth\Concerns;
 
-use Illuminate\Support\Facades\Auth;
+use CraftCms\Cms\Cms;
 use Illuminate\Support\Facades\Session;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 trait ConfirmsPasswords
 {
     protected function confirmPassword(): void
     {
-        Session::passwordConfirmed();
+        Session::put(Cms::config()->getPasswordConfirmationKey(), now()->unix());
     }
 
     protected function requireConfirmedPassword(?string $message = null): void
@@ -38,9 +39,9 @@ trait ConfirmsPasswords
 
     protected function confirmedPasswordTimeout(): int|false
     {
-        if (Auth::check()) {
+        if (craftAuth()->check()) {
             $maximumSecondsSinceConfirmation = $this->passwordConfirmationDuration();
-            $confirmedAt = Session::get('auth.password_confirmed_at');
+            $confirmedAt = Session::get(Cms::config()->getPasswordConfirmationKey());
 
             if ($confirmedAt !== null) {
                 $diff = now()->unix() - $confirmedAt;

--- a/src/Blade/Directives/AuthDirective.php
+++ b/src/Blade/Directives/AuthDirective.php
@@ -7,11 +7,11 @@ namespace CraftCms\Cms\Blade\Directives;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Edition;
 use Illuminate\Auth\AuthenticationException;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL as LaravelUrl;
 use Illuminate\View\Compilers\BladeCompiler;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\currentUser;
 
 class AuthDirective
@@ -27,14 +27,14 @@ class AuthDirective
 
     public static function requireLogin(): void
     {
-        if (Auth::guest()) {
+        if (craftAuth()->guest()) {
             throw new AuthenticationException('Unauthenticated.');
         }
     }
 
     public static function requireGuest(): void
     {
-        if (Auth::check()) {
+        if (craftAuth()->check()) {
             redirect(LaravelUrl::returnUrl())->throwResponse();
         }
     }

--- a/src/Cms.php
+++ b/src/Cms.php
@@ -15,7 +15,6 @@ use CraftCms\Cms\Support\Facades\Updates;
 use CraftCms\Cms\Support\Facades\Users;
 use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -65,7 +64,7 @@ readonly class Cms
 
         // If the user is logged in *and* has a preferred time zone, use that
         // (don't actually try to fetch the user, as plugins haven't been loaded yet)
-        if (request()->isCpRequest() && Auth::hasUser() && $id = Auth::id()) {
+        if (request()->isCpRequest() && craftAuth()->hasUser() && ($id = craftAuth()->id())) {
             $timezone = Users::getUserPreference($id, 'timeZone');
         }
 

--- a/src/Config/GeneralConfig.php
+++ b/src/Config/GeneralConfig.php
@@ -11,6 +11,8 @@ use CraftCms\Cms\Support\Config as ConfigHelper;
 use CraftCms\Cms\Support\Env;
 use CraftCms\Cms\Support\Facades\I18N;
 use CraftCms\Cms\Support\PHP;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 use Override;
@@ -86,6 +88,48 @@ class GeneralConfig extends BaseConfig
      * @group Routing
      */
     public string $actionTrigger = 'actions';
+
+    /**
+     * @var string|null The Laravel authentication guard Craft should use.
+     *
+     * Set this to `craft` to use Craft’s dedicated guard and user provider. If this is `null`, Craft will continue using Laravel’s default guard.
+     * Configure <config5:authPasswordBroker> as well if Craft should use a separate password broker.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->authGuard('craft')
+     * ```
+     * ```shell Environment Override
+     * CRAFT_AUTH_GUARD=craft
+     * ```
+     * :::
+     *
+     * @group Security
+     *
+     * @see getAuthGuard()
+     */
+    public ?string $authGuard = null;
+
+    /**
+     * @var string|null The Laravel password broker Craft should use.
+     *
+     * If this is `null`, Craft will continue using Laravel’s default password broker. To isolate password resets, define a separate broker, provider,
+     * and token table in `config/auth.php`, and set this to the broker name.
+     *
+     * ::: code
+     * ```php Static Config
+     * ->authPasswordBroker('craft')
+     * ```
+     * ```shell Environment Override
+     * CRAFT_AUTH_PASSWORD_BROKER=craft
+     * ```
+     * :::
+     *
+     * @group Security
+     *
+     * @see getAuthPasswordBroker()
+     */
+    public ?string $authPasswordBroker = null;
 
     /**
      * @var mixed The maximum age of activity events before garbage collection deletes them.
@@ -6183,6 +6227,36 @@ class GeneralConfig extends BaseConfig
         $this->verifyEmailSuccessPath = $value;
 
         return $this;
+    }
+
+    /**
+     * Returns the Laravel authentication guard Craft should use.
+     *
+     * @see authGuard
+     */
+    public function getAuthGuard(): string
+    {
+        return $this->authGuard ?? Auth::getDefaultDriver();
+    }
+
+    /**
+     * Returns the Laravel password broker Craft should use.
+     *
+     * @see authPasswordBroker
+     */
+    public function getAuthPasswordBroker(): string
+    {
+        return $this->authPasswordBroker ?? Password::getDefaultDriver();
+    }
+
+    /**
+     * Returns the session key used to store the password confirmation timestamp.
+     */
+    public function getPasswordConfirmationKey(): string
+    {
+        return $this->authGuard === null
+            ? 'auth.password_confirmed_at'
+            : sprintf('auth.%s.password_confirmed_at', $this->authGuard);
     }
 
     /**

--- a/src/Cp/Cp.php
+++ b/src/Cp/Cp.php
@@ -67,7 +67,7 @@ readonly class Cp
                 'cpTrigger' => $generalConfig->cpTrigger,
                 'baseCpUrl' => Url::cpUrl(),
                 'defaultCpLocale' => $generalConfig->defaultCpLocale,
-                'rememberedUserSessionDuration' => (int) config('auth.guards.craft.remember', 20160) * 60,
+                'rememberedUserSessionDuration' => (int) config(sprintf('auth.guards.%s.remember', Cms::config()->getAuthGuard()), 20160) * 60,
                 'runQueueAutomatically' => $generalConfig->runQueueAutomatically,
             ]);
     }

--- a/src/Dashboard/Widgets/QuickPost.php
+++ b/src/Dashboard/Widgets/QuickPost.php
@@ -17,9 +17,9 @@ use CraftCms\Cms\Section\Enums\SectionType;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\Sections;
 use CraftCms\Cms\Support\Facades\Sites;
-use Illuminate\Support\Facades\Auth;
 use Override;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\currentUser;
 use function CraftCms\Cms\t;
 
@@ -198,7 +198,7 @@ class QuickPost extends Widget
         }
 
         return [
-            'params' => ['siteId' => $siteId, 'section' => $section->handle, 'type' => $entryType->handle, 'authorId' => Auth::id()],
+            'params' => ['siteId' => $siteId, 'section' => $section->handle, 'type' => $entryType->handle, 'authorId' => craftAuth()->id()],
         ];
     }
 

--- a/src/Database/Migrations/2026_09_01_160000_replace_announcements_with_notifications.php
+++ b/src/Database/Migrations/2026_09_01_160000_replace_announcements_with_notifications.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\Cp\Notifications\CpNotification;
 use CraftCms\Cms\Database\LaravelMigrations;
 use CraftCms\Cms\Database\Migration;
@@ -25,8 +26,9 @@ return new class extends Migration
             return;
         }
 
+        $provider = config(sprintf('auth.guards.%s.provider', Cms::config()->getAuthGuard()));
         /** @var class-string<Model> $authModel */
-        $authModel = config('auth.providers.users.model');
+        $authModel = config("auth.providers.$provider.model");
         $notifiableType = (new $authModel)->getMorphClass();
 
         DB::table('announcements')

--- a/src/Database/Migrations/Install.php
+++ b/src/Database/Migrations/Install.php
@@ -34,7 +34,6 @@ use CraftCms\Cms\Support\Facades\Users;
 use CraftCms\Cms\Support\Str;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Prompts\Support\Logger;
@@ -42,6 +41,7 @@ use ReflectionClass;
 use RuntimeException;
 use Throwable;
 
+use function CraftCms\Cms\craftAuth;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\warning;
@@ -1338,7 +1338,7 @@ class Install extends Migration
             ]);
 
             if (! app()->runningInConsole()) {
-                Auth::login($user);
+                craftAuth()->login($user);
             }
 
             $logger?->success('Saved.');

--- a/src/Field/Assets.php
+++ b/src/Field/Assets.php
@@ -57,7 +57,6 @@ use CraftCms\Cms\Support\Html;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
@@ -65,6 +64,7 @@ use Illuminate\Validation\Validator;
 use Override;
 use Symfony\Component\Mime\MimeTypes;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -616,7 +616,7 @@ class Assets extends BaseRelationField
                         $asset->setMimeType(File::getMimeType($tempPath, checkExtension: false) ?? $file['mimeType']);
                         $asset->newFolderId = $uploadFolderId;
                         $asset->setVolumeId($uploadFolder->volumeId);
-                        $asset->uploaderId = Auth::id();
+                        $asset->uploaderId = craftAuth()->id();
                         $asset->avoidFilenameConflicts = true;
                         $asset->ruleset->useScenario(AssetRules::SCENARIO_CREATE);
 

--- a/src/Field/BaseRelationField.php
+++ b/src/Field/BaseRelationField.php
@@ -66,7 +66,6 @@ use GraphQL\Type\Definition\Type;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
@@ -75,6 +74,7 @@ use Override;
 use RuntimeException;
 use Tpetry\QueryExpressions\Language\Alias;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 use function CraftCms\Cms\template;
 
@@ -1565,7 +1565,7 @@ abstract class BaseRelationField extends Field implements CrossSiteCopyableField
                 );
                 $siteIds = Arr::where($siteIds, fn ($siteId) => $siteId !== $element->siteId);
                 if (! empty($siteIds)) {
-                    $userId = Auth::id();
+                    $userId = craftAuth()->id();
                     $timestamp = now();
 
                     foreach ($siteIds as $siteId) {

--- a/src/Field/ContentBlock.php
+++ b/src/Field/ContentBlock.php
@@ -43,12 +43,12 @@ use CraftCms\Cms\Support\Json as JsonHelper;
 use CraftCms\Cms\User\Elements\User;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Validator;
 use InvalidArgumentException;
 use Override;
 use RuntimeException;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -793,7 +793,7 @@ class ContentBlock extends Field implements ElementContainerFieldInterface, Fiel
                 )
             ) {
                 // Duplicate it as a draft. (We'll drop its draft status from NestedElementManager::saveNestedElements().)
-                $contentBlock = app(Drafts::class)->createDraft($contentBlock, Auth::id(), null, null, [
+                $contentBlock = app(Drafts::class)->createDraft($contentBlock, craftAuth()->id(), null, null, [
                     'canonicalId' => $contentBlock->id,
                     'primaryOwnerId' => $element->id,
                     'owner' => $element,

--- a/src/Field/Matrix.php
+++ b/src/Field/Matrix.php
@@ -75,7 +75,6 @@ use CraftCms\Cms\View\LegacyAssets\MatrixAsset;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
@@ -86,6 +85,7 @@ use Override;
 use RuntimeException;
 use Tpetry\QueryExpressions\Language\Alias;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 use function CraftCms\Cms\template;
 
@@ -1723,7 +1723,7 @@ class Matrix extends Field implements EagerLoadingFieldInterface, ElementContain
                     )
                 ) {
                     // Duplicate it as a draft. (We'll drop its draft status from NestedElementManager::saveNestedElements().)
-                    $entry = app(Drafts::class)->createDraft($entry, Auth::id(), null, null, [
+                    $entry = app(Drafts::class)->createDraft($entry, craftAuth()->id(), null, null, [
                         'canonicalId' => $entry->id,
                         'primaryOwnerId' => $element->id,
                         'owner' => $element,

--- a/src/Gql/Gql.php
+++ b/src/Gql/Gql.php
@@ -68,13 +68,13 @@ use GraphQL\Validator\Rules\QueryDepth;
 use GraphQL\Validator\Rules\ValidationRule;
 use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use Throwable;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -260,7 +260,7 @@ class Gql
             }
         }
 
-        if (! $generalConfig->enableGraphqlIntrospection && Auth::guest()) {
+        if (! $generalConfig->enableGraphqlIntrospection && craftAuth()->guest()) {
             $validationRules[DisableIntrospection::class] = new DisableIntrospection(0);
         }
 

--- a/src/Gql/Resolvers/Mutations/Entry.php
+++ b/src/Gql/Resolvers/Mutations/Entry.php
@@ -20,9 +20,10 @@ use CraftCms\Cms\Support\Facades\Elements;
 use CraftCms\Cms\Support\Facades\Sites;
 use Error;
 use GraphQL\Type\Definition\ResolveInfo;
-use Illuminate\Support\Facades\Auth;
 use Override;
 use Throwable;
+
+use function CraftCms\Cms\craftAuth;
 
 class Entry extends ElementMutationResolver
 {
@@ -85,7 +86,7 @@ class Entry extends ElementMutationResolver
             $entry->ruleset->useScenario(ElementRules::SCENARIO_ESSENTIALS);
             Drafts::saveElementAsDraft(
                 $entry,
-                creatorId: Auth::id(),
+                creatorId: craftAuth()->id(),
                 name: $arguments['draftName'] ?? null,
                 notes: $arguments['draftNotes'] ?? null,
             );

--- a/src/Http/Controllers/Auth/AuthenticationController.php
+++ b/src/Http/Controllers/Auth/AuthenticationController.php
@@ -21,13 +21,14 @@ use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Passwords\PasswordBroker;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\URL;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
+
+use function CraftCms\Cms\craftAuth;
 
 abstract readonly class AuthenticationController
 {
@@ -40,7 +41,7 @@ abstract readonly class AuthenticationController
 
     protected function completeLogin(Request $request, CraftUser $user, bool $remember): Response
     {
-        auth()->loginUsingId($user->getAuthIdentifier(), $remember);
+        craftAuth()->loginUsingId($user->getAuthIdentifier(), $remember);
 
         return $this->handleSuccessfulLogin($request, $user);
     }
@@ -94,7 +95,7 @@ abstract readonly class AuthenticationController
         [$authError, $message] = $this->auth->getLoginFailureInfo($authError, $user);
 
         event(new Failed(
-            guard: Auth::getDefaultDriver(),
+            guard: Cms::config()->getAuthGuard(),
             user: $user,
             credentials: $request->only('loginName', 'password'),
         ));
@@ -152,13 +153,13 @@ abstract readonly class AuthenticationController
 
         // If someone is logged in and it’s not this person, log them out
         if ($request->craftUser() && $request->craftUser()->getCraftUserId() !== $user->id) {
-            auth()->logout();
+            craftAuth()->logout();
         }
 
         event(new UserEmailVerifying($user));
 
         /** @var PasswordBroker $broker */
-        $broker = Password::broker();
+        $broker = Password::broker(Cms::config()->getAuthPasswordBroker());
         if (! $broker->tokenExists($user, $request->input('code'))) {
             return $this->processInvalidToken($request, $user);
         }
@@ -177,7 +178,7 @@ abstract readonly class AuthenticationController
         }
 
         // If they don't have a verification code at all, and they're already logged-in, just send them to the post-login URL
-        if ($user && ! auth()->guest()) {
+        if ($user && ! craftAuth()->guest()) {
             return redirect(URL::returnUrl());
         }
 
@@ -208,7 +209,7 @@ abstract readonly class AuthenticationController
             return false;
         }
 
-        return (bool) auth()->loginUsingId($user->id);
+        return (bool) craftAuth()->loginUsingId($user->id);
     }
 
     protected function redirectUserToCp(User $user): ?Response

--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -33,6 +33,7 @@ use Tpetry\QueryExpressions\Function\String\Lower;
 
 use function CraftCms\Cms\action_url;
 use function CraftCms\Cms\cp_url;
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\site_url;
 use function CraftCms\Cms\template;
 
@@ -88,7 +89,7 @@ readonly class LoginController extends AuthenticationController
         // to avoid strange behaviour, clear out whatever's left so that we start with the right amount of time
         // see https://github.com/craftcms/cms/pull/18753
         if ($forElevatedSession) {
-            $request->session()->forget('auth.password_confirmed_at');
+            $request->session()->forget($this->generalConfig->getPasswordConfirmationKey());
         }
 
         // If the current user is being impersonated, get the impersonator instead
@@ -126,7 +127,7 @@ readonly class LoginController extends AuthenticationController
         /**
          * @var EloquentUserProvider $provider
          */
-        $provider = auth()->getProvider();
+        $provider = craftAuth()->getProvider();
 
         $user = $this->retrieveLoginUser($request->input('loginName'));
 
@@ -185,7 +186,7 @@ readonly class LoginController extends AuthenticationController
     {
         $request->session()->forget('url.intended');
 
-        auth()->logout();
+        craftAuth()->logout();
 
         if ($request->wantsJson()) {
             return $this->asSuccess();

--- a/src/Http/Controllers/Auth/PasskeyController.php
+++ b/src/Http/Controllers/Auth/PasskeyController.php
@@ -12,12 +12,12 @@ use CraftCms\Cms\Auth\Models\WebAuthn;
 use CraftCms\Cms\Auth\Passkeys\Passkeys;
 use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\User\Contracts\CraftUser;
-use Illuminate\Auth\SessionGuard;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpFoundation\Response;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 readonly class PasskeyController extends AuthenticationController
@@ -66,8 +66,7 @@ readonly class PasskeyController extends AuthenticationController
             return $this->asFailure(t('Passkey authentication failed.'));
         }
 
-        /** @var SessionGuard $guard */
-        $guard = auth();
+        $guard = craftAuth();
         $user = $guard->getProvider()->retrieveById($credential->userId);
 
         if (! $user instanceof CraftUser) {

--- a/src/Http/Controllers/Auth/SessionInfoController.php
+++ b/src/Http/Controllers/Auth/SessionInfoController.php
@@ -75,7 +75,7 @@ readonly class SessionInfoController
             ]);
         }
 
-        $request->session()->forget('auth.password_confirmed_at');
+        $request->session()->forget($generalConfig->getPasswordConfirmationKey());
         $user = $impersonation->getImpersonator() ?? $request->craftUser()?->asElement();
 
         if (! $user) {

--- a/src/Http/Controllers/Auth/VerifyEmailController.php
+++ b/src/Http/Controllers/Auth/VerifyEmailController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Http\Controllers\Auth;
 
 use CraftCms\Cms\Auth\AuthMethods;
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\Element\Exceptions\InvalidElementException;
 use CraftCms\Cms\Support\Flash;
 use CraftCms\Cms\User\Elements\User;
@@ -61,7 +62,7 @@ readonly class VerifyEmailController extends AuthenticationController
         abort_if(! $user, 400, 'Invalid user UUID: '.$request->input('uid'));
 
         /** @var PasswordBroker $broker */
-        $broker = Password::broker();
+        $broker = Password::broker(Cms::config()->getAuthPasswordBroker());
         if (! $broker->tokenExists($user, $request->input('code'))) {
             return $this->processInvalidToken($request, $user);
         }

--- a/src/Http/Controllers/Users/ImpersonationController.php
+++ b/src/Http/Controllers/Users/ImpersonationController.php
@@ -13,7 +13,6 @@ use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\User\Users;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\Rule;
@@ -21,6 +20,7 @@ use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 readonly class ImpersonationController
@@ -52,7 +52,7 @@ readonly class ImpersonationController
         $this->impersonation->setImpersonatorId($this->request->craftUser()?->getCraftUserId());
 
         try {
-            if (! Auth::loginUsingId($user->id)) {
+            if (! craftAuth()->loginUsingId($user->id)) {
                 throw new RuntimeException('Unable to retrieve the user being impersonated.');
             }
         } catch (Throwable) {
@@ -105,7 +105,7 @@ readonly class ImpersonationController
         $this->impersonation->setImpersonatorId($prevUserId);
 
         try {
-            if (! Auth::loginUsingId($user->id)) {
+            if (! craftAuth()->loginUsingId($user->id)) {
                 throw new RuntimeException('Unable to retrieve the user being impersonated.');
             }
         } catch (Throwable) {

--- a/src/Http/Controllers/Users/SaveUserController.php
+++ b/src/Http/Controllers/Users/SaveUserController.php
@@ -31,6 +31,7 @@ use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -530,7 +531,7 @@ readonly class SaveUserController
             return false;
         }
 
-        auth()->login(UserModel::findOrFail($user->id));
+        craftAuth()->login(UserModel::findOrFail($user->id));
 
         return true;
     }

--- a/src/Http/Middleware/AuthenticateCraftSession.php
+++ b/src/Http/Middleware/AuthenticateCraftSession.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http\Middleware;
+
+use CraftCms\Cms\Auth\AuthMethods;
+use CraftCms\Cms\Auth\Impersonation;
+use CraftCms\Cms\Auth\SessionAuth;
+use CraftCms\Cms\Cms;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Request;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Override;
+
+class AuthenticateCraftSession extends AuthenticateSession
+{
+    #[Override]
+    /** @param Request $request */
+    protected function logout(mixed $request): never
+    {
+        if (Cms::config()->authGuard === null) {
+            parent::logout($request);
+        }
+
+        $guard = Cms::config()->getAuthGuard();
+        $this->guard()->logoutCurrentDevice();
+
+        $sessionKeys = [
+            'password_hash_'.$guard,
+            Cms::config()->getPasswordConfirmationKey(),
+        ];
+
+        if (SessionAuth::$authAccessParam !== null) {
+            $sessionKeys[] = SessionAuth::$authAccessParam;
+        }
+
+        $request->session()->forget($sessionKeys);
+        app(AuthMethods::class)->setUser(null);
+        app(Impersonation::class)->setImpersonatorId(null);
+
+        throw new AuthenticationException(
+            'Unauthenticated.',
+            [$guard],
+            $this->redirectTo($request),
+        );
+    }
+}

--- a/src/Http/Middleware/UseCraftAuthGuard.php
+++ b/src/Http/Middleware/UseCraftAuthGuard.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CraftCms\Cms\Http\Middleware;
+
+use Closure;
+use CraftCms\Cms\Cms;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Http\Request;
+
+class UseCraftAuthGuard
+{
+    public function __construct(private readonly AuthManager $auth) {}
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if (Cms::config()->authGuard === null) {
+            return $next($request);
+        }
+
+        $defaultGuard = $this->auth->getDefaultDriver();
+        $this->auth->shouldUse(Cms::config()->getAuthGuard());
+
+        try {
+            return $next($request);
+        } finally {
+            $this->auth->shouldUse($defaultGuard);
+        }
+    }
+}

--- a/src/Http/Mixins/RequestMixin.php
+++ b/src/Http/Mixins/RequestMixin.php
@@ -27,7 +27,7 @@ class RequestMixin
              * @phpstan-ignore-next-line
              */
             $request = $this;
-            $user = $request->user();
+            $user = $request->user(Cms::config()->authGuard);
 
             if ($user === null || $user instanceof CraftUser) {
                 return $user;

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -37,7 +37,6 @@ use Illuminate\Routing\UrlGenerator;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
@@ -50,6 +49,7 @@ use RuntimeException;
 use stdClass;
 
 use function CraftCms\Cms\action_url;
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 class AppServiceProvider extends ServiceProvider
@@ -174,7 +174,7 @@ class AppServiceProvider extends ServiceProvider
         });
 
         UrlGenerator::macro('returnUrl', function (?string $defaultUrl = null): string {
-            $defaultUrl ??= Auth::guest()
+            $defaultUrl ??= craftAuth()->guest()
                 ? action_url('users/redirect')
                 : $this->defaultReturnUrl();
 

--- a/src/Route/RouteServiceProvider.php
+++ b/src/Route/RouteServiceProvider.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\Auth\LoginRateLimiter;
 use CraftCms\Cms\Auth\TwoFactorRateLimiter;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Http\Middleware\AddLogContext;
+use CraftCms\Cms\Http\Middleware\AuthenticateCraftSession;
 use CraftCms\Cms\Http\Middleware\CheckForUpdates;
 use CraftCms\Cms\Http\Middleware\CheckRequirements;
 use CraftCms\Cms\Http\Middleware\Enforce2fa;
@@ -27,19 +28,20 @@ use CraftCms\Cms\Http\Middleware\RunQueue;
 use CraftCms\Cms\Http\Middleware\SetHeaders;
 use CraftCms\Cms\Http\Middleware\ShowBrokenImage;
 use CraftCms\Cms\Http\Middleware\UpdateLocale;
+use CraftCms\Cms\Http\Middleware\UseCraftAuthGuard;
 use CraftCms\Cms\Http\Middleware\UseWriteConnection;
 use CraftCms\Cms\Route\Data\Route;
 use CraftCms\Cms\Site\Events\SiteDeleted;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
 use CraftCms\Cms\Support\Str;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance as LaravelMaintenanceMiddleware;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as LaravelRouteServiceProvider;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
-use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
@@ -58,6 +60,7 @@ class RouteServiceProvider extends ServiceProvider
          * as they rewrite the incoming request.
          */
         $kernel = $this->app->get(HttpKernel::class);
+        $kernel->addToMiddlewarePriorityBefore(AuthenticatesRequests::class, UseCraftAuthGuard::class);
         $globalMiddleware = array_map(
             fn (string $middleware): string => $middleware === LaravelMaintenanceMiddleware::class
                 ? CraftMaintenanceMiddleware::class
@@ -156,7 +159,9 @@ class RouteServiceProvider extends ServiceProvider
 
     private function bootMiddleware(Router $router): void
     {
-        $router->aliasMiddleware('password.confirm', RequireConfirmedPassword::class);
+        if (Cms::config()->authGuard === null) {
+            $router->aliasMiddleware('password.confirm', RequireConfirmedPassword::class);
+        }
 
         collect([
             UseWriteConnection::class,
@@ -172,6 +177,8 @@ class RouteServiceProvider extends ServiceProvider
             CraftMaintenanceMiddleware::class,
         ])->each(fn (string $middleware) => $router->pushMiddlewareToGroup('craft', $middleware));
 
+        $router->prependMiddlewareToGroup('craft', UseCraftAuthGuard::class);
+
         collect([
             RequireCpRequest::class,
             CheckRequirements::class,
@@ -182,7 +189,7 @@ class RouteServiceProvider extends ServiceProvider
 
         collect([
             'web',
-            AuthenticateSession::class,
+            AuthenticateCraftSession::class,
             RunQueue::class,
             HandleTemplateRequest::class,
         ])->each(fn (string $middleware) => $router->pushMiddlewareToGroup('craft.web', $middleware));

--- a/src/Site/Sites.php
+++ b/src/Site/Sites.php
@@ -35,7 +35,6 @@ use Illuminate\Container\Attributes\Scoped;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -43,6 +42,7 @@ use InvalidArgumentException;
 use Throwable;
 use Tpetry\QueryExpressions\Language\Alias;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\currentUser;
 use function CraftCms\Cms\maxPowerCaptain;
 
@@ -881,7 +881,7 @@ class Sites
     {
         $withDisabled ??= (
             app()->runningInConsole() ||
-            (request()->isCpRequest() && Auth::check())
+            (request()->isCpRequest() && craftAuth()->check())
         );
 
         return $withDisabled ? $this->allSitesById : $this->enabledSitesById;

--- a/src/Support/Api.php
+++ b/src/Support/Api.php
@@ -19,13 +19,13 @@ use Illuminate\Foundation\Application;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
 use Imagick;
 use Throwable;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\normalizeVersion;
 
 /**
@@ -157,7 +157,7 @@ class Api
             }
         }
 
-        if ($user = Auth::getUser()) {
+        if ($user = craftAuth()->getUser()) {
             /** @var User $user */
             $headers['X-Craft-User-Email'] = $user->email;
         }

--- a/src/Twig/Nodes/RequireAdminNode.php
+++ b/src/Twig/Nodes/RequireAdminNode.php
@@ -6,7 +6,6 @@ namespace CraftCms\Cms\Twig\Nodes;
 
 use CraftCms\Cms\Cms;
 use Illuminate\Auth\AuthenticationException;
-use Illuminate\Support\Facades\Auth;
 use Override;
 use Twig\Attribute\YieldReady;
 use Twig\Compiler;
@@ -20,7 +19,7 @@ class RequireAdminNode extends Node
     {
         $compiler
             ->addDebugInfo($this)
-            ->write('if (! $user = '.Auth::class."::user()) {\n")
+            ->write("if (! \$user = \\CraftCms\\Cms\\craftAuth()->user()) {\n")
             ->indent()
             ->write('throw new '.AuthenticationException::class."('Unauthenticated.');\n")
             ->outdent()

--- a/src/Twig/Nodes/RequireGuestNode.php
+++ b/src/Twig/Nodes/RequireGuestNode.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Twig\Nodes;
 
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\URL;
 use Override;
 use Twig\Attribute\YieldReady;
@@ -22,7 +21,7 @@ class RequireGuestNode extends Node
     {
         $compiler
             ->addDebugInfo($this)
-            ->write('if ('.Auth::class."::check()) {\n")
+            ->write("if (\\CraftCms\\Cms\\craftAuth()->check()) {\n")
             ->indent()
             ->write('redirect('.URL::class."::returnUrl())->throwResponse();\n")
             ->outdent()

--- a/src/Twig/Nodes/RequireLoginNode.php
+++ b/src/Twig/Nodes/RequireLoginNode.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CraftCms\Cms\Twig\Nodes;
 
 use Illuminate\Auth\AuthenticationException;
-use Illuminate\Support\Facades\Auth;
 use Override;
 use Twig\Attribute\YieldReady;
 use Twig\Compiler;
@@ -22,7 +21,7 @@ class RequireLoginNode extends Node
     {
         $compiler
             ->addDebugInfo($this)
-            ->write('if ('.Auth::class."::guest()) {\n")
+            ->write("if (\\CraftCms\\Cms\\craftAuth()->guest()) {\n")
             ->indent()
             ->write('throw new '.AuthenticationException::class."('Unauthenticated.');\n")
             ->outdent()

--- a/src/User/Elements/User.php
+++ b/src/User/Elements/User.php
@@ -79,7 +79,6 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB as DbFacade;
 use Illuminate\Support\Facades\Gate;
@@ -89,6 +88,7 @@ use LogicException;
 use Override;
 use Stringable;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\currentUser;
 use function CraftCms\Cms\t;
 
@@ -422,7 +422,7 @@ class User extends Element implements AuthenticatableContract, AuthorizableContr
     /** @return MorphMany<DatabaseNotification, Model&AuthenticatableContract> */
     public function notifications(): MorphMany
     {
-        $user = Auth::getProvider()->retrieveById($this->getAuthIdentifier());
+        $user = craftAuth()->getProvider()->retrieveById($this->getAuthIdentifier());
 
         if (! $user instanceof Model || ! method_exists($user, 'notifications')) {
             throw new LogicException('The configured auth model must be an Eloquent model using Laravel\'s Notifiable trait to receive database notifications.');
@@ -2299,7 +2299,13 @@ JS, [
         }
 
         if (! $isNew && $changePassword && isset($newPassword) && ! app()->runningInConsole()) {
-            Auth::logoutOtherDevices($newPassword);
+            $guard = craftAuth();
+
+            if (! method_exists($guard, 'logoutOtherDevices')) {
+                throw new LogicException('Craft auth guard does not support logging out other devices.');
+            }
+
+            $guard->logoutOtherDevices($newPassword);
         }
 
         if ($this->sendVerificationEmailAfterRequest && isset($this->unverifiedEmail)) {

--- a/src/User/Notifications/SendQueuedUserNotifications.php
+++ b/src/User/Notifications/SendQueuedUserNotifications.php
@@ -10,9 +10,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\SendQueuedNotifications;
-use Illuminate\Support\Facades\Auth;
 use LogicException;
 use Override;
+
+use function CraftCms\Cms\craftAuth;
 
 class SendQueuedUserNotifications extends SendQueuedNotifications
 {
@@ -27,7 +28,7 @@ class SendQueuedUserNotifications extends SendQueuedNotifications
     {
         if ($notifiables instanceof User) {
             $this->restoreUserElements = true;
-            $notifiables = Auth::getProvider()->retrieveById($notifiables->getAuthIdentifier());
+            $notifiables = craftAuth()->getProvider()->retrieveById($notifiables->getAuthIdentifier());
 
             if (! $notifiables instanceof Model || ! $notifiables instanceof CraftUser) {
                 throw new LogicException('The configured auth model must be an Eloquent model implementing CraftUser.');

--- a/src/User/Users.php
+++ b/src/User/Users.php
@@ -258,7 +258,7 @@ class Users
      */
     public function sendPasswordResetEmail(User $user): bool
     {
-        return Password::broker()->sendResetLink(['email' => $user->email]) === Password::RESET_LINK_SENT;
+        return Password::broker(Cms::config()->getAuthPasswordBroker())->sendResetLink(['email' => $user->email]) === Password::RESET_LINK_SENT;
     }
 
     /**
@@ -916,7 +916,7 @@ class Users
         $this->validateUserChanges($user, $changes);
 
         /** @var PasswordBroker $broker */
-        $broker = Password::broker();
+        $broker = Password::broker(Cms::config()->getAuthPasswordBroker());
         $token = $broker->createToken($user);
 
         $indexAttributesChanged = $this->saveUserChanges($user, $userModel, $changes);

--- a/src/View/LegacyAssets/CpAsset.php
+++ b/src/View/LegacyAssets/CpAsset.php
@@ -8,9 +8,9 @@ use CraftCms\Cms\Cp\Cp;
 use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\View\Enums\Position;
 use CraftCms\Cms\View\HtmlStack;
-use Illuminate\Support\Facades\Auth;
 
 use function CraftCms\Cms\craftAsset;
+use function CraftCms\Cms\craftAuth;
 
 /**
  * @deprecated
@@ -103,7 +103,7 @@ class CpAsset implements LegacyAssetInterface
             $except[] = 'cpTrigger';
         }
 
-        if (! Auth::check()) {
+        if (! craftAuth()->check()) {
             $except[] = 'runQueueAutomatically';
         }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -17,6 +17,7 @@ use CraftCms\Cms\View\TemplateEngine;
 use CraftCms\Cms\View\TemplateMode;
 use Fruitcake\LaravelDebugbar\LaravelDebugbar;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -89,7 +90,7 @@ function currentUser(): ?CraftUser
         return null;
     }
 
-    $user = Auth::user();
+    $user = craftAuth()->user();
 
     if ($user === null || $user instanceof CraftUser) {
         return $user;
@@ -99,6 +100,11 @@ function currentUser(): ?CraftUser
         'The authenticated user must implement %s to be used by Craft.',
         CraftUser::class,
     ));
+}
+
+function craftAuth(): Guard
+{
+    return Auth::guard(Cms::config()->getAuthGuard());
 }
 
 function currentUserElement(): ?UserElement

--- a/tests/.pest/snapshots/Unit/Twig/Nodes/RequireAdminNodeTest/it_compiles.snap
+++ b/tests/.pest/snapshots/Unit/Twig/Nodes/RequireAdminNodeTest/it_compiles.snap
@@ -1,5 +1,5 @@
 // line 1
-if (! $user = Illuminate\Support\Facades\Auth::user()) {
+if (! $user = \CraftCms\Cms\craftAuth()->user()) {
     throw new Illuminate\Auth\AuthenticationException('Unauthenticated.');
 }
 if (! $user->isAdmin()) {

--- a/tests/.pest/snapshots/Unit/Twig/Nodes/RequireAdminNodeTest/it_compiles_with_requireAdminChanges.snap
+++ b/tests/.pest/snapshots/Unit/Twig/Nodes/RequireAdminNodeTest/it_compiles_with_requireAdminChanges.snap
@@ -1,5 +1,5 @@
 // line 1
-if (! $user = Illuminate\Support\Facades\Auth::user()) {
+if (! $user = \CraftCms\Cms\craftAuth()->user()) {
     throw new Illuminate\Auth\AuthenticationException('Unauthenticated.');
 }
 if (! $user->isAdmin()) {

--- a/tests/.pest/snapshots/Unit/Twig/Nodes/RequireGuestNodeTest/it_compiles.snap
+++ b/tests/.pest/snapshots/Unit/Twig/Nodes/RequireGuestNodeTest/it_compiles.snap
@@ -1,4 +1,4 @@
 // line 1
-if (Illuminate\Support\Facades\Auth::check()) {
+if (\CraftCms\Cms\craftAuth()->check()) {
     redirect(Illuminate\Support\Facades\URL::returnUrl())->throwResponse();
 }

--- a/tests/.pest/snapshots/Unit/Twig/Nodes/RequireLoginNodeTest/it_compiles.snap
+++ b/tests/.pest/snapshots/Unit/Twig/Nodes/RequireLoginNodeTest/it_compiles.snap
@@ -1,4 +1,4 @@
 // line 1
-if (Illuminate\Support\Facades\Auth::guest()) {
+if (\CraftCms\Cms\craftAuth()->guest()) {
     throw new Illuminate\Auth\AuthenticationException('Unauthenticated.');
 }

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -3,11 +3,14 @@
 declare(strict_types=1);
 
 use craft\web\twig\Extension;
+use CraftCms\Cms\Config\GeneralConfig;
 use CraftCms\Cms\Database\Migrator;
 use CraftCms\Cms\Support\File;
 use CraftCms\Cms\Support\Json;
+use CraftCms\Cms\Twig\Extensions\LaravelExtension;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 
 arch('No debug functions')
@@ -70,3 +73,13 @@ arch('Don\'t use legacy aliases')
     ->expect(['Craft::getAlias', 'Craft::setAlias', 'Craft::getRootAlias'])
     ->not()
     ->toBeUsed();
+
+arch('Craft authentication uses its configured guard')
+    ->expect([Auth::class, 'auth'])
+    ->not
+    ->toBeUsed()
+    ->ignoring([
+        GeneralConfig::class,
+        LaravelExtension::class,
+        'CraftCms\\Cms\\craftAuth',
+    ]);

--- a/tests/Feature/Auth/Concerns/ConfirmsPasswordsTest.php
+++ b/tests/Feature/Auth/Concerns/ConfirmsPasswordsTest.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 use CraftCms\Cms\Auth\Concerns\ConfirmsPasswords;
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\User\Elements\User;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -81,4 +85,18 @@ test('password confirmation can be disabled', function () {
 
     expect(new TestConfirmsPasswords()->confirmedPasswordTimeout())->toBeFalse();
     expect(new TestConfirmsPasswords()->isPasswordConfirmed())->toBeTrue();
+});
+
+test('password confirmation is isolated for a configured Craft guard', function () {
+    Cms::config()->authGuard = 'craft';
+    Auth::guard('craft')->login(User::find()->first());
+    Session::forget('auth.craft.password_confirmed_at');
+    Session::put('auth.password_confirmed_at', now()->unix());
+
+    expect(new TestConfirmsPasswords()->isPasswordConfirmed())->toBeFalse();
+
+    new TestConfirmsPasswords()->confirmPassword();
+
+    expect(Session::get('auth.craft.password_confirmed_at'))->toBe(now()->unix())
+        ->and(new TestConfirmsPasswords()->isPasswordConfirmed())->toBeTrue();
 });

--- a/tests/Feature/Auth/ConfiguredGuardTest.php
+++ b/tests/Feature/Auth/ConfiguredGuardTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+use CraftCms\Cms\Auth\AuthMethods;
+use CraftCms\Cms\Auth\AuthServiceProvider;
+use CraftCms\Cms\Auth\Impersonation;
+use CraftCms\Cms\Auth\SessionAuth;
+use CraftCms\Cms\Cms;
+use CraftCms\Cms\Http\Controllers\Auth\LoginController;
+use CraftCms\Cms\Http\Controllers\Gql\TokensController;
+use CraftCms\Cms\Http\Middleware\UseCraftAuthGuard;
+use CraftCms\Cms\User\Models\User;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Auth\Middleware\RequirePassword;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Routing\Router;
+use Illuminate\Session\Middleware\AuthenticateSession as LaravelAuthenticateSession;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Session;
+use RuntimeException;
+
+use function CraftCms\Cms\cp_url;
+use function CraftCms\Cms\currentUser;
+use function Pest\Laravel\get;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\post;
+use function Pest\Laravel\postJson;
+
+beforeEach(function () {
+    ConfiguredGuardTestUserProvider::$user = null;
+
+    config()->set([
+        'auth.defaults.guard' => 'host',
+        'auth.guards.host' => [
+            'driver' => 'session',
+            'provider' => 'host-users',
+        ],
+        'auth.providers.host-users' => [
+            'driver' => 'test-host-users',
+        ],
+    ]);
+
+    Auth::provider('test-host-users', fn () => new ConfiguredGuardTestUserProvider);
+    Auth::forgetGuards();
+
+    Cms::config()->authGuard = 'craft';
+});
+
+it('keeps Craft and host authentication isolated', function () {
+    $hostUser = new GenericUser(['id' => 42, 'password' => '']);
+    ConfiguredGuardTestUserProvider::$user = $hostUser;
+    Auth::guard('host')->login($hostUser);
+
+    $craftUser = User::firstOrFail();
+
+    postJson(action([LoginController::class, 'attemptLogin']), [
+        'loginName' => $craftUser->email,
+        'password' => 'craftcms2018!!',
+    ])->assertOk();
+
+    expect(Auth::getDefaultDriver())->toBe('host')
+        ->and(Auth::guard('host')->user())->toBe($hostUser)
+        ->and(Auth::guard('craft')->id())->toBe($craftUser->id)
+        ->and(currentUser()?->getCraftUserId())->toBe($craftUser->id);
+});
+
+it('does not treat a host user as authenticated on protected Craft routes', function () {
+    $hostUser = new GenericUser(['id' => 42, 'password' => '']);
+    ConfiguredGuardTestUserProvider::$user = $hostUser;
+    Auth::guard('host')->login($hostUser);
+
+    get(cp_url('dashboard'))->assertRedirect(cp_url('login'));
+
+    expect(Auth::getDefaultDriver())->toBe('host')
+        ->and(Auth::guard('host')->user())->toBe($hostUser)
+        ->and(currentUser())->toBeNull();
+});
+
+it('logs out only the Craft guard', function () {
+    $hostUser = new GenericUser(['id' => 42, 'password' => '']);
+    ConfiguredGuardTestUserProvider::$user = $hostUser;
+    Auth::guard('host')->login($hostUser);
+    Auth::guard('craft')->login(User::firstOrFail());
+
+    post(action([LoginController::class, 'logout']))->assertRedirect();
+
+    expect(Auth::guard('host')->user())->toBe($hostUser)
+        ->and(Auth::guard('craft')->guest())->toBeTrue();
+});
+
+it('restores the host default guard when Craft middleware throws', function () {
+    expect(fn () => app(UseCraftAuthGuard::class)->handle(
+        request(),
+        fn () => throw new RuntimeException('Expected failure'),
+    ))->toThrow(RuntimeException::class, 'Expected failure');
+
+    expect(Auth::getDefaultDriver())->toBe('host');
+});
+
+it('uses an independently configured password broker', function () {
+    config()->set('auth.passwords.craft-test', [
+        ...config('auth.passwords.users'),
+        'provider' => 'craft',
+    ]);
+    Cms::config()->authPasswordBroker = 'craft-test';
+    expect(Password::broker(Cms::config()->getAuthPasswordBroker()))->toBe(Password::broker('craft-test'))
+        ->not->toBe(Password::broker());
+});
+
+it('requires Craft password confirmation on protected Craft routes', function () {
+    app(Router::class)->aliasMiddleware('password.confirm', RequirePassword::class);
+    Auth::guard('craft')->login(User::firstOrFail());
+    Session::put('auth.password_confirmed_at', now()->unix());
+    Session::forget('auth.craft.password_confirmed_at');
+
+    postJson(action([TokensController::class, 'accessToken'], ['tokenId' => 999999]))
+        ->assertStatus(423);
+});
+
+it('accepts Craft password confirmation on protected Craft routes', function () {
+    app(Router::class)->aliasMiddleware('password.confirm', RequirePassword::class);
+    Auth::guard('craft')->login(User::firstOrFail());
+    Session::forget('auth.password_confirmed_at');
+    Session::put('auth.craft.password_confirmed_at', now()->unix());
+
+    postJson(action([TokensController::class, 'accessToken'], ['tokenId' => 999999]))
+        ->assertNotFound();
+});
+
+it('preserves the host session when the Craft password hash changes', function () {
+    Route::get('_test/craft-session-auth', fn () => response()->noContent())
+        ->middleware(['craft', 'craft.web']);
+
+    $hostUser = new GenericUser(['id' => 42, 'password' => 'host-password-hash']);
+    ConfiguredGuardTestUserProvider::$user = $hostUser;
+    Auth::guard('host')->login($hostUser);
+
+    $craftUser = User::firstOrFail();
+    Auth::guard('craft')->login($craftUser);
+    app(AuthMethods::class)->setUser($craftUser);
+    app(Impersonation::class)->setImpersonatorId($craftUser->id);
+
+    Session::put([
+        'host-state' => 'preserved',
+        'password_hash_craft' => 'stale-password-hash',
+        'auth.craft.password_confirmed_at' => now()->unix(),
+        SessionAuth::$authAccessParam => ['test-action'],
+    ]);
+
+    LaravelAuthenticateSession::redirectUsing(fn () => null);
+
+    try {
+        getJson('_test/craft-session-auth')->assertUnauthorized();
+    } finally {
+        LaravelAuthenticateSession::redirectUsing(fn () => route('login'));
+    }
+
+    Auth::forgetGuards();
+
+    expect(Auth::guard('host')->user()?->getAuthIdentifier())->toBe(42)
+        ->and(Auth::guard('craft')->guest())->toBeTrue()
+        ->and(Session::get('host-state'))->toBe('preserved')
+        ->and(Session::has('password_hash_craft'))->toBeFalse()
+        ->and(Session::has('auth.craft.password_confirmed_at'))->toBeFalse()
+        ->and(Session::has(SessionAuth::$authAccessParam))->toBeFalse()
+        ->and(Session::has('__impersonator_id'))->toBeFalse()
+        ->and(app(Impersonation::class)->getImpersonatorId())->toBeNull()
+        ->and(Session::has('user.id'))->toBeFalse()
+        ->and(Session::has('user.login_id'))->toBeFalse()
+        ->and(Session::has('user.remember'))->toBeFalse()
+        ->and(Session::has('user.pending_2fa_at'))->toBeFalse();
+});
+
+it('fills missing Craft guard and provider configuration defaults', function () {
+    $guard = config('auth.guards.craft');
+    $provider = config('auth.providers.craft');
+
+    try {
+        config()->set('auth.guards.craft', ['remember' => 60]);
+        config()->set('auth.providers.craft', ['model' => User::class]);
+
+        new AuthServiceProvider(app())->register();
+
+        expect(config('auth.guards.craft'))->toBe([
+            'driver' => 'session',
+            'provider' => 'craft',
+            'remember' => 60,
+        ])->and(config('auth.providers.craft'))->toBe([
+            'driver' => 'eloquent',
+            'model' => User::class,
+        ]);
+    } finally {
+        config()->set('auth.guards.craft', $guard);
+        config()->set('auth.providers.craft', $provider);
+    }
+});
+
+class ConfiguredGuardTestUserProvider implements UserProvider
+{
+    public static ?Authenticatable $user = null;
+
+    public function retrieveById($identifier): ?Authenticatable
+    {
+        return self::$user?->getAuthIdentifier() === $identifier ? self::$user : null;
+    }
+
+    public function retrieveByToken($identifier, #[SensitiveParameter] $token): ?Authenticatable
+    {
+        return null;
+    }
+
+    public function updateRememberToken(Authenticatable $user, #[SensitiveParameter] $token): void {}
+
+    public function retrieveByCredentials(#[SensitiveParameter] array $credentials): ?Authenticatable
+    {
+        return null;
+    }
+
+    public function validateCredentials(Authenticatable $user, #[SensitiveParameter] array $credentials): bool
+    {
+        return false;
+    }
+
+    public function rehashPasswordIfRequired(Authenticatable $user, #[SensitiveParameter] array $credentials, bool $force = false): void {}
+}

--- a/tests/Feature/Auth/ConfiguredGuardTest.php
+++ b/tests/Feature/Auth/ConfiguredGuardTest.php
@@ -21,7 +21,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
-use RuntimeException;
 
 use function CraftCms\Cms\cp_url;
 use function CraftCms\Cms\currentUser;

--- a/tests/Feature/User/UsersTest.php
+++ b/tests/Feature/User/UsersTest.php
@@ -342,6 +342,7 @@ test('set verification code', function (bool $tokenFailure) {
     $user = UserModel::factory()->createElement(['active' => false, 'pending' => false]);
 
     if ($tokenFailure) {
+        Password::shouldReceive('getDefaultDriver')->once()->andReturn('users');
         Password::shouldReceive('broker->createToken')->once()->andThrow(new RuntimeException('Token failed'));
         expect(fn () => $this->users->setVerificationCodeOnUser($user))->toThrow(RuntimeException::class, 'Token failed');
         expect($user->pending)->toBeFalse()->and(UserModel::findOrFail($user->id)->pending)->toBeFalse();

--- a/tests/Unit/CmsTest.php
+++ b/tests/Unit/CmsTest.php
@@ -14,6 +14,7 @@ use CraftCms\Cms\Support\Facades\Sites;
 use CraftCms\Cms\Support\Facades\Updates;
 use CraftCms\Cms\Support\Facades\Users;
 use CraftCms\Cms\User\Contracts\CraftUser;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -26,6 +27,10 @@ use Illuminate\Support\Facades\Schema;
 beforeEach(function () {
     Context::forgetHidden('craft.info');
     Context::forgetHidden('craft.isInstalled');
+
+    $this->authGuard = Mockery::mock(Guard::class);
+    Auth::shouldReceive('getDefaultDriver')->andReturn('web');
+    Auth::shouldReceive('guard')->with('web')->andReturn($this->authGuard);
 });
 
 function createInfoTable(): void
@@ -72,7 +77,7 @@ it('uses the logged-in CP user timezone preference first', function () {
     Cms::config()->cpTrigger = 'admin';
     app()->instance('request', Request::create('/admin'));
 
-    Auth::shouldReceive('hasUser')->andReturnTrue()
+    $this->authGuard->shouldReceive('hasUser')->andReturnTrue()
         ->shouldReceive('id')->once()->andReturn(42);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'timeZone')->andReturn('Europe/Brussels');
 
@@ -162,8 +167,8 @@ it('resolves CP timezone preferences after switching users and request context',
     Cms::config()->timezone = 'Europe/Paris';
     app()->instance('request', Request::create('/admin'));
 
-    Auth::shouldReceive('hasUser')->andReturnTrue();
-    Auth::shouldReceive('id')->twice()->andReturn(42, 43);
+    $this->authGuard->shouldReceive('hasUser')->andReturnTrue();
+    $this->authGuard->shouldReceive('id')->twice()->andReturn(42, 43);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'timeZone')->andReturn('Asia/Tokyo');
     Users::shouldReceive('getUserPreference')->once()->with(43, 'timeZone')->andReturn('America/New_York');
 
@@ -210,7 +215,7 @@ it('uses a valid CP user language preference', function () {
     Updates::shouldReceive('isCraftUpdatePending')->once()->andReturn(false);
     $user = Mockery::mock(CraftUser::class);
     $user->shouldReceive('getAuthIdentifier')->once()->andReturn(42);
-    Auth::shouldReceive('user')->once()->andReturn($user);
+    $this->authGuard->shouldReceive('user')->once()->andReturn($user);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'language')->andReturn('pt-BR');
     I18N::shouldReceive('validateAppLocaleId')->once()->with('pt-BR')->andReturn(true);
 
@@ -222,7 +227,7 @@ it('falls back to the configured default CP language', function () {
     Cms::config()->cpTrigger = 'admin';
     Cms::config()->defaultCpLanguage = 'es';
     Updates::shouldReceive('isCraftUpdatePending')->once()->andReturn(false);
-    Auth::shouldReceive('user')->once()->andReturnNull();
+    $this->authGuard->shouldReceive('user')->once()->andReturnNull();
 
     expect(Cms::targetLanguage(Request::create('/admin')))->toBe('es');
 });
@@ -234,7 +239,7 @@ it('falls back to the accepted language when the CP user preference is invalid a
     Updates::shouldReceive('isCraftUpdatePending')->once()->andReturn(false);
     $user = Mockery::mock(CraftUser::class);
     $user->shouldReceive('getAuthIdentifier')->once()->andReturn(42);
-    Auth::shouldReceive('user')->once()->andReturn($user);
+    $this->authGuard->shouldReceive('user')->once()->andReturn($user);
     Users::shouldReceive('getUserPreference')->once()->with(42, 'language')->andReturn('not-real');
     I18N::shouldReceive('validateAppLocaleId')->once()->with('not-real')->andReturn(false);
     I18N::shouldReceive('getAppLocaleIds')->once()->andReturn(collect(['it', 'en']));

--- a/tests/Unit/Cp/NavigationTest.php
+++ b/tests/Unit/Cp/NavigationTest.php
@@ -11,6 +11,7 @@ use CraftCms\Cms\Support\Facades\Volumes;
 use CraftCms\Cms\Twig\Variables\Cp;
 use CraftCms\Cms\User\Contracts\CraftUser;
 use CraftCms\Cms\Utility\Utilities;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
@@ -30,7 +31,10 @@ beforeEach(function () {
     $user->shouldReceive('isAdmin')->andReturnTrue();
     $user->shouldReceive('can')->andReturnTrue();
 
-    Auth::shouldReceive('user')->andReturn($user);
+    $this->authGuard = Mockery::mock(Guard::class);
+    $this->authGuard->shouldReceive('user')->andReturn($user);
+    Auth::shouldReceive('getDefaultDriver')->andReturn('web');
+    Auth::shouldReceive('guard')->with('web')->andReturn($this->authGuard);
     Auth::shouldReceive('userResolver')->andReturn(fn () => $user);
 });
 

--- a/tests/Unit/EditionTest.php
+++ b/tests/Unit/EditionTest.php
@@ -8,6 +8,7 @@ use CraftCms\Cms\License\License;
 use CraftCms\Cms\Support\Env;
 use CraftCms\Cms\Support\Facades\ProjectConfig;
 use CraftCms\Cms\User\Contracts\CraftUser;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Context;
@@ -152,7 +153,10 @@ it('determines if the edition can be upgraded', function () {
     $admin = Mockery::mock(CraftUser::class);
     $admin->shouldReceive('isAdmin')->andReturnTrue();
 
-    Auth::shouldReceive('user')->andReturn(null, $user, $admin, $admin, $admin);
+    $guard = Mockery::mock(Guard::class);
+    $guard->shouldReceive('user')->andReturn(null, $user, $admin, $admin, $admin);
+    Auth::shouldReceive('getDefaultDriver')->andReturn('web');
+    Auth::shouldReceive('guard')->with('web')->andReturn($guard);
 
     // Not logged in
     expect(Edition::canUpgrade())->toBefalse();

--- a/tests/Unit/Element/ElementWrites/PropagateElementTest.php
+++ b/tests/Unit/Element/ElementWrites/PropagateElementTest.php
@@ -25,6 +25,7 @@ use CraftCms\Cms\Support\Facades\Sites as SitesFacade;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\User\Elements\User;
 use CraftCms\Cms\User\Models\User as UserModel;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
@@ -298,7 +299,10 @@ it('adds a linked validation error when the current user can fix the propagated 
 
     swapUrlRequest('/admin/entries/100?foo=bar&site=primary');
     request()->attributes->set('isCpRequest', true);
-    Auth::shouldReceive('user')->andReturn(new AuthorizedAuthUser);
+    $guard = Mockery::mock(Guard::class);
+    $guard->shouldReceive('user')->andReturn(new AuthorizedAuthUser);
+    Auth::shouldReceive('getDefaultDriver')->andReturn('web');
+    Auth::shouldReceive('guard')->with('web')->andReturn($guard);
     SitesFacade::shouldReceive('isMultiSite')->andReturnFalse();
     SitesFacade::shouldReceive('getPrimarySite')->andReturn($this->primarySite);
 

--- a/tests/Unit/Route/RouteServiceProviderTest.php
+++ b/tests/Unit/Route/RouteServiceProviderTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use CraftCms\Cms\Http\Middleware\AuthenticateCraftSession;
+use CraftCms\Cms\Http\Middleware\UseCraftAuthGuard;
 use CraftCms\Cms\Http\Middleware\UseWriteConnection;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Router;
@@ -10,5 +12,7 @@ it('only applies write connection routing to Craft routes', function () {
     $router = app(Router::class);
 
     expect(app(Kernel::class)->getGlobalMiddleware())->not->toContain(UseWriteConnection::class)
-        ->and($router->getMiddlewareGroups()['craft'][0])->toBe(UseWriteConnection::class);
+        ->and($router->getMiddlewareGroups()['craft'][0])->toBe(UseCraftAuthGuard::class)
+        ->and($router->getMiddlewareGroups()['craft'][1])->toBe(UseWriteConnection::class)
+        ->and($router->getMiddlewareGroups()['craft.web'])->toContain(AuthenticateCraftSession::class);
 });

--- a/yii2-adapter/legacy/base/LogTargetTrait.php
+++ b/yii2-adapter/legacy/base/LogTargetTrait.php
@@ -10,13 +10,14 @@ namespace craft\base;
 use Craft;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Facades\Security;
-use Illuminate\Support\Facades\Auth;
 use Throwable;
 use yii\base\InvalidConfigException;
 use yii\helpers\VarDumper;
 use yii\log\Target;
 use yii\web\Request;
 use yii\web\Session;
+
+use function CraftCms\Cms\craftAuth;
 
 /**
  * LogTargetTrait implements the common methods and properties for log target classes.
@@ -65,7 +66,7 @@ trait LogTargetTrait
         }
 
         $user = Craft::$app->has('user', true) ? Craft::$app->getUser() : null;
-        if ($user && ($identity = Auth::user())) {
+        if ($user && ($identity = craftAuth()->user())) {
             $userID = $identity->getId();
         } else {
             $userID = '-';

--- a/yii2-adapter/legacy/console/User.php
+++ b/yii2-adapter/legacy/console/User.php
@@ -8,9 +8,9 @@
 namespace craft\console;
 
 use CraftCms\Cms\User\Elements\User as UserElement;
-use Illuminate\Support\Facades\Auth;
 use yii\base\Component;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\currentUser;
 
 /**
@@ -62,7 +62,13 @@ class User extends Component
      */
     public function setIdentity(?UserElement $identity = null): void
     {
-        Auth::login($identity);
+        if ($identity === null) {
+            craftAuth()->logout();
+
+            return;
+        }
+
+        craftAuth()->login($identity);
     }
 
     /**

--- a/yii2-adapter/legacy/controllers/SsoController.php
+++ b/yii2-adapter/legacy/controllers/SsoController.php
@@ -17,12 +17,13 @@ use CraftCms\Cms\Component\Exceptions\MissingComponentException;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\Support\Json;
 use Exception;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Throwable;
 use yii\web\HttpException;
 use yii\web\Response;
+
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\renderObjectTemplate;
 use function CraftCms\Cms\t;
 
@@ -137,7 +138,7 @@ class SsoController extends Controller
 
         return $this->redirect(
             $returnUrl
-                ? renderObjectTemplate($returnUrl, Auth::user())
+                ? renderObjectTemplate($returnUrl, craftAuth()->user())
                 : $this->request->getPathInfo()
         );
     }

--- a/yii2-adapter/legacy/elements/Category.php
+++ b/yii2-adapter/legacy/elements/Category.php
@@ -42,13 +42,13 @@ use CraftCms\Yii2Adapter\Element\Queries\CategoryQuery;
 use CraftCms\Yii2Adapter\Validation\LegacyElementRules;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Tpetry\QueryExpressions\Language\Alias;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -518,7 +518,7 @@ class Category extends Element
             ],
         ];
 
-        $user = Auth::user();
+        $user = craftAuth()->user();
 
         $ancestors = $this->getAncestors();
         if ($ancestors instanceof ElementQueryInterface) {

--- a/yii2-adapter/legacy/filters/BasicHttpAuthStatic.php
+++ b/yii2-adapter/legacy/filters/BasicHttpAuthStatic.php
@@ -10,9 +10,10 @@ namespace craft\filters;
 use Craft;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Support\Env;
-use Illuminate\Support\Facades\Auth;
 use yii\base\InvalidConfigException;
 use yii\filters\auth\HttpBasicAuth;
+
+use function CraftCms\Cms\craftAuth;
 
 /**
  * Filter for adding basic HTTP authentication with static credentials to site requests.
@@ -55,7 +56,7 @@ class BasicHttpAuthStatic extends HttpBasicAuth
             throw new InvalidConfigException('Basic authentication is not configured.');
         }
 
-        $currentUser = Auth::user();
+        $currentUser = craftAuth()->user();
 
         if ($currentUser) {
             return true;

--- a/yii2-adapter/legacy/services/Categories.php
+++ b/yii2-adapter/legacy/services/Categories.php
@@ -34,7 +34,6 @@ use CraftCms\Cms\View\TemplateResolver;
 use CraftCms\Yii2Adapter\DeprecatedConcepts;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Throwable;
@@ -42,6 +41,7 @@ use Tpetry\QueryExpressions\Language\Alias;
 use yii\base\Component;
 use yii\base\Exception;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\maxPowerCaptain;
 
 /**
@@ -169,7 +169,7 @@ class Categories extends Component
             return $this->getAllGroups();
         }
 
-        $user = Auth::user();
+        $user = craftAuth()->user();
 
         if (!$user) {
             return [];

--- a/yii2-adapter/legacy/services/Elements.php
+++ b/yii2-adapter/legacy/services/Elements.php
@@ -80,7 +80,6 @@ use CraftCms\DependencyAwareCache\Dependency\TagDependency;
 use DateTime;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
@@ -91,6 +90,7 @@ use yii\base\Exception;
 use yii\base\InvalidCallException;
 use yii\web\ForbiddenHttpException;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -1713,7 +1713,7 @@ class Elements extends Component
 
     private function _checkAuthorization(ElementInterface $element, string $ability, ?User $user = null): bool
     {
-        $user ??= Auth::user();
+        $user ??= craftAuth()->user();
 
         if (!$user) {
             return false;

--- a/yii2-adapter/legacy/services/Sso.php
+++ b/yii2-adapter/legacy/services/Sso.php
@@ -12,15 +12,18 @@ use craft\auth\sso\ProviderInterface;
 use craft\errors\AuthProviderNotFoundException;
 use craft\errors\SsoFailedException;
 use CraftCms\Cms\Auth\Models\SsoIdentity;
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\Support\MemoizableArray;
 use CraftCms\Cms\User\Elements\User;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\SessionGuard;
 use Throwable;
 use Tpetry\QueryExpressions\Language\Alias;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
+
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -256,7 +259,7 @@ class Sso extends Component
      */
     public function loginUser(ProviderInterface $provider, User $user, ?int $sessionDuration = null, bool $rememberMe = false): bool
     {
-        if (Auth::check()) {
+        if (craftAuth()->check()) {
             return true;
         }
 
@@ -268,7 +271,9 @@ class Sso extends Component
 
         // Try logging them in
         try {
-            Auth::setRememberDuration($sessionDuration ?? config('auth.guards.craft.remember', 576000))->login($user, $rememberMe);
+            /** @var SessionGuard $guard */
+            $guard = craftAuth();
+            $guard->setRememberDuration($sessionDuration ?? config(sprintf('auth.guards.%s.remember', Cms::config()->getAuthGuard()), 576000))->login($user, $rememberMe);
         } catch (Throwable $e) {
             throw new SsoFailedException($provider, $user, t("Unable to login", category: 'auth'), previous: $e);
         }

--- a/yii2-adapter/legacy/services/Users.php
+++ b/yii2-adapter/legacy/services/Users.php
@@ -15,6 +15,7 @@ use craft\events\UserGroupsAssignEvent;
 use craft\events\UserPhotoEvent;
 use CraftCms\Cms\Asset\Exceptions\ImageException;
 use CraftCms\Cms\Asset\Exceptions\VolumeException;
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\Database\Table;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\Element\Exceptions\InvalidElementException;
@@ -276,14 +277,11 @@ class Users extends Component
      * @param string $code The verification code to check for.
      *
      * @return bool Whether the code is still valid.
-     * @deprecated 6.0.0. Use `Password::tokenExists($user, $code)`
+     * @deprecated 6.0.0. Use `Password::broker(Cms::config()->getAuthPasswordBroker())->tokenExists($user, $code)`
      */
     public function isVerificationCodeValidForUser(User $user, string $code): bool
     {
-        /** @var \Illuminate\Auth\Passwords\PasswordBroker $broker */
-        $broker = Password::broker();
-
-        if ($broker->tokenExists($user, $code)) {
+        if (Password::broker(Cms::config()->getAuthPasswordBroker())->tokenExists($user, $code)) {
             return true;
         }
 

--- a/yii2-adapter/legacy/services/Users.php
+++ b/yii2-adapter/legacy/services/Users.php
@@ -281,7 +281,10 @@ class Users extends Component
      */
     public function isVerificationCodeValidForUser(User $user, string $code): bool
     {
-        if (Password::broker(Cms::config()->getAuthPasswordBroker())->tokenExists($user, $code)) {
+        /** @var \Illuminate\Auth\Passwords\PasswordBroker $broker */
+        $broker = Password::broker(Cms::config()->getAuthPasswordBroker());
+
+        if ($broker->tokenExists($user, $code)) {
             return true;
         }
 

--- a/yii2-adapter/legacy/web/Application.php
+++ b/yii2-adapter/legacy/web/Application.php
@@ -22,7 +22,6 @@ use CraftCms\Yii2Adapter\Http\CaptureOriginalActionRequestUri;
 use CraftCms\Yii2Adapter\Web\Response as IlluminateBridgeResponse;
 use Illuminate\Http\Request as IlluminateRequest;
 use Illuminate\Routing\Router;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use IntlDateFormatter;
@@ -36,6 +35,8 @@ use yii\base\InvalidRouteException;
 use yii\web\BadRequestHttpException;
 use yii\web\NotFoundHttpException;
 use yii\web\Response as BaseResponse;
+
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -188,7 +189,7 @@ class Application extends \yii\web\Application
                     ($firstSeg = $request->getSegment(1)) !== null &&
                     ($plugin = app(Plugins::class)->getPlugin($firstSeg)) !== null
                 ) {
-                    if (Auth::guest()) {
+                    if (craftAuth()->guest()) {
                         return $userSession->loginRequired();
                     }
 

--- a/yii2-adapter/legacy/web/Controller.php
+++ b/yii2-adapter/legacy/web/Controller.php
@@ -19,7 +19,6 @@ use CraftCms\Cms\Support\Json;
 use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\User\Elements\User;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 use yii\base\Action;
@@ -32,6 +31,7 @@ use yii\web\MethodNotAllowedHttpException;
 use yii\web\Response as YiiResponse;
 use yii\web\UnauthorizedHttpException;
 
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\currentUser;
 use function CraftCms\Cms\renderObjectTemplate;
 use function CraftCms\Cms\t;
@@ -260,7 +260,7 @@ abstract class Controller extends \yii\web\Controller
             if ($isCpRequest) {
                 $this->requireLogin();
                 $this->requirePermission('accessCp');
-            } elseif (Auth::guest()) {
+            } elseif (craftAuth()->guest()) {
                 if ($isLive) {
                     throw new ForbiddenHttpException();
                 } else {
@@ -517,7 +517,7 @@ abstract class Controller extends \yii\web\Controller
     {
         $userSession = Craft::$app->getUser();
 
-        if (Auth::guest()) {
+        if (craftAuth()->guest()) {
             $userSession->loginRequired();
             Craft::$app->end();
         }
@@ -533,7 +533,7 @@ abstract class Controller extends \yii\web\Controller
     {
         $userSession = Craft::$app->getUser();
 
-        if (!Auth::guest()) {
+        if (!craftAuth()->guest()) {
             $userSession->guestRequired();
             Craft::$app->end();
         }
@@ -569,7 +569,7 @@ abstract class Controller extends \yii\web\Controller
      */
     public function requirePermission(string $permissionName): void
     {
-        Gate::forUser(Auth::user())->authorize($permissionName);
+        Gate::forUser(craftAuth()->user())->authorize($permissionName);
     }
 
     /**

--- a/yii2-adapter/legacy/web/User.php
+++ b/yii2-adapter/legacy/web/User.php
@@ -16,11 +16,12 @@ use CraftCms\Cms\Auth\Passkeys\Passkeys;
 use CraftCms\Cms\Cms;
 use CraftCms\Cms\Support\Facades\Users;
 use CraftCms\Cms\User\Elements\User as UserElement;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL;
 use yii\web\ForbiddenHttpException;
 use yii\web\IdentityInterface;
+
+use function CraftCms\Cms\craftAuth;
 use function CraftCms\Cms\t;
 
 /**
@@ -64,7 +65,7 @@ class User extends \CraftCms\Yii2Adapter\Web\User
      */
     public function loginByUserId(int $userId, int $duration = 0): bool
     {
-        return Auth::loginUsingId($userId, $duration > 0) !== false;
+        return craftAuth()->loginUsingId($userId, $duration > 0) !== false;
     }
 
     /**
@@ -180,7 +181,7 @@ class User extends \CraftCms\Yii2Adapter\Web\User
      */
     public function getIsGuest(): bool
     {
-        return Auth::guest();
+        return craftAuth()->guest();
     }
 
     /**
@@ -207,7 +208,7 @@ class User extends \CraftCms\Yii2Adapter\Web\User
     public function getRemainingSessionTime(): int
     {
         // Are they logged in?
-        if (Auth::check()) {
+        if (craftAuth()->check()) {
             return (int) CarbonInterval::minutes(config('session.lifetime', 120))->totalSeconds;
         }
 
@@ -262,7 +263,7 @@ class User extends \CraftCms\Yii2Adapter\Web\User
      */
     public function getIsAdmin(): bool
     {
-        $user = Auth::user();
+        $user = craftAuth()->user();
 
         return ($user && $user->admin);
     }
@@ -276,7 +277,7 @@ class User extends \CraftCms\Yii2Adapter\Web\User
      */
     public function checkPermission(string $permissionName): bool
     {
-        return Gate::check($permissionName);
+        return Gate::forUser(craftAuth()->user())->check($permissionName);
     }
 
     /**

--- a/yii2-adapter/src/Announcement/Jobs/SendAnnouncement.php
+++ b/yii2-adapter/src/Announcement/Jobs/SendAnnouncement.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CraftCms\Yii2Adapter\Announcement\Jobs;
 
 use craft\services\Announcements;
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\Cp\Notifications\CpNotification;
 use CraftCms\Cms\Edition;
 use CraftCms\Cms\Plugin\Plugins;
@@ -52,8 +53,9 @@ class SendAnnouncement extends Job
 
         $totalUsers = $userQuery->count();
         $batchSize = 100;
+        $provider = config(sprintf('auth.guards.%s.provider', Cms::config()->getAuthGuard()));
         /** @var class-string<Model> $userModel */
-        $userModel = config('auth.providers.users.model');
+        $userModel = config("auth.providers.$provider.model");
 
         $userQuery->chunk($batchSize, function(Collection $users, int $batchIndex) use ($totalUsers, $batchSize, $byline, $userModel): void {
             $this->setProgress((int) ((($batchIndex * $batchSize) / max($totalUsers, 1)) * 100));

--- a/yii2-adapter/src/Event/EventCompatibility.php
+++ b/yii2-adapter/src/Event/EventCompatibility.php
@@ -47,6 +47,7 @@ use craft\utilities\ClearCaches;
 use craft\web\Application;
 use craft\web\twig\variables\Cp;
 use craft\web\View;
+use CraftCms\Cms\Cms;
 use CraftCms\Cms\Edition\Events\EditionChanged;
 use CraftCms\Cms\Shared\Concerns\LegacyEventConstants;
 use CraftCms\Cms\User\Elements\User;
@@ -155,18 +156,30 @@ readonly class EventCompatibility
         });
 
         Event::listen(function(Authenticated $event) {
+            if ($event->guard !== Cms::config()->getAuthGuard()) {
+                return;
+            }
+
             /** @var User $user */
             $user = $event->user;
             app('Craft')->getUser()->setIdentity(new IdentityWrapper($user));
         });
 
         Event::listen(function(Login $event) {
+            if ($event->guard !== Cms::config()->getAuthGuard()) {
+                return;
+            }
+
             /** @var User $user */
             $user = $event->user;
             app('Craft')->getUser()->setIdentity(new IdentityWrapper($user));
         });
 
-        Event::listen(Logout::class, function() {
+        Event::listen(Logout::class, function(Logout $event) {
+            if ($event->guard !== Cms::config()->getAuthGuard()) {
+                return;
+            }
+
             app('Craft')->getUser()->setIdentity(null);
         });
 

--- a/yii2-adapter/src/Web/User.php
+++ b/yii2-adapter/src/Web/User.php
@@ -10,6 +10,8 @@ use RuntimeException;
 use yii\db\BaseActiveRecord;
 use yii\web\IdentityInterface;
 
+use function CraftCms\Cms\craftAuth;
+
 class User extends \yii\web\User
 {
     private IdentityInterface|false|null $_identity = false;
@@ -25,7 +27,7 @@ class User extends \yii\web\User
             return $this->_identity;
         }
 
-        $identity = $this->getIlluminateAuthManager()->user();
+        $identity = craftAuth()->user();
 
         if ($identity !== null) {
             $identity = $this->convertIlluminateIdentity($identity);
@@ -59,7 +61,7 @@ class User extends \yii\web\User
         $this->setIdentity($identity);
 
         if ($identity === null) {
-            $this->getIlluminateAuthManager()->logout();
+            craftAuth()->logout();
 
             return;
         }
@@ -74,7 +76,7 @@ class User extends \yii\web\User
          * When "Remember me for 2 weeks" is checked, the duration will be larger
          * than 3600, so we pass remember to Laravel's auth as well.
          */
-        $this->getIlluminateAuthManager()->loginUsingId($id, remember: $duration > 3600);
+        craftAuth()->loginUsingId($id, remember: $duration > 3600);
     }
 
     protected function convertIlluminateIdentity(mixed $identity): IdentityInterface

--- a/yii2-adapter/tests-laravel/Legacy/AuthEventCompatibilityTest.php
+++ b/yii2-adapter/tests-laravel/Legacy/AuthEventCompatibilityTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use craft\console\User as ConsoleUser;
+use craft\elements\User as UserElement;
+use craft\services\Users as LegacyUsers;
+use CraftCms\Cms\Cms;
+use CraftCms\Yii2Adapter\IdentityWrapper;
+use Illuminate\Auth\Events\Authenticated;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Auth\Passwords\PasswordBroker;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Password;
+use yii\web\IdentityInterface;
+
+beforeEach(function() {
+    Cms::config()->authGuard = 'craft';
+    Cms::config()->authPasswordBroker = 'craft';
+
+    $this->legacyUser = app('Craft')->getUser();
+    $this->authUser = new GenericUser(['id' => 42, 'password' => '']);
+});
+
+it('ignores authentication events from other guards', function() {
+    $identity = Mockery::mock(IdentityInterface::class);
+    $this->legacyUser->setIdentity($identity);
+
+    Event::dispatch(new Authenticated('host', $this->authUser));
+    Event::dispatch(new Login('host', $this->authUser, false));
+    Event::dispatch(new Logout('host', $this->authUser));
+
+    expect($this->legacyUser->getIdentity())->toBe($identity);
+});
+
+it('synchronizes authentication events from the Craft guard', function() {
+    Event::dispatch(new Authenticated('craft', $this->authUser));
+
+    expect($this->legacyUser->getIdentity())->toBeInstanceOf(IdentityWrapper::class);
+
+    $this->legacyUser->setIdentity(null);
+    Event::dispatch(new Login('craft', $this->authUser, false));
+
+    expect($this->legacyUser->getIdentity())->toBeInstanceOf(IdentityWrapper::class);
+
+    Event::dispatch(new Logout('craft', $this->authUser));
+
+    expect($this->legacyUser->getIdentity())->toBeNull();
+});
+
+it('reads the current identity from the Craft guard', function() {
+    $guard = Mockery::mock(StatefulGuard::class);
+    $guard->shouldReceive('user')->once()->andReturnNull();
+    Auth::shouldReceive('guard')->once()->with('craft')->andReturn($guard);
+
+    expect($this->legacyUser->getIdentity())->toBeNull();
+});
+
+it('switches identity through the Craft guard', function() {
+    $identity = Mockery::mock(IdentityInterface::class);
+    $identity->shouldReceive('getId')->once()->andReturn(42);
+
+    $guard = Mockery::mock(StatefulGuard::class);
+    $guard->shouldReceive('loginUsingId')->once()->with(42, false);
+    $guard->shouldReceive('logout')->once();
+    Auth::shouldReceive('guard')->twice()->with('craft')->andReturn($guard);
+
+    $this->legacyUser->switchIdentity($identity);
+    $this->legacyUser->switchIdentity(null);
+});
+
+it('clears the console identity through the Craft guard', function() {
+    $guard = Mockery::mock(StatefulGuard::class);
+    $guard->shouldReceive('logout')->once();
+    Auth::shouldReceive('guard')->once()->with('craft')->andReturn($guard);
+
+    new ConsoleUser()->setIdentity();
+});
+
+it('checks legacy verification codes through the Craft password broker', function() {
+    $user = Mockery::mock(UserElement::class);
+    $broker = Mockery::mock(PasswordBroker::class);
+    $broker->shouldReceive('tokenExists')->once()->with($user, 'code')->andReturnTrue();
+    Password::shouldReceive('broker')->once()->with('craft')->andReturn($broker);
+
+    expect(new LegacyUsers()->isVerificationCodeValidForUser($user, 'code'))->toBeTrue();
+});


### PR DESCRIPTION
### Description

Adds optional `authGuard` and `authPasswordBroker` general config settings so Craft authentication can use a dedicated Laravel guard, user provider, and password broker. Existing Laravel defaults remain in use when the settings are unset. Setting `CRAFT_AUTH_GUARD=craft` selects the registered Craft session guard and provider.

Routes, authentication events, password confirmation, and forced session invalidation respect the selected guard while preserving the host application's session. An architecture test enforces `craftAuth()` usage across core and adapter code.

Password-reset isolation requires a separately configured broker and token table. This change does not rename Craft's `users` table or introduce a separate database connection.

### Related issues

Fixes #19598.
