### PR TITLE
[6.x] Fix structure index controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574), [#19563](https://github.com/craftcms/cms/pull/19563), [#19588](https://github.com/craftcms/cms/pull/19588), and [#19585](https://github.com/craftcms/cms/pull/19585) for details.
 
+- Fixed a bug where the “Structure” sorting option was missing from structure element indexes.
 - Fixed a bug where field types could remain unchanged or switch to an unintended option when their combobox query was submitted with <kbd>Return</kbd>. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed a bug where brand icons, including the Markdown field type icon, were not displayed in combobox options. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder. ([#19603](https://github.com/craftcms/cms/pull/19603))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 > [!IMPORTANT]
 > This update contains breaking changes for plugins. See [#19574](https://github.com/craftcms/cms/pull/19574), [#19563](https://github.com/craftcms/cms/pull/19563), [#19588](https://github.com/craftcms/cms/pull/19588), and [#19585](https://github.com/craftcms/cms/pull/19585) for details.
 
-- Fixed a bug where the “Structure” sorting option was missing from structure element indexes.
+- Fixed a bug where the “Structure” sorting option was missing from structure element indexes. ([#19620](https://github.com/craftcms/cms/pull/19620))
 - Fixed a bug where field types could remain unchanged or switch to an unintended option when their combobox query was submitted with <kbd>Return</kbd>. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed a bug where brand icons, including the Markdown field type icon, were not displayed in combobox options. ([#19614](https://github.com/craftcms/cms/pull/19614))
 - Fixed user photo asset selections not being saved, and restricted the photo selector to images in the configured volume and subfolder. ([#19603](https://github.com/craftcms/cms/pull/19603))

--- a/src/Http/ViewModels/ContentIndexViewModel.php
+++ b/src/Http/ViewModels/ContentIndexViewModel.php
@@ -273,7 +273,7 @@ abstract class ContentIndexViewModel extends ViewModel
      */
     public function sortOptions(): array
     {
-        [$sourceKey] = $this->sourceState();
+        [$sourceKey, $source] = $this->sourceState();
 
         if ($sourceKey === null) {
             return [];
@@ -281,6 +281,14 @@ abstract class ContentIndexViewModel extends ViewModel
 
         $indexState = $this->indexState();
         $options = [];
+
+        if (isset($source['structureId'])) {
+            $options['structure'] = [
+                'label' => t('Structure'),
+                'value' => 'structure',
+                'defaultDir' => 'asc',
+            ];
+        }
 
         foreach ($indexState->sortOptions($this->elementType) as $option) {
             $value = self::addressableSortAttribute($option);

--- a/tests/Feature/Http/Controllers/ContentIndexControllerTest.php
+++ b/tests/Feature/Http/Controllers/ContentIndexControllerTest.php
@@ -243,7 +243,19 @@ it('orders a structure source by its structure rather than a literal column', fu
     ]))
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('source.structureId', $structure->id)
             ->where('sort.0.field', 'structure')
+            ->where('structure.id', $structure->id)
+            ->where('viewModes', fn ($modes) => collect($modes)->contains(
+                fn (array $mode): bool => $mode['mode'] === 'structure' && $mode['structuresOnly'] === true,
+            ))
+            ->where('sortOptions', fn ($options) => collect($options)->contains(
+                fn (array $option): bool => $option === [
+                    'label' => 'Structure',
+                    'value' => 'structure',
+                    'defaultDir' => 'asc',
+                ],
+            ))
             ->where('pagination.total', 3)
             ->where('data.0.id', $c->id)
             ->where('data.1.id', $a->id)

--- a/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Entries/EditEntryControllerTest.php
@@ -12,8 +12,10 @@ use CraftCms\Cms\FieldLayout\FieldLayoutTab;
 use CraftCms\Cms\FieldLayout\LayoutElements\Entries\EntryTitleField;
 use CraftCms\Cms\FieldLayout\Models\FieldLayout as FieldLayoutModel;
 use CraftCms\Cms\Http\Controllers\Entries\StoreEntryController;
+use CraftCms\Cms\Section\Enums\SectionType;
 use CraftCms\Cms\Section\Models\Section;
 use CraftCms\Cms\Section\Models\SectionSiteSettings;
+use CraftCms\Cms\Structure\Models\Structure;
 use CraftCms\Cms\Support\Facades\Elements;
 use CraftCms\Cms\Support\Facades\Sections;
 use CraftCms\Cms\User\Elements\User;
@@ -117,6 +119,23 @@ it('compiles the meta fields into a sidebar form', function () {
                     && in_array('notes', $paths, true);
             })
             ->where('metadataHtml', fn (?string $html) => is_string($html) && $html !== '')
+            ->etc()
+        );
+});
+
+it('includes the parent field for structure entries', function () {
+    $structure = Structure::factory()->create();
+    $this->section->update([
+        'type' => SectionType::Structure,
+        'structureId' => $structure->id,
+    ]);
+    Sections::refreshSections();
+
+    get($this->entry->getCpEditUrl())
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('sidebarForm.nodes', fn (Collection $nodes) => $nodes
+                ->contains(fn (array $node) => ($node['control']['path'] ?? null) === ['parentId']))
             ->etc()
         );
 });


### PR DESCRIPTION
### Description

Adds the missing Structure sorting option to structure element indexes and regression coverage for the structure view mode and Parent field.