### PR TITLE
[6.x] Fix admin table pagination controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574), [#19563](https://github.com/craftcms/cms/pull/19563), [#19588](https://github.com/craftcms/cms/pull/19588), and [#19585](https://github.com/craftcms/cms/pull/19585) for details.
 
+- Fixed a bug where unpaginated Inertia admin tables could show nonfunctional pagination controls. ([#19618](https://github.com/craftcms/cms/pull/19618))
 - Fixed a bug where field types could remain unchanged or switch to an unintended option when their combobox query was submitted with <kbd>Return</kbd>. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed a bug where brand icons, including the Markdown field type icon, were not displayed in combobox options. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder. ([#19603](https://github.com/craftcms/cms/pull/19603))

--- a/resources/js/modules/elements/components/BaseElementIndex.vue
+++ b/resources/js/modules/elements/components/BaseElementIndex.vue
@@ -72,7 +72,14 @@
       if (v) props.table.setPageSize(parseInt(String(v)));
     },
   });
-  const showPagination = computed(() => props.table.getPageCount() > 1);
+  const showPagination = computed(
+    () =>
+      props.table.getPageCount() > 1 &&
+      Boolean(
+        props.table.options.manualPagination ||
+        props.table.options.getPaginationRowModel
+      )
+  );
   const showPageSize = computed(() => props.enableAdjustPageSize);
   const pageSizeLabel = t('Items per page');
   const showDisplayedRows = computed(


### PR DESCRIPTION
### Description

Only show Inertia admin table pagination controls when the TanStack table explicitly configures client-side or server-side pagination.