### PR TITLE
[6.x] Fix save-and-continue redirects for new items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574), [#19563](https://github.com/craftcms/cms/pull/19563), [#19588](https://github.com/craftcms/cms/pull/19588), and [#19585](https://github.com/craftcms/cms/pull/19585) for details.
 
+- Fixed a bug where Save and continue editing left newly created control panel items on their creation page. ([#19619](https://github.com/craftcms/cms/pull/19619))
 - Fixed a bug where field types could remain unchanged or switch to an unintended option when their combobox query was submitted with <kbd>Return</kbd>. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed a bug where brand icons, including the Markdown field type icon, were not displayed in combobox options. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder. ([#19603](https://github.com/craftcms/cms/pull/19603))

--- a/src/Filesystem/Filesystems/Filesystem.php
+++ b/src/Filesystem/Filesystems/Filesystem.php
@@ -7,13 +7,16 @@ namespace CraftCms\Cms\Filesystem\Filesystems;
 use CraftCms\Cms\Component\Component;
 use CraftCms\Cms\Component\Concerns\ConfigurableComponent;
 use CraftCms\Cms\Component\Concerns\SavableComponent;
+use CraftCms\Cms\Component\Contracts\CpEditable;
 use CraftCms\Cms\Filesystem\Contracts\FsInterface;
+use CraftCms\Cms\Support\Url;
 use CraftCms\Cms\Validation\Rules\HandleRule;
 use Override;
 
+use function CraftCms\Cms\currentUser;
 use function CraftCms\Cms\t;
 
-abstract class Filesystem extends Component implements FsInterface
+abstract class Filesystem extends Component implements CpEditable, FsInterface
 {
     use ConfigurableComponent;
     use SavableComponent;
@@ -39,6 +42,15 @@ abstract class Filesystem extends Component implements FsInterface
     public function getRootUrl(): ?string
     {
         return null;
+    }
+
+    public function getCpEditUrl(): ?string
+    {
+        if (! $this->handle || ! currentUser()?->isAdmin()) {
+            return null;
+        }
+
+        return Url::cpUrl("settings/filesystems/{$this->handle}");
     }
 
     abstract public function getDiskConfig(): array;

--- a/src/Http/RespondsWithFlash.php
+++ b/src/Http/RespondsWithFlash.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CraftCms\Cms\Http;
 
+use CraftCms\Cms\Component\Contracts\CpEditable;
 use CraftCms\Cms\Component\Contracts\Identifiable;
 use CraftCms\Cms\Support\Arr;
 use CraftCms\Cms\Support\Flash;
@@ -136,6 +137,10 @@ trait RespondsWithFlash
         }
 
         $redirect ??= $this->getPostedRedirectUrl($model);
+
+        if ($redirect === null && ! request()->expectsJson() && request()->isCpRequest() && $model instanceof CpEditable) {
+            $redirect = $model->getCpEditUrl();
+        }
 
         return $this->asSuccess($message, $data, $redirect);
     }

--- a/tests/Feature/Http/Controllers/FieldsControllerTest.php
+++ b/tests/Feature/Http/Controllers/FieldsControllerTest.php
@@ -362,11 +362,15 @@ it('normalizes namespaced condition builder values', function () {
 it('can save a new field', function () {
     $currentCount = FieldModel::count();
 
-    $this->postJson(action([FieldsController::class, 'store']), [
-        'type' => PlainText::class,
-        'name' => 'My plaintext field',
-        'handle' => 'plainText',
-    ])->assertOk();
+    $response = $this->postJson(
+        action([FieldsController::class, 'store']),
+        [
+            'type' => PlainText::class,
+            'name' => 'My plaintext field',
+            'handle' => 'plainText',
+        ],
+        ['Accept' => 'text/html', 'X-Inertia' => 'true'],
+    );
 
     expect(FieldModel::count())->toBe($currentCount + 1);
     tap(FieldModel::query()->latest('id')->firstOrFail(), function (FieldModel $field) {
@@ -374,6 +378,8 @@ it('can save a new field', function () {
         expect($field->handle)->toBe('plainText');
         expect($field->type)->toBe(PlainText::class);
     });
+
+    $response->assertRedirect(Fields::getFieldByHandle('plainText')->getCpEditUrl());
 });
 
 it('can save a new field with settings posted as a url-encoded string', function () {

--- a/tests/Feature/Http/Controllers/Settings/EntryTypesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/EntryTypesControllerTest.php
@@ -190,17 +190,19 @@ function validEntryTypeData(array $overrides = []): array
 it('can save an entry type', function () {
     expect(EntryType::count())->toBe(1);
 
-    post(action([EntryTypesController::class, 'store']), validEntryTypeData([
-        'fieldLayout' => [
-            'generatedFields' => [[
-                'name' => 'Summary',
-                'handle' => 'summary',
-                'template' => '{title}',
-            ]],
-        ],
-    ]))
-        ->assertSessionDoesntHaveErrors()
-        ->assertRedirectBack();
+    $response = postJson(
+        action([EntryTypesController::class, 'store']),
+        validEntryTypeData([
+            'fieldLayout' => [
+                'generatedFields' => [[
+                    'name' => 'Summary',
+                    'handle' => 'summary',
+                    'template' => '{title}',
+                ]],
+            ],
+        ]),
+        ['Accept' => 'text/html', 'X-Inertia' => 'true'],
+    );
 
     expect(EntryType::count())->toBe(2);
     /** @var CraftCms\Cms\Entry\Data\EntryType $entryType */
@@ -209,6 +211,7 @@ it('can save an entry type', function () {
     expect($entryType->handle)->toBe('a_new_entry_type');
     expect($entryType->getFieldLayout()->getGeneratedFields()[0])
         ->toMatchArray(['name' => 'Summary', 'handle' => 'summary', 'template' => '{title}']);
+    $response->assertRedirect($entryType->getCpEditUrl());
 });
 
 test('values are validated', function (string $attribute, string $value = '') {

--- a/tests/Feature/Http/Controllers/Settings/FilesystemsControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/FilesystemsControllerTest.php
@@ -188,14 +188,18 @@ test('edit renders existing filesystems as read-only when admin changes are disa
 });
 
 test('save creates filesystem with valid data', function () {
-    postJson(action([FilesystemsController::class, 'store']), [
-        'type' => Local::class,
-        'name' => 'New Test Filesystem',
-        'handle' => 'newTestFilesystem',
-        'settings' => [
-            'path' => sys_get_temp_dir().'/test-uploads',
+    $response = postJson(
+        action([FilesystemsController::class, 'store']),
+        [
+            'type' => Local::class,
+            'name' => 'New Test Filesystem',
+            'handle' => 'newTestFilesystem',
+            'settings' => [
+                'path' => sys_get_temp_dir().'/test-uploads',
+            ],
         ],
-    ])->assertOk();
+        ['Accept' => 'text/html', 'X-Inertia' => 'true'],
+    );
 
     $fs = Filesystems::getFilesystemByHandle('newTestFilesystem');
     expect($fs)->not()->toBeNull()
@@ -203,6 +207,7 @@ test('save creates filesystem with valid data', function () {
         ->and($fs->getSettings())->toMatchArray([
             'path' => File::normalizePath(sys_get_temp_dir().'/test-uploads', '/'),
         ]);
+    $response->assertRedirect(Url::cpUrl("settings/filesystems/{$fs->handle}"));
 });
 
 test('refreshes filesystem settings without saving', function () {

--- a/tests/Feature/Http/Controllers/Settings/VolumesControllerTest.php
+++ b/tests/Feature/Http/Controllers/Settings/VolumesControllerTest.php
@@ -198,18 +198,23 @@ describe('create / edit', function () {
 
 describe('store', function () {
     test('store creates volume with valid data', function () {
-        postJson(action([VolumesController::class, 'store']), [
-            'name' => 'New Volume',
-            'handle' => 'newVolume',
-            'fsHandle' => 'disk:test-disk',
-            'assetTransformer' => 'craft',
-        ])->assertOk();
+        $response = postJson(
+            action([VolumesController::class, 'store']),
+            [
+                'name' => 'New Volume',
+                'handle' => 'newVolume',
+                'fsHandle' => 'disk:test-disk',
+                'assetTransformer' => 'craft',
+            ],
+            ['Accept' => 'text/html', 'X-Inertia' => 'true'],
+        );
 
         app()->forgetInstance(Volumes::class);
         $volume = app(Volumes::class)->getVolumeByHandle('newVolume');
         expect($volume)->not()->toBeNull();
         expect($volume->name)->toBe('New Volume')
             ->and($volume->getAssetTransformerHandle(false))->toBe('craft');
+        $response->assertRedirect(Url::cpUrl("settings/assets/volumes/{$volume->id}"));
     });
 
     test('store updates existing volume', function () {


### PR DESCRIPTION
### Description

Fix Save and continue editing for newly created control panel items by falling back to the saved model edit URL when no redirect was posted.

Expose filesystem edit URLs through the existing CpEditable contract.